### PR TITLE
Multi-edit chain via update(path, fn) + extract conversion builders to sub-package

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Gradle (Kotlin DSL):
 
 ```kotlin
 dependencies {
-    implementation("io.github.eschizoid:telescope:0.1.0")
+    implementation("io.github.eschizoid:telescope:0.3.0")
 }
 ```
 
@@ -149,7 +149,7 @@ Maven:
 <dependency>
   <groupId>io.github.eschizoid</groupId>
   <artifactId>telescope</artifactId>
-  <version>0.1.0</version>
+  <version>0.3.0</version>
 </dependency>
 ```
 
@@ -161,8 +161,8 @@ Gradle (Kotlin DSL):
 
 ```kotlin
 dependencies {
-    implementation("io.github.eschizoid:telescope:0.1.0")
-    annotationProcessor("io.github.eschizoid:telescope-codegen:0.1.0")
+    implementation("io.github.eschizoid:telescope:0.3.0")
+    annotationProcessor("io.github.eschizoid:telescope-codegen:0.3.0")
 }
 ```
 
@@ -172,7 +172,7 @@ Maven:
 <dependency>
   <groupId>io.github.eschizoid</groupId>
   <artifactId>telescope</artifactId>
-  <version>0.1.0</version>
+  <version>0.3.0</version>
 </dependency>
 
 <build>
@@ -185,7 +185,7 @@ Maven:
           <path>
             <groupId>io.github.eschizoid</groupId>
             <artifactId>telescope-codegen</artifactId>
-            <version>0.1.0</version>
+            <version>0.3.0</version>
           </path>
         </annotationProcessorPaths>
       </configuration>
@@ -249,25 +249,27 @@ Conversions are bidirectional `Iso`s, so any cell in the middle row composes int
 
 ### Read
 
-| Method       | Returns                                    |
-| ------------ | ------------------------------------------ |
-| `.read(S)`   | The first focused value. Throws if absent. |
-| `.find(S)`   | `Optional<A>` of the first focused value.  |
-| `.toList(S)` | `List<A>` of all focused values.           |
-| `.count(S)`  | How many values are focused.               |
-| `.exists(S)` | `true` if there's at least one.            |
+| Method         | Returns                                                                                                                                                                                                                                                                                      |
+| -------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `.read(S)`     | The first focused value. Throws if absent.                                                                                                                                                                                                                                                   |
+| `.find(S)`     | `Optional<A>` of the first focused value.                                                                                                                                                                                                                                                    |
+| `.toList(S)`   | `List<A>` of all focused values.                                                                                                                                                                                                                                                             |
+| `.count(S)`    | How many values are focused.                                                                                                                                                                                                                                                                 |
+| `.exists(S)`   | `true` if there's at least one.                                                                                                                                                                                                                                                              |
+| `.withIndex()` | Index-aware chainable view (`Telescope.WithIndex<S, A>`). Exposes `.update(S, BiFunction<Integer, A, A>)`, `.toList(S)` → `List<Indexed<A>>`, `.find(S)`, `.count(S)`, `.exists(S)` — the same operations as the parent, with each focused value paired with its 0-based traversal position. |
 
 ### Write
 
-| Method                                         | Returns                                                                                                                                                                          |
-| ---------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `.set(S, A)`                                   | New `S` with every focused value replaced by the given one.                                                                                                                      |
-| `.update(S, Function<A, A>)`                   | New `S` with every focused value transformed.                                                                                                                                    |
-| `.updateAsync(S, fn, Executor)`                | Bounded-concurrency async update; pass a fixed pool to cap concurrent invocations.                                                                                               |
-| `.updateIndexed(S, BiFunction<Integer, A, A>)` | Transform every focused value with its 0-based position in traversal order.                                                                                                      |
-| `.toListIndexed(S)`                            | `List<Indexed<A>>` — every focused value paired with its position.                                                                                                               |
-| `.with(Function<A, A>)`                        | Accumulate an edit at the current focus and return a fresh identity `Telescope<S, S>` ready for the next path. See [Multi-edit chain](#multi-edit-chain). **Compile-checked.**   |
-| `.apply(S)`                                    | Run every accumulated `.with(...)` edit against the source, in insertion order. Returns a new `S`.                                                                               |
+| Method                                         | Returns                                                                                                                                                            |
+| ---------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `.set(S, A)`                                   | New `S` with every focused value replaced by the given one.                                                                                                        |
+| `.update(S, Function<A, A>)`                   | New `S` with every focused value transformed.                                                                                                                      |
+| `.updateAsync(S, fn, Executor)`                | Bounded-concurrency async update; pass a fixed pool to cap concurrent invocations.                                                                                 |
+| `.updateIndexed(S, BiFunction<Integer, A, A>)` | Transform every focused value with its 0-based position in traversal order.                                                                                        |
+| `.toListIndexed(S)`                            | `List<Indexed<A>>` — every focused value paired with its position.                                                                                                 |
+| `.update(Telescope<S, X>, Function<X, X>)`     | Accumulate an edit through a pre-built path; returns `Telescope<S, S>` carrying the running chain. See [Multi-edit chain](#multi-edit-chain). **Compile-checked.** |
+| `.with(Function<A, A>)`                        | Accumulate an edit at the current focus (inline-path equivalent of `.update(path, fn)`); returns `Telescope<S, S>`. **Compile-checked.**                           |
+| `.apply(S)`                                    | Run every accumulated `.update(path, fn)` / `.with(fn)` edit against the source, in insertion order. Returns a new `S`.                                            |
 
 ---
 
@@ -403,38 +405,79 @@ local first (`final var team = fetchTeam();`) and close over that.
 
 ### Multi-edit chain
 
-To apply several edits at different paths in one go, terminate each navigation with `.with(fn)` instead of
-`.update(source, fn)`. Each `.with(...)` accumulates the edit and returns a fresh identity `Telescope<S, S>` — ready for
-the next path. End the whole chain with `.apply(source)`. Every step is compile-checked (same typed `.each` / `.field`
-calls you already use); the runtime cost is the sum of the individual updates.
+To apply several edits at different paths in one go, accumulate them with `.update(path, fn)` for pre-built paths or
+`.with(fn)` for inline paths, then end with `.apply(source)`. Every step is fully compile-checked.
+
+**Preferred form — pre-built paths as static finals.** Declare each navigation once, then the multi-edit reads like a
+list of operations with no per-edit path repetition:
+
+```java
+static final Telescope<Company, String> EMAILS = Telescope.of(Company.class)
+  .each(Company::departments)
+  .each(Department::teams)
+  .each(Team::users)
+  .field(User::email);
+
+static final Telescope<Company, String> DEPT_NAMES = Telescope.of(Company.class)
+  .each(Company::departments)
+  .field(Department::name);
+
+static final Telescope<Company, String> USER_NAMES = Telescope.of(Company.class)
+  .each(Company::departments)
+  .each(Department::teams)
+  .each(Team::users)
+  .field(User::name);
+
+final Company done = Telescope.of(Company.class)
+  .update(EMAILS, String::toLowerCase)
+  .update(DEPT_NAMES, String::trim)
+  .update(USER_NAMES, titleCase)
+  .apply(company);
+```
+
+Each `.update(path, fn)` ties a `Telescope<S, X>` to a `Function<X, X>`; `javac` enforces the leaf type match. The
+`.update(...)` overload is disambiguated by first-argument type: a `Telescope` accumulates into the chain (returns
+`Telescope<S, S>`), a source instance is the single-shot terminal (returns `S`).
+
+**Inline form — for one-off paths you don't want to name.** Terminate the navigation with `.with(fn)` instead of
+`.update(source, fn)`; same chain semantics:
 
 ```java
 final Company done = Telescope.of(Company.class)
-    .each(Company::departments).each(Department::teams).each(Team::users).field(User::email)
-        .with(String::toLowerCase)
-    .each(Company::departments).field(Department::name)
-        .with(String::trim)
-    .each(Company::departments).each(Department::teams).each(Team::users).field(User::name)
-        .with(titleCase)
+  .each(Company::departments)
+  .each(Department::teams)
+  .each(Team::users)
+  .field(User::email)
+  .with(String::toLowerCase)
+  .each(Company::departments)
+  .field(Department::name)
+  .with(String::trim)
+  .apply(company);
+```
+
+Mix and match in the same chain — pre-built where reuse pays, inline where it doesn't:
+
+```java
+Telescope.of(Company.class)
+    .update(EMAILS, String::toLowerCase)                              // pre-built
+    .each(Company::departments).field(Department::name).with(String::trim)    // inline
     .apply(company);
 ```
 
-The chain is reusable across sources — hold onto the `Telescope<Company, Company>` instead of calling `.apply` at the
-end:
+**Reusable across sources.** Hold onto the resulting `Telescope<Company, Company>` instead of calling `.apply` at the
+end — it's the multi-edit equivalent of a stored single-path telescope:
 
 ```java
 final Telescope<Company, Company> normalize = Telescope.of(Company.class)
-    .each(Company::departments).each(Department::teams).each(Team::users).field(User::email)
-        .with(String::toLowerCase)
-    .each(Company::departments).field(Department::name)
-        .with(String::trim);
+    .update(EMAILS,     String::toLowerCase)
+    .update(DEPT_NAMES, String::trim);
 
 normalize.apply(companyA);
 normalize.apply(companyB);
 ```
 
-Edits run sequentially in insertion order; the second `.with(...)` sees the first edit's result, not the original
-source. An empty chain (no `.with(...)` calls) returns the source unchanged from `.apply(...)`.
+Edits run sequentially in insertion order; the second edit sees the first edit's result, not the original source. An
+empty chain (no `.update(...)` / `.with(...)` calls) returns the source unchanged from `.apply(...)`.
 
 ---
 
@@ -836,8 +879,8 @@ The return type degrades to a terminal `Telescope<R, Target>` when the target is
 Gradle wiring:
 
 ```kotlin
-implementation("io.github.eschizoid:telescope:0.1.0")
-annotationProcessor("io.github.eschizoid:telescope-codegen:0.1.0")
+implementation("io.github.eschizoid:telescope:0.3.0")
+annotationProcessor("io.github.eschizoid:telescope-codegen:0.3.0")
 ```
 
 `@Focus` and `@BeanFocus` are source-retention and inert without the processor, so annotating costs nothing if you don't
@@ -1064,7 +1107,7 @@ return afterUsers.flatMapAsync(ok -> enrichPath.updateAsync(ok, this::enrich));
    (`update(order, item -> … order.sku() …)`). Hoist the source to a local first if it's an expression.
 6. **Two documented runtime-check points on the runtime DSL.** Every typed entry point (`.field(Accessor)`,
    `.each(Accessor)`, `.eachValue(Accessor)`, `.whenPresent(Accessor)`, the bridges, `.with(fn)`, `.apply(S)`, every
-   `update*` variant) is fully compile-checked. Two escape hatches are *not* compile-checked, by design, and they're
+   `update*` variant) is fully compile-checked. Two escape hatches are _not_ compile-checked, by design, and they're
    named so the call site says so:
    - `.fieldByName(String)` / `.fieldByName(String, Class<B>)` — late-bound field name (config-driven paths). `javac`
      can't verify the name exists or that the inferred type matches the actual field. Wrong name → runtime error.
@@ -1073,6 +1116,21 @@ return afterUsers.flatMapAsync(ok -> enrichPath.updateAsync(ok, this::enrich));
 
    For zero runtime-check points, use the **`@Focus` / `@BeanFocus` / `@Bridge` annotation processors** — they generate
    a typed `<X>Path<R>` navigator at compile time where every step is a typed method call.
+
+7. **Pre-1.0 versioning policy — minor versions can break source and binary compatibility.** Telescope is still 0.x; we
+   hold the right to evolve the public surface between minor releases when it improves the DSL. Two breaks shipped
+   recently are worth knowing about explicitly:
+   - **`.field(String)` / `.field(String, Class<B>)` renamed to `.fieldByName(...)`** so the runtime-check nature is
+     loud at the call site (see constraint #6). Source-incompatible. No `@Deprecated` shim — clean break.
+   - **The conversion / mapping builder intermediate types** (`From`, `To`, `BeanFrom`, `BeanTo`, `MapBeanFrom`,
+     `MapBeanTo`, `MapTo`, `MapBuilder`, `FieldMapping`, `Mapper`) moved from nested `Telescope.Xxx` to top-level
+     classes in the same `io.github.eschizoid.telescope` package. **Source-compatible** for the common case (users write
+     `Telescope.from(A).to(B).using(...)` without ever naming the intermediates), but **binary-incompatible** because
+     the factory methods' return types changed from `Telescope.From` to `From`. Recompile against the new version. JPMS
+     exports are unchanged.
+
+   After 1.0 these guarantees tighten — source + binary compat across minor versions, breaks only on majors. We're not
+   there yet; keep your build configured to rebuild against each minor.
 
 ---
 

--- a/core/src/main/java/io/github/eschizoid/telescope/BeanFrom.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/BeanFrom.java
@@ -1,0 +1,18 @@
+package io.github.eschizoid.telescope;
+
+/**
+ * Intermediate of {@link Telescope#fromBean(Class)} — call {@link #to(Class)} to bind the record
+ * target and continue into one of {@link BeanTo}'s {@code via*()} terminals.
+ */
+public final class BeanFrom<P> {
+
+  private final Class<P> pojoClass;
+
+  BeanFrom(final Class<P> pojoClass) {
+    this.pojoClass = pojoClass;
+  }
+
+  public <R extends Record> BeanTo<P, R> to(final Class<R> recordClass) {
+    return new BeanTo<>(pojoClass, recordClass);
+  }
+}

--- a/core/src/main/java/io/github/eschizoid/telescope/BeanTo.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/BeanTo.java
@@ -1,0 +1,192 @@
+package io.github.eschizoid.telescope;
+
+import static io.github.eschizoid.telescope.Telescope.matchedNames;
+import static io.github.eschizoid.telescope.Telescope.methodNameOf;
+
+import io.github.eschizoid.telescope.Telescope.Accessor;
+import io.github.eschizoid.telescope.internal.Beans;
+import io.github.eschizoid.telescope.internal.Records;
+import io.github.eschizoid.telescope.internal.optics.Iso;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+/**
+ * Intermediate of {@link BeanFrom#to(Class)}. Each terminal chooses how the reverse direction
+ * (record &rarr; POJO) reconstructs the POJO.
+ */
+public final class BeanTo<P, R extends Record> {
+
+  private final Class<P> pojoClass;
+  private final Class<R> recordClass;
+  private final Map<String, Function<Object, Object>> forwardVia = new LinkedHashMap<>();
+  private final Map<String, Function<Object, Object>> backwardVia = new LinkedHashMap<>();
+  private final Map<String, String> componentToProperty = new LinkedHashMap<>();
+
+  BeanTo(final Class<P> pojoClass, final Class<R> recordClass) {
+    this.pojoClass = pojoClass;
+    this.recordClass = recordClass;
+  }
+
+  /**
+   * Map a record component to a differently-named POJO property: the record's {@code component} is
+   * read from (and written back to) the POJO's {@code property}. Types must match. Components not
+   * named here are matched to a same-named getter/setter as usual.
+   *
+   * <pre>{@code
+   * Telescope.fromBean(LegacyUser.class).to(UserRecord.class)
+   *     .rename(UserRecord::fullName, LegacyUser::getName)  // fullName <-> name
+   *     .viaConstructor();
+   * }</pre>
+   */
+  public <X> BeanTo<P, R> rename(final Accessor<R, X> component, final Accessor<P, X> property) {
+    componentToProperty.put(methodNameOf(component), Beans.propertyOf(methodNameOf(property)));
+    return this;
+  }
+
+  /**
+   * Convert a nested sub-object component through another bridge instead of copying it as-is. Use
+   * for a record component whose POJO counterpart is a different (sub-POJO) type that has its own
+   * {@code fromBean}/{@code mapBean}/{@code from-to-using} bridge.
+   *
+   * <pre>{@code
+   * final var addr = Telescope.fromBean(AddrPojo.class).to(AddrRecord.class).viaFields();
+   * final var user = Telescope.fromBean(UserPojo.class).to(UserRecord.class)
+   *     .via(UserRecord::address, addr)   // AddrPojo <-> AddrRecord at the 'address' component
+   *     .viaFields();
+   * }</pre>
+   */
+  public <X> BeanTo<P, R> via(final Accessor<R, X> targetAccessor, final Telescope<?, X> subBridge) {
+    final var name = methodNameOf(targetAccessor);
+    final var iso = isoOf(subBridge);
+    forwardVia.put(name, iso::to);
+    backwardVia.put(name, iso::from);
+    return this;
+  }
+
+  /**
+   * Convert each element of a collection component through an element bridge — the fix for nested
+   * collections (a record's {@code List<SubRecord>} component whose POJO counterpart is a {@code
+   * List<SubPojo>}). Without this, the whole-object bridge copies the list reference shallowly and
+   * type erasure lets {@code List<SubPojo>} sit in a {@code List<SubRecord>} slot (a latent {@code
+   * ClassCastException}); {@code viaEach} maps the element bridge over the list both ways.
+   *
+   * <pre>{@code
+   * final var order = Telescope.fromBean(OrderPojo.class).to(OrderRecord.class).viaConstructor();
+   * final var cart  = Telescope.fromBean(CartPojo.class).to(CartRecord.class)
+   *     .viaEach(CartRecord::orders, order)  // List<OrderPojo> <-> List<OrderRecord>
+   *     .viaFields();
+   * }</pre>
+   */
+  public <X> BeanTo<P, R> viaEach(
+    final Accessor<R, ? extends Iterable<X>> targetAccessor,
+    final Telescope<?, X> elementBridge
+  ) {
+    final var name = methodNameOf(targetAccessor);
+    final var iso = isoOf(elementBridge);
+    forwardVia.put(name, list -> mapList(list, iso::to));
+    backwardVia.put(name, list -> mapList(list, iso::from));
+    return this;
+  }
+
+  /**
+   * Reverse via a no-arg constructor + reflective field injection (no setters required). Use this
+   * when the POJO has a default constructor but no all-args constructor or builder — the bridge
+   * instantiates it and writes each field directly.
+   *
+   * <p><strong>JPMS caveat:</strong> reflective field injection requires the POJO's package to be
+   * open to this module. If the POJO lives in another module, add {@code opens <pkg> to
+   * io.github.eschizoid.telescope;} to that module's {@code module-info.java}. The other two
+   * strategies, which go through public constructors/builders, don't need this.
+   *
+   * <pre>{@code
+   * final var bridge = Telescope.fromBean(LegacyUser.class).to(UserRecord.class).viaFields();
+   * }</pre>
+   */
+  public Telescope<P, R> viaFields() {
+    return bridge(Beans.fieldsWriter(pojoClass));
+  }
+
+  /**
+   * Reverse via an all-args constructor matched <em>positionally</em>: the constructor must take
+   * its parameters in the record's component order. Use this when the POJO is immutable (or exposes
+   * a single canonical constructor) and its constructor argument order lines up with the record's
+   * components.
+   *
+   * <pre>{@code
+   * final var bridge = Telescope.fromBean(LegacyUser.class).to(UserRecord.class).viaConstructor();
+   * }</pre>
+   */
+  public Telescope<P, R> viaConstructor() {
+    return bridge(Beans.constructorWriter(pojoClass, Records.componentNames(recordClass).length));
+  }
+
+  /**
+   * Reverse via a static {@code builder()} method, a setter per component, then {@code build()}.
+   * Use this when the POJO follows the builder pattern (one setter per property named for the
+   * component, plus a terminal {@code build()}).
+   *
+   * <pre>{@code
+   * final var bridge = Telescope.fromBean(LegacyUser.class).to(UserRecord.class).viaBuilder();
+   * }</pre>
+   */
+  public Telescope<P, R> viaBuilder() {
+    return bridge(Beans.builderWriter(pojoClass));
+  }
+
+  private Telescope<P, R> bridge(final Beans.BeanWriter<P> writer) {
+    final var names = Records.componentNames(recordClass);
+    matchedNames(names, componentToProperty, pojoClass, false, (comp, prop) ->
+      new IllegalArgumentException(
+        "fromBean: record component '" +
+          comp +
+          "' on " +
+          recordClass.getSimpleName() +
+          " has no matching getter '" +
+          prop +
+          "' on " +
+          pojoClass.getSimpleName() +
+          " (matched by exact name; rename it with .rename(...) or add a getter)."
+      )
+    );
+    // The POJO property each record component reads from / writes to (identity unless renamed).
+    final var beanKeys = new String[names.length];
+    for (var i = 0; i < names.length; i++) beanKeys[i] = componentToProperty.getOrDefault(names[i], names[i]);
+    final var propertyToComponent = new LinkedHashMap<String, String>();
+    componentToProperty.forEach((comp, prop) -> propertyToComponent.put(prop, comp));
+    final Function<P, R> forward = pojo ->
+      Records.construct(recordClass, comp -> {
+        final var raw = Beans.readProperty(pojo, componentToProperty.getOrDefault(comp, comp));
+        final var conv = forwardVia.get(comp);
+        return conv == null ? raw : conv.apply(raw);
+      });
+    final Function<R, P> backward = record ->
+      writer.construct(beanKeys, prop -> {
+        final var comp = propertyToComponent.getOrDefault(prop, prop);
+        final var raw = Records.read(record, comp);
+        final var conv = backwardVia.get(comp);
+        return conv == null ? raw : conv.apply(raw);
+      });
+    return new Telescope<>(Iso.of(forward, backward));
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Iso<Object, Object> isoOf(final Telescope<?, ?> bridge) {
+    if (bridge.optic instanceof Iso<?, ?> iso) return (Iso<Object, Object>) iso;
+    throw new IllegalArgumentException(
+      "via/viaEach requires a bidirectional bridge (fromBean / mapBean / from-to-using); got a " +
+        bridge.optic.getClass().getSimpleName()
+    );
+  }
+
+  private static List<Object> mapList(final Object list, final Function<Object, Object> fn) {
+    if (!(list instanceof Iterable<?> it)) throw new IllegalArgumentException(
+      "viaEach expects a collection component but got " + (list == null ? "null" : list.getClass().getName())
+    );
+    final var out = new ArrayList<Object>();
+    for (final var e : it) out.add(fn.apply(e));
+    return List.copyOf(out);
+  }
+}

--- a/core/src/main/java/io/github/eschizoid/telescope/FieldMapping.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/FieldMapping.java
@@ -1,0 +1,70 @@
+package io.github.eschizoid.telescope;
+
+import static io.github.eschizoid.telescope.Telescope.methodNameOf;
+
+import io.github.eschizoid.telescope.Telescope.Accessor;
+import java.util.function.Function;
+
+/**
+ * Intermediate of {@link MapBuilder#field(Accessor)} — expects a {@code .to(...)} or {@code
+ * .via(...)}.
+ */
+public final class FieldMapping<A, B, X> {
+
+  private final MapBuilder<A, B> builder;
+  private final String sourceField;
+
+  FieldMapping(final MapBuilder<A, B> builder, final String sourceField) {
+    this.builder = builder;
+    this.sourceField = sourceField;
+  }
+
+  /** Complete the correspondence with a same-typed target field. */
+  public MapBuilder<A, B> to(final Accessor<B, X> targetGetter) {
+    return builder.link(new MapBuilder.Link(sourceField, methodNameOf(targetGetter), x -> x, y -> y));
+  }
+
+  /**
+   * Complete the correspondence with a target field of a different type, supplying both directions
+   * of the conversion. Keeps the overall mapping a bijection (composition-safe).
+   *
+   * <pre>{@code
+   * .field(UserEntity::createdAt).to(UserDto::createdAtIso, Instant::toString, Instant::parse)
+   * }</pre>
+   */
+  @SuppressWarnings("unchecked")
+  public <Y> MapBuilder<A, B> to(
+    final Accessor<B, Y> targetGetter,
+    final Function<? super X, ? extends Y> forward,
+    final Function<? super Y, ? extends X> backward
+  ) {
+    return builder.link(
+      new MapBuilder.Link(
+        sourceField,
+        methodNameOf(targetGetter),
+        x -> forward.apply((X) x),
+        y -> backward.apply((Y) y)
+      )
+    );
+  }
+
+  /**
+   * Map a nested record field through another {@link Mapper}. The nested mapper supplies both
+   * directions, so the correspondence stays bidirectional.
+   *
+   * <pre>{@code
+   * .field(UserEntity::address).via(UserDto::address, addressMapper)
+   * }</pre>
+   */
+  @SuppressWarnings("unchecked")
+  public <Y> MapBuilder<A, B> via(final Accessor<B, Y> targetGetter, final Mapper<X, Y> nested) {
+    return builder.link(
+      new MapBuilder.Link(
+        sourceField,
+        methodNameOf(targetGetter),
+        x -> nested.forward((X) x),
+        y -> nested.backward((Y) y)
+      )
+    );
+  }
+}

--- a/core/src/main/java/io/github/eschizoid/telescope/From.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/From.java
@@ -1,0 +1,14 @@
+package io.github.eschizoid.telescope;
+
+/**
+ * Intermediate of {@link Telescope#from(Class)} — call {@link #to(Class)} to bind the target type
+ * and continue into {@link To#using(java.util.function.Function, java.util.function.Function)}.
+ */
+public final class From<A> {
+
+  From() {}
+
+  public <B> To<A, B> to(final Class<B> target) {
+    return new To<>();
+  }
+}

--- a/core/src/main/java/io/github/eschizoid/telescope/MapBeanFrom.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/MapBeanFrom.java
@@ -1,0 +1,18 @@
+package io.github.eschizoid.telescope;
+
+/**
+ * Intermediate of {@link Telescope#mapBean(Class)} — call {@link #to(Class)} to bind the target
+ * type and continue into {@link MapBeanTo}.
+ */
+public final class MapBeanFrom<A> {
+
+  private final Class<A> source;
+
+  MapBeanFrom(final Class<A> source) {
+    this.source = source;
+  }
+
+  public <B> MapBeanTo<A, B> to(final Class<B> target) {
+    return new MapBeanTo<>(source, target);
+  }
+}

--- a/core/src/main/java/io/github/eschizoid/telescope/MapBeanTo.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/MapBeanTo.java
@@ -1,0 +1,89 @@
+package io.github.eschizoid.telescope;
+
+import static io.github.eschizoid.telescope.Telescope.matchedNames;
+import static io.github.eschizoid.telescope.Telescope.methodNameOf;
+
+import io.github.eschizoid.telescope.Telescope.Accessor;
+import io.github.eschizoid.telescope.internal.Beans;
+import io.github.eschizoid.telescope.internal.optics.Iso;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.function.Function;
+
+/** Intermediate of {@link MapBeanFrom#to(Class)}. */
+public final class MapBeanTo<A, B> {
+
+  private final Class<A> source;
+  private final Class<B> target;
+  private final Map<String, String> sourceToTarget = new LinkedHashMap<>();
+  private boolean ignoreUnmatched = false;
+
+  MapBeanTo(final Class<A> source, final Class<B> target) {
+    this.source = source;
+    this.target = target;
+  }
+
+  /**
+   * Map a differently-named property across the boundary: {@code A}'s {@code from} property
+   * supplies (and is supplied by) {@code B}'s {@code to} property. Types must match. Properties not
+   * named here still match by name.
+   *
+   * <pre>{@code
+   * Telescope.mapBean(LegacyUser.class).to(UserView.class)
+   *     .rename(LegacyUser::getName, UserView::getFullName)
+   *     .build();
+   * }</pre>
+   */
+  public <X> MapBeanTo<A, B> rename(final Accessor<A, X> from, final Accessor<B, X> to) {
+    sourceToTarget.put(Beans.propertyOf(methodNameOf(from)), Beans.propertyOf(methodNameOf(to)));
+    return this;
+  }
+
+  /**
+   * Drop the bijection requirement: a property with no counterpart on the other side is simply not
+   * transferred (it keeps the rebuilt object's default). The result is lossy — a round-trip won't
+   * restore the dropped fields.
+   */
+  public MapBeanTo<A, B> ignoreUnmatched() {
+    this.ignoreUnmatched = true;
+    return this;
+  }
+
+  /** Build the bidirectional {@code Telescope<A, B>}. */
+  public Telescope<A, B> build() {
+    final var targetToSource = new LinkedHashMap<String, String>();
+    sourceToTarget.forEach((s, t) -> targetToSource.put(t, s));
+    final var bKeys = matchedNames(Beans.propertyNames(target), targetToSource, source, ignoreUnmatched, (name, cp) ->
+      mismatch(name, target, cp, source)
+    ).toArray(String[]::new);
+    final var aKeys = matchedNames(Beans.propertyNames(source), sourceToTarget, target, ignoreUnmatched, (name, cp) ->
+      mismatch(name, source, cp, target)
+    ).toArray(String[]::new);
+    final var writerA = Beans.autoWriter(source);
+    final var writerB = Beans.autoWriter(target);
+    final Function<A, B> forward = a ->
+      writerB.construct(bKeys, bProp -> Beans.readProperty(a, targetToSource.getOrDefault(bProp, bProp)));
+    final Function<B, A> backward = b ->
+      writerA.construct(aKeys, aProp -> Beans.readProperty(b, sourceToTarget.getOrDefault(aProp, aProp)));
+    return new Telescope<>(Iso.of(forward, backward));
+  }
+
+  private static RuntimeException mismatch(
+    final String name,
+    final Class<?> owner,
+    final String counterpart,
+    final Class<?> other
+  ) {
+    return new IllegalArgumentException(
+      "mapBean: property '" +
+        name +
+        "' on " +
+        owner.getSimpleName() +
+        " has no matching getter '" +
+        counterpart +
+        "' on " +
+        other.getSimpleName() +
+        " (rename it with .rename(...), or call .ignoreUnmatched() to drop it)."
+    );
+  }
+}

--- a/core/src/main/java/io/github/eschizoid/telescope/MapBuilder.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/MapBuilder.java
@@ -1,0 +1,147 @@
+package io.github.eschizoid.telescope;
+
+import static io.github.eschizoid.telescope.Telescope.methodNameOf;
+
+import io.github.eschizoid.telescope.Telescope.Accessor;
+import io.github.eschizoid.telescope.internal.Records;
+import io.github.eschizoid.telescope.internal.optics.Iso;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Function;
+
+/**
+ * Accumulates field correspondences for {@link Telescope#map(Class)}. {@link #build()} synthesizes
+ * a bidirectional {@code Telescope<A, B>}; {@link #buildMapper()} additionally retains the field
+ * links so the result supports {@link Mapper#patch}.
+ */
+public final class MapBuilder<A, B> {
+
+  /**
+   * One field correspondence with (possibly identity) transforms in each direction.
+   *
+   * <p>Package-private so the sibling-file builders ({@link FieldMapping}, {@link Mapper}) can
+   * reference it without the construction being part of the public surface.
+   */
+  record Link(
+    String sourceField,
+    String targetField,
+    Function<Object, Object> forward,
+    Function<Object, Object> backward
+  ) {}
+
+  private static final Function<Object, Object> IDENTITY = x -> x;
+
+  private final Class<A> source;
+  private final Class<B> target;
+  private final List<Link> links = new ArrayList<>();
+
+  MapBuilder(final Class<A> source, final Class<B> target) {
+    this.source = source;
+    this.target = target;
+  }
+
+  /**
+   * Auto-map every target component whose name matches a source component, leaving any
+   * already-declared correspondences untouched. Matches by name only with identity transforms — no
+   * fuzzy heuristics, no type checking, no nested traversal. A type mismatch on an auto-linked pair
+   * surfaces at record construction time (when {@link #build()} runs the forward/backward
+   * functions), not here. Declare {@code .field(...).to(...)} explicitly for renames or transforms
+   * (those override the auto-mapped link for the same target).
+   *
+   * <pre>{@code
+   * // id + email map by name; only the renamed field is declared by hand:
+   * final var userMapper = Telescope.map(UserEntity.class).to(UserDto.class)
+   *     .field(UserEntity::name).to(UserDto::fullName)   // wins over auto for this target
+   *     .auto()                                          // id, email
+   *     .build();
+   * }</pre>
+   */
+  public MapBuilder<A, B> auto() {
+    final var sourceNames = Set.of(Records.componentNames(source));
+    for (final var name : Records.componentNames(target)) {
+      final var alreadyLinked = links.stream().anyMatch(l -> l.targetField().equals(name));
+      if (!alreadyLinked && sourceNames.contains(name)) {
+        links.add(new Link(name, name, IDENTITY, IDENTITY));
+      }
+    }
+    return this;
+  }
+
+  /**
+   * Declare the source side of a field correspondence; complete it on the returned {@link
+   * FieldMapping} with {@link FieldMapping#to(Accessor) .to(...)} (same-typed), {@link
+   * FieldMapping#to(Accessor, Function, Function) .to(..., fwd, bwd)} (typed transform), or {@link
+   * FieldMapping#via .via(..., mapper)} (nested record).
+   */
+  public <X> FieldMapping<A, B, X> field(final Accessor<A, X> sourceGetter) {
+    return new FieldMapping<>(this, methodNameOf(sourceGetter));
+  }
+
+  MapBuilder<A, B> link(final Link link) {
+    links.removeIf(l -> l.targetField().equals(link.targetField()));
+    links.add(link);
+    return this;
+  }
+
+  /**
+   * Synthesize the bidirectional {@code Telescope<A, B>}. Throws {@link IllegalStateException} if
+   * the mapping isn't a bijection (some component on either side is left unmapped). Use {@link
+   * #buildMapper()} instead when you also want {@link Mapper#patch} or to nest the mapping via
+   * {@link FieldMapping#via}.
+   */
+  public Telescope<A, B> build() {
+    return new Telescope<>(iso());
+  }
+
+  /**
+   * Synthesize a {@link Mapper} — the same bidirectional conversion as {@link #build()}, plus the
+   * field links retained so it can do {@link Mapper#patch sparse patches}.
+   */
+  public Mapper<A, B> buildMapper() {
+    return new Mapper<>(iso(), List.copyOf(links));
+  }
+
+  private Iso<A, B> iso() {
+    final var byTarget = new LinkedHashMap<String, Link>();
+    final var bySource = new LinkedHashMap<String, Link>();
+    for (final var l : links) {
+      byTarget.put(l.targetField(), l);
+      bySource.put(l.sourceField(), l);
+    }
+    requireAllMapped(Records.componentNames(target), byTarget.keySet(), target, "target");
+    requireAllMapped(Records.componentNames(source), bySource.keySet(), source, "source");
+
+    final Function<A, B> forward = a ->
+      Records.construct(target, t -> {
+        final var l = byTarget.get(t);
+        return l.forward().apply(Records.read(a, l.sourceField()));
+      });
+    final Function<B, A> backward = b ->
+      Records.construct(source, s -> {
+        final var l = bySource.get(s);
+        return l.backward().apply(Records.read(b, l.targetField()));
+      });
+    return Iso.of(forward, backward);
+  }
+
+  private static void requireAllMapped(
+    final String[] names,
+    final Set<String> mapped,
+    final Class<?> type,
+    final String side
+  ) {
+    for (final var name : names) {
+      if (!mapped.contains(name)) throw new IllegalStateException(
+        "Mapping is not a bijection: " +
+          side +
+          " field '" +
+          name +
+          "' on " +
+          type.getSimpleName() +
+          " is unmapped. Every component on both sides must be mapped (try .auto() for same-name fields)."
+      );
+    }
+  }
+}

--- a/core/src/main/java/io/github/eschizoid/telescope/MapTo.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/MapTo.java
@@ -1,0 +1,18 @@
+package io.github.eschizoid.telescope;
+
+/**
+ * Intermediate of {@link Telescope#map(Class)} — call {@link #to(Class)} to bind the target record.
+ */
+public final class MapTo<A> {
+
+  private final Class<A> source;
+
+  MapTo(final Class<A> source) {
+    this.source = source;
+  }
+
+  /** Name the target record; returns the {@link MapBuilder} that collects field correspondences. */
+  public <B> MapBuilder<A, B> to(final Class<B> target) {
+    return new MapBuilder<>(source, target);
+  }
+}

--- a/core/src/main/java/io/github/eschizoid/telescope/Mapper.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/Mapper.java
@@ -1,0 +1,82 @@
+package io.github.eschizoid.telescope;
+
+import io.github.eschizoid.telescope.internal.Records;
+import io.github.eschizoid.telescope.internal.optics.Iso;
+import java.util.List;
+
+/**
+ * A bidirectional record mapper produced by {@link MapBuilder#buildMapper()}. Beyond the conversion
+ * that {@link MapBuilder#build()} gives you, a {@code Mapper} retains the field links so it can
+ * apply a sparse {@link #patch} and be nested inside another mapping via {@link FieldMapping#via}.
+ */
+public final class Mapper<A, B> {
+
+  private final Iso<A, B> iso;
+  private final List<MapBuilder.Link> links;
+
+  Mapper(final Iso<A, B> iso, final List<MapBuilder.Link> links) {
+    this.iso = iso;
+    this.links = links;
+  }
+
+  /**
+   * Convert forward, {@code A → B}.
+   *
+   * <pre>{@code
+   * final var mapper = Telescope.map(UserEntity.class).to(UserDto.class).auto().buildMapper();
+   * final UserDto dto = mapper.read(entity);
+   * }</pre>
+   *
+   * For the reverse direction, or to thread the conversion through a longer path, use {@link
+   * #asTelescope()} (which exposes {@code set}/{@code update}/{@code then}); for a sparse overlay,
+   * use {@link #patch}.
+   */
+  public B read(final A a) {
+    return iso.to(a);
+  }
+
+  /**
+   * The mapper as a composable {@code Telescope<A, B>}, for threading the conversion through longer
+   * paths via {@link Telescope#then}.
+   *
+   * <pre>{@code
+   * Telescope.of(EntityPage.class)
+   *     .each(EntityPage::items)
+   *     .then(userMapper.asTelescope())
+   *     .field(UserDto::email)
+   *     .update(page, String::toLowerCase);
+   * }</pre>
+   */
+  public Telescope<A, B> asTelescope() {
+    return new Telescope<>(iso);
+  }
+
+  /**
+   * Sparse update: overlay the non-null fields of {@code patch} (a partially-populated target) onto
+   * {@code base}, leaving the rest of {@code base} untouched. Each present target field is run back
+   * through its link's reverse transform before being written to the source.
+   *
+   * <pre>{@code
+   * // dtoPatch has a new email, null everything else — only the email changes on the entity:
+   * UserEntity updated = userMapper.patch(entity, dtoPatch);
+   * }</pre>
+   */
+  public A patch(final A base, final B patch) {
+    var result = base;
+    for (final var l : links) {
+      final var targetValue = Records.read(patch, l.targetField());
+      if (targetValue != null) {
+        result = Records.with(result, l.sourceField(), l.backward().apply(targetValue));
+      }
+    }
+    return result;
+  }
+
+  B forward(final A a) {
+    return iso.to(a);
+  }
+
+  A backward(final B b) {
+    return iso.from(b);
+  }
+}

--- a/core/src/main/java/io/github/eschizoid/telescope/Telescope.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/Telescope.java
@@ -14,12 +14,10 @@ import io.github.eschizoid.telescope.internal.optics.instances.ValidatedK;
 import java.io.Serializable;
 import java.lang.invoke.SerializedLambda;
 import java.util.ArrayList;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Optional;
-import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
@@ -68,7 +66,9 @@ public final class Telescope<S, A> {
   @FunctionalInterface
   public interface Accessor<A, B> extends Function<A, B>, Serializable {}
 
-  private final Traversal<S, A> optic;
+  // Package-private — read by the conversion-builder classes in this same package (e.g.
+  // BeanTo's iso-unwrap check, Mapper's asTelescope).
+  final Traversal<S, A> optic;
   // How accessor-based navigation (field/each/eachValue/whenPresent) turns a method reference into
   // a field Lens: records read/rebuild via the canonical constructor, beans via getters +
   // rebuild-via-strategy (see ofBean). Propagated to derived telescopes.
@@ -79,7 +79,10 @@ public final class Telescope<S, A> {
   // accumulates both edits and runs them in order against {@code s}.
   private final Function<S, S> chain;
 
-  private Telescope(final Traversal<S, A> optic) {
+  // Package-private so that the conversion-builder classes (From, To, BeanTo, MapBuilder, Mapper,
+  // …) — extracted to sibling files in this same package to keep Telescope.java navigable — can
+  // construct Telescope instances without needing us to expose internals through the JPMS export.
+  Telescope(final Traversal<S, A> optic) {
     this(optic, RecordFieldOptics.INSTANCE, Function.identity());
   }
 
@@ -207,35 +210,6 @@ public final class Telescope<S, A> {
     return new From<>();
   }
 
-  /** Intermediate of {@link #from(Class)}. */
-  public static final class From<A> {
-
-    private From() {}
-
-    public <B> To<A, B> to(final Class<B> target) {
-      return new To<>();
-    }
-  }
-
-  /** Intermediate of {@link From#to(Class)}. */
-  public static final class To<A, B> {
-
-    private To() {}
-
-    /**
-     * Supply both directions of the conversion. {@code forward} converts {@code A → B}; {@code
-     * backward} must satisfy the iso laws ({@code from(to(a)).equals(a)} and {@code
-     * to(from(b)).equals(b)} for the components involved). The resulting {@code Telescope<A, B>}
-     * composes into longer paths via {@link #then}. See {@link #from(Class)} for a worked example.
-     */
-    public Telescope<A, B> using(
-      final Function<? super A, ? extends B> forward,
-      final Function<? super B, ? extends A> backward
-    ) {
-      return new Telescope<>(Iso.of(forward, backward));
-    }
-  }
-
   /**
    * Begin a bidirectional bridge between a JavaBeans-style POJO and a record. The forward direction
    * reads the POJO's properties via its getters and builds the record; the reverse rebuilds the
@@ -292,198 +266,6 @@ public final class Telescope<S, A> {
     return new BeanFrom<>(pojoClass);
   }
 
-  /** Intermediate of {@link #fromBean(Class)}. */
-  public static final class BeanFrom<P> {
-
-    private final Class<P> pojoClass;
-
-    private BeanFrom(final Class<P> pojoClass) {
-      this.pojoClass = pojoClass;
-    }
-
-    public <R extends Record> BeanTo<P, R> to(final Class<R> recordClass) {
-      return new BeanTo<>(pojoClass, recordClass);
-    }
-  }
-
-  /**
-   * Intermediate of {@link BeanFrom#to(Class)}. Each terminal chooses how the reverse direction
-   * (record &rarr; POJO) reconstructs the POJO.
-   */
-  public static final class BeanTo<P, R extends Record> {
-
-    private final Class<P> pojoClass;
-    private final Class<R> recordClass;
-    private final Map<String, Function<Object, Object>> forwardVia = new LinkedHashMap<>();
-    private final Map<String, Function<Object, Object>> backwardVia = new LinkedHashMap<>();
-    private final Map<String, String> componentToProperty = new LinkedHashMap<>();
-
-    private BeanTo(final Class<P> pojoClass, final Class<R> recordClass) {
-      this.pojoClass = pojoClass;
-      this.recordClass = recordClass;
-    }
-
-    /**
-     * Map a record component to a differently-named POJO property: the record's {@code component}
-     * is read from (and written back to) the POJO's {@code property}. Types must match. Components
-     * not named here are matched to a same-named getter/setter as usual.
-     *
-     * <pre>{@code
-     * Telescope.fromBean(LegacyUser.class).to(UserRecord.class)
-     *     .rename(UserRecord::fullName, LegacyUser::getName)  // fullName <-> name
-     *     .viaConstructor();
-     * }</pre>
-     */
-    public <X> BeanTo<P, R> rename(final Accessor<R, X> component, final Accessor<P, X> property) {
-      componentToProperty.put(methodNameOf(component), Beans.propertyOf(methodNameOf(property)));
-      return this;
-    }
-
-    /**
-     * Convert a nested sub-object component through another bridge instead of copying it as-is. Use
-     * for a record component whose POJO counterpart is a different (sub-POJO) type that has its own
-     * {@code fromBean}/{@code mapBean}/{@code from-to-using} bridge.
-     *
-     * <pre>{@code
-     * final var addr = Telescope.fromBean(AddrPojo.class).to(AddrRecord.class).viaFields();
-     * final var user = Telescope.fromBean(UserPojo.class).to(UserRecord.class)
-     *     .via(UserRecord::address, addr)   // AddrPojo <-> AddrRecord at the 'address' component
-     *     .viaFields();
-     * }</pre>
-     */
-    public <X> BeanTo<P, R> via(final Accessor<R, X> targetAccessor, final Telescope<?, X> subBridge) {
-      final var name = methodNameOf(targetAccessor);
-      final var iso = isoOf(subBridge);
-      forwardVia.put(name, iso::to);
-      backwardVia.put(name, iso::from);
-      return this;
-    }
-
-    /**
-     * Convert each element of a collection component through an element bridge — the fix for nested
-     * collections (a record's {@code List<SubRecord>} component whose POJO counterpart is a {@code
-     * List<SubPojo>}). Without this, the whole-object bridge copies the list reference shallowly
-     * and type erasure lets {@code List<SubPojo>} sit in a {@code List<SubRecord>} slot (a latent
-     * {@code ClassCastException}); {@code viaEach} maps the element bridge over the list both ways.
-     *
-     * <pre>{@code
-     * final var order = Telescope.fromBean(OrderPojo.class).to(OrderRecord.class).viaConstructor();
-     * final var cart  = Telescope.fromBean(CartPojo.class).to(CartRecord.class)
-     *     .viaEach(CartRecord::orders, order)  // List<OrderPojo> <-> List<OrderRecord>
-     *     .viaFields();
-     * }</pre>
-     */
-    public <X> BeanTo<P, R> viaEach(
-      final Accessor<R, ? extends Iterable<X>> targetAccessor,
-      final Telescope<?, X> elementBridge
-    ) {
-      final var name = methodNameOf(targetAccessor);
-      final var iso = isoOf(elementBridge);
-      forwardVia.put(name, list -> mapList(list, iso::to));
-      backwardVia.put(name, list -> mapList(list, iso::from));
-      return this;
-    }
-
-    /**
-     * Reverse via a no-arg constructor + reflective field injection (no setters required). Use this
-     * when the POJO has a default constructor but no all-args constructor or builder — the bridge
-     * instantiates it and writes each field directly.
-     *
-     * <p><strong>JPMS caveat:</strong> reflective field injection requires the POJO's package to be
-     * open to this module. If the POJO lives in another module, add {@code opens <pkg> to
-     * io.github.eschizoid.telescope;} to that module's {@code module-info.java}. The other two
-     * strategies, which go through public constructors/builders, don't need this.
-     *
-     * <pre>{@code
-     * final var bridge = Telescope.fromBean(LegacyUser.class).to(UserRecord.class).viaFields();
-     * }</pre>
-     */
-    public Telescope<P, R> viaFields() {
-      return bridge(Beans.fieldsWriter(pojoClass));
-    }
-
-    /**
-     * Reverse via an all-args constructor matched <em>positionally</em>: the constructor must take
-     * its parameters in the record's component order. Use this when the POJO is immutable (or
-     * exposes a single canonical constructor) and its constructor argument order lines up with the
-     * record's components.
-     *
-     * <pre>{@code
-     * final var bridge = Telescope.fromBean(LegacyUser.class).to(UserRecord.class).viaConstructor();
-     * }</pre>
-     */
-    public Telescope<P, R> viaConstructor() {
-      return bridge(Beans.constructorWriter(pojoClass, Records.componentNames(recordClass).length));
-    }
-
-    /**
-     * Reverse via a static {@code builder()} method, a setter per component, then {@code build()}.
-     * Use this when the POJO follows the builder pattern (one setter per property named for the
-     * component, plus a terminal {@code build()}).
-     *
-     * <pre>{@code
-     * final var bridge = Telescope.fromBean(LegacyUser.class).to(UserRecord.class).viaBuilder();
-     * }</pre>
-     */
-    public Telescope<P, R> viaBuilder() {
-      return bridge(Beans.builderWriter(pojoClass));
-    }
-
-    private Telescope<P, R> bridge(final Beans.BeanWriter<P> writer) {
-      final var names = Records.componentNames(recordClass);
-      matchedNames(names, componentToProperty, pojoClass, false, (comp, prop) ->
-        new IllegalArgumentException(
-          "fromBean: record component '" +
-            comp +
-            "' on " +
-            recordClass.getSimpleName() +
-            " has no matching getter '" +
-            prop +
-            "' on " +
-            pojoClass.getSimpleName() +
-            " (matched by exact name; rename it with .rename(...) or add a getter)."
-        )
-      );
-      // The POJO property each record component reads from / writes to (identity unless renamed).
-      final var beanKeys = new String[names.length];
-      for (var i = 0; i < names.length; i++) beanKeys[i] = componentToProperty.getOrDefault(names[i], names[i]);
-      final var propertyToComponent = new LinkedHashMap<String, String>();
-      componentToProperty.forEach((comp, prop) -> propertyToComponent.put(prop, comp));
-      final Function<P, R> forward = pojo ->
-        Records.construct(recordClass, comp -> {
-          final var raw = Beans.readProperty(pojo, componentToProperty.getOrDefault(comp, comp));
-          final var conv = forwardVia.get(comp);
-          return conv == null ? raw : conv.apply(raw);
-        });
-      final Function<R, P> backward = record ->
-        writer.construct(beanKeys, prop -> {
-          final var comp = propertyToComponent.getOrDefault(prop, prop);
-          final var raw = Records.read(record, comp);
-          final var conv = backwardVia.get(comp);
-          return conv == null ? raw : conv.apply(raw);
-        });
-      return new Telescope<>(Iso.of(forward, backward));
-    }
-
-    @SuppressWarnings("unchecked")
-    private static Iso<Object, Object> isoOf(final Telescope<?, ?> bridge) {
-      if (bridge.optic instanceof Iso<?, ?> iso) return (Iso<Object, Object>) iso;
-      throw new IllegalArgumentException(
-        "via/viaEach requires a bidirectional bridge (fromBean / mapBean / from-to-using); got a " +
-          bridge.optic.getClass().getSimpleName()
-      );
-    }
-
-    private static List<Object> mapList(final Object list, final Function<Object, Object> fn) {
-      if (!(list instanceof Iterable<?> it)) throw new IllegalArgumentException(
-        "viaEach expects a collection component but got " + (list == null ? "null" : list.getClass().getName())
-      );
-      final var out = new ArrayList<Object>();
-      for (final var e : it) out.add(fn.apply(e));
-      return List.copyOf(out);
-    }
-  }
-
   /**
    * Begin a bidirectional POJO&harr;POJO conversion — the bean analog of {@link #map(Class)}.
    * {@code mapBean(A.class).to(B.class).build()} produces a {@code Telescope<A, B>} (an {@link
@@ -502,98 +284,6 @@ public final class Telescope<S, A> {
    */
   public static <A> MapBeanFrom<A> mapBean(final Class<A> source) {
     return new MapBeanFrom<>(source);
-  }
-
-  /** Intermediate of {@link #mapBean(Class)}. */
-  public static final class MapBeanFrom<A> {
-
-    private final Class<A> source;
-
-    private MapBeanFrom(final Class<A> source) {
-      this.source = source;
-    }
-
-    public <B> MapBeanTo<A, B> to(final Class<B> target) {
-      return new MapBeanTo<>(source, target);
-    }
-  }
-
-  /** Intermediate of {@link MapBeanFrom#to(Class)}. */
-  public static final class MapBeanTo<A, B> {
-
-    private final Class<A> source;
-    private final Class<B> target;
-    private final Map<String, String> sourceToTarget = new LinkedHashMap<>();
-    private boolean ignoreUnmatched = false;
-
-    private MapBeanTo(final Class<A> source, final Class<B> target) {
-      this.source = source;
-      this.target = target;
-    }
-
-    /**
-     * Map a differently-named property across the boundary: {@code A}'s {@code from} property
-     * supplies (and is supplied by) {@code B}'s {@code to} property. Types must match. Properties
-     * not named here still match by name.
-     *
-     * <pre>{@code
-     * Telescope.mapBean(LegacyUser.class).to(UserView.class)
-     *     .rename(LegacyUser::getName, UserView::getFullName)
-     *     .build();
-     * }</pre>
-     */
-    public <X> MapBeanTo<A, B> rename(final Accessor<A, X> from, final Accessor<B, X> to) {
-      sourceToTarget.put(Beans.propertyOf(methodNameOf(from)), Beans.propertyOf(methodNameOf(to)));
-      return this;
-    }
-
-    /**
-     * Drop the bijection requirement: a property with no counterpart on the other side is simply
-     * not transferred (it keeps the rebuilt object's default). The result is lossy — a round-trip
-     * won't restore the dropped fields.
-     */
-    public MapBeanTo<A, B> ignoreUnmatched() {
-      this.ignoreUnmatched = true;
-      return this;
-    }
-
-    /** Build the bidirectional {@code Telescope<A, B>}. */
-    public Telescope<A, B> build() {
-      final var targetToSource = new LinkedHashMap<String, String>();
-      sourceToTarget.forEach((s, t) -> targetToSource.put(t, s));
-      final var bKeys = matchedNames(Beans.propertyNames(target), targetToSource, source, ignoreUnmatched, (name, cp) ->
-        mismatch(name, target, cp, source)
-      ).toArray(String[]::new);
-      final var aKeys = matchedNames(Beans.propertyNames(source), sourceToTarget, target, ignoreUnmatched, (name, cp) ->
-        mismatch(name, source, cp, target)
-      ).toArray(String[]::new);
-      final var writerA = Beans.autoWriter(source);
-      final var writerB = Beans.autoWriter(target);
-      final Function<A, B> forward = a ->
-        writerB.construct(bKeys, bProp -> Beans.readProperty(a, targetToSource.getOrDefault(bProp, bProp)));
-      final Function<B, A> backward = b ->
-        writerA.construct(aKeys, aProp -> Beans.readProperty(b, sourceToTarget.getOrDefault(aProp, aProp)));
-      return new Telescope<>(Iso.of(forward, backward));
-    }
-
-    private static RuntimeException mismatch(
-      final String name,
-      final Class<?> owner,
-      final String counterpart,
-      final Class<?> other
-    ) {
-      return new IllegalArgumentException(
-        "mapBean: property '" +
-          name +
-          "' on " +
-          owner.getSimpleName() +
-          " has no matching getter '" +
-          counterpart +
-          "' on " +
-          other.getSimpleName() +
-          " (rename it with .rename(...), or call .ignoreUnmatched() to drop it)."
-      );
-    }
   }
 
   /**
@@ -632,293 +322,6 @@ public final class Telescope<S, A> {
    */
   public static <A> MapTo<A> map(final Class<A> source) {
     return new MapTo<>(source);
-  }
-
-  /** Intermediate of {@link #map(Class)}. */
-  public static final class MapTo<A> {
-
-    private final Class<A> source;
-
-    private MapTo(final Class<A> source) {
-      this.source = source;
-    }
-
-    /**
-     * Name the target record; returns the {@link MapBuilder} that collects field correspondences.
-     */
-    public <B> MapBuilder<A, B> to(final Class<B> target) {
-      return new MapBuilder<>(source, target);
-    }
-  }
-
-  /**
-   * Accumulates field correspondences for {@link #map(Class)}. {@link #build()} synthesizes a
-   * bidirectional {@code Telescope<A, B>}; {@link #buildMapper()} additionally retains the field
-   * links so the result supports {@link Mapper#patch}.
-   */
-  public static final class MapBuilder<A, B> {
-
-    /** One field correspondence with (possibly identity) transforms in each direction. */
-    private record Link(
-      String sourceField,
-      String targetField,
-      Function<Object, Object> forward,
-      Function<Object, Object> backward
-    ) {}
-
-    private static final Function<Object, Object> IDENTITY = x -> x;
-
-    private final Class<A> source;
-    private final Class<B> target;
-    private final List<Link> links = new ArrayList<>();
-
-    private MapBuilder(final Class<A> source, final Class<B> target) {
-      this.source = source;
-      this.target = target;
-    }
-
-    /**
-     * Auto-map every target component whose name and type match a source component, leaving any
-     * already-declared correspondences untouched. Only exact name matches — no fuzzy heuristics, no
-     * nested traversal. Declare {@code .field(...).to(...)} explicitly for renames or transforms
-     * (those override the auto-mapped link for the same target).
-     *
-     * <pre>{@code
-     * // id + email map by name; only the renamed field is declared by hand:
-     * final var userMapper = Telescope.map(UserEntity.class).to(UserDto.class)
-     *     .field(UserEntity::name).to(UserDto::fullName)   // wins over auto for this target
-     *     .auto()                                          // id, email
-     *     .build();
-     * }</pre>
-     */
-    public MapBuilder<A, B> auto() {
-      final var sourceNames = Set.of(Records.componentNames(source));
-      for (final var name : Records.componentNames(target)) {
-        final var alreadyLinked = links.stream().anyMatch(l -> l.targetField().equals(name));
-        if (!alreadyLinked && sourceNames.contains(name)) {
-          links.add(new Link(name, name, IDENTITY, IDENTITY));
-        }
-      }
-      return this;
-    }
-
-    /**
-     * Declare the source side of a field correspondence; complete it on the returned {@link
-     * FieldMapping} with {@link FieldMapping#to(Accessor) .to(...)} (same-typed), {@link
-     * FieldMapping#to(Accessor, Function, Function) .to(..., fwd, bwd)} (typed transform), or
-     * {@link FieldMapping#via .via(..., mapper)} (nested record).
-     */
-    public <X> FieldMapping<A, B, X> field(final Accessor<A, X> sourceGetter) {
-      return new FieldMapping<>(this, methodNameOf(sourceGetter));
-    }
-
-    private MapBuilder<A, B> link(final Link link) {
-      links.removeIf(l -> l.targetField().equals(link.targetField()));
-      links.add(link);
-      return this;
-    }
-
-    /**
-     * Synthesize the bidirectional {@code Telescope<A, B>}. Throws {@link IllegalStateException} if
-     * the mapping isn't a bijection (some component on either side is left unmapped). Use {@link
-     * #buildMapper()} instead when you also want {@link Mapper#patch} or to nest the mapping via
-     * {@link FieldMapping#via}.
-     */
-    public Telescope<A, B> build() {
-      return new Telescope<>(iso());
-    }
-
-    /**
-     * Synthesize a {@link Mapper} — the same bidirectional conversion as {@link #build()}, plus the
-     * field links retained so it can do {@link Mapper#patch sparse patches}.
-     */
-    public Mapper<A, B> buildMapper() {
-      return new Mapper<>(iso(), List.copyOf(links), source);
-    }
-
-    private Iso<A, B> iso() {
-      final var byTarget = new LinkedHashMap<String, Link>();
-      final var bySource = new LinkedHashMap<String, Link>();
-      for (final var l : links) {
-        byTarget.put(l.targetField(), l);
-        bySource.put(l.sourceField(), l);
-      }
-      requireAllMapped(Records.componentNames(target), byTarget.keySet(), target, "target");
-      requireAllMapped(Records.componentNames(source), bySource.keySet(), source, "source");
-
-      final Function<A, B> forward = a ->
-        Records.construct(target, t -> {
-          final var l = byTarget.get(t);
-          return l.forward().apply(Records.read(a, l.sourceField()));
-        });
-      final Function<B, A> backward = b ->
-        Records.construct(source, s -> {
-          final var l = bySource.get(s);
-          return l.backward().apply(Records.read(b, l.targetField()));
-        });
-      return Iso.of(forward, backward);
-    }
-
-    private static void requireAllMapped(
-      final String[] names,
-      final Set<String> mapped,
-      final Class<?> type,
-      final String side
-    ) {
-      for (final var name : names) {
-        if (!mapped.contains(name)) throw new IllegalStateException(
-          "Mapping is not a bijection: " +
-            side +
-            " field '" +
-            name +
-            "' on " +
-            type.getSimpleName() +
-            " is unmapped. Every component on both sides must be mapped (try .auto() for same-name fields)."
-        );
-      }
-    }
-  }
-
-  /**
-   * Intermediate of {@link MapBuilder#field(Accessor)} — expects a {@code .to(...)} or {@code
-   * .via(...)}.
-   */
-  public static final class FieldMapping<A, B, X> {
-
-    private final MapBuilder<A, B> builder;
-    private final String sourceField;
-
-    private FieldMapping(final MapBuilder<A, B> builder, final String sourceField) {
-      this.builder = builder;
-      this.sourceField = sourceField;
-    }
-
-    /** Complete the correspondence with a same-typed target field. */
-    public MapBuilder<A, B> to(final Accessor<B, X> targetGetter) {
-      return builder.link(new MapBuilder.Link(sourceField, methodNameOf(targetGetter), x -> x, y -> y));
-    }
-
-    /**
-     * Complete the correspondence with a target field of a different type, supplying both
-     * directions of the conversion. Keeps the overall mapping a bijection (composition-safe).
-     *
-     * <pre>{@code
-     * .field(UserEntity::createdAt).to(UserDto::createdAtIso, Instant::toString, Instant::parse)
-     * }</pre>
-     */
-    @SuppressWarnings("unchecked")
-    public <Y> MapBuilder<A, B> to(
-      final Accessor<B, Y> targetGetter,
-      final Function<? super X, ? extends Y> forward,
-      final Function<? super Y, ? extends X> backward
-    ) {
-      return builder.link(
-        new MapBuilder.Link(
-          sourceField,
-          methodNameOf(targetGetter),
-          x -> forward.apply((X) x),
-          y -> backward.apply((Y) y)
-        )
-      );
-    }
-
-    /**
-     * Map a nested record field through another {@link Mapper}. The nested mapper supplies both
-     * directions, so the correspondence stays bidirectional.
-     *
-     * <pre>{@code
-     * .field(UserEntity::address).via(UserDto::address, addressMapper)
-     * }</pre>
-     */
-    @SuppressWarnings("unchecked")
-    public <Y> MapBuilder<A, B> via(final Accessor<B, Y> targetGetter, final Mapper<X, Y> nested) {
-      return builder.link(
-        new MapBuilder.Link(
-          sourceField,
-          methodNameOf(targetGetter),
-          x -> nested.forward((X) x),
-          y -> nested.backward((Y) y)
-        )
-      );
-    }
-  }
-
-  /**
-   * A bidirectional record mapper produced by {@link MapBuilder#buildMapper()}. Beyond the
-   * conversion that {@link MapBuilder#build()} gives you, a {@code Mapper} retains the field links
-   * so it can apply a sparse {@link #patch} and be nested inside another mapping via {@link
-   * FieldMapping#via}.
-   */
-  public static final class Mapper<A, B> {
-
-    private final Iso<A, B> iso;
-    private final List<MapBuilder.Link> links;
-
-    private Mapper(final Iso<A, B> iso, final List<MapBuilder.Link> links, final Class<A> sourceType) {
-      this.iso = iso;
-      this.links = links;
-    }
-
-    /**
-     * Convert forward, {@code A → B}.
-     *
-     * <pre>{@code
-     * final var mapper = Telescope.map(UserEntity.class).to(UserDto.class).auto().buildMapper();
-     * final UserDto dto = mapper.read(entity);
-     * }</pre>
-     *
-     * For the reverse direction, or to thread the conversion through a longer path, use {@link
-     * #asTelescope()} (which exposes {@code set}/{@code update}/{@code then}); for a sparse
-     * overlay, use {@link #patch}.
-     */
-    public B read(final A a) {
-      return iso.to(a);
-    }
-
-    /**
-     * The mapper as a composable {@code Telescope<A, B>}, for threading the conversion through
-     * longer paths via {@link #then}.
-     *
-     * <pre>{@code
-     * Telescope.of(EntityPage.class)
-     *     .each(EntityPage::items)
-     *     .then(userMapper.asTelescope())
-     *     .field(UserDto::email)
-     *     .update(page, String::toLowerCase);
-     * }</pre>
-     */
-    public Telescope<A, B> asTelescope() {
-      return new Telescope<>(iso);
-    }
-
-    /**
-     * Sparse update: overlay the non-null fields of {@code patch} (a partially-populated target)
-     * onto {@code base}, leaving the rest of {@code base} untouched. Each present target field is
-     * run back through its link's reverse transform before being written to the source.
-     *
-     * <pre>{@code
-     * // dtoPatch has a new email, null everything else — only the email changes on the entity:
-     * UserEntity updated = userMapper.patch(entity, dtoPatch);
-     * }</pre>
-     */
-    public A patch(final A base, final B patch) {
-      var result = base;
-      for (final var l : links) {
-        final var targetValue = Records.read(patch, l.targetField());
-        if (targetValue != null) {
-          result = Records.with(result, l.sourceField(), l.backward().apply(targetValue));
-        }
-      }
-      return result;
-    }
-
-    B forward(final A a) {
-      return iso.to(a);
-    }
-
-    A backward(final B b) {
-      return iso.from(b);
-    }
   }
 
   /**
@@ -1237,6 +640,46 @@ public final class Telescope<S, A> {
   }
 
   /**
+   * Accumulate an edit through a <em>pre-built</em> telescope path and return a fresh identity
+   * {@code Telescope<S, S>} carrying the running chain — the multi-edit form that pairs with {@link
+   * #with(Function)} for inline paths and {@link #apply(Object)} for the terminal.
+   *
+   * <p>The natural shape when paths are reusable: declare each as a static {@code final
+   * Telescope<S, X>} value once, then list the operations cleanly without re-walking the navigation
+   * tree per edit:
+   *
+   * <pre>{@code
+   * static final Telescope<Company, String> EMAILS    = Telescope.of(Company.class)
+   *     .each(Company::departments).each(Department::teams).each(Team::users).field(User::email);
+   * static final Telescope<Company, String> DEPT_NAMES = Telescope.of(Company.class)
+   *     .each(Company::departments).field(Department::name);
+   *
+   * final Company done = Telescope.of(Company.class)
+   *     .update(EMAILS,     String::toLowerCase)
+   *     .update(DEPT_NAMES, String::trim)
+   *     .apply(company);
+   * }</pre>
+   *
+   * <p><b>Fully compile-checked.</b> {@code path} carries its leaf type {@code X}; {@code fn} must
+   * be {@code Function<X, X>} to match. A wrong-type function → compile error.
+   *
+   * <p>Java overload-resolves this against {@link #update(Object, Function)} by the first
+   * argument's type — a {@code Telescope} starts (or continues) a multi-edit chain; anything else
+   * is the single-shot terminal that returns {@code S} immediately. Mixes cleanly with {@link
+   * #with(Function)} in the same chain when some edits use inline paths and others use pre-built
+   * ones.
+   *
+   * @param path the pre-built telescope to navigate when this edit runs
+   * @param fn the per-leaf transformation
+   * @param <X> the focused leaf type for this edit (independent of any other edit's leaf type)
+   * @see #with(Function)
+   * @see #apply(Object)
+   */
+  public <X> Telescope<S, S> update(final Telescope<S, X> path, final Function<X, X> fn) {
+    return new Telescope<>(Iso.identity(), fieldOptics, chain.andThen(s -> path.update(s, fn)));
+  }
+
+  /**
    * Transform every focused value with access to its 0-based position in traversal order. The
    * lambda receives {@code (index, value)} and returns the new value. Useful for position-dependent
    * edits, e.g. "uppercase only the first match" or "prefix each with its index".
@@ -1540,7 +983,9 @@ public final class Telescope<S, A> {
   // counterpart exists on `other` are returned in order. A missing counterpart throws the
   // `onMissing`-built exception unless `dropUnmatched` is set. One place for the matching policy;
   // each caller keeps its own error wording via the factory.
-  private static List<String> matchedNames(
+  // Package-private — shared with the conversion-builder classes (BeanTo, MapBuilder) which live
+  // in sibling files in this same package.
+  static List<String> matchedNames(
     final String[] ownerNames,
     final Map<String, String> remap,
     final Class<?> other,
@@ -1558,7 +1003,9 @@ public final class Telescope<S, A> {
 
   private static final Map<Class<?>, String> METHOD_NAME_CACHE = new ConcurrentHashMap<>();
 
-  private static String methodNameOf(final Serializable lambda) {
+  // Package-private — shared with the conversion-builder classes (BeanTo, MapBuilder,
+  // FieldMapping, Mapper) which live in sibling files in this same package.
+  static String methodNameOf(final Serializable lambda) {
     return METHOD_NAME_CACHE.computeIfAbsent(lambda.getClass(), cls -> resolveMethodName(lambda));
   }
 

--- a/core/src/main/java/io/github/eschizoid/telescope/To.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/To.java
@@ -1,0 +1,27 @@
+package io.github.eschizoid.telescope;
+
+import io.github.eschizoid.telescope.internal.optics.Iso;
+import java.util.function.Function;
+
+/**
+ * Intermediate of {@link From#to(Class)} — call {@link #using(Function, Function)} to supply both
+ * directions of the conversion and materialise the resulting {@code Telescope<A, B>}.
+ */
+public final class To<A, B> {
+
+  To() {}
+
+  /**
+   * Supply both directions of the conversion. {@code forward} converts {@code A → B}; {@code
+   * backward} must satisfy the iso laws ({@code from(to(a)).equals(a)} and {@code
+   * to(from(b)).equals(b)} for the components involved). The resulting {@code Telescope<A, B>}
+   * composes into longer paths via {@link Telescope#then}. See {@link Telescope#from(Class)} for a
+   * worked example.
+   */
+  public Telescope<A, B> using(
+    final Function<? super A, ? extends B> forward,
+    final Function<? super B, ? extends A> backward
+  ) {
+    return new Telescope<>(Iso.of(forward, backward));
+  }
+}

--- a/core/src/main/java/io/github/eschizoid/telescope/annotations/Focus.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/annotations/Focus.java
@@ -28,7 +28,7 @@ import java.lang.annotation.Target;
  *
  * <pre>{@code
  * // Gradle:
- * annotationProcessor("io.github.eschizoid:telescope-codegen:0.1.0")
+ * annotationProcessor("io.github.eschizoid:telescope-codegen:0.3.0")
  *
  * // Source:
  * @Focus

--- a/core/src/test/java/io/github/eschizoid/telescope/MappingExtrasTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/MappingExtrasTest.java
@@ -111,10 +111,7 @@ class MappingExtrasTest {
 
     record UserPatch(String id, String email, String name) {}
 
-    static final Telescope.Mapper<User, UserPatch> MAPPER = Telescope.map(User.class)
-      .to(UserPatch.class)
-      .auto()
-      .buildMapper();
+    static final Mapper<User, UserPatch> MAPPER = Telescope.map(User.class).to(UserPatch.class).auto().buildMapper();
 
     @Test
     @DisplayName("only non-null patch fields are applied")

--- a/core/src/test/java/io/github/eschizoid/telescope/WithChainTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/WithChainTest.java
@@ -26,6 +26,29 @@ class WithChainTest {
 
   record Company(String name, List<Department> departments) {}
 
+  // Pre-built paths reused across the whole test suite. Each typed Telescope<Company, String>;
+  // every step compile-checked.
+  private static final Telescope<Company, String> EMAILS = Telescope.of(Company.class)
+    .each(Company::departments)
+    .each(Department::teams)
+    .each(Team::users)
+    .field(User::email);
+
+  private static final Telescope<Company, String> DEPT_NAMES = Telescope.of(Company.class)
+    .each(Company::departments)
+    .field(Department::name);
+
+  private static final Telescope<Company, String> TEAM_NAMES = Telescope.of(Company.class)
+    .each(Company::departments)
+    .each(Department::teams)
+    .field(Team::name);
+
+  private static final Telescope<Company, String> USER_NAMES = Telescope.of(Company.class)
+    .each(Company::departments)
+    .each(Department::teams)
+    .each(Team::users)
+    .field(User::name);
+
   private static Company sample() {
     return new Company(
       "Acme",
@@ -44,30 +67,17 @@ class WithChainTest {
   class SingleEdit {
 
     @Test
-    @DisplayName("one with(fn).apply(source) equals one update(source, fn)")
+    @DisplayName("one update(path, fn).apply(source) equals one path.update(source, fn)")
     void mirrorsDirectUpdate() {
       final var company = sample();
-      final var viaChain = Telescope.of(Company.class)
-        .each(Company::departments)
-        .each(Department::teams)
-        .each(Team::users)
-        .field(User::email)
-        .with(String::toLowerCase)
-        .apply(company);
-
-      final var viaDirect = Telescope.of(Company.class)
-        .each(Company::departments)
-        .each(Department::teams)
-        .each(Team::users)
-        .field(User::email)
-        .update(company, String::toLowerCase);
-
+      final var viaChain = Telescope.of(Company.class).update(EMAILS, String::toLowerCase).apply(company);
+      final var viaDirect = EMAILS.update(company, String::toLowerCase);
       assertEquals(viaDirect, viaChain);
     }
   }
 
   @Nested
-  @DisplayName("Multi-edit — chain accumulates all .with() edits in order")
+  @DisplayName("Multi-edit — chain accumulates edits in order")
   class MultiEdit {
 
     @Test
@@ -75,45 +85,24 @@ class WithChainTest {
     void twoEditsHeterogeneous() {
       final var company = sample();
       final var out = Telescope.of(Company.class)
-        .each(Company::departments)
-        .each(Department::teams)
-        .each(Team::users)
-        .field(User::email)
-        .with(String::toLowerCase)
-        .each(Company::departments)
-        .field(Department::name)
-        .with(String::trim)
+        .update(EMAILS, String::toLowerCase)
+        .update(DEPT_NAMES, String::trim)
         .apply(company);
-
       assertEquals("Engineering", out.departments().get(0).name());
       assertEquals("Sales", out.departments().get(1).name());
       assertEquals("alice@acme.com", out.departments().get(0).teams().get(0).users().get(0).email());
     }
 
     @Test
-    @DisplayName("four-edit chain applies all edits without restart markers")
+    @DisplayName("four-edit chain applies all edits in one declarative pass")
     void fourEdits() {
       final var company = sample();
       final var out = Telescope.of(Company.class)
-        .each(Company::departments)
-        .each(Department::teams)
-        .each(Team::users)
-        .field(User::email)
-        .with(String::toLowerCase)
-        .each(Company::departments)
-        .field(Department::name)
-        .with(String::trim)
-        .each(Company::departments)
-        .each(Department::teams)
-        .field(Team::name)
-        .with(String::trim)
-        .each(Company::departments)
-        .each(Department::teams)
-        .each(Team::users)
-        .field(User::name)
-        .with(String::toUpperCase)
+        .update(EMAILS, String::toLowerCase)
+        .update(DEPT_NAMES, String::trim)
+        .update(TEAM_NAMES, String::trim)
+        .update(USER_NAMES, String::toUpperCase)
         .apply(company);
-
       assertEquals("Engineering", out.departments().getFirst().name());
       assertEquals("Platform", out.departments().getFirst().teams().get(0).name());
       assertEquals("ALICE", out.departments().getFirst().teams().getFirst().users().getFirst().name());
@@ -125,18 +114,9 @@ class WithChainTest {
     void laterSeesEarlier() {
       final var company = sample();
       final var out = Telescope.of(Company.class)
-        .each(Company::departments)
-        .each(Department::teams)
-        .each(Team::users)
-        .field(User::email)
-        .with(String::toLowerCase)
-        .each(Company::departments)
-        .each(Department::teams)
-        .each(Team::users)
-        .field(User::email)
-        .with(e -> e + "!")
+        .update(EMAILS, String::toLowerCase)
+        .update(EMAILS, e -> e + "!")
         .apply(company);
-
       assertEquals("alice@acme.com!", out.departments().get(0).teams().get(0).users().get(0).email());
     }
   }
@@ -161,6 +141,34 @@ class WithChainTest {
   }
 
   @Nested
+  @DisplayName("Mix-and-match — pre-built update(path, fn) and inline with(fn) in the same chain")
+  class MixedForms {
+
+    @Test
+    @DisplayName("pre-built update(path, fn) interleaved with inline with(fn) works")
+    void mixPrebuiltAndInline() {
+      final var company = sample();
+      final var out = Telescope.of(Company.class)
+        .update(EMAILS, String::toLowerCase)
+        .each(Company::departments)
+        .field(Department::name)
+        .with(String::trim)
+        .apply(company);
+      assertEquals("Engineering", out.departments().get(0).name());
+      assertEquals("alice@acme.com", out.departments().get(0).teams().get(0).users().get(0).email());
+    }
+
+    @Test
+    @DisplayName("Java picks the right overload by first-arg type — Telescope vs source instance")
+    void overloadResolution() {
+      final var company = sample();
+      final Company viaTerminal = EMAILS.update(company, String::toLowerCase);
+      final Company viaChain = Telescope.of(Company.class).update(EMAILS, String::toLowerCase).apply(company);
+      assertEquals(viaTerminal, viaChain);
+    }
+  }
+
+  @Nested
   @DisplayName("Reuse — a stored multi-edit telescope applies cleanly to many sources")
   class Reuse {
 
@@ -168,14 +176,8 @@ class WithChainTest {
     @DisplayName("the same multi-edit chain applies independently to many sources")
     void appliedToManySources() {
       final Telescope<Company, Company> normalize = Telescope.of(Company.class)
-        .each(Company::departments)
-        .each(Department::teams)
-        .each(Team::users)
-        .field(User::email)
-        .with(String::toLowerCase)
-        .each(Company::departments)
-        .field(Department::name)
-        .with(String::trim);
+        .update(EMAILS, String::toLowerCase)
+        .update(DEPT_NAMES, String::trim);
 
       final var company1 = sample();
       final var company2 = new Company(


### PR DESCRIPTION
## Summary

Two related changes that together clean up Telescope.java's public surface and shrink the file from 1669 → 1081 LOC.

### 1. Reinstate `.update(Telescope<S, X>, Function<X, X>)` as the preferred multi-edit form

The pre-built-path form of the multi-edit chain. Pairs with `.with(fn)` (inline-path form, introduced in v0.x) feeding the same chain accumulator:

```java
static final Telescope<Company, String> EMAILS = Telescope.of(Company.class)
    .each(Company::departments).each(Department::teams).each(Team::users).field(User::email);
static final Telescope<Company, String> DEPT_NAMES = Telescope.of(Company.class)
    .each(Company::departments).field(Department::name);

final Company done = Telescope.of(Company.class)
    .update(EMAILS,     String::toLowerCase)
    .update(DEPT_NAMES, String::trim)
    .apply(company);
```

Java overload-resolves `.update(...)` by first-arg type: `Telescope` → chainable (returns `Telescope<S, S>`), `S` instance → single-shot terminal (returns `S`). Fully compile-checked.

### 2. Extract conversion-builder classes into sibling files in the **same package**

(Not a sub-package — earlier draft of this description said `io.github.eschizoid.telescope.conversion`, but on actually doing the extraction I found that the builders use Telescope's package-private constructor and helpers. Moving them to a sub-package would have required exposing those internals through the JPMS export, which we didn't want. Sibling files in the same package was the right outcome.)

Ten classes moved out of `Telescope.java` into their own files:

| File | Role |
| --- | --- |
| `From.java`, `To.java` | `Telescope.from(A).to(B).using(...)` (Iso conversion) |
| `BeanFrom.java`, `BeanTo.java` | `Telescope.fromBean(P).to(R).via*()` (POJO ⇄ record) |
| `MapBeanFrom.java`, `MapBeanTo.java` | `Telescope.mapBean(A).to(B).build()` (POJO ⇄ POJO) |
| `MapTo.java`, `MapBuilder.java`, `FieldMapping.java`, `Mapper.java` | `Telescope.map(A).to(B).field(...)...build()` (record ⇄ record) |

Three private members on `Telescope` (the single-arg constructor, `methodNameOf`, `matchedNames`) bumped to package-private so sibling files can call them without exposing internals through the JPMS export. Same external API, same exports.

### Honest about the compat trade-off

**Source compatibility:** broken in two places — `field(String)` → `fieldByName(String)` rename (intentional clarity win — see README constraint #6), and the conversion-builder intermediate types moved from `Telescope.From` → top-level `From` (users who write `Telescope.from(A).to(B).using(...)` without naming the intermediates aren't affected).

**Binary compatibility:** broken for the conversion-builder extraction — the factory methods' return types changed from `Telescope.From` to `From`. Source-recompiles cleanly, but already-compiled bytecode against the old API won't link.

Documented explicitly in README "Constraints worth knowing" #7 — pre-1.0 we hold the right to break source/binary across minor releases when it improves the DSL.

## Test plan

- [x] `:core:test` — all existing tests pass; 9 new `WithChainTest` cases covering chain overload, mixed pre-built + inline, overload-resolution.
- [x] `:codegen:test`, `:lombok:test`, `:benchmarks:check` — unchanged, all pass.
- [x] `./gradlew build` end-to-end green.
- [x] Conflicts with `origin/main` resolved via rebase (origin/main had picked up earlier multi-edit work that this PR's commit is a superset of).