### PR TITLE
chore(core): Warning cleanup on Telescope.java

### DIFF
--- a/core/src/main/java/io/github/eschizoid/telescope/BeanTo.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/BeanTo.java
@@ -185,7 +185,7 @@ public final class BeanTo<P, R extends Record> {
     if (!(list instanceof Iterable<?> it)) throw new IllegalArgumentException(
       "viaEach expects a collection component but got " + (list == null ? "null" : list.getClass().getName())
     );
-    final var out = new ArrayList<Object>();
+    final var out = new ArrayList<>();
     for (final var e : it) out.add(fn.apply(e));
     return List.copyOf(out);
   }

--- a/core/src/main/java/io/github/eschizoid/telescope/Either.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/Either.java
@@ -132,7 +132,7 @@ public sealed interface Either<L, R> {
 
   /**
    * Map the left side. Leaves a {@code Right} unchanged. Useful for translating typed errors to a
-   * different error type at a boundary (e.g. mapping a {@code ParseError} to a {@code String}
+   * different error type at a boundary (e.g., mapping a {@code ParseError} to a {@code String}
    * before reporting).
    *
    * <pre>{@code

--- a/core/src/main/java/io/github/eschizoid/telescope/Telescope.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/Telescope.java
@@ -116,7 +116,7 @@ public final class Telescope<S, A> {
    * @see #lens
    * @see #fromBean(Class)
    */
-  public static <S> Telescope<S, S> of(final Class<S> rootType) {
+  public static <S> Telescope<S, S> of(@SuppressWarnings("unused") final Class<S> rootType) {
     return new Telescope<>(Iso.identity());
   }
 
@@ -194,7 +194,7 @@ public final class Telescope<S, A> {
    * POJO&harr;record or POJO&harr;POJO <em>conversion</em>, use {@link #fromBean(Class)} / {@link
    * #mapBean(Class)}.
    */
-  public static <P> Telescope<P, P> ofBean(final Class<P> pojoClass) {
+  public static <P> Telescope<P, P> ofBean(@SuppressWarnings("unused") final Class<P> pojoClass) {
     return new Telescope<>(Iso.identity(), BeanFieldOptics.INSTANCE);
   }
 
@@ -253,7 +253,7 @@ public final class Telescope<S, A> {
    * @see #map(Class)
    * @see #fromBean(Class)
    */
-  public static <A> From<A> from(final Class<A> source) {
+  public static <A> From<A> from(@SuppressWarnings("unused") final Class<A> source) {
     return new From<>();
   }
 
@@ -383,7 +383,7 @@ public final class Telescope<S, A> {
    * import static io.github.eschizoid.telescope.Mapping.auto;
    *
    * final Telescope<UserEntity, UserDto> userMapper = Telescope.map(
-   *     to (UserEntity::name,    UserDto::fullName),                   // rename, same type
+   *     to(UserEntity::name,    UserDto::fullName),                    // rename, same type
    *     via(UserEntity::address, UserDto::address, addressMapper),     // nested mapper
    *     auto());                                                       // backfill same-name fields
    * }</pre>
@@ -407,18 +407,9 @@ public final class Telescope<S, A> {
    * @see #all(Edit[])
    */
   @SafeVarargs
+  @SuppressWarnings("varargs") // mapInternal receives the array as-is; no heap pollution risk.
   public static <A, B> Telescope<A, B> map(final Mapping<A, B>... mappings) {
-    Class<A> source = null;
-    Class<B> target = null;
-    for (final var m : mappings) {
-      if (source == null) source = m.sourceClass();
-      if (target == null) target = m.targetClass();
-      if (source != null && target != null) break;
-    }
-    if (source == null || target == null) throw classInferenceFailure(mappings.length);
-    final var mb = new MapBuilder<>(source, target);
-    for (final var m : mappings) m.apply(mb);
-    return mb.build();
+    return mapInternal(mappings).build();
   }
 
   /**
@@ -432,7 +423,15 @@ public final class Telescope<S, A> {
    * @see #map(Mapping[])
    */
   @SafeVarargs
+  @SuppressWarnings("varargs") // mapInternal receives the array as-is; no heap pollution risk.
   public static <A, B> Mapper<A, B> mapper(final Mapping<A, B>... mappings) {
+    return mapInternal(mappings).buildMapper();
+  }
+
+  // Recover source/target classes from the first row that carries them and apply every row onto a
+  // fresh MapBuilder. Non-varargs receiver — both @SafeVarargs entries (map, mapper) hand off the
+  // existing array; the only thing that differs between them is the terminal build vs buildMapper.
+  private static <A, B> MapBuilder<A, B> mapInternal(final Mapping<A, B>[] mappings) {
     Class<A> source = null;
     Class<B> target = null;
     for (final var m : mappings) {
@@ -440,22 +439,14 @@ public final class Telescope<S, A> {
       if (target == null) target = m.targetClass();
       if (source != null && target != null) break;
     }
-    if (source == null || target == null) throw classInferenceFailure(mappings.length);
+    if (source == null || target == null) throw new IllegalArgumentException(
+      "Telescope.map(Mapping<A, B>...) / Telescope.mapper(...) needs at least one row that carries " +
+        "the source/target classes (a to(...) or via(...) row, or auto(A.class, B.class)). " +
+        (mappings.length == 0 ? "No rows were passed." : "Got " + mappings.length + " bare auto() row(s).")
+    );
     final var mb = new MapBuilder<>(source, target);
     for (final var m : mappings) m.apply(mb);
-    return mb.buildMapper();
-  }
-
-  // Thrown by Telescope.map / Telescope.mapper when every row is auto() with no explicit
-  // source/target classes for the factory to recover via SerializedLambda. Used in both entries so
-  // the message stays consistent.
-  private static IllegalArgumentException classInferenceFailure(final int rowCount) {
-    return new IllegalArgumentException(
-      "Telescope.map(Mapping<A, B>...) needs at least one row that carries the source/target " +
-        "classes (a to(...) or via(...) row, or auto(A.class, B.class)). Got " +
-        rowCount +
-        " row(s), all auto() with no explicit classes."
-    );
+    return mb;
   }
 
   /**
@@ -520,7 +511,7 @@ public final class Telescope<S, A> {
    * <p>For a fully compile-checked path, use {@link #field(Accessor)} (e.g. {@code
    * .field(User::email)}) or the {@code @Focus} annotation processor.
    */
-  public <B> Telescope<S, B> fieldByName(final String fieldName, final Class<B> fieldType) {
+  public <B> Telescope<S, B> fieldByName(final String fieldName, @SuppressWarnings("unused") final Class<B> fieldType) {
     return fieldByName(fieldName);
   }
 
@@ -1056,7 +1047,7 @@ public final class Telescope<S, A> {
    * @see #updateEither
    */
   public <E> Validated<E, S> updateValidated(final S source, final Function<? super A, ? extends Validated<E, A>> fn) {
-    return ValidatedK.unbox(optic.modifyF(ValidatedK.<E>forError(), source, a -> ValidatedK.box(fn.apply(a))));
+    return ValidatedK.unbox(optic.modifyF(ValidatedK.forError(), source, a -> ValidatedK.box(fn.apply(a))));
   }
 
   /**
@@ -1069,7 +1060,7 @@ public final class Telescope<S, A> {
    * @see #updateValidated
    */
   public <E> Either<E, S> updateEither(final S source, final Function<? super A, ? extends Either<E, A>> fn) {
-    return EitherK.unbox(optic.modifyF(EitherK.<E>forLeft(), source, a -> EitherK.box(fn.apply(a))));
+    return EitherK.unbox(optic.modifyF(EitherK.forLeft(), source, a -> EitherK.box(fn.apply(a))));
   }
 
   /**
@@ -1140,7 +1131,7 @@ public final class Telescope<S, A> {
   // Package-private — shared with the conversion-builder classes (BeanTo, MapBuilder,
   // FieldMapping, Mapper) which live in sibling files in this same package.
   static String methodNameOf(final Serializable lambda) {
-    return METHOD_NAME_CACHE.computeIfAbsent(lambda.getClass(), cls -> resolveMethodName(lambda));
+    return METHOD_NAME_CACHE.computeIfAbsent(lambda.getClass(), _ -> resolveMethodName(lambda));
   }
 
   private static String resolveMethodName(final Serializable lambda) {
@@ -1162,13 +1153,18 @@ public final class Telescope<S, A> {
   // class of a method-reference accessor (e.g. UserEntity.class from UserEntity::name) via
   // SerializedLambda. Records can't extend other types, so for record accessors the declaring class
   // is always the receiver type; for beans, a method inherited from a superclass returns the
-  // superclass — callers that need the receiver type must obtain it some other way.
+  // superclass — callers that need the receiver type must obtain it some other way. Lambdas
+  // (a -> a.x()) are rejected the same way methodNameOf rejects them: a lambda's implClass is the
+  // enclosing class (not the receiver), which silently breaks Mapping class inference.
   @SuppressWarnings("unchecked")
   static <A> Class<A> implClassOf(final Serializable lambda) {
     try {
       final var writeReplace = lambda.getClass().getDeclaredMethod("writeReplace");
       writeReplace.setAccessible(true);
       final var serialized = (SerializedLambda) writeReplace.invoke(lambda);
+      if (serialized.getImplMethodName().startsWith("lambda$")) throw new IllegalArgumentException(
+        "expected a method reference (e.g. UserEntity::name); got a lambda: " + serialized.getImplMethodName()
+      );
       return (Class<A>) Class.forName(serialized.getImplClass().replace('/', '.'));
     } catch (final ReflectiveOperationException e) {
       throw new IllegalArgumentException("expected a method reference; got: " + lambda, e);

--- a/core/src/main/java/io/github/eschizoid/telescope/To.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/To.java
@@ -5,7 +5,7 @@ import java.util.function.Function;
 
 /**
  * Intermediate of {@link From#to(Class)} — call {@link #using(Function, Function)} to supply both
- * directions of the conversion and materialise the resulting {@code Telescope<A, B>}.
+ * directions of the conversion and materialize the resulting {@code Telescope<A, B>}.
  */
 public final class To<A, B> {
 

--- a/core/src/main/java/io/github/eschizoid/telescope/Validated.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/Validated.java
@@ -150,7 +150,7 @@ public sealed interface Validated<E, A> {
    */
   default <T> Validated<T, A> mapErrors(final Function<? super E, ? extends T> f) {
     return switch (this) {
-      case Invalid<E, A> inv -> new Invalid<>(inv.errors().stream().<T>map(f::apply).toList());
+      case Invalid<E, A> inv -> new Invalid<>(inv.errors().stream().<T>map(f).toList());
       case Valid<E, A> v -> new Valid<>(v.value());
     };
   }

--- a/core/src/main/java/io/github/eschizoid/telescope/internal/Beans.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/internal/Beans.java
@@ -172,8 +172,8 @@ public final class Beans {
    * static {@code builder()}, then a no-arg constructor with setters, then a no-arg constructor
    * with field injection. Used by the record-less POJO APIs ({@code Telescope.ofBean} / {@code
    * mapBean}) where there is no canonical component order, so the positional {@link
-   * #constructorWriter} is not a candidate. Throws if none applies (e.g. an immutable all-args-only
-   * POJO).
+   * #constructorWriter} is not a candidate. Throws if none applies (e.g., an immutable
+   * all-args-only POJO).
    */
   public static <P> BeanWriter<P> autoWriter(final Class<P> cls) {
     if (hasStaticBuilder(cls)) return builderWriter(cls);

--- a/core/src/main/java/io/github/eschizoid/telescope/internal/Records.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/internal/Records.java
@@ -30,7 +30,7 @@ public final class Records {
   /**
    * A {@link Lens} over a record component, identified by name. The {@code get} reads the
    * component; {@code set}/{@code modify} return a copy of the record with that one part replaced.
-   * Backs {@link io.github.eschizoid.telescope.Telescope}'s {@code .field(String)} overload.
+   * Backs {@link io.github.eschizoid.telescope.Telescope}'s {@code .fieldByName(String)} overload.
    *
    * <pre>{@code
    * record User(String name, int age) {}

--- a/core/src/main/java/io/github/eschizoid/telescope/internal/Records.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/internal/Records.java
@@ -29,9 +29,8 @@ public final class Records {
 
   /**
    * A {@link Lens} over a record component, identified by name. The {@code get} reads the
-   * component; {@code set}/{@code modify} return a copy of the record with that one component
-   * replaced. Backs {@link io.github.eschizoid.telescope.Telescope}'s {@code .field(String)}
-   * overload.
+   * component; {@code set}/{@code modify} return a copy of the record with that one part replaced.
+   * Backs {@link io.github.eschizoid.telescope.Telescope}'s {@code .field(String)} overload.
    *
    * <pre>{@code
    * record User(String name, int age) {}
@@ -90,9 +89,9 @@ public final class Records {
   }
 
   /**
-   * Return a copy of {@code source} with one component replaced by {@code value}; all other
-   * components carry over. Returns {@code null} for a {@code null} source; throws "Not a record"
-   * for a non-record, "No field" for an unknown name.
+   * Return a copy of {@code source} with one part replaced by {@code value}; all other components
+   * carry over. Returns {@code null} for a {@code null} source; throws "Not a record" for a
+   * non-record, "No field" for an unknown name.
    *
    * <pre>{@code
    * record User(String name, int age) {}

--- a/core/src/test/java/io/github/eschizoid/telescope/MappingVarargsTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/MappingVarargsTest.java
@@ -4,7 +4,6 @@ import static io.github.eschizoid.telescope.Mapping.auto;
 import static io.github.eschizoid.telescope.Mapping.to;
 import static io.github.eschizoid.telescope.Mapping.via;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.DisplayName;
@@ -109,9 +108,20 @@ class MappingVarargsTest {
     }
 
     @Test
-    @DisplayName("Telescope.map() with no rows at all throws IAE")
+    @DisplayName("Telescope.map() with no rows at all says \"No rows were passed\"")
     void zeroRowsFails() {
-      assertThrows(IllegalArgumentException.class, () -> Telescope.<SameA, SameB>map());
+      final var ex = assertThrows(IllegalArgumentException.class, () -> Telescope.<SameA, SameB>map());
+      assertEquals(true, ex.getMessage().contains("No rows were passed"));
+    }
+
+    @Test
+    @DisplayName("a lambda passed to to(...) is rejected at map(...) time (not silently misclassed)")
+    void lambdaInToIsRejected() {
+      // a -> a.x() is a lambda, not a method reference. Mapping.sourceClass() must throw via
+      // Telescope.implClassOf rather than silently returning the lambda's enclosing class.
+      final Telescope.Accessor<SameA, String> lambda = a -> a.x();
+      final Mapping<SameA, SameB> bad = to(lambda, SameB::x);
+      assertThrows(IllegalArgumentException.class, () -> Telescope.map(bad, auto()));
     }
   }
 
@@ -227,8 +237,8 @@ class MappingVarargsTest {
       final var dto = mapper.read(src);
       assertEquals("x", dto.x());
       assertEquals(7, dto.y());
-      // ADDR mapper above is constructed exactly the same way; the field roundtrips via its iso
-      assertSame(ADDR, ADDR);
+      // Reverse direction closes the bijection — the iso must round-trip identically.
+      assertEquals(src, mapper.backward(dto));
     }
   }
 }

--- a/core/src/test/java/io/github/eschizoid/telescope/MappingVarargsTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/MappingVarargsTest.java
@@ -5,6 +5,7 @@ import static io.github.eschizoid.telescope.Mapping.to;
 import static io.github.eschizoid.telescope.Mapping.via;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -104,18 +105,18 @@ class MappingVarargsTest {
     void pureBareAutoFails() {
       final Mapping<SameA, SameB> bare = auto();
       final var ex = assertThrows(IllegalArgumentException.class, () -> Telescope.map(bare));
-      assertEquals(true, ex.getMessage().contains("auto(A.class, B.class)"));
+      assertTrue(ex.getMessage().contains("auto(A.class, B.class)"), ex.getMessage());
     }
 
     @Test
     @DisplayName("Telescope.map() with no rows at all says \"No rows were passed\"")
     void zeroRowsFails() {
       final var ex = assertThrows(IllegalArgumentException.class, () -> Telescope.<SameA, SameB>map());
-      assertEquals(true, ex.getMessage().contains("No rows were passed"));
+      assertTrue(ex.getMessage().contains("No rows were passed"), ex.getMessage());
     }
 
     @Test
-    @DisplayName("a lambda passed to to(...) is rejected at map(...) time (not silently misclassed)")
+    @DisplayName("a lambda passed to to(...) is rejected at map(...) time (not silently misclassified)")
     void lambdaInToIsRejected() {
       // a -> a.x() is a lambda, not a method reference. Mapping.sourceClass() must throw via
       // Telescope.implClassOf rather than silently returning the lambda's enclosing class.


### PR DESCRIPTION
## Summary

Mostly cosmetic cleanup of the IntelliJ "Problems" panel on `Telescope.java`, plus one user-visible behavior change called out below.

- `@SuppressWarnings("unused")` on the four inference-only `Class<T>` factories — `Telescope.of`, `ofBean`, `from`, `fieldByName(String, Class<B>)`. The Class arg is documented as inference sugar; the runtime never reads it.
- Rename unused lambda arg `cls ->` to `_ ->` in `methodNameOf` (Java 22+ unnamed lambda parameter).
- Extract `mapInternal` helper to deduplicate the class-recovery + apply loop shared between `Telescope.map(Mapping<A,B>...)` and `Telescope.mapper(...)`. `@SafeVarargs` + `@SuppressWarnings("varargs")` at the call site silence the remaining heap-pollution lint (the array hands off unchanged).
- Drop redundant explicit `<E>` type arguments in `updateValidated` / `updateEither` (inferable from `forError()` / `forLeft()` return types).
- Stale javadoc reference fixed in `internal/Records.java`: `Telescope.field(String)` → `Telescope.fieldByName(String)`.
- Test assertions: `assertEquals(true, ...)` → `assertTrue(..., message)` for clearer failure output in `MappingVarargsTest`. "misclassed" typo → "misclassified" in a test display name.
- Incidental `spotlessApply` cosmetics on adjacent files (`e.g.` → `e.g.,`).

## Behavior change (user-visible)

**`Telescope.implClassOf(...)` now rejects lambdas the same way `methodNameOf` already did.** Previously, passing a lambda (e.g. `a -> a.x()`) where a method reference is expected — via `Mapping.to(lambda, ...)` — would silently return the lambda's enclosing class as the type-pair key, producing wrong class inference at construction time and hard-to-diagnose mapping failures. Now the lambda check fires immediately with a clear `IllegalArgumentException`. This is a bug fix, but it IS a behavior change: code that previously failed silently with bogus inference will now throw at `Telescope.map(...)` time. The new behavior is correct; the old behavior was a latent footgun.

## Test plan

- [x] `./gradlew :core:test` clean (all existing tests pass).
- [x] New `lambdaInToIsRejected` test pins the rejection behavior so the bug fix doesn't silently regress.