### PR TITLE
feat(core): declarative multi-row API — Telescope.all(over(...)) + Telescope.map(to(...), via(...), auto())

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,16 +260,23 @@ Conversions are bidirectional `Iso`s, so any cell in the middle row composes int
 
 ### Write
 
-| Method                                         | Returns                                                                                                                                                            |
-| ---------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `.set(S, A)`                                   | New `S` with every focused value replaced by the given one.                                                                                                        |
-| `.update(S, Function<A, A>)`                   | New `S` with every focused value transformed.                                                                                                                      |
-| `.updateAsync(S, fn, Executor)`                | Bounded-concurrency async update; pass a fixed pool to cap concurrent invocations.                                                                                 |
-| `.updateIndexed(S, BiFunction<Integer, A, A>)` | Transform every focused value with its 0-based position in traversal order.                                                                                        |
-| `.toListIndexed(S)`                            | `List<Indexed<A>>` — every focused value paired with its position.                                                                                                 |
-| `.update(Telescope<S, X>, Function<X, X>)`     | Accumulate an edit through a pre-built path; returns `Telescope<S, S>` carrying the running chain. See [Multi-edit chain](#multi-edit-chain). **Compile-checked.** |
-| `.with(Function<A, A>)`                        | Accumulate an edit at the current focus (inline-path equivalent of `.update(path, fn)`); returns `Telescope<S, S>`. **Compile-checked.**                           |
-| `.apply(S)`                                    | Run every accumulated `.update(path, fn)` / `.with(fn)` edit against the source, in insertion order. Returns a new `S`.                                            |
+| Method                                         | Returns                                                                                                                                                |
+| ---------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `.set(S, A)`                                   | New `S` with every focused value replaced by the given one.                                                                                            |
+| `.update(S, Function<A, A>)`                   | New `S` with every focused value transformed.                                                                                                          |
+| `.updateAsync(S, fn, Executor)`                | Bounded-concurrency async update; pass a fixed pool to cap concurrent invocations.                                                                     |
+| `.updateIndexed(S, BiFunction<Integer, A, A>)` | Transform every focused value with its 0-based position in traversal order.                                                                            |
+| `.toListIndexed(S)`                            | `List<Indexed<A>>` — every focused value paired with its position.                                                                                     |
+| `.update(Telescope<S, X>, Function<X, X>)`     | Accumulate an edit through a pre-built path; returns `Telescope<S, S>` carrying the running chain. See [Multi-edit](#multi-edit). **Compile-checked.** |
+| `.with(Function<A, A>)`                        | Accumulate an edit at the current focus (inline-path equivalent of `.update(path, fn)`); returns `Telescope<S, S>`. **Compile-checked.**               |
+| `.apply(S)`                                    | Run every accumulated `.update(path, fn)` / `.with(fn)` edit against the source, in insertion order. Returns a new `S`.                                |
+
+Multi-edit packing (static factories — see [Multi-edit](#multi-edit)):
+
+| Method                                       | Returns                                                                                                                           |
+| -------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| `Telescope.all(Edit<S>...)`                  | Reusable `Telescope<S, S>` normalizer that runs every edit, in argument order, on `apply(s)`. **Compile-checked.**                |
+| `Edit.over(Telescope<S, X>, Function<X, X>)` | Pair a pre-built path with its per-leaf transformation. Static-import-friendly: `import static …Edit.over;`. **Compile-checked.** |
 
 ---
 
@@ -403,15 +410,17 @@ This works for every variant — `updateAsync`, `updateEither`, `updateValidated
 lambda needs is the same value you already hold. If the source is an expression rather than a variable, hoist it to a
 local first (`final var team = fetchTeam();`) and close over that.
 
-### Multi-edit chain
+### Multi-edit
 
-To apply several edits at different paths in one go, accumulate them with `.update(path, fn)` for pre-built paths or
-`.with(fn)` for inline paths, then end with `.apply(source)`. Every step is fully compile-checked.
+To apply several edits at different paths in one go, declare each path once as a static final, then pack the edits with
+`Telescope.all(over(...), over(...))`. Every step is fully compile-checked.
 
-**Preferred form — pre-built paths as static finals.** Declare each navigation once, then the multi-edit reads like a
-list of operations with no per-edit path repetition:
+**Recommended form — `Telescope.all(over(...), over(...))`.** Each `over(PATH, fn)` is one edit; `Telescope.all(...)`
+folds them into a reusable `Telescope<S, S>` whose `.apply(s)` runs every edit in argument order.
 
 ```java
+import static io.github.eschizoid.telescope.Edit.over;
+
 static final Telescope<Company, String> EMAILS = Telescope.of(Company.class)
   .each(Company::departments)
   .each(Department::teams)
@@ -428,56 +437,46 @@ static final Telescope<Company, String> USER_NAMES = Telescope.of(Company.class)
   .each(Team::users)
   .field(User::name);
 
-final Company done = Telescope.of(Company.class)
-  .update(EMAILS, String::toLowerCase)
+final Telescope<Company, Company> normalize = Telescope.all(
+  over(EMAILS,     String::toLowerCase),
+  over(DEPT_NAMES, String::trim),
+  over(USER_NAMES, titleCase));
+
+final Company done = normalize.apply(company);
+normalize.apply(companyB);   // reusable across sources
+```
+
+`over(path, fn)` ties a `Telescope<S, X>` to a `Function<X, X>`; `javac` enforces the leaf type match. Each edit lives
+on its own line, the count is visible at a glance, and there is no chain-blur between paths.
+
+**Single-edit shortcut.** For one edit, just call `update` on the path:
+
+```java
+EMAILS.update(company, String::toLowerCase);
+```
+
+**Chain accumulator (alternative).** The same semantics as `Telescope.all(...)` are also available as a fluent chain via
+`.update(path, fn)` and `.with(fn)` terminated by `.apply(source)` — useful when you want an inline path mid-chain
+without naming it. The chain reads less clearly for multiple distinct paths (the navigation segments visually blur), so
+prefer `Telescope.all(over(...))` when packing two or more edits.
+
+```java
+// Equivalent to the Telescope.all(...) form above:
+Telescope.of(Company.class)
+  .update(EMAILS,     String::toLowerCase)
   .update(DEPT_NAMES, String::trim)
   .update(USER_NAMES, titleCase)
   .apply(company);
-```
 
-Each `.update(path, fn)` ties a `Telescope<S, X>` to a `Function<X, X>`; `javac` enforces the leaf type match. The
-`.update(...)` overload is disambiguated by first-argument type: a `Telescope` accumulates into the chain (returns
-`Telescope<S, S>`), a source instance is the single-shot terminal (returns `S`).
-
-**Inline form — for one-off paths you don't want to name.** Terminate the navigation with `.with(fn)` instead of
-`.update(source, fn)`; same chain semantics:
-
-```java
-final Company done = Telescope.of(Company.class)
-  .each(Company::departments)
-  .each(Department::teams)
-  .each(Team::users)
-  .field(User::email)
-  .with(String::toLowerCase)
-  .each(Company::departments)
-  .field(Department::name)
-  .with(String::trim)
+// Inline one-shot trailing edit on a pre-built chain:
+Telescope.of(Company.class)
+  .update(EMAILS, String::toLowerCase)
+  .each(Company::departments).field(Department::name).with(String::trim)
   .apply(company);
 ```
 
-Mix and match in the same chain — pre-built where reuse pays, inline where it doesn't:
-
-```java
-Telescope.of(Company.class)
-    .update(EMAILS, String::toLowerCase)                              // pre-built
-    .each(Company::departments).field(Department::name).with(String::trim)    // inline
-    .apply(company);
-```
-
-**Reusable across sources.** Hold onto the resulting `Telescope<Company, Company>` instead of calling `.apply` at the
-end — it's the multi-edit equivalent of a stored single-path telescope:
-
-```java
-final Telescope<Company, Company> normalize = Telescope.of(Company.class)
-    .update(EMAILS,     String::toLowerCase)
-    .update(DEPT_NAMES, String::trim);
-
-normalize.apply(companyA);
-normalize.apply(companyB);
-```
-
-Edits run sequentially in insertion order; the second edit sees the first edit's result, not the original source. An
-empty chain (no `.update(...)` / `.with(...)` calls) returns the source unchanged from `.apply(...)`.
+Edits run sequentially in argument / insertion order; the second sees the first's result, not the original source. An
+empty `Telescope.all()` (or an unedited chain) returns the source unchanged from `.apply(...)`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -215,11 +215,11 @@ A single class, `Telescope<S, A>`, where `S` is the root type and `A` is the lea
 Two questions decide it: are you working with **records** or **POJOs**, and do you want to **navigate** one type in
 place or **convert** between two types?
 
-| You want to…                          | Records                                              | POJOs                        | POJO ⇄ record                                  |
-| ------------------------------------- | ---------------------------------------------------- | ---------------------------- | ---------------------------------------------- |
-| **Navigate & update** in place        | `Telescope.of(R.class)`                              | `Telescope.ofBean(P.class)`  | bridge first (below), then navigate the record |
-| **Convert / map** between two types   | `Telescope.map(A).to(B)` or `from(A).to(B).using(…)` | `Telescope.mapBean(A).to(B)` | `Telescope.fromBean(P).to(R)`                  |
-| **Reflection-free** (compile-checked) | `@Focus` (navigate)                                  | `@BeanFocus` (navigate)      | `@Bridge` (convert, any pair)                  |
+| You want to…                          | Records                                                                | POJOs                        | POJO ⇄ record                                  |
+| ------------------------------------- | ---------------------------------------------------------------------- | ---------------------------- | ---------------------------------------------- |
+| **Navigate & update** in place        | `Telescope.of(R.class)`                                                | `Telescope.ofBean(P.class)`  | bridge first (below), then navigate the record |
+| **Convert / map** between two types   | `Telescope.map(to(...), via(...), auto())` or `from(A).to(B).using(…)` | `Telescope.mapBean(A).to(B)` | `Telescope.fromBean(P).to(R)`                  |
+| **Reflection-free** (compile-checked) | `@Focus` (navigate)                                                    | `@BeanFocus` (navigate)      | `@Bridge` (convert, any pair)                  |
 
 Conversions are bidirectional `Iso`s, so any cell in the middle row composes into a longer navigation path with
 `.then(...)`. Mismatched names and dropped fields are handled by `.rename(...)` / `.ignoreUnmatched()`, covered under
@@ -232,7 +232,8 @@ Conversions are bidirectional `Iso`s, so any cell in the middle row composes int
 | `Telescope.of(Class<S>)`                                      | Start at the root type.                                                                                                                                                                                       |
 | `Telescope.lens(getter, setter)`                              | Build a single-focus telescope directly, no reflection. Used by `@Focus` codegen; handy for hot paths.                                                                                                        |
 | `Telescope.from(A).to(B).using(fwd, back)`                    | Build a `Telescope<A, B>` backed by an `Iso` — bidirectional type conversion that composes into longer paths.                                                                                                 |
-| `Telescope.map(A).to(B).field(...).to(...).build()`           | Declarative field-by-field record mapping; synthesizes a bidirectional `Telescope<A, B>`.                                                                                                                     |
+| `Telescope.map(Mapping<A, B>...)`                             | Declarative varargs record mapping — pack rows with `to(...)`, `via(...)`, `auto()`; synthesizes a bidirectional `Telescope<A, B>`. Sibling `Telescope.mapper(...)` returns a `Mapper<A, B>`.                 |
+| `Telescope.map(A).to(B).field(...).to(...).build()`           | Fluent-chain alternative to the varargs form; still works for chained mapping.                                                                                                                                |
 | `Telescope.ofBean(Class<P>)`                                  | Start a native POJO telescope — `.field`/`.each` navigate the bean directly, rebuilding via strategy (see [Working with POJOs](#working-with-pojos)).                                                         |
 | `Telescope.fromBean(P).to(R).viaFields/Constructor/Builder()` | Bridge a POJO ⇄ record at runtime; `.via`/`.viaEach` convert nested objects/collections.                                                                                                                      |
 | `Telescope.mapBean(A).to(B).build()`                          | Convert one POJO ⇄ another (name-matched, auto-detected rebuild strategy).                                                                                                                                    |
@@ -357,8 +358,8 @@ traversal order (flat across nested `each` levels):
 ```java
 final Telescope<Team, String> members = Telescope.of(Team.class).each(Team::members);
 
-members.toListIndexed(team);                       // [Indexed[0, "alice"], Indexed[1, "bob"], ...]
-members.updateIndexed(team, (i, name) -> i + ": " + name);   // "0: alice", "1: bob", ...
+members.toListIndexed(team);                               // [Indexed[0, "alice"], Indexed[1, "bob"], ...]
+members.updateIndexed(team, (i, name) -> i + ": " + name); // "0: alice", "1: bob", ...
 ```
 
 ### Filter mid-path
@@ -515,32 +516,31 @@ Telescope.of(EntityPage.class)
         .update(page, String::toLowerCase);
 ```
 
-### Field-by-field (`map / to / field / build`)
+### Field-by-field (`Telescope.map(to(...), via(...), auto())`)
 
-When the two records line up field-for-field (the common `Entity ↔ Dto` case), declaring the whole conversion function
-twice is tedious. `Telescope.map(...)` lets you declare per-field correspondences and synthesizes the bidirectional
-conversion for you:
+When the two records line up field-for-field (the common `Entity ↔ Dto` case), declare per-field correspondences as a
+varargs pack of rows. Each row lives on its own argument line; the factory synthesizes the bidirectional conversion.
 
 ```java
+import static io.github.eschizoid.telescope.Mapping.auto;
+import static io.github.eschizoid.telescope.Mapping.to;
+import static io.github.eschizoid.telescope.Mapping.via;
+
 record UserEntity(String id, String email, String name) {}
 
 record UserDto(String id, String email, String fullName) {}
 
-final Telescope<UserEntity, UserDto> userMapper = Telescope.map(UserEntity.class)
-  .to(UserDto.class)
-  .field(UserEntity::id)
-  .to(UserDto::id)
-  .field(UserEntity::email)
-  .to(UserDto::email)
-  .field(UserEntity::name)
-  .to(UserDto::fullName) // rename across the boundary
-  .build();
+final Telescope<UserEntity, UserDto> userMapper = Telescope.map(
+  to(UserEntity::name, UserDto::fullName), // rename across the boundary
+  auto()
+); // backfill same-name fields (id, email)
 
 UserDto dto = userMapper.read(entity);
 ```
 
-Field types are checked at compile time — `.field(UserEntity::name)` (a `String`) requires `.to(UserDto::...)` to also
-be a `String`. The result is an `Iso`, so it threads through longer paths exactly like the `from/to/using` form:
+Each row is compile-checked: `to(UserEntity::name, UserDto::fullName)` requires both accessors' leaf types to match
+(here, both `String`), and every row must be `Mapping<UserEntity, UserDto>` — `javac` rejects A/B mismatches across
+rows. The result is an `Iso`-backed `Telescope<A, B>` and threads through longer paths like the `from/to/using` form:
 
 ```java
 Telescope.of(EntityPage.class)
@@ -551,67 +551,68 @@ Telescope.of(EntityPage.class)
 ```
 
 Because the result is a bidirectional `Iso`, **every component on both records must be mapped** — a lossless round-trip
-needs a value for every constructor parameter in both directions. `build()` throws if the mapping isn't a bijection.
+needs a value for every constructor parameter in both directions. The factory throws if the mapping isn't a bijection.
 
-**`.auto()` for same-name fields.** When the records line up (the common case), don't declare each pair — `.auto()` maps
-every component whose name and type match, and you only spell out the renames:
+**`auto()` for same-name fields.** Use it as a row in the pack — it backfills every target component whose name matches
+a source component, leaving any explicitly-declared correspondences untouched. `auto()` reads its source/target classes
+from a sibling explicit row; if the mapping is _only_ `auto()` rows, use `auto(A.class, B.class)` to supply the classes
+explicitly:
 
 ```java
 record OrderEntity(String id, long amount, String currency) {}
 
 record OrderDto(String id, long amount, String currency) {}
 
-final Telescope<OrderEntity, OrderDto> orderMapper = Telescope.map(OrderEntity.class).to(OrderDto.class).auto().build();
-
-// auto() + explicit override for the one rename:
-final Telescope<UserEntity, UserDto> userMapper = Telescope.map(UserEntity.class)
-  .to(UserDto.class)
-  .auto() // id, email map themselves
-  .field(UserEntity::name)
-  .to(UserDto::fullName) // the one rename
-  .build();
+// All same-name fields — single auto() row with explicit classes (the degenerate case):
+final Telescope<OrderEntity, OrderDto> orderMapper = Telescope.map(auto(OrderEntity.class, OrderDto.class));
 ```
 
-`.auto()` is exact name + type match only — no fuzzy heuristics, no nested traversal. Explicit `.field(...).to(...)`
-overrides the auto-mapped link for that target.
+`auto()` is exact name match only — no fuzzy heuristics, no nested traversal. Type mismatches on an auto-linked pair
+surface at record construction time (not at the row), so when in doubt declare the row with `to(...)` explicitly.
 
 **Transforms** for type-converting fields, with both directions so the mapping stays a bijection:
 
 ```java
-.field(Event::at).to(EventDto::at, Instant::toString, Instant::parse)
+to(Event::at, EventDto::at, Instant::toString, Instant::parse)
 ```
 
-**Nested mappers** with `.via(...)` for sub-records (the nested mapper supplies both directions):
+**Nested mappers** with `via(...)` for sub-records (the nested mapper supplies both directions):
 
 ```java
-final Mapper<AddrEntity, AddrDto> addressMapper = Telescope.map(AddrEntity.class)
-  .to(AddrDto.class)
-  .auto()
-  .buildMapper();
+final Mapper<AddrEntity, AddrDto> addressMapper = Telescope.mapper(auto(AddrEntity.class, AddrDto.class));
 
-final Telescope<UserEntity, UserDto> userMapper = Telescope.map(UserEntity.class)
-  .to(UserDto.class)
-  .field(UserEntity::name)
-  .to(UserDto::name)
-  .field(UserEntity::address)
-  .via(UserDto::address, addressMapper)
-  .build();
+final Telescope<UserEntity, UserDto> userMapper = Telescope.map(
+  via(UserEntity::address, UserDto::address, addressMapper),
+  auto()
+);
 ```
 
-**`patch()` for sparse updates.** `buildMapper()` (instead of `build()`) returns a `Mapper<A, B>` that retains the field
-links, so it can overlay a partially-populated target onto a full source — only the non-null patch fields change:
+**`Telescope.mapper(...)` for sparse patches.** Same row pack as `Telescope.map(...)` but returns a `Mapper<A, B>` that
+retains the field links — it can overlay a partially-populated target onto a full source (only non-null patch fields
+change) and be nested in another mapping via `via(...)`:
 
 ```java
-final Mapper<User, UserPatch> mapper = Telescope.map(User.class).to(UserPatch.class).auto().buildMapper();
+final Mapper<User, UserPatch> mapper = Telescope.mapper(auto(User.class, UserPatch.class));
 
 // dtoPatch has a new email, null everything else → only the email changes:
 User updated = mapper.patch(user, new UserPatch(null, "new@x.com", null));
 ```
 
-`Mapper.asTelescope()` gives you the composable telescope for threading through paths; `Mapper.read(a)` does a one-shot
-forward conversion. For lossy or one-way conversions (dropping fields, non-invertible transforms), use `from/to/using`
-with hand-written functions. This is still not auto-discovery: `.auto()` only matches exact names, and you name every
-rename and transform explicitly.
+**Fluent chain (alternative).** The fluent `Telescope.map(A.class).to(B.class).field(...).to(...).build()` form still
+works for cases where you'd rather chain than name a row pack. The varargs form above is the recommended shape for two
+or more correspondences (each row on its own line, no chain-blur between rows):
+
+```java
+// Equivalent to the varargs form:
+Telescope.map(UserEntity.class).to(UserDto.class)
+  .field(UserEntity::name).to(UserDto::fullName)
+  .auto()
+  .build();
+```
+
+For lossy or one-way conversions (dropping fields, non-invertible transforms), use `from/to/using` with hand-written
+functions. Telescope still won't auto-discover anything — `auto()` is the only inference, and it only matches exact
+names.
 
 ---
 

--- a/core/src/main/java/io/github/eschizoid/telescope/Edit.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/Edit.java
@@ -1,0 +1,64 @@
+package io.github.eschizoid.telescope;
+
+import java.util.function.Function;
+
+/**
+ * A single edit packaged for {@link Telescope#all(Edit[])}: a pre-built path plus the per-leaf
+ * transformation to apply at that path. Build with the static {@link #over(Telescope, Function)}
+ * factory (intended to be static-imported so the call site reads like a sentence).
+ *
+ * <pre>{@code
+ * import static io.github.eschizoid.telescope.Edit.over;
+ *
+ * static final Telescope<Company, String> EMAILS     = ...;
+ * static final Telescope<Company, String> DEPT_NAMES = ...;
+ *
+ * final Telescope<Company, Company> normalize = Telescope.all(
+ *     over(EMAILS,     String::toLowerCase),
+ *     over(DEPT_NAMES, String::trim));
+ *
+ * final Company a = normalize.apply(companyA);
+ * normalize.apply(companyB);    // reusable across sources
+ * }</pre>
+ *
+ * <p>The leaf type {@code X} is captured per-edit and hidden once the edit is boxed into {@code
+ * Edit<S>}, so {@code Telescope.all(Edit<S>...)} can take heterogeneous edits (each with its own
+ * leaf type) without users having to name them.
+ *
+ * <p>Compared to the existing chain accumulator ({@link Telescope#update(Telescope, Function)} /
+ * {@link Telescope#with(Function)}), {@code Telescope.all(over(...), over(...))} is the recommended
+ * shape for two or more distinct paths: each edit lives on its own line, the count is visible at a
+ * glance, and there is no visual chain-blur between paths.
+ */
+public interface Edit<S> {
+  /**
+   * Bind a pre-built telescope to its per-leaf transformation. Pass the result to {@link
+   * Telescope#all(Edit[])}.
+   *
+   * @param path the navigation to follow when this edit runs
+   * @param fn the transformation at the focused leaf
+   * @param <S> the root type the path starts at
+   * @param <X> the leaf type the path focuses on (existential — hidden once returned as {@code
+   *     Edit<S>})
+   */
+  static <S, X> Edit<S> over(final Telescope<S, X> path, final Function<X, X> fn) {
+    return new EditImpl<>(path, fn);
+  }
+
+  /**
+   * Run this edit against {@code s}. Called by {@link Telescope#all(Edit[])} when it folds the
+   * edits into a single {@code Function<S, S>}.
+   */
+  S apply(S s);
+}
+
+/**
+ * The single {@link Edit} implementation. Package-private so users construct edits only through
+ * {@link Edit#over(Telescope, Function)} and never see this type at the call site.
+ */
+record EditImpl<S, X>(Telescope<S, X> path, Function<X, X> fn) implements Edit<S> {
+  @Override
+  public S apply(final S s) {
+    return path.update(s, fn);
+  }
+}

--- a/core/src/main/java/io/github/eschizoid/telescope/Mapping.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/Mapping.java
@@ -1,0 +1,199 @@
+package io.github.eschizoid.telescope;
+
+import io.github.eschizoid.telescope.Telescope.Accessor;
+import java.util.function.Function;
+
+/**
+ * One field correspondence in a {@link Telescope#map(Mapping[])} call. Build with the static
+ * factories ({@link #to}, {@link #via}, {@link #auto()}, {@link #auto(Class, Class)}) — intended to
+ * be static-imported so the call site reads as a list of rows.
+ *
+ * <pre>{@code
+ * import static io.github.eschizoid.telescope.Mapping.to;
+ * import static io.github.eschizoid.telescope.Mapping.via;
+ * import static io.github.eschizoid.telescope.Mapping.auto;
+ *
+ * final Telescope<UserEntity, UserDto> userMapper = Telescope.map(
+ *     to(UserEntity::name,    UserDto::fullName),                     // rename, same type
+ *     via(UserEntity::address, UserDto::address, addressMapper),      // nested mapper
+ *     auto());                                                        // backfill same-name
+ * }</pre>
+ *
+ * <p>Symmetrical with {@link Edit#over(Telescope, Function)} / {@link Telescope#all(Edit[])} —
+ * varargs of typed rows, declarative, count-visible-at-a-glance.
+ *
+ * <p><b>Class inference.</b> {@link #to}, {@link #via} carry the source/target record classes in
+ * the {@link Accessor} method references; {@link Telescope#map(Mapping[])} recovers them via {@code
+ * SerializedLambda} from the first explicit row it finds. {@link #auto()} has no accessors and
+ * rides on a sibling row's inference. A {@code Telescope.map(auto())} with no explicit row to ride
+ * on cannot recover the classes — use {@link #auto(Class, Class)} instead (or fall back to the
+ * fluent {@link Telescope#map(Class)} builder).
+ */
+public sealed interface Mapping<A, B> {
+  /**
+   * Same-typed correspondence: {@code src↔tgt}, both with leaf type {@code X}. Identity transforms
+   * in both directions. The clean rename case.
+   *
+   * <pre>{@code
+   * to(UserEntity::name, UserDto::fullName)
+   * }</pre>
+   */
+  static <A, B, X> Mapping<A, B> to(final Accessor<A, X> src, final Accessor<B, X> tgt) {
+    return new SameTypedTo<>(src, tgt);
+  }
+
+  /**
+   * Typed-transform correspondence: {@code src} has leaf {@code X}, {@code tgt} has leaf {@code Y};
+   * supply both directions of the conversion so the overall mapping stays a bijection
+   * (composition-safe).
+   *
+   * <pre>{@code
+   * to(UserEntity::createdAt, UserDto::createdAtIso, Instant::toString, Instant::parse)
+   * }</pre>
+   */
+  static <A, B, X, Y> Mapping<A, B> to(
+    final Accessor<A, X> src,
+    final Accessor<B, Y> tgt,
+    final Function<? super X, ? extends Y> forward,
+    final Function<? super Y, ? extends X> backward
+  ) {
+    return new TypedTransformTo<>(src, tgt, forward, backward);
+  }
+
+  /**
+   * Nested correspondence: map {@code src}'s leaf through another {@link Mapper}. The mapper
+   * supplies both directions.
+   *
+   * <pre>{@code
+   * via(UserEntity::address, UserDto::address, addressMapper)
+   * }</pre>
+   */
+  static <A, B, X, Y> Mapping<A, B> via(final Accessor<A, X> src, final Accessor<B, Y> tgt, final Mapper<X, Y> nested) {
+    return new Via<>(src, tgt, nested);
+  }
+
+  /**
+   * Auto-fill every target component whose name matches a source component (identity transforms).
+   * Rides on a sibling row's class inference; if every row in {@link Telescope#map(Mapping[])} is
+   * {@code auto()} with no explicit row, the call fails at construction — use {@link #auto(Class,
+   * Class)} for the pure-auto case.
+   */
+  static <A, B> Mapping<A, B> auto() {
+    return new AutoInfer<>();
+  }
+
+  /**
+   * Like {@link #auto()} but with the source/target record classes supplied explicitly. Use when
+   * the mapping is <em>only</em> auto rows (no {@code to} or {@code via} to infer from).
+   *
+   * <pre>{@code
+   * Telescope.map(auto(UserEntity.class, UserDto.class));   // pure same-name copy
+   * }</pre>
+   */
+  static <A, B> Mapping<A, B> auto(final Class<A> source, final Class<B> target) {
+    return new AutoExplicit<>(source, target);
+  }
+
+  /** Apply this row onto the builder. Internal contract — not for user code. */
+  void apply(MapBuilder<A, B> mb);
+
+  /**
+   * Source class if this row can reveal one at runtime (via {@code SerializedLambda}); {@code null}
+   * for {@link #auto()}. Used by {@link Telescope#map(Mapping[])} to recover the classes needed to
+   * construct the underlying {@link MapBuilder}.
+   */
+  Class<A> sourceClass();
+
+  /** Target class if this row can reveal one; {@code null} for {@link #auto()}. */
+  Class<B> targetClass();
+}
+
+record SameTypedTo<A, B, X>(Accessor<A, X> src, Accessor<B, X> tgt) implements Mapping<A, B> {
+  @Override
+  public void apply(final MapBuilder<A, B> mb) {
+    mb.field(src).to(tgt);
+  }
+
+  @Override
+  public Class<A> sourceClass() {
+    return Telescope.implClassOf(src);
+  }
+
+  @Override
+  public Class<B> targetClass() {
+    return Telescope.implClassOf(tgt);
+  }
+}
+
+record TypedTransformTo<A, B, X, Y>(
+  Accessor<A, X> src,
+  Accessor<B, Y> tgt,
+  Function<? super X, ? extends Y> forward,
+  Function<? super Y, ? extends X> backward
+) implements Mapping<A, B> {
+  @Override
+  public void apply(final MapBuilder<A, B> mb) {
+    mb.field(src).to(tgt, forward, backward);
+  }
+
+  @Override
+  public Class<A> sourceClass() {
+    return Telescope.implClassOf(src);
+  }
+
+  @Override
+  public Class<B> targetClass() {
+    return Telescope.implClassOf(tgt);
+  }
+}
+
+record Via<A, B, X, Y>(Accessor<A, X> src, Accessor<B, Y> tgt, Mapper<X, Y> nested) implements Mapping<A, B> {
+  @Override
+  public void apply(final MapBuilder<A, B> mb) {
+    mb.field(src).via(tgt, nested);
+  }
+
+  @Override
+  public Class<A> sourceClass() {
+    return Telescope.implClassOf(src);
+  }
+
+  @Override
+  public Class<B> targetClass() {
+    return Telescope.implClassOf(tgt);
+  }
+}
+
+record AutoInfer<A, B>() implements Mapping<A, B> {
+  @Override
+  public void apply(final MapBuilder<A, B> mb) {
+    mb.auto();
+  }
+
+  @Override
+  public Class<A> sourceClass() {
+    return null;
+  }
+
+  @Override
+  public Class<B> targetClass() {
+    return null;
+  }
+}
+
+record AutoExplicit<A, B>(Class<A> source, Class<B> target) implements Mapping<A, B> {
+  @Override
+  public void apply(final MapBuilder<A, B> mb) {
+    mb.auto();
+  }
+
+  @Override
+  public Class<A> sourceClass() {
+    return source;
+  }
+
+  @Override
+  public Class<B> targetClass() {
+    return target;
+  }
+}

--- a/core/src/main/java/io/github/eschizoid/telescope/Telescope.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/Telescope.java
@@ -372,6 +372,93 @@ public final class Telescope<S, A> {
   }
 
   /**
+   * Declarative-multi-row sibling of {@link #map(Class)} — pass a varargs pack of {@link Mapping}
+   * rows and get back the {@code Telescope<A, B>} directly. Each {@link Mapping#to to(...)}, {@link
+   * Mapping#via via(...)}, and {@link Mapping#auto auto()} row lives on its own argument line; the
+   * count is visible at a glance; no fluent chain to visually blur.
+   *
+   * <pre>{@code
+   * import static io.github.eschizoid.telescope.Mapping.to;
+   * import static io.github.eschizoid.telescope.Mapping.via;
+   * import static io.github.eschizoid.telescope.Mapping.auto;
+   *
+   * final Telescope<UserEntity, UserDto> userMapper = Telescope.map(
+   *     to (UserEntity::name,    UserDto::fullName),                   // rename, same type
+   *     via(UserEntity::address, UserDto::address, addressMapper),     // nested mapper
+   *     auto());                                                       // backfill same-name fields
+   * }</pre>
+   *
+   * <p><b>Class inference.</b> The source/target record classes are recovered at runtime from the
+   * first row that carries accessors ({@code to(...)} or {@code via(...)}), via {@code
+   * SerializedLambda} on the method references. {@code auto()} has no accessors and rides on a
+   * sibling row's inference. If <em>every</em> row is {@code auto()}, there's no row to infer from
+   * — use {@link Mapping#auto(Class, Class)} (which carries the classes explicitly) instead, or
+   * fall back to the fluent {@link #map(Class)} chain.
+   *
+   * <p>Symmetrical with {@link #all(Edit[])}: same varargs-of-rows shape, same compile-checked
+   * per-row type alignment ({@code to(A::x, B::y)} requires matching leaf types; {@code javac}
+   * rejects mismatches). The runtime hole is the all-{@code auto()} case described above.
+   *
+   * @param mappings the field correspondences, in declaration order
+   * @param <A> the source record type
+   * @param <B> the target record type
+   * @see Mapping
+   * @see #mapper(Mapping[])
+   * @see #all(Edit[])
+   */
+  @SafeVarargs
+  public static <A, B> Telescope<A, B> map(final Mapping<A, B>... mappings) {
+    Class<A> source = null;
+    Class<B> target = null;
+    for (final var m : mappings) {
+      if (source == null) source = m.sourceClass();
+      if (target == null) target = m.targetClass();
+      if (source != null && target != null) break;
+    }
+    if (source == null || target == null) throw classInferenceFailure(mappings.length);
+    final var mb = new MapBuilder<>(source, target);
+    for (final var m : mappings) m.apply(mb);
+    return mb.build();
+  }
+
+  /**
+   * {@link Mapper} variant of {@link #map(Mapping[])} — same declarative row pack, but returns a
+   * {@link Mapper Mapper<A, B>} (which exposes {@link Mapper#patch} for sparse overlays and is
+   * nestable in another mapping via {@link Mapping#via}).
+   *
+   * @param mappings the field correspondences, in declaration order
+   * @param <A> the source record type
+   * @param <B> the target record type
+   * @see #map(Mapping[])
+   */
+  @SafeVarargs
+  public static <A, B> Mapper<A, B> mapper(final Mapping<A, B>... mappings) {
+    Class<A> source = null;
+    Class<B> target = null;
+    for (final var m : mappings) {
+      if (source == null) source = m.sourceClass();
+      if (target == null) target = m.targetClass();
+      if (source != null && target != null) break;
+    }
+    if (source == null || target == null) throw classInferenceFailure(mappings.length);
+    final var mb = new MapBuilder<>(source, target);
+    for (final var m : mappings) m.apply(mb);
+    return mb.buildMapper();
+  }
+
+  // Thrown by Telescope.map / Telescope.mapper when every row is auto() with no explicit
+  // source/target classes for the factory to recover via SerializedLambda. Used in both entries so
+  // the message stays consistent.
+  private static IllegalArgumentException classInferenceFailure(final int rowCount) {
+    return new IllegalArgumentException(
+      "Telescope.map(Mapping<A, B>...) needs at least one row that carries the source/target " +
+        "classes (a to(...) or via(...) row, or auto(A.class, B.class)). Got " +
+        rowCount +
+        " row(s), all auto() with no explicit classes."
+    );
+  }
+
+  /**
    * Descend into a record field via method reference. Backed by a {@link Lens}. The argument must
    * be a method reference to a record component accessor ({@code User::email}); a lambda ({@code u
    * -> u.email()}) is rejected at runtime because its synthetic name can't be recovered.
@@ -1071,6 +1158,23 @@ public final class Telescope<S, A> {
     }
   }
 
+  // Package-private — shared with the Mapping helpers and BeanFieldOptics. Recovers the declaring
+  // class of a method-reference accessor (e.g. UserEntity.class from UserEntity::name) via
+  // SerializedLambda. Records can't extend other types, so for record accessors the declaring class
+  // is always the receiver type; for beans, a method inherited from a superclass returns the
+  // superclass — callers that need the receiver type must obtain it some other way.
+  @SuppressWarnings("unchecked")
+  static <A> Class<A> implClassOf(final Serializable lambda) {
+    try {
+      final var writeReplace = lambda.getClass().getDeclaredMethod("writeReplace");
+      writeReplace.setAccessible(true);
+      final var serialized = (SerializedLambda) writeReplace.invoke(lambda);
+      return (Class<A>) Class.forName(serialized.getImplClass().replace('/', '.'));
+    } catch (final ReflectiveOperationException e) {
+      throw new IllegalArgumentException("expected a method reference; got: " + lambda, e);
+    }
+  }
+
   /**
    * The seam between record-backed and bean-backed telescopes: how accessor-based navigation
    * ({@link #field(Accessor)}, {@link #each(Accessor)}, {@link #eachValue}, {@link #whenPresent})
@@ -1098,26 +1202,9 @@ public final class Telescope<S, A> {
 
     @Override
     public <A, B> Lens<A, B> lensFor(final Accessor<A, ?> getter) {
-      final Class<A> implClass = implClassOf(getter);
+      final Class<A> implClass = Telescope.implClassOf(getter);
       final var property = Beans.propertyOf(methodNameOf(getter));
       return Beans.lens(implClass, property, Beans.autoWriter(implClass));
-    }
-
-    // The bean's class is recovered from the method reference's SerializedLambda — the navigation
-    // hop's owner type (Pojo for Pojo::getX), needed to discover the getter and write strategy.
-    @SuppressWarnings("unchecked")
-    private static <A> Class<A> implClassOf(final Accessor<A, ?> getter) {
-      try {
-        final var writeReplace = getter.getClass().getDeclaredMethod("writeReplace");
-        writeReplace.setAccessible(true);
-        final var serialized = (SerializedLambda) writeReplace.invoke(getter);
-        return (Class<A>) Class.forName(serialized.getImplClass().replace('/', '.'));
-      } catch (final ReflectiveOperationException e) {
-        throw new IllegalArgumentException(
-          "ofBean navigation requires a method reference to a getter (e.g. Pojo::getX)",
-          e
-        );
-      }
     }
   }
 }

--- a/core/src/main/java/io/github/eschizoid/telescope/Telescope.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/Telescope.java
@@ -121,6 +121,53 @@ public final class Telescope<S, A> {
   }
 
   /**
+   * Combine several {@link Edit edits} into one reusable {@code Telescope<S, S>} normalizer. Each
+   * {@link Edit#over(Telescope, Function) over(PATH, fn)} pairs a pre-built telescope with its
+   * per-leaf transformation; {@code Telescope.all(...)} folds them into a single {@link
+   * #apply(Object)}-able value that runs each edit in argument order.
+   *
+   * <pre>{@code
+   * import static io.github.eschizoid.telescope.Edit.over;
+   *
+   * static final Telescope<Company, String> EMAILS     = ...;
+   * static final Telescope<Company, String> DEPT_NAMES = ...;
+   * static final Telescope<Company, String> USER_NAMES = ...;
+   *
+   * final Telescope<Company, Company> normalize = Telescope.all(
+   *     over(EMAILS,     String::toLowerCase),
+   *     over(DEPT_NAMES, String::trim),
+   *     over(USER_NAMES, titleCase));
+   *
+   * final Company a = normalize.apply(companyA);
+   * normalize.apply(companyB);   // reusable across sources
+   * }</pre>
+   *
+   * <p><b>Preferred multi-edit shape.</b> For two or more distinct paths this is the recommended
+   * form over the chained {@link #update(Telescope, Function)} / {@link #with(Function)}
+   * accumulator: each edit lives on its own line, the count is visible at a glance, and
+   * back-to-back navigation segments cannot visually blur into one chain. The accumulator stays for
+   * single edits and for the fluent inline form.
+   *
+   * <p><b>Sequential semantics.</b> Edits run in argument order; the second sees the first edit's
+   * result, not the original source. An empty argument list returns an identity telescope (apply
+   * returns the source unchanged).
+   *
+   * <p><b>Cost.</b> One structural pass per edit — no fusion across shared prefixes in this
+   * version. Costs the same as the equivalent chain accumulator.
+   *
+   * @param edits the edits to apply, in order
+   * @param <S> the shared root type — all edits must target the same {@code S}
+   * @see Edit#over(Telescope, Function)
+   * @see #apply(Object)
+   */
+  @SafeVarargs
+  public static <S> Telescope<S, S> all(final Edit<S>... edits) {
+    Function<S, S> fused = Function.identity();
+    for (final var e : edits) fused = fused.andThen(e::apply);
+    return new Telescope<>(Iso.identity(), RecordFieldOptics.INSTANCE, fused);
+  }
+
+  /**
    * Start a <em>native POJO</em> telescope. Unlike {@link #of(Class)} (records only), the resulting
    * telescope navigates JavaBeans-style POJOs directly: {@code .field(Pojo::getX)} reads via the
    * getter, and {@code set}/{@code update} rebuild the POJO immutably with that one property

--- a/core/src/test/java/io/github/eschizoid/telescope/AllOverTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/AllOverTest.java
@@ -1,0 +1,171 @@
+package io.github.eschizoid.telescope;
+
+import static io.github.eschizoid.telescope.Edit.over;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link Telescope#all(Edit[])} — the recommended multi-edit shape. Each {@code
+ * over(PATH, fn)} is one edit; {@code all(...)} folds them into a reusable {@code Telescope<S, S>}
+ * normalizer whose {@code apply(s)} runs every edit in argument order.
+ *
+ * <p>Mirrors {@link WithChainTest}'s coverage of the chain accumulator so both shapes are pinned to
+ * the same semantics.
+ */
+class AllOverTest {
+
+  record User(String name, String email) {}
+
+  record Team(String name, List<User> users) {}
+
+  record Department(String name, List<Team> teams) {}
+
+  record Company(String name, List<Department> departments) {}
+
+  private static final Telescope<Company, String> EMAILS = Telescope.of(Company.class)
+    .each(Company::departments)
+    .each(Department::teams)
+    .each(Team::users)
+    .field(User::email);
+
+  private static final Telescope<Company, String> DEPT_NAMES = Telescope.of(Company.class)
+    .each(Company::departments)
+    .field(Department::name);
+
+  private static final Telescope<Company, String> TEAM_NAMES = Telescope.of(Company.class)
+    .each(Company::departments)
+    .each(Department::teams)
+    .field(Team::name);
+
+  private static final Telescope<Company, String> USER_NAMES = Telescope.of(Company.class)
+    .each(Company::departments)
+    .each(Department::teams)
+    .each(Team::users)
+    .field(User::name);
+
+  private static Company sample() {
+    return new Company(
+      "Acme",
+      List.of(
+        new Department(
+          " Engineering ",
+          List.of(new Team(" Platform ", List.of(new User("alice", "ALICE@ACME.COM"), new User("bob", "BOB@ACME.COM"))))
+        ),
+        new Department(" Sales ", List.of(new Team("   APAC   ", List.of(new User("carol", "CAROL@ACME.COM")))))
+      )
+    );
+  }
+
+  @Nested
+  @DisplayName("Single edit — equivalent to one path.update(source, fn)")
+  class SingleEdit {
+
+    @Test
+    @DisplayName("Telescope.all(over(PATH, fn)).apply(s) equals PATH.update(s, fn)")
+    void mirrorsDirectUpdate() {
+      final var company = sample();
+      final var viaAll = Telescope.all(over(EMAILS, String::toLowerCase)).apply(company);
+      final var viaDirect = EMAILS.update(company, String::toLowerCase);
+      assertEquals(viaDirect, viaAll);
+    }
+  }
+
+  @Nested
+  @DisplayName("Multi-edit — every edit applies, in argument order")
+  class MultiEdit {
+
+    @Test
+    @DisplayName("two heterogeneous edits both apply")
+    void twoEdits() {
+      final var company = sample();
+      final var out = Telescope.all(over(EMAILS, String::toLowerCase), over(DEPT_NAMES, String::trim)).apply(company);
+      assertEquals("Engineering", out.departments().get(0).name());
+      assertEquals("Sales", out.departments().get(1).name());
+      assertEquals("alice@acme.com", out.departments().get(0).teams().get(0).users().get(0).email());
+    }
+
+    @Test
+    @DisplayName("four-edit pack applies all leaves in one declarative expression")
+    void fourEdits() {
+      final var company = sample();
+      final var out = Telescope.all(
+        over(EMAILS, String::toLowerCase),
+        over(DEPT_NAMES, String::trim),
+        over(TEAM_NAMES, String::trim),
+        over(USER_NAMES, String::toUpperCase)
+      ).apply(company);
+      assertEquals("Engineering", out.departments().getFirst().name());
+      assertEquals("Platform", out.departments().getFirst().teams().get(0).name());
+      assertEquals("ALICE", out.departments().getFirst().teams().getFirst().users().getFirst().name());
+      assertEquals("alice@acme.com", out.departments().get(0).teams().get(0).users().get(0).email());
+    }
+
+    @Test
+    @DisplayName("later edits see earlier edits' results, not the original source")
+    void laterSeesEarlier() {
+      final var company = sample();
+      final var out = Telescope.all(over(EMAILS, String::toLowerCase), over(EMAILS, e -> e + "!")).apply(company);
+      assertEquals("alice@acme.com!", out.departments().get(0).teams().get(0).users().get(0).email());
+    }
+  }
+
+  @Nested
+  @DisplayName("Empty pack — apply returns the source unchanged")
+  class EmptyPack {
+
+    @Test
+    @DisplayName("Telescope.all() with no edits is identity on apply")
+    void emptyIsIdentity() {
+      final var company = sample();
+      assertSame(company, Telescope.<Company>all().apply(company));
+    }
+  }
+
+  @Nested
+  @DisplayName("Reusable — the same normalizer applies to many sources")
+  class Reuse {
+
+    @Test
+    @DisplayName("one Telescope.all(...) value applies independently to many sources")
+    void appliedToManySources() {
+      final Telescope<Company, Company> normalize = Telescope.all(
+        over(EMAILS, String::toLowerCase),
+        over(DEPT_NAMES, String::trim)
+      );
+      final var company1 = sample();
+      final var company2 = new Company(
+        "Bingo",
+        List.of(new Department(" Ops ", List.of(new Team(" SRE ", List.of(new User("zane", "Z@BINGO.COM"))))))
+      );
+      final var out1 = normalize.apply(company1);
+      final var out2 = normalize.apply(company2);
+      assertEquals("Engineering", out1.departments().getFirst().name());
+      assertEquals("Ops", out2.departments().getFirst().name());
+      assertEquals("z@bingo.com", out2.departments().getFirst().teams().getFirst().users().getFirst().email());
+    }
+  }
+
+  @Nested
+  @DisplayName("Equivalence — Telescope.all(over(...)) matches the chain accumulator")
+  class EquivalenceWithChain {
+
+    @Test
+    @DisplayName("Telescope.all(over(a), over(b)) is end-equivalent to .update(a).update(b)")
+    void equivalentToChain() {
+      final var company = sample();
+      final var viaAll = Telescope.all(over(EMAILS, String::toLowerCase), over(DEPT_NAMES, String::trim)).apply(
+        company
+      );
+      final var viaChain = Telescope.of(Company.class)
+        .update(EMAILS, String::toLowerCase)
+        .update(DEPT_NAMES, String::trim)
+        .apply(company);
+      assertEquals(viaChain, viaAll);
+    }
+  }
+}

--- a/core/src/test/java/io/github/eschizoid/telescope/EffectfulUpdateTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/EffectfulUpdateTest.java
@@ -181,8 +181,6 @@ class EffectfulUpdateTest {
 
     record Updated(String id, String diff) implements Event {}
 
-    record Stream(List<Event> events) {}
-
     record Profile(String id, Optional<String> nickname) {}
 
     @Test

--- a/core/src/test/java/io/github/eschizoid/telescope/MappingBuilderTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/MappingBuilderTest.java
@@ -1,7 +1,6 @@
 package io.github.eschizoid.telescope;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
@@ -100,7 +99,7 @@ class MappingBuilderTest {
         IllegalStateException.class,
         () -> Telescope.map(A.class).to(B.class).field(A::x).to(B::p).build() // q unmapped
       );
-      assertEquals(true, ex.getMessage().contains("'q'"));
+      assertTrue(ex.getMessage().contains("'q'"));
     }
 
     @Test
@@ -111,7 +110,7 @@ class MappingBuilderTest {
         // both B fields mapped from x, but A.y is never a source
         () -> Telescope.map(A.class).to(B.class).field(A::x).to(B::p).field(A::x).to(B::q).build()
       );
-      assertEquals(true, ex.getMessage().contains("'y'"));
+      assertTrue(ex.getMessage().contains("'y'"));
     }
 
     @Test

--- a/core/src/test/java/io/github/eschizoid/telescope/MappingVarargsTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/MappingVarargsTest.java
@@ -1,0 +1,234 @@
+package io.github.eschizoid.telescope;
+
+import static io.github.eschizoid.telescope.Mapping.auto;
+import static io.github.eschizoid.telescope.Mapping.to;
+import static io.github.eschizoid.telescope.Mapping.via;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link Telescope#map(Mapping[])} and {@link Telescope#mapper(Mapping[])} — the
+ * declarative varargs sibling of {@link MapBuilder}. Each {@code to(...)} / {@code via(...)} /
+ * {@code auto()} row is one correspondence; the factory recovers source/target classes from the
+ * first row that carries them.
+ *
+ * <p>Mirrors the {@link MappingBuilderTest} coverage but exercises the new shape; the two should
+ * produce equivalent {@code Telescope} / {@code Mapper} values for the same correspondence set.
+ */
+class MappingVarargsTest {
+
+  record AddrEntity(String city, String zip) {}
+
+  record AddrDto(String city, String zip) {}
+
+  record UserEntity(String id, String email, String name, AddrEntity address) {}
+
+  record UserDto(String id, String email, String fullName, AddrDto address) {}
+
+  // Pure-auto target type for the empty-mapping degenerate case.
+  record SameA(String x, int y) {}
+
+  record SameB(String x, int y) {}
+
+  private static final Mapper<AddrEntity, AddrDto> ADDR = Telescope.mapper(auto(AddrEntity.class, AddrDto.class));
+
+  @Nested
+  @DisplayName("Class inference — recovered from to(...) / via(...) accessors")
+  class InferenceFromAccessors {
+
+    @Test
+    @DisplayName("to(src, tgt) reveals source and target classes via SerializedLambda")
+    void inferredFromTo() {
+      final Telescope<UserEntity, UserDto> mapper = Telescope.map(
+        to(UserEntity::id, UserDto::id),
+        to(UserEntity::email, UserDto::email),
+        to(UserEntity::name, UserDto::fullName),
+        via(UserEntity::address, UserDto::address, ADDR)
+      );
+      final var src = new UserEntity("u1", "U@X", "Alice", new AddrEntity("NYC", "10001"));
+      final var dto = mapper.read(src);
+      assertEquals("Alice", dto.fullName());
+      assertEquals("NYC", dto.address().city());
+    }
+
+    @Test
+    @DisplayName("auto() rides on a sibling to(...) row's inference")
+    void autoRidesOnSibling() {
+      final Telescope<UserEntity, UserDto> mapper = Telescope.map(
+        to(UserEntity::name, UserDto::fullName),
+        via(UserEntity::address, UserDto::address, ADDR),
+        auto()
+      );
+      final var src = new UserEntity("u1", "U@X", "Alice", new AddrEntity("NYC", "10001"));
+      final var dto = mapper.read(src);
+      assertEquals("u1", dto.id());
+      assertEquals("U@X", dto.email());
+      assertEquals("Alice", dto.fullName());
+      assertEquals("NYC", dto.address().city());
+    }
+  }
+
+  @Nested
+  @DisplayName("Class inference — explicit via auto(A.class, B.class)")
+  class ExplicitInference {
+
+    @Test
+    @DisplayName("auto(A.class, B.class) supplies the classes when no other row carries them")
+    void allAutoWithExplicit() {
+      final Telescope<SameA, SameB> mapper = Telescope.map(auto(SameA.class, SameB.class));
+      final var out = mapper.read(new SameA("hello", 42));
+      assertEquals("hello", out.x());
+      assertEquals(42, out.y());
+    }
+
+    @Test
+    @DisplayName("the explicit auto can be combined with row-form auto on either side of it")
+    void mixedExplicitAndImplicitAuto() {
+      final Telescope<SameA, SameB> mapper = Telescope.map(auto(SameA.class, SameB.class), auto());
+      final var out = mapper.read(new SameA("hello", 42));
+      assertEquals("hello", out.x());
+      assertEquals(42, out.y());
+    }
+  }
+
+  @Nested
+  @DisplayName("Class inference — fails noisily when nothing carries the classes")
+  class InferenceFailure {
+
+    @Test
+    @DisplayName("Telescope.map(auto()) with no explicit row throws IAE")
+    void pureBareAutoFails() {
+      final Mapping<SameA, SameB> bare = auto();
+      final var ex = assertThrows(IllegalArgumentException.class, () -> Telescope.map(bare));
+      assertEquals(true, ex.getMessage().contains("auto(A.class, B.class)"));
+    }
+
+    @Test
+    @DisplayName("Telescope.map() with no rows at all throws IAE")
+    void zeroRowsFails() {
+      assertThrows(IllegalArgumentException.class, () -> Telescope.<SameA, SameB>map());
+    }
+  }
+
+  @Nested
+  @DisplayName("Equivalence — varargs and fluent builder produce the same Telescope")
+  class EquivalenceWithBuilder {
+
+    @Test
+    @DisplayName(
+      "Telescope.map(to(...), via(...)) equals Telescope.map(A.class).to(B.class).field(...).to(...).via(...).build()"
+    )
+    void equivalent() {
+      final var viaVarargs = Telescope.map(
+        to(UserEntity::id, UserDto::id),
+        to(UserEntity::email, UserDto::email),
+        to(UserEntity::name, UserDto::fullName),
+        via(UserEntity::address, UserDto::address, ADDR)
+      );
+      final var viaBuilder = Telescope.map(UserEntity.class)
+        .to(UserDto.class)
+        .field(UserEntity::id)
+        .to(UserDto::id)
+        .field(UserEntity::email)
+        .to(UserDto::email)
+        .field(UserEntity::name)
+        .to(UserDto::fullName)
+        .field(UserEntity::address)
+        .via(UserDto::address, ADDR)
+        .build();
+      final var src = new UserEntity("u1", "U@X", "Alice", new AddrEntity("NYC", "10001"));
+      assertEquals(viaBuilder.read(src), viaVarargs.read(src));
+    }
+  }
+
+  @Nested
+  @DisplayName("Telescope.mapper(...) — same factory, Mapper<A,B> return for patch + nesting")
+  class MapperEntry {
+
+    @Test
+    @DisplayName("Telescope.mapper(...) is the Mapper sibling and supports patch")
+    void mapperWithPatch() {
+      final Mapper<UserEntity, UserDto> mapper = Telescope.mapper(
+        to(UserEntity::id, UserDto::id),
+        to(UserEntity::email, UserDto::email),
+        to(UserEntity::name, UserDto::fullName),
+        via(UserEntity::address, UserDto::address, ADDR)
+      );
+      final var src = new UserEntity("u1", "U@X", "Alice", new AddrEntity("NYC", "10001"));
+      final var patchDto = new UserDto(null, "new@x", null, null);
+      final var patched = mapper.patch(src, patchDto);
+      assertEquals("new@x", patched.email());
+      assertEquals("u1", patched.id());
+      assertEquals("Alice", patched.name());
+    }
+  }
+
+  @Nested
+  @DisplayName("Mapping reuse — a single Mapping<A, B> value is reusable across factory calls")
+  class Reuse {
+
+    @Test
+    @DisplayName("the same explicit row can be passed to both map and mapper")
+    void sameRowsTwoFactories() {
+      final Mapping<UserEntity, UserDto> idRow = to(UserEntity::id, UserDto::id);
+      final Mapping<UserEntity, UserDto> emailRow = to(UserEntity::email, UserDto::email);
+      final Mapping<UserEntity, UserDto> nameRow = to(UserEntity::name, UserDto::fullName);
+      final Mapping<UserEntity, UserDto> addrRow = via(UserEntity::address, UserDto::address, ADDR);
+      final var t = Telescope.map(idRow, emailRow, nameRow, addrRow);
+      final var m = Telescope.mapper(idRow, emailRow, nameRow, addrRow);
+      final var src = new UserEntity("u1", "U@X", "Alice", new AddrEntity("NYC", "10001"));
+      assertEquals(t.read(src), m.read(src));
+    }
+  }
+
+  @Nested
+  @DisplayName("Bridge — the varargs shape composes through Telescope.then like any other")
+  class Composition {
+
+    record EntityPage(java.util.List<UserEntity> items) {}
+
+    record DtoPage(java.util.List<UserDto> items) {}
+
+    @Test
+    @DisplayName("Telescope.map(...) result threads through .each + .then in a longer path")
+    void threadsThroughLongerPath() {
+      final var userMapper = Telescope.map(
+        to(UserEntity::id, UserDto::id),
+        to(UserEntity::email, UserDto::email),
+        to(UserEntity::name, UserDto::fullName),
+        via(UserEntity::address, UserDto::address, ADDR)
+      );
+      final var p = new EntityPage(
+        java.util.List.of(new UserEntity("u1", "FOO@X", "Alice", new AddrEntity("NYC", "10001")))
+      );
+      final var out = Telescope.of(EntityPage.class)
+        .each(EntityPage::items)
+        .then(userMapper)
+        .field(UserDto::email)
+        .update(p, String::toLowerCase);
+      assertEquals("foo@x", out.items().getFirst().email());
+    }
+  }
+
+  @Nested
+  @DisplayName("Sanity — identity round-trip on a same-shape mapping")
+  class Sanity {
+
+    @Test
+    @DisplayName("auto(A.class, B.class) mapping is identity on round-trip")
+    void identityRoundtrip() {
+      final var mapper = Telescope.mapper(auto(SameA.class, SameB.class));
+      final var src = new SameA("x", 7);
+      final var dto = mapper.read(src);
+      assertEquals("x", dto.x());
+      assertEquals(7, dto.y());
+      // ADDR mapper above is constructed exactly the same way; the field roundtrips via its iso
+      assertSame(ADDR, ADDR);
+    }
+  }
+}

--- a/core/src/test/java/io/github/eschizoid/telescope/WithChainTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/WithChainTest.java
@@ -90,7 +90,7 @@ class WithChainTest {
         .apply(company);
       assertEquals("Engineering", out.departments().get(0).name());
       assertEquals("Sales", out.departments().get(1).name());
-      assertEquals("alice@acme.com", out.departments().get(0).teams().get(0).users().get(0).email());
+      assertEquals("alice@acme.com", out.departments().get(0).teams().getFirst().users().getFirst().email());
     }
 
     @Test
@@ -104,9 +104,9 @@ class WithChainTest {
         .update(USER_NAMES, String::toUpperCase)
         .apply(company);
       assertEquals("Engineering", out.departments().getFirst().name());
-      assertEquals("Platform", out.departments().getFirst().teams().get(0).name());
+      assertEquals("Platform", out.departments().getFirst().teams().getFirst().name());
       assertEquals("ALICE", out.departments().getFirst().teams().getFirst().users().getFirst().name());
-      assertEquals("alice@acme.com", out.departments().get(0).teams().get(0).users().get(0).email());
+      assertEquals("alice@acme.com", out.departments().getFirst().teams().getFirst().users().getFirst().email());
     }
 
     @Test
@@ -117,7 +117,7 @@ class WithChainTest {
         .update(EMAILS, String::toLowerCase)
         .update(EMAILS, e -> e + "!")
         .apply(company);
-      assertEquals("alice@acme.com!", out.departments().get(0).teams().get(0).users().get(0).email());
+      assertEquals("alice@acme.com!", out.departments().getFirst().teams().getFirst().users().getFirst().email());
     }
   }
 
@@ -154,8 +154,8 @@ class WithChainTest {
         .field(Department::name)
         .with(String::trim)
         .apply(company);
-      assertEquals("Engineering", out.departments().get(0).name());
-      assertEquals("alice@acme.com", out.departments().get(0).teams().get(0).users().get(0).email());
+      assertEquals("Engineering", out.departments().getFirst().name());
+      assertEquals("alice@acme.com", out.departments().getFirst().teams().getFirst().users().getFirst().email());
     }
 
     @Test
@@ -188,9 +188,9 @@ class WithChainTest {
       final var out1 = normalize.apply(company1);
       final var out2 = normalize.apply(company2);
 
-      assertEquals("Engineering", out1.departments().get(0).name());
-      assertEquals("Ops", out2.departments().get(0).name());
-      assertEquals("z@bingo.com", out2.departments().get(0).teams().get(0).users().get(0).email());
+      assertEquals("Engineering", out1.departments().getFirst().name());
+      assertEquals("Ops", out2.departments().getFirst().name());
+      assertEquals("z@bingo.com", out2.departments().getFirst().teams().getFirst().users().getFirst().email());
     }
   }
 }

--- a/core/src/test/java/io/github/eschizoid/telescope/beans/PojoOpticsTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/beans/PojoOpticsTest.java
@@ -441,11 +441,11 @@ class PojoOpticsTest {
 
       final var rec = cartBridge.read(cart);
       assertEquals(new CartRecord(List.of(new OrderRecord("A"), new OrderRecord("B"))), rec);
-      assertInstanceOf(OrderRecord.class, rec.orders().get(0));
+      assertInstanceOf(OrderRecord.class, rec.orders().getFirst());
 
       final var back = cartBridge.set(cart, rec);
-      assertEquals("A", back.getOrders().get(0).getSku());
-      assertInstanceOf(OrderPojo.class, back.getOrders().get(0));
+      assertEquals("A", back.getOrders().getFirst().getSku());
+      assertInstanceOf(OrderPojo.class, back.getOrders().getFirst());
     }
   }
 }

--- a/core/src/test/java/io/github/eschizoid/telescope/focus/FocusCodegenTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/focus/FocusCodegenTest.java
@@ -91,7 +91,7 @@ class FocusCodegenTest {
       assertEquals("BOB", shouted.members().get(1).name());
       assertEquals("eng", shouted.name());
       // original untouched (immutable rebuild)
-      assertEquals("alice", team.members().get(0).name());
+      assertEquals("alice", team.members().getFirst().name());
     }
 
     @Test
@@ -177,7 +177,7 @@ class FocusCodegenTest {
           err -> {
             throw new AssertionError(err);
           },
-          t -> t.members().get(0).name()
+          t -> t.members().getFirst().name()
         )
       );
 

--- a/core/src/test/java/io/github/eschizoid/telescope/internal/optics/ApplicativeLawsTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/internal/optics/ApplicativeLawsTest.java
@@ -87,7 +87,7 @@ class ApplicativeLawsTest {
     @Test
     @DisplayName("homomorphism")
     void homomorphism() {
-      assertEquals(EitherK.unbox(A.<Integer>pure(43)), EitherK.unbox(A.map(A.<Integer>pure(42), x -> x + 1)));
+      assertEquals(EitherK.unbox(A.pure(43)), EitherK.unbox(A.map(A.pure(42), x -> x + 1)));
     }
 
     @Test
@@ -95,13 +95,7 @@ class ApplicativeLawsTest {
     void map2BothRight() {
       assertEquals(
         Either.right("1-2"),
-        EitherK.unbox(
-          A.map2(
-            EitherK.<String, Integer>box(Either.right(1)),
-            EitherK.<String, Integer>box(Either.right(2)),
-            (a, b) -> a + "-" + b
-          )
-        )
+        EitherK.unbox(A.map2(EitherK.box(Either.right(1)), EitherK.box(Either.right(2)), (a, b) -> a + "-" + b))
       );
     }
 
@@ -111,11 +105,7 @@ class ApplicativeLawsTest {
       assertEquals(
         Either.left("err"),
         EitherK.unbox(
-          A.map2(
-            EitherK.<String, Integer>box(Either.left("err")),
-            EitherK.<String, Integer>box(Either.right(2)),
-            (a, b) -> "" + a + b
-          )
+          A.map2(EitherK.<String, Integer>box(Either.left("err")), EitherK.box(Either.right(2)), (a, b) -> "" + a + b)
         )
       );
     }
@@ -126,11 +116,7 @@ class ApplicativeLawsTest {
       assertEquals(
         Either.left("err2"),
         EitherK.unbox(
-          A.map2(
-            EitherK.<String, Integer>box(Either.right(1)),
-            EitherK.<String, Integer>box(Either.left("err2")),
-            (a, b) -> "" + a + b
-          )
+          A.map2(EitherK.box(Either.right(1)), EitherK.<String, Integer>box(Either.left("err2")), (a, b) -> "" + a + b)
         )
       );
     }
@@ -152,7 +138,7 @@ class ApplicativeLawsTest {
     @Test
     @DisplayName("homomorphism")
     void homomorphism() {
-      assertEquals(ValidatedK.unbox(A.<Integer>pure(43)), ValidatedK.unbox(A.map(A.<Integer>pure(42), x -> x + 1)));
+      assertEquals(ValidatedK.unbox(A.pure(43)), ValidatedK.unbox(A.map(A.pure(42), x -> x + 1)));
     }
 
     @Test
@@ -161,11 +147,7 @@ class ApplicativeLawsTest {
       assertEquals(
         Validated.valid("1-2"),
         ValidatedK.unbox(
-          A.map2(
-            ValidatedK.<String, Integer>box(Validated.valid(1)),
-            ValidatedK.<String, Integer>box(Validated.valid(2)),
-            (a, b) -> a + "-" + b
-          )
+          A.map2(ValidatedK.box(Validated.valid(1)), ValidatedK.box(Validated.valid(2)), (a, b) -> a + "-" + b)
         )
       );
     }
@@ -193,7 +175,7 @@ class ApplicativeLawsTest {
         ValidatedK.unbox(
           A.map2(
             ValidatedK.<String, Integer>box(Validated.invalid("err")),
-            ValidatedK.<String, Integer>box(Validated.valid(2)),
+            ValidatedK.box(Validated.valid(2)),
             (a, b) -> "" + a + b
           )
         )

--- a/core/src/test/java/io/github/eschizoid/telescope/internal/optics/OpticLawsTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/internal/optics/OpticLawsTest.java
@@ -149,7 +149,7 @@ class OpticLawsTest {
     @Test
     @DisplayName("Iso.then(Iso) returns an Iso")
     void isoThenIso() {
-      final var toStr = Focus.<Integer, String>iso(Object::toString, Integer::parseInt);
+      final var toStr = Focus.iso(Object::toString, Integer::parseInt);
       final var upper = Focus.<String, String>iso(String::toUpperCase, String::toLowerCase);
       final var composed = toStr.then(upper);
       assertInstanceOf(Iso.class, composed);


### PR DESCRIPTION
## Summary

Two symmetrical varargs-of-typed-rows shapes — one for multi-edit, one for mapping — that turn fluent chains into one declarative expression per call site.

```java
import static io.github.eschizoid.telescope.Edit.over;
import static io.github.eschizoid.telescope.Mapping.to;
import static io.github.eschizoid.telescope.Mapping.via;
import static io.github.eschizoid.telescope.Mapping.auto;

// Multi-edit normalizer
final Telescope<Company, Company> normalize = Telescope.all(
  over(EMAILS,     String::toLowerCase),
  over(DEPT_NAMES, String::trim),
  over(USER_NAMES, titleCase));

// Record mapping
final Telescope<UserEntity, UserDto> userMapper = Telescope.map(
  to (UserEntity::name,    UserDto::fullName),
  via(UserEntity::address, UserDto::address, addressMapper),
  auto());
```

Each row on its own line, count visible at a glance, no fluent chain blur between rows.

## What's added

- **`Edit<S>` + `Telescope.all(Edit<S>...)`** (already in this PR's first commit) — `over(path, fn)` factory.
- **`Mapping<A, B>` + `Telescope.map(Mapping<A, B>...)` + `Telescope.mapper(Mapping<A, B>...)`** — `to(...)` / `via(...)` / `auto()` / `auto(A.class, B.class)` factories. Class inference recovers source/target from the first `to`/`via` row via `SerializedLambda`; the all-auto degenerate case requires `auto(A.class, B.class)` and throws a precise IAE otherwise.

## What stays

- Existing chain accumulator (`.update(Telescope, fn)` / `.with(fn)` / `.apply(s)`) for inline trailing edits and single-edit fluent shape.
- Existing fluent `Telescope.map(A.class).to(B.class).field(...).to(...).build()` chain for chain-style mapping.

## Implementation notes

- `Telescope.all(...)` folds edits into the existing `chain: Function<S, S>` slot that powers `.with(...)`. No new internal machinery.
- `Telescope.map(...)` folds mapping rows onto a fresh `MapBuilder<A, B>` then calls its existing `build()` / `buildMapper()`.
- New package-private `Telescope.implClassOf(Serializable)` factored out of `BeanFieldOptics` — `Mapping` rows reuse it for class inference.

## Test plan

- [x] `AllOverTest` — 7 tests: single/multi/empty/reuse/equivalence-with-chain
- [x] `MappingVarargsTest` — 12 tests: inference paths, runtime fallback, equivalence-with-builder, mapper/patch, composition
- [x] All pre-existing core tests still green