### PR TITLE
feat(core): writeBean hints + Set container + autoWriter ctor fallback + lattice/Beans test coverage

### DIFF
--- a/benchmarks/src/jmh/java/io/github/eschizoid/telescope/benchmarks/TelescopeBenchmark.java
+++ b/benchmarks/src/jmh/java/io/github/eschizoid/telescope/benchmarks/TelescopeBenchmark.java
@@ -252,15 +252,11 @@ public class TelescopeBenchmark {
     lensCity = companyDepartment.then(departmentAddress).then(addressCity);
 
     // (d) reflection-based record-to-record mapper (renames name -> fullName across the boundary).
-    userMapper = Telescope.map(UserEntity.class)
-      .to(UserDto.class)
-      .field(UserEntity::id)
-      .to(UserDto::id)
-      .field(UserEntity::email)
-      .to(UserDto::email)
-      .field(UserEntity::name)
-      .to(UserDto::fullName)
-      .build();
+    userMapper = Telescope.map(
+      UserEntity.class,
+      UserDto.class,
+      io.github.eschizoid.telescope.mapping.Mapping.to(UserEntity::name, UserDto::fullName)
+    );
 
     // POJO mirror of the record tree.
     final var addr = new AddressBean();
@@ -291,11 +287,11 @@ public class TelescopeBenchmark {
       .field(DepartmentBean::getAddress)
       .field(AddressBean::getCity);
 
-    // (f) POJO<->POJO conversion.
-    mapBeanConv = Telescope.mapBean(UserBeanA.class).to(UserBeanB.class).build();
+    // (f) POJO<->POJO conversion via the unified deep-map factory.
+    mapBeanConv = Telescope.map(UserBeanA.class, UserBeanB.class);
 
-    // (g) POJO->record bridge (forward read uses getters; viaFields picks the reverse strategy).
-    fromBeanConv = Telescope.fromBean(UserBeanA.class).to(UserEntity.class).viaFields();
+    // (g) POJO->record bridge via the unified deep-map factory.
+    fromBeanConv = Telescope.map(UserBeanA.class, UserEntity.class);
   }
 
   // ---- (a) deep-field update via reflection ----------------------------------------------------

--- a/core/src/main/java/io/github/eschizoid/telescope/Telescope.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/Telescope.java
@@ -15,7 +15,9 @@ import io.github.eschizoid.telescope.internal.optics.instances.EitherK;
 import io.github.eschizoid.telescope.internal.optics.instances.OptionalK;
 import io.github.eschizoid.telescope.internal.optics.instances.ValidatedK;
 import io.github.eschizoid.telescope.mapping.DeepMap;
+import io.github.eschizoid.telescope.mapping.MapStep;
 import io.github.eschizoid.telescope.mapping.Mapping;
+import io.github.eschizoid.telescope.mapping.WriteHint;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
@@ -223,7 +225,7 @@ public final class Telescope<S, A> {
    * that is always safe; with mutable POJOs the new and old object share those sub-objects, so
    * treat the shared parts as effectively immutable (don't mutate them afterward). For
    * POJO&harr;record or POJO&harr;POJO <em>conversion</em>, use {@link #map(Class, Class,
-   * io.github.eschizoid.telescope.mapping.Mapping[])} — the same deep recursive factory handles
+   * io.github.eschizoid.telescope.mapping.MapStep...)} — the same deep recursive factory handles
    * both kinds and any cross-paradigm mix.
    */
   public static <P> Telescope<P, P> ofBean(final Class<P> pojoClass) {
@@ -280,10 +282,10 @@ public final class Telescope<S, A> {
    *
    * <p>For a field-by-field declarative mapping between two records or POJOs (no hand-written
    * conversion functions), use {@link #map(Class, Class,
-   * io.github.eschizoid.telescope.mapping.Mapping[])} — it handles both record↔record, POJO↔POJO,
+   * io.github.eschizoid.telescope.mapping.MapStep...)} — it handles both record↔record, POJO↔POJO,
    * and any cross-paradigm mix at any depth.
    *
-   * @see #map(Class, Class, io.github.eschizoid.telescope.mapping.Mapping[])
+   * @see #map(Class, Class, io.github.eschizoid.telescope.mapping.MapStep...)
    */
   public static <A> From<A> from(final Class<A> source) {
     return new From<>();
@@ -292,12 +294,14 @@ public final class Telescope<S, A> {
   /**
    * Deep recursive mapping: pass the source/target root classes up front (either side may be a
    * record or a POJO — {@link io.github.eschizoid.telescope.internal.Reflective} dispatches per
-   * side), then varargs of overrides. Recursion does the rest — same-name components identity-map,
-   * nested records/POJOs recurse, {@code List<X>↔List<Y>} / {@code Map<K, X>↔Map<K, Y>} / {@code
-   * Optional<X>↔Optional<Y>} lift the inner Iso through the container automatically. Override rows
-   * are typed by their accessors and apply <em>wherever</em> recursion lands on the matching {@code
-   * (sourceClass, targetClass)} pair — a single {@code to(UserEntity::name, UserDto::fullName)} at
-   * the top of a multi-level mapping affects every User↔UserDto encounter in the tree.
+   * side), then varargs of {@link MapStep} rows. Recursion does the rest — same-name components
+   * identity-map, nested records/POJOs recurse, {@code List<X>↔List<Y>} / {@code Set<X>↔Set<Y>} /
+   * {@code Map<K, X>↔Map<K, Y>} / {@code Optional<X>↔Optional<Y>} lift the inner Iso through the
+   * container automatically. Containers nest to any depth ({@code List<Map<K, Set<X>>>} resolves by
+   * construction). Override rows are typed by their accessors and apply <em>wherever</em> recursion
+   * lands on the matching {@code (sourceClass, targetClass)} pair — a single {@code
+   * to(UserEntity::name, UserDto::fullName)} at the top of a multi-level mapping affects every
+   * User↔UserDto encounter in the tree.
    *
    * <pre>{@code
    * import static io.github.eschizoid.telescope.mapping.Mapping.to;
@@ -309,7 +313,7 @@ public final class Telescope<S, A> {
    * // Everything else — Address, nested Lists, Map values, Optional<User> — figures itself out.
    * }</pre>
    *
-   * <p><b>Same-name 1-liner.</b> No overrides means pure deep auto-recursion:
+   * <p><b>Same-name 1-liner.</b> No rows means pure deep auto-recursion:
    *
    * <pre>{@code
    * Telescope.map(UserEntity.class, UserDto.class);   // recurses; every component lines up by name
@@ -319,46 +323,43 @@ public final class Telescope<S, A> {
    * Optional<User>}) terminate naturally — the recursion caches the in-progress type pair and
    * re-uses it instead of descending infinitely.
    *
-   * <p><b>Override rows accepted.</b> {@link Mapping#to(Accessor, Accessor) to(src, tgt)}, {@link
-   * Mapping#to(Accessor, Accessor, java.util.function.Function, java.util.function.Function)
-   * to(src, tgt, fwd, bwd)}, {@link Mapping#via(Accessor, Accessor, Mapper) via(src, tgt, mapper)}.
-   * That's it — recursion handles every "auto" case, so no explicit auto row exists.
+   * <p><b>Row kinds accepted.</b>
+   *
+   * <ul>
+   *   <li>{@link Mapping#to(Accessor, Accessor) to(src, tgt)} — same-typed rename
+   *   <li>{@link Mapping#to(Accessor, Accessor, java.util.function.Function,
+   *       java.util.function.Function) to(src, tgt, fwd, bwd)} — typed transform
+   *   <li>{@link Mapping#via(Accessor, Accessor, Mapper) via(src, tgt, mapper)} — nested mapper
+   *   <li>{@link WriteHint#writeBean(Class, WriteHint.WriteStrategy) writeBean(target, strategy)} —
+   *       per-target write-strategy override (e.g. force {@code CONSTRUCTOR} for an immutable
+   *       all-args-only POJO that {@code Beans.autoWriter} refuses)
+   * </ul>
    *
    * @param source the source root class — record or POJO (root of the recursion)
    * @param target the target root class — record or POJO (root of the recursion)
-   * @param overrides rename / typed-transform / nested-mapper rows; applied wherever recursion
-   *     encounters their {@code (sourceClass, targetClass)} pair
+   * @param steps {@code Mapping} field overrides and/or {@code WriteHint} construction directives
    * @param <A> the source root type
    * @param <B> the target root type
-   * @see #mapper(Class, Class, Mapping[])
+   * @see #mapper(Class, Class, MapStep...)
    * @see Mapping
+   * @see WriteHint
    * @see DeepMap
    */
-  // No @SafeVarargs needed: Mapping<?, ?> is reifiable (wildcards), so this varargs method does
+  // No @SafeVarargs needed: MapStep is reifiable (no type parameter), so this varargs method does
   // not produce heap-pollution warnings for callers.
-  public static <A, B> Telescope<A, B> map(
-    final Class<A> source,
-    final Class<B> target,
-    final Mapping<?, ?>... overrides
-  ) {
-    return new Telescope<>(DeepMap.resolve(source, target, overrides));
+  public static <A, B> Telescope<A, B> map(final Class<A> source, final Class<B> target, final MapStep... steps) {
+    return new Telescope<>(DeepMap.resolve(source, target, steps));
   }
 
   /**
-   * {@link Mapper} sibling of {@link #map(Class, Class, Mapping[])} — same deep recursion, but
+   * {@link Mapper} sibling of {@link #map(Class, Class, MapStep...)} — same deep recursion, but
    * returns a {@code Mapper<A, B>} (exposes {@link Mapper#patch} for sparse overlays at the top
    * level and is nestable in another mapping via {@link Mapping#via(Accessor, Accessor, Mapper)}).
    *
-   * @see #map(Class, Class, Mapping[])
+   * @see #map(Class, Class, MapStep...)
    */
-  // No @SafeVarargs needed: Mapping<?, ?> is reifiable (wildcards), so this varargs method does
-  // not produce heap-pollution warnings for callers.
-  public static <A, B> Mapper<A, B> mapper(
-    final Class<A> source,
-    final Class<B> target,
-    final Mapping<?, ?>... overrides
-  ) {
-    return DeepMap.resolveMapper(source, target, overrides);
+  public static <A, B> Mapper<A, B> mapper(final Class<A> source, final Class<B> target, final MapStep... steps) {
+    return DeepMap.resolveMapper(source, target, steps);
   }
 
   /**
@@ -547,7 +548,7 @@ public final class Telescope<S, A> {
   /**
    * Compose this telescope with another via the lattice's {@code .then}. Lets you build a path in
    * pieces and stitch them together, and is how reusable conversions ({@link #from}, {@link
-   * #map(Class, Class, io.github.eschizoid.telescope.mapping.Mapping[])}) get threaded into a
+   * #map(Class, Class, io.github.eschizoid.telescope.mapping.MapStep...)}) get threaded into a
    * longer path.
    *
    * <pre>{@code

--- a/core/src/main/java/io/github/eschizoid/telescope/Telescope.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/Telescope.java
@@ -16,8 +16,6 @@ import io.github.eschizoid.telescope.internal.optics.instances.OptionalK;
 import io.github.eschizoid.telescope.internal.optics.instances.ValidatedK;
 import io.github.eschizoid.telescope.mapping.DeepMap;
 import io.github.eschizoid.telescope.mapping.MapStep;
-import io.github.eschizoid.telescope.mapping.Mapping;
-import io.github.eschizoid.telescope.mapping.WriteHint;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
@@ -326,13 +324,17 @@ public final class Telescope<S, A> {
    * <p><b>Row kinds accepted.</b>
    *
    * <ul>
-   *   <li>{@link Mapping#to(Accessor, Accessor) to(src, tgt)} — same-typed rename
-   *   <li>{@link Mapping#to(Accessor, Accessor, java.util.function.Function,
-   *       java.util.function.Function) to(src, tgt, fwd, bwd)} — typed transform
-   *   <li>{@link Mapping#via(Accessor, Accessor, Mapper) via(src, tgt, mapper)} — nested mapper
-   *   <li>{@link WriteHint#writeBean(Class, WriteHint.WriteStrategy) writeBean(target, strategy)} —
-   *       per-target write-strategy override (e.g. force {@code CONSTRUCTOR} for an immutable
-   *       all-args-only POJO that {@code Beans.autoWriter} refuses)
+   *   <li>{@link io.github.eschizoid.telescope.mapping.Mapping#to(Accessor, Accessor) to(src, tgt)}
+   *       — same-typed rename
+   *   <li>{@link io.github.eschizoid.telescope.mapping.Mapping#to(Accessor, Accessor,
+   *       java.util.function.Function, java.util.function.Function) to(src, tgt, fwd, bwd)} — typed
+   *       transform
+   *   <li>{@link io.github.eschizoid.telescope.mapping.Mapping#via(Accessor, Accessor, Mapper)
+   *       via(src, tgt, mapper)} — nested mapper
+   *   <li>{@link io.github.eschizoid.telescope.mapping.WriteHint#writeBean(Class,
+   *       io.github.eschizoid.telescope.mapping.WriteHint.WriteStrategy) writeBean(target,
+   *       strategy)} — per-target write-strategy override (e.g. force {@code CONSTRUCTOR} for an
+   *       immutable all-args-only POJO that {@code Beans.autoWriter} refuses)
    * </ul>
    *
    * @param source the source root class — record or POJO (root of the recursion)
@@ -341,8 +343,8 @@ public final class Telescope<S, A> {
    * @param <A> the source root type
    * @param <B> the target root type
    * @see #mapper(Class, Class, MapStep...)
-   * @see Mapping
-   * @see WriteHint
+   * @see io.github.eschizoid.telescope.mapping.Mapping
+   * @see io.github.eschizoid.telescope.mapping.WriteHint
    * @see DeepMap
    */
   // No @SafeVarargs needed: MapStep is reifiable (no type parameter), so this varargs method does
@@ -354,7 +356,8 @@ public final class Telescope<S, A> {
   /**
    * {@link Mapper} sibling of {@link #map(Class, Class, MapStep...)} — same deep recursion, but
    * returns a {@code Mapper<A, B>} (exposes {@link Mapper#patch} for sparse overlays at the top
-   * level and is nestable in another mapping via {@link Mapping#via(Accessor, Accessor, Mapper)}).
+   * level and is nestable in another mapping via {@link
+   * io.github.eschizoid.telescope.mapping.Mapping#via(Accessor, Accessor, Mapper)}).
    *
    * @see #map(Class, Class, MapStep...)
    */

--- a/core/src/main/java/io/github/eschizoid/telescope/annotations/Bridge.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/annotations/Bridge.java
@@ -29,7 +29,7 @@ import java.lang.annotation.Target;
  *
  * <p>This is the reflection-free, compile-checked counterpart to the runtime {@link
  * io.github.eschizoid.telescope.Telescope#map(Class, Class,
- * io.github.eschizoid.telescope.mapping.Mapping[])} — that single factory handles record↔record,
+ * io.github.eschizoid.telescope.mapping.MapStep...)} — that single factory handles record↔record,
  * POJO↔POJO, and POJO↔record at any depth. For renames or per-field transforms (which can't be
  * expressed in an annotation), use the runtime form instead.
  *
@@ -50,7 +50,7 @@ import java.lang.annotation.Target;
  * }</pre>
  *
  * @see io.github.eschizoid.telescope.Telescope#map(Class, Class,
- *     io.github.eschizoid.telescope.mapping.Mapping[])
+ *     io.github.eschizoid.telescope.mapping.MapStep...)
  */
 @Retention(RetentionPolicy.SOURCE)
 @Target(ElementType.TYPE)

--- a/core/src/main/java/io/github/eschizoid/telescope/annotations/package-info.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/annotations/package-info.java
@@ -13,7 +13,7 @@
  *   <li>{@link io.github.eschizoid.telescope.annotations.Bridge} — applied to a record to generate
  *       a reflection-free, compile-checked bridge to a sibling POJO; the runtime counterpart of the
  *       deep recursive {@link io.github.eschizoid.telescope.Telescope#map(Class, Class,
- *       io.github.eschizoid.telescope.mapping.Mapping[])} factory.
+ *       io.github.eschizoid.telescope.mapping.MapStep...)} factory.
  * </ul>
  *
  * <p>The annotations themselves carry no runtime behavior — they are read by the {@code

--- a/core/src/main/java/io/github/eschizoid/telescope/conversion/Mapper.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/conversion/Mapper.java
@@ -9,7 +9,7 @@ import java.util.function.Function;
 
 /**
  * A bidirectional mapper produced by the deep recursive factory {@link Telescope#mapper(Class,
- * Class, io.github.eschizoid.telescope.mapping.Mapping[])}. Wraps an {@link Iso} for the
+ * Class, io.github.eschizoid.telescope.mapping.MapStep...)}. Wraps an {@link Iso} for the
  * forward/backward conversion and (optionally) a per-target-component patch table for sparse {@link
  * #patch} overlays.
  *

--- a/core/src/main/java/io/github/eschizoid/telescope/internal/Beans.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/internal/Beans.java
@@ -30,12 +30,19 @@ public final class Beans {
 
   private Beans() {}
 
-  private static final Map<Class<?>, Map<String, Method>> GETTERS = new ConcurrentHashMap<>();
   // ClassValue is the JDK-provided cache that genuinely permits class unloading: the entry is held
-  // off-heap from the Class, so a cached BeanWriter (which strongly references reflective members
-  // and therefore the Class itself) cannot prevent its key from becoming unreachable. WeakHashMap
+  // off-heap from the Class, so a cached value (which strongly references reflective members and
+  // therefore the Class itself) cannot prevent its key from becoming unreachable. WeakHashMap
   // wouldn't work here — its strong values would chain back to the weak key, keeping the entry
-  // alive. ClassValue is threadsafe by construction.
+  // alive. ClassValue is threadsafe by construction. Both the per-class getter map and the
+  // auto-writer use it for the same reason — keep classloader-unload behavior consistent.
+  private static final ClassValue<Map<String, Method>> GETTERS = new ClassValue<>() {
+    @Override
+    protected Map<String, Method> computeValue(final Class<?> type) {
+      return scanGetters(type);
+    }
+  };
+
   private static final ClassValue<BeanWriter<?>> AUTO_WRITER_CACHE = new ClassValue<>() {
     @Override
     protected BeanWriter<?> computeValue(final Class<?> type) {
@@ -87,7 +94,7 @@ public final class Beans {
   }
 
   private static Map<String, Method> getters(final Class<?> cls) {
-    return GETTERS.computeIfAbsent(cls, Beans::scanGetters);
+    return GETTERS.get(cls);
   }
 
   private static Map<String, Method> scanGetters(final Class<?> cls) {
@@ -213,6 +220,28 @@ public final class Beans {
   }
 
   private static <P> BeanWriter<P> computeAutoWriter(final Class<P> cls) {
+    // Each *Writer constructor still throws IllegalStateException with messages referencing the
+    // demolished fromBean(...).viaX() APIs (kept for source compatibility inside the writer
+    // classes). When autoWriter surfaces those at the public Telescope.map(...) layer, rewrite the
+    // message to point at the current API. The original exception becomes the cause.
+    try {
+      return computeAutoWriterUnsafe(cls);
+    } catch (final IllegalStateException e) {
+      final var msg = e.getMessage();
+      if (msg != null && msg.contains("fromBean")) throw new IllegalStateException(
+        "Auto write-strategy detection for " +
+          cls.getName() +
+          " selected a strategy whose underlying writer rejected the class: " +
+          msg.replaceAll("fromBean\\(\\.\\.\\.\\)\\.via(\\w+)\\(\\)", "writeBean(targetClass, $1)") +
+          " Either fix the class shape (add a builder() / no-arg ctor / etc.) or declare an explicit " +
+          "writeBean(targetClass, strategy) hint at the Telescope.map(...) call site.",
+        e
+      );
+      throw e;
+    }
+  }
+
+  private static <P> BeanWriter<P> computeAutoWriterUnsafe(final Class<P> cls) {
     if (hasStaticBuilder(cls)) return builderWriter(cls);
     if (hasNoArgConstructor(cls)) return hasAnySetter(cls) ? settersWriter(cls) : fieldsWriter(cls);
     final var props = propertyNames(cls);

--- a/core/src/main/java/io/github/eschizoid/telescope/internal/Beans.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/internal/Beans.java
@@ -7,8 +7,10 @@ import java.lang.reflect.Field;
 import java.lang.reflect.InaccessibleObjectException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.WeakHashMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 
@@ -31,6 +33,13 @@ public final class Beans {
   private Beans() {}
 
   private static final Map<Class<?>, Map<String, Method>> GETTERS = new ConcurrentHashMap<>();
+  // WeakHashMap so a long-running JVM with classloader churn (servlet containers, OSGi, JRebel)
+  // doesn't accumulate stale Class<?> keys keeping their loaders alive. Synchronized wrap because
+  // WeakHashMap is not threadsafe; the lookup/compute race is benign — both threads would compute
+  // an equivalent writer.
+  private static final Map<Class<?>, BeanWriter<?>> AUTO_WRITER_CACHE = Collections.synchronizedMap(
+    new WeakHashMap<>()
+  );
 
   /**
    * Read a bean property by name via its {@code getX()} / {@code isX()} accessor. Throws if no
@@ -185,21 +194,62 @@ public final class Beans {
   /**
    * Pick a <em>name-based</em> write strategy for {@code cls} by probing in priority order: a
    * static {@code builder()}, then a no-arg constructor with setters, then a no-arg constructor
-   * with field injection. Used by the record-less POJO APIs ({@code Telescope.ofBean} / {@code
-   * mapBean}) where there is no canonical component order, so the positional {@link
-   * #constructorWriter} is not a candidate. Throws if none applies (e.g., an immutable
-   * all-args-only POJO).
+   * with field injection, then — as a last resort — a single public all-args constructor (compiled
+   * with {@code -parameters} so its arguments can be matched by name without positional ambiguity).
+   * The result is cached per class.
+   *
+   * <p>Used by both the record-less POJO APIs ({@link
+   * io.github.eschizoid.telescope.Telescope#ofBean(Class) Telescope.ofBean}) and by the deep
+   * mapping path when no explicit {@code writeBean} hint applies. Throws if none of the strategies
+   * applies (e.g., an immutable all-args-only POJO compiled without {@code -parameters}); the
+   * recommended escape is to declare a {@code writeBean(target, CONSTRUCTOR)} hint at the {@code
+   * Telescope.map(...)} call site.
    */
+  @SuppressWarnings("unchecked")
   public static <P> BeanWriter<P> autoWriter(final Class<P> cls) {
+    final var cached = (BeanWriter<P>) AUTO_WRITER_CACHE.get(cls);
+    if (cached != null) return cached;
+    final var computed = computeAutoWriter(cls);
+    AUTO_WRITER_CACHE.put(cls, computed);
+    return computed;
+  }
+
+  private static <P> BeanWriter<P> computeAutoWriter(final Class<P> cls) {
     if (hasStaticBuilder(cls)) return builderWriter(cls);
     if (hasNoArgConstructor(cls)) return hasAnySetter(cls) ? settersWriter(cls) : fieldsWriter(cls);
+    final var props = propertyNames(cls);
+    final var sole = solePublicConstructor(cls, props.length);
+    // Refuse to silently use positional fallback: getter-iteration order is not guaranteed to match
+    // constructor parameter order. Requiring -parameters yields named matching and eliminates the
+    // silent-data-shuffle hazard the explicit writeBean(...) hint accepts.
+    if (sole != null && allParameterNamesPresent(sole)) return constructorWriter(cls, props.length);
     throw new IllegalStateException(
       "No name-based write strategy for " +
         cls.getName() +
-        " — needs a static builder(), a no-arg constructor with setters, or a no-arg constructor (field injection). " +
-        "Immutable all-args-only POJOs aren't supported by the auto path; use a record, or the " +
-        "fromBean(...).viaConstructor() bridge where the record gives a canonical parameter order."
+        " — needs a static builder(), a no-arg constructor with setters, a no-arg constructor (field injection), " +
+        "or exactly one public constructor whose arity matches the property count (" +
+        props.length +
+        ") and was compiled with -parameters. " +
+        "For ambiguous multi-constructor POJOs or classes compiled without -parameters, declare an explicit " +
+        "writeBean(targetClass, CONSTRUCTOR) hint at the Telescope.map(...) call site."
     );
+  }
+
+  private static <P> Constructor<P> solePublicConstructor(final Class<P> cls, final int arity) {
+    Constructor<P> found = null;
+    for (final var c : cls.getConstructors()) {
+      if (c.getParameterCount() != arity) continue;
+      if (found != null) return null; // ambiguous — auto path refuses
+      @SuppressWarnings("unchecked")
+      final var cast = (Constructor<P>) c;
+      found = cast;
+    }
+    return found;
+  }
+
+  private static boolean allParameterNamesPresent(final Constructor<?> ctor) {
+    for (final var p : ctor.getParameters()) if (!p.isNamePresent()) return false;
+    return true;
   }
 
   /**

--- a/core/src/main/java/io/github/eschizoid/telescope/internal/Beans.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/internal/Beans.java
@@ -7,10 +7,8 @@ import java.lang.reflect.Field;
 import java.lang.reflect.InaccessibleObjectException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.WeakHashMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 
@@ -33,13 +31,17 @@ public final class Beans {
   private Beans() {}
 
   private static final Map<Class<?>, Map<String, Method>> GETTERS = new ConcurrentHashMap<>();
-  // WeakHashMap so a long-running JVM with classloader churn (servlet containers, OSGi, JRebel)
-  // doesn't accumulate stale Class<?> keys keeping their loaders alive. Synchronized wrap because
-  // WeakHashMap is not threadsafe; the lookup/compute race is benign — both threads would compute
-  // an equivalent writer.
-  private static final Map<Class<?>, BeanWriter<?>> AUTO_WRITER_CACHE = Collections.synchronizedMap(
-    new WeakHashMap<>()
-  );
+  // ClassValue is the JDK-provided cache that genuinely permits class unloading: the entry is held
+  // off-heap from the Class, so a cached BeanWriter (which strongly references reflective members
+  // and therefore the Class itself) cannot prevent its key from becoming unreachable. WeakHashMap
+  // wouldn't work here — its strong values would chain back to the weak key, keeping the entry
+  // alive. ClassValue is threadsafe by construction.
+  private static final ClassValue<BeanWriter<?>> AUTO_WRITER_CACHE = new ClassValue<>() {
+    @Override
+    protected BeanWriter<?> computeValue(final Class<?> type) {
+      return computeAutoWriter(type);
+    }
+  };
 
   /**
    * Read a bean property by name via its {@code getX()} / {@code isX()} accessor. Throws if no
@@ -207,11 +209,7 @@ public final class Beans {
    */
   @SuppressWarnings("unchecked")
   public static <P> BeanWriter<P> autoWriter(final Class<P> cls) {
-    final var cached = (BeanWriter<P>) AUTO_WRITER_CACHE.get(cls);
-    if (cached != null) return cached;
-    final var computed = computeAutoWriter(cls);
-    AUTO_WRITER_CACHE.put(cls, computed);
-    return computed;
+    return (BeanWriter<P>) AUTO_WRITER_CACHE.get(cls);
   }
 
   private static <P> BeanWriter<P> computeAutoWriter(final Class<P> cls) {
@@ -221,17 +219,20 @@ public final class Beans {
     final var sole = solePublicConstructor(cls, props.length);
     // Refuse to silently use positional fallback: getter-iteration order is not guaranteed to match
     // constructor parameter order. Requiring -parameters yields named matching and eliminates the
-    // silent-data-shuffle hazard the explicit writeBean(...) hint accepts.
-    if (sole != null && allParameterNamesPresent(sole)) return constructorWriter(cls, props.length);
+    // silent-data-shuffle hazard the explicit writeBean(...) hint accepts. Also require every ctor
+    // parameter name to appear in the getter-derived property set — otherwise `getURL()` → property
+    // `"URL"` mismatched against a ctor parameter named `"url"` would silently pass null into the
+    // constructor under the lookup `valueByName("url")`.
+    if (sole != null && allParameterNamesMatchProperties(sole, props)) return constructorWriter(cls, props.length);
     throw new IllegalStateException(
       "No name-based write strategy for " +
         cls.getName() +
         " — needs a static builder(), a no-arg constructor with setters, a no-arg constructor (field injection), " +
         "or exactly one public constructor whose arity matches the property count (" +
         props.length +
-        ") and was compiled with -parameters. " +
-        "For ambiguous multi-constructor POJOs or classes compiled without -parameters, declare an explicit " +
-        "writeBean(targetClass, CONSTRUCTOR) hint at the Telescope.map(...) call site."
+        "), was compiled with -parameters, and whose parameter names line up with the getter-derived properties. " +
+        "For ambiguous multi-constructor POJOs, classes compiled without -parameters, or constructor/getter " +
+        "name mismatches, declare an explicit writeBean(targetClass, CONSTRUCTOR) hint at the Telescope.map(...) call site."
     );
   }
 
@@ -247,8 +248,12 @@ public final class Beans {
     return found;
   }
 
-  private static boolean allParameterNamesPresent(final Constructor<?> ctor) {
-    for (final var p : ctor.getParameters()) if (!p.isNamePresent()) return false;
+  private static boolean allParameterNamesMatchProperties(final Constructor<?> ctor, final String[] propertyNames) {
+    final var props = new java.util.HashSet<>(java.util.Arrays.asList(propertyNames));
+    for (final var p : ctor.getParameters()) {
+      if (!p.isNamePresent()) return false;
+      if (!props.contains(p.getName())) return false;
+    }
     return true;
   }
 

--- a/core/src/main/java/io/github/eschizoid/telescope/internal/Beans.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/internal/Beans.java
@@ -231,21 +231,34 @@ public final class Beans {
         "or exactly one public constructor whose arity matches the property count (" +
         props.length +
         "), was compiled with -parameters, and whose parameter names line up with the getter-derived properties. " +
-        "For ambiguous multi-constructor POJOs, classes compiled without -parameters, or constructor/getter " +
-        "name mismatches, declare an explicit writeBean(targetClass, CONSTRUCTOR) hint at the Telescope.map(...) call site."
+        "Primary fix: recompile the target class with javac -parameters so its constructor arguments can be " +
+        "matched by name. The writeBean(targetClass, CONSTRUCTOR) hint at the Telescope.map(...) call site is " +
+        "an escape hatch, but note it falls back to POSITIONAL argument matching when -parameters is absent — " +
+        "argument order is then the getter-discovery order (not a stable, user-defined canonical order), so " +
+        "the hint should still be paired with -parameters to be safe."
     );
   }
 
+  /**
+   * Probe for the unique public constructor of {@code arity}. Two passes so the probe matches what
+   * {@link ConstructorWriter} actually does: that writer scans {@code getDeclaredConstructors()}
+   * (any access) and throws on multiple matches. So a class with one public + one non-public ctor
+   * of the requested arity would survive a public-only check but blow up later when {@code
+   * ConstructorWriter} sees both. We refuse here in both cases — non-public same-arity sibling or
+   * multiple publics — so the auto path stays consistent with its delegate.
+   */
   private static <P> Constructor<P> solePublicConstructor(final Class<P> cls, final int arity) {
+    var declaredCount = 0;
+    for (final var c : cls.getDeclaredConstructors()) if (c.getParameterCount() == arity) declaredCount++;
+    if (declaredCount != 1) return null; // ambiguous declared-set, or zero matches
     Constructor<P> found = null;
     for (final var c : cls.getConstructors()) {
       if (c.getParameterCount() != arity) continue;
-      if (found != null) return null; // ambiguous — auto path refuses
       @SuppressWarnings("unchecked")
       final var cast = (Constructor<P>) c;
       found = cast;
     }
-    return found;
+    return found; // non-null only if the unique declared ctor of that arity is public
   }
 
   private static boolean allParameterNamesMatchProperties(final Constructor<?> ctor, final String[] propertyNames) {

--- a/core/src/main/java/io/github/eschizoid/telescope/internal/Reflective.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/internal/Reflective.java
@@ -83,7 +83,11 @@ public interface Reflective {
       @Override
       @SuppressWarnings({ "rawtypes", "unchecked" })
       public Object construct(final Class<?> cls, final Function<String, Object> valueByName) {
-        final var writer = (Beans.BeanWriter) hints.getOrDefault(cls, Beans.autoWriter((Class) cls));
+        // Lazy fallback — Beans.autoWriter may throw for classes that REQUIRE a hint (e.g.
+        // immutable all-args POJOs the auto path refuses). getOrDefault would eagerly evaluate
+        // the default and short-circuit the hint mechanism entirely.
+        final var hinted = (Beans.BeanWriter) hints.get(cls);
+        final var writer = hinted != null ? hinted : Beans.autoWriter((Class) cls);
         return writer.construct(Beans.propertyNames(cls), valueByName);
       }
 

--- a/core/src/main/java/io/github/eschizoid/telescope/internal/Reflective.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/internal/Reflective.java
@@ -1,6 +1,7 @@
 package io.github.eschizoid.telescope.internal;
 
 import java.lang.reflect.Type;
+import java.util.Map;
 import java.util.function.Function;
 
 /**
@@ -53,6 +54,44 @@ public interface Reflective {
    */
   static Reflective of(final Class<?> cls) {
     return cls.isRecord() ? RECORDS : BEANS;
+  }
+
+  /**
+   * Bean reflective that consults {@code hints} before falling back to {@link Beans#autoWriter}.
+   * Used by {@link io.github.eschizoid.telescope.mapping.DeepMap DeepMap} when the user supplies
+   * {@code writeBean(targetClass, strategy)} rows — the hint map is keyed on target class and
+   * provides a pre-instantiated {@link Beans.BeanWriter}, so eager construction has already
+   * validated strategy applicability.
+   */
+  static Reflective beansWithHints(final Map<Class<?>, Beans.BeanWriter<?>> hints) {
+    return new Reflective() {
+      @Override
+      public String[] names(final Class<?> cls) {
+        return Beans.propertyNames(cls);
+      }
+
+      @Override
+      public Type genericType(final Class<?> cls, final String name) {
+        return Beans.propertyType(cls, name);
+      }
+
+      @Override
+      public Object read(final Object value, final String name) {
+        return Beans.readProperty(value, name);
+      }
+
+      @Override
+      @SuppressWarnings({ "rawtypes", "unchecked" })
+      public Object construct(final Class<?> cls, final Function<String, Object> valueByName) {
+        final var writer = (Beans.BeanWriter) hints.getOrDefault(cls, Beans.autoWriter((Class) cls));
+        return writer.construct(Beans.propertyNames(cls), valueByName);
+      }
+
+      @Override
+      public String normalize(final String rawMethodName) {
+        return Beans.propertyOf(rawMethodName);
+      }
+    };
   }
 
   Reflective RECORDS = new Reflective() {

--- a/core/src/main/java/io/github/eschizoid/telescope/internal/Reflective.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/internal/Reflective.java
@@ -83,9 +83,10 @@ public interface Reflective {
       @Override
       @SuppressWarnings({ "rawtypes", "unchecked" })
       public Object construct(final Class<?> cls, final Function<String, Object> valueByName) {
-        // Lazy fallback — Beans.autoWriter may throw for classes that REQUIRE a hint (e.g.
-        // immutable all-args POJOs the auto path refuses). getOrDefault would eagerly evaluate
-        // the default and short-circuit the hint mechanism entirely.
+        // Lazy fallback — Beans.autoWriter may throw for classes the auto path refuses (ambiguous
+        // multi-ctor POJOs, classes compiled without -parameters, or ctor/getter name mismatches);
+        // when a hint exists it MUST win, otherwise autoWriter's pre-emptive throw would defeat the
+        // hint mechanism. getOrDefault would eagerly evaluate the default and short-circuit it.
         final var hinted = (Beans.BeanWriter) hints.get(cls);
         final var writer = hinted != null ? hinted : Beans.autoWriter((Class) cls);
         return writer.construct(Beans.propertyNames(cls), valueByName);

--- a/core/src/main/java/io/github/eschizoid/telescope/internal/optics/Iso.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/internal/optics/Iso.java
@@ -1,9 +1,12 @@
 package io.github.eschizoid.telescope.internal.optics;
 
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -111,8 +114,8 @@ public interface Iso<A, B> extends Lens<A, B>, Prism<A, B> {
    */
   static <X, Y> Iso<List<X>, List<Y>> liftList(final Iso<X, Y> element) {
     return of(
-      xs -> xs == null ? null : xs.stream().map(element::to).collect(Collectors.toList()),
-      ys -> ys == null ? null : ys.stream().map(element::from).collect(Collectors.toList())
+      xs -> xs == null ? null : xs.stream().map(element::to).collect(Collectors.toCollection(ArrayList::new)),
+      ys -> ys == null ? null : ys.stream().map(element::from).collect(Collectors.toCollection(ArrayList::new))
     );
   }
 
@@ -124,6 +127,24 @@ public interface Iso<A, B> extends Lens<A, B>, Prism<A, B> {
    */
   static <X, Y> Iso<Optional<X>, Optional<Y>> liftOptional(final Iso<X, Y> element) {
     return of(ox -> ox == null ? null : ox.map(element::to), oy -> oy == null ? null : oy.map(element::from));
+  }
+
+  /**
+   * Lift an element-level {@code Iso<X, Y>} into a {@code Set}-level {@code Iso<Set<X>, Set<Y>>}.
+   * Output is a {@link LinkedHashSet} preserving forward-pass iteration order. A {@code null} set
+   * round-trips to {@code null}.
+   *
+   * <p><b>Lawfulness caveat.</b> Set semantics are non-injective for element types whose {@code
+   * equals} collapses distinct values (e.g. {@code Set<Optional<X>>} where every {@code
+   * Optional.empty()} compares equal). Round-trip equality holds under {@code Set.equals} on the
+   * resulting set, not on the multiset of source elements. Use {@link #liftList} when element
+   * identity must survive.
+   */
+  static <X, Y> Iso<Set<X>, Set<Y>> liftSet(final Iso<X, Y> element) {
+    return of(
+      xs -> xs == null ? null : xs.stream().map(element::to).collect(Collectors.toCollection(LinkedHashSet::new)),
+      ys -> ys == null ? null : ys.stream().map(element::from).collect(Collectors.toCollection(LinkedHashSet::new))
+    );
   }
 
   /**

--- a/core/src/main/java/io/github/eschizoid/telescope/mapping/DeepMap.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/mapping/DeepMap.java
@@ -23,9 +23,11 @@ import java.util.UUID;
  * Engine for {@link Telescope#map(Class, Class, MapStep...)} / {@link Telescope#mapper(Class,
  * Class, MapStep...)}. Walks the source/target structure pair-by-pair and caches an {@link Iso} per
  * {@code (sourceClass, targetClass)} pair encountered — same-named scalar components identity-link
- * via {@link Iso#identity()}, nested records/beans recurse, {@code List<X>↔List<Y>} / {@code Map<K,
- * X>↔Map<K, Y>} / {@code Optional<X>↔Optional<Y>} lift the inner element {@code Iso} through the
- * container via {@link Iso#liftList}, {@link Iso#liftOptional}, {@link Iso#liftMapValues}.
+ * via {@link Iso#identity()}, nested records/beans recurse, and same-kind container components
+ * ({@code List<X>↔List<Y>} / {@code Set<X>↔Set<Y>} / {@code Map<K, X>↔Map<K, Y>} / {@code
+ * Optional<X>↔Optional<Y>}) lift the inner element {@code Iso} through the container via {@link
+ * Iso#liftList}, {@link Iso#liftSet}, {@link Iso#liftMapValues}, {@link Iso#liftOptional}.
+ * Containers nest to any depth — the recursion peels one shape per pass and dispatches the rest.
  *
  * <p><b>Lattice-first.</b> The cache value is {@link Iso} directly — the lattice primitive. No
  * intermediate Object-typed plumbing, no parallel link tables. Per-record assembly composes
@@ -124,33 +126,48 @@ public final class DeepMap {
   @SuppressWarnings({ "unchecked", "rawtypes" })
   private static Beans.BeanWriter<?> writerFor(final WriteHint<?> hint) {
     final var cls = (Class) hint.targetClass();
-    return switch (hint.strategy()) {
-      case BUILDER -> Beans.builderWriter(cls);
-      case SETTERS -> Beans.settersWriter(cls);
-      case FIELDS -> Beans.fieldsWriter(cls);
-      case CONSTRUCTOR -> Beans.constructorWriter(cls, Beans.propertyNames(cls).length);
-    };
+    try {
+      return switch (hint.strategy()) {
+        case BUILDER -> Beans.builderWriter(cls);
+        case SETTERS -> Beans.settersWriter(cls);
+        case FIELDS -> Beans.fieldsWriter(cls);
+        case CONSTRUCTOR -> Beans.constructorWriter(cls, Beans.propertyNames(cls).length);
+      };
+    } catch (final IllegalStateException e) {
+      // The underlying *Writer constructors throw with messages that still reference the demolished
+      // fromBean(...).viaX() API surface. Rewrap with a writeBean(...)-shaped message so the user
+      // sees the actually-callable API in the error, keeping the original as the cause.
+      throw new IllegalStateException(
+        "writeBean(" + hint.targetClass().getName() + ", " + hint.strategy() + ") is not applicable: " + e.getMessage(),
+        e
+      );
+    }
   }
 
   /**
-   * Reject any {@code writeBean(...)} hint whose target class was never encountered as a target
-   * during recursion. Silently swallowed hints (typo in the class literal, refactored class) would
-   * mean the user believes they've forced a strategy but the default fires instead — catch that at
-   * resolve time rather than letting it slip into production.
+   * Reject any {@code writeBean(...)} hint whose target class was never encountered <em>on either
+   * side</em> of a resolved type pair. Source-side classes are constructed during {@code
+   * Mapper.backward} / {@code Iso.from}, so a hint on a bean source root (e.g. {@code map(Bean,
+   * Record, writeBean(Bean, ...))}) is genuinely used — it governs the backward direction. Silently
+   * swallowed hints (typo in the class literal, refactored class) still surface here at resolve
+   * time rather than slipping into production.
    */
   private static void validateAllHintsConsumed(
     final Map<Class<?>, Beans.BeanWriter<?>> hintMap,
     final Map<TypePair, Iso<?, ?>> cache
   ) {
     if (hintMap.isEmpty()) return;
-    final var seenTargets = new HashSet<Class<?>>();
-    for (final var pair : cache.keySet()) seenTargets.add(pair.target);
+    final var seen = new HashSet<Class<?>>();
+    for (final var pair : cache.keySet()) {
+      seen.add(pair.source);
+      seen.add(pair.target);
+    }
     final var unused = new ArrayList<String>();
-    for (final var hintCls : hintMap.keySet()) if (!seenTargets.contains(hintCls)) unused.add(hintCls.getName());
+    for (final var hintCls : hintMap.keySet()) if (!seen.contains(hintCls)) unused.add(hintCls.getName());
     if (!unused.isEmpty()) throw new IllegalArgumentException(
-      "Unused writeBean hints — targets never encountered during deep-mapping recursion: " +
+      "Unused writeBean hints — classes never encountered during deep-mapping recursion: " +
         String.join(", ", unused) +
-        ". Remove the row, or verify the class is actually reached by the source structure."
+        ". Remove the row, or verify the class is actually reached by the source/target structure."
     );
   }
 

--- a/core/src/main/java/io/github/eschizoid/telescope/mapping/DeepMap.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/mapping/DeepMap.java
@@ -2,10 +2,12 @@ package io.github.eschizoid.telescope.mapping;
 
 import io.github.eschizoid.telescope.Telescope;
 import io.github.eschizoid.telescope.conversion.Mapper;
+import io.github.eschizoid.telescope.internal.Beans;
 import io.github.eschizoid.telescope.internal.Reflective;
 import io.github.eschizoid.telescope.internal.optics.Iso;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.time.temporal.Temporal;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -14,13 +16,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 
 /**
- * Engine for {@link Telescope#map(Class, Class, Mapping[])} / {@link Telescope#mapper(Class, Class,
- * Mapping[])}. Walks the source/target structure pair-by-pair and caches an {@link Iso} per {@code
- * (sourceClass, targetClass)} pair encountered — same-named scalar components identity-link via
- * {@link Iso#identity()}, nested records/beans recurse, {@code List<X>↔List<Y>} / {@code Map<K,
+ * Engine for {@link Telescope#map(Class, Class, MapStep...)} / {@link Telescope#mapper(Class,
+ * Class, MapStep...)}. Walks the source/target structure pair-by-pair and caches an {@link Iso} per
+ * {@code (sourceClass, targetClass)} pair encountered — same-named scalar components identity-link
+ * via {@link Iso#identity()}, nested records/beans recurse, {@code List<X>↔List<Y>} / {@code Map<K,
  * X>↔Map<K, Y>} / {@code Optional<X>↔Optional<Y>} lift the inner element {@code Iso} through the
  * container via {@link Iso#liftList}, {@link Iso#liftOptional}, {@link Iso#liftMapValues}.
  *
@@ -48,20 +51,12 @@ public final class DeepMap {
   // ---------- Public entries (called from Telescope.map / Telescope.mapper) ----------
 
   @SuppressWarnings("exports") // Intentional: Iso is module-internal; consumed only by Telescope.
-  public static <A, B> Iso<A, B> resolve(
-    final Class<A> source,
-    final Class<B> target,
-    final Mapping<?, ?>[] overrides
-  ) {
-    return resolution(source, target, overrides).iso;
+  public static <A, B> Iso<A, B> resolve(final Class<A> source, final Class<B> target, final MapStep[] steps) {
+    return resolution(source, target, steps).iso;
   }
 
-  public static <A, B> Mapper<A, B> resolveMapper(
-    final Class<A> source,
-    final Class<B> target,
-    final Mapping<?, ?>[] overrides
-  ) {
-    final var r = resolution(source, target, overrides);
+  public static <A, B> Mapper<A, B> resolveMapper(final Class<A> source, final Class<B> target, final MapStep[] steps) {
+    final var r = resolution(source, target, steps);
     return new Mapper<>(r.iso, source, target, r.patchTable);
   }
 
@@ -71,18 +66,92 @@ public final class DeepMap {
   private static <A, B> Resolution<A, B> resolution(
     final Class<A> source,
     final Class<B> target,
-    final Mapping<?, ?>[] overrides
+    final MapStep[] steps
   ) {
-    final var overrideTable = groupOverridesByPair(overrides);
+    final var overrides = new ArrayList<Mapping<?, ?>>();
+    final var hints = new ArrayList<WriteHint<?>>();
+    for (final var step : steps) {
+      if (step instanceof Mapping<?, ?> m) overrides.add(m);
+      else if (step instanceof WriteHint<?> h) hints.add(h);
+    }
+    final var hintMap = buildHintMap(hints);
+    // One bean-side Reflective per resolution call: a singleton Reflective.BEANS when no hints
+    // exist, otherwise one hint-aware Reflective threaded through every recursion call so the
+    // anonymous instance isn't re-allocated per type pair.
+    final var beanRefl = hintMap.isEmpty() ? Reflective.BEANS : Reflective.beansWithHints(hintMap);
+    final var overrideTable = groupOverridesByPair(overrides.toArray(Mapping<?, ?>[]::new));
     final var cache = new HashMap<TypePair, Iso<?, ?>>();
     final var topSteps = new LinkedHashMap<String, FieldStep>();
-    populateIso(source, target, overrideTable, cache, topSteps);
+    populateIso(source, target, overrideTable, beanRefl, cache, topSteps);
+    validateAllHintsConsumed(hintMap, cache);
     final var iso = (Iso<A, B>) Objects.requireNonNull(cache.get(new TypePair(source, target)));
     final var patchTable = new LinkedHashMap<String, Mapper.PatchEntry>();
     topSteps.forEach((tgtName, step) ->
       patchTable.put(tgtName, new Mapper.PatchEntry(step.sourceName, v -> ((Iso<Object, Object>) step.iso).from(v)))
     );
     return new Resolution<>(iso, patchTable);
+  }
+
+  // ---------- Hint validation + writer eager construction ----------
+
+  /**
+   * Build the {@code targetClass -> BeanWriter} map from the hint list. Validates eagerly:
+   * duplicate-target hints, record-targeted hints, and incompatible strategies (e.g. {@code
+   * BUILDER} on a class with no static {@code builder()}) all throw at this point — so a
+   * misconfigured hint surfaces at {@code Telescope.map(...)} call time rather than at the first
+   * {@code iso.to()} invocation.
+   */
+  private static Map<Class<?>, Beans.BeanWriter<?>> buildHintMap(final List<WriteHint<?>> hints) {
+    final var map = new HashMap<Class<?>, Beans.BeanWriter<?>>();
+    for (final var hint : hints) {
+      final var cls = hint.targetClass();
+      if (cls.isRecord()) throw new IllegalArgumentException(
+        "writeBean hint targets a record class (" +
+          cls.getName() +
+          "). Records are always reconstructed via the canonical constructor; the hint cannot apply. " +
+          "Remove the writeBean(...) row, or move it to the bean side of the mapping."
+      );
+      if (map.containsKey(cls)) throw new IllegalArgumentException(
+        "Duplicate writeBean hint for " +
+          cls.getName() +
+          ". Each target class may declare at most one writeBean(...) row per Telescope.map(...) call."
+      );
+      map.put(cls, writerFor(hint));
+    }
+    return map;
+  }
+
+  @SuppressWarnings({ "unchecked", "rawtypes" })
+  private static Beans.BeanWriter<?> writerFor(final WriteHint<?> hint) {
+    final var cls = (Class) hint.targetClass();
+    return switch (hint.strategy()) {
+      case BUILDER -> Beans.builderWriter(cls);
+      case SETTERS -> Beans.settersWriter(cls);
+      case FIELDS -> Beans.fieldsWriter(cls);
+      case CONSTRUCTOR -> Beans.constructorWriter(cls, Beans.propertyNames(cls).length);
+    };
+  }
+
+  /**
+   * Reject any {@code writeBean(...)} hint whose target class was never encountered as a target
+   * during recursion. Silently swallowed hints (typo in the class literal, refactored class) would
+   * mean the user believes they've forced a strategy but the default fires instead — catch that at
+   * resolve time rather than letting it slip into production.
+   */
+  private static void validateAllHintsConsumed(
+    final Map<Class<?>, Beans.BeanWriter<?>> hintMap,
+    final Map<TypePair, Iso<?, ?>> cache
+  ) {
+    if (hintMap.isEmpty()) return;
+    final var seenTargets = new HashSet<Class<?>>();
+    for (final var pair : cache.keySet()) seenTargets.add(pair.target);
+    final var unused = new ArrayList<String>();
+    for (final var hintCls : hintMap.keySet()) if (!seenTargets.contains(hintCls)) unused.add(hintCls.getName());
+    if (!unused.isEmpty()) throw new IllegalArgumentException(
+      "Unused writeBean hints — targets never encountered during deep-mapping recursion: " +
+        String.join(", ", unused) +
+        ". Remove the row, or verify the class is actually reached by the source structure."
+    );
   }
 
   // ---------- Override grouping ----------
@@ -106,6 +175,7 @@ public final class DeepMap {
     final Class<S> source,
     final Class<T> target,
     final Map<TypePair, List<Mapping<?, ?>>> overrides,
+    final Reflective beanRefl,
     final Map<TypePair, Iso<?, ?>> cache,
     final Map<String, FieldStep> topStepsOut
   ) {
@@ -113,8 +183,8 @@ public final class DeepMap {
     if (cache.containsKey(key)) return;
     cache.put(key, null); // reserve slot so cycle-re-entry short-circuits
 
-    final var srcRefl = Reflective.of(source);
-    final var tgtRefl = Reflective.of(target);
+    final var srcRefl = pickReflective(source, beanRefl);
+    final var tgtRefl = pickReflective(target, beanRefl);
 
     final var byTargetName = new LinkedHashMap<String, FieldStep>();
     final var bySourceName = new LinkedHashMap<String, FieldStep>();
@@ -174,7 +244,7 @@ public final class DeepMap {
       final var step = new FieldStep(
         name,
         name,
-        autoIso(srcRefl.genericType(source, name), tgtRefl.genericType(target, name), name, overrides, cache)
+        autoIso(srcRefl.genericType(source, name), tgtRefl.genericType(target, name), name, overrides, beanRefl, cache)
       );
       byTargetName.put(name, step);
       bySourceName.put(name, step);
@@ -210,6 +280,7 @@ public final class DeepMap {
     final Type tgtType,
     final String componentName,
     final Map<TypePair, List<Mapping<?, ?>>> overrides,
+    final Reflective beanRefl,
     final Map<TypePair, Iso<?, ?>> cache
   ) {
     // (a) Same generic type → identity Iso.
@@ -218,7 +289,7 @@ public final class DeepMap {
     // (b) Both reflectable (record or bean) → recurse, return cache-reading Iso so cycles work.
     if (srcType instanceof Class<?> srcCls && tgtType instanceof Class<?> tgtCls) {
       if (isReflectable(srcCls) && isReflectable(tgtCls)) {
-        populateIso(srcCls, tgtCls, overrides, cache, null);
+        populateIso(srcCls, tgtCls, overrides, beanRefl, cache, null);
         return lazyCacheIso(cache, new TypePair(srcCls, tgtCls));
       }
     }
@@ -246,10 +317,12 @@ public final class DeepMap {
         tgtShape.elementType,
         componentName + "[*]",
         overrides,
+        beanRefl,
         cache
       );
       return switch (srcShape.kind) {
         case LIST -> Iso.liftList(eraseIso(elementIso));
+        case SET -> Iso.liftSet(eraseIso(elementIso));
         case MAP_VALUES -> Iso.liftMapValues(eraseIso(elementIso));
         case OPTIONAL -> Iso.liftOptional(eraseIso(elementIso));
       };
@@ -280,6 +353,16 @@ public final class DeepMap {
   }
 
   /**
+   * Pick the right {@link Reflective} for {@code cls}: records always go through {@link
+   * Reflective#RECORDS}; beans go through {@code beanRefl}, which is built once per {@link
+   * #resolution} call (a singleton {@link Reflective#BEANS} when no hints exist, otherwise a single
+   * hint-aware instance shared across the entire recursion).
+   */
+  private static Reflective pickReflective(final Class<?> cls, final Reflective beanRefl) {
+    return cls.isRecord() ? Reflective.RECORDS : beanRefl;
+  }
+
+  /**
    * "field" for records, "property" for beans — used in error messages to read correctly per side.
    */
   private static String slot(final Reflective refl) {
@@ -298,9 +381,8 @@ public final class DeepMap {
     if (CharSequence.class.isAssignableFrom(cls)) return false;
     if (Number.class.isAssignableFrom(cls)) return false;
     if (cls == Boolean.class || cls == Character.class) return false;
-    if (java.time.temporal.Temporal.class.isAssignableFrom(cls)) return false;
-    if (UUID.class.isAssignableFrom(cls)) return false;
-    return true;
+    if (Temporal.class.isAssignableFrom(cls)) return false;
+    return !UUID.class.isAssignableFrom(cls);
   }
 
   // ---------- Iso assembly ----------
@@ -363,7 +445,8 @@ public final class DeepMap {
   private record FieldStep(String sourceName, String targetName, Iso<?, ?> iso) {}
 
   /**
-   * Bundled return from {@link #resolution(Class, Class, Mapping[])} — the Iso and the patch table.
+   * Bundled return from {@link #resolution(Class, Class, MapStep...)} — the Iso and the patch
+   * table.
    */
   private record Resolution<A, B>(Iso<A, B> iso, Map<String, Mapper.PatchEntry> patchTable) {}
 
@@ -379,6 +462,7 @@ public final class DeepMap {
   private record ContainerShape(Kind kind, Type elementType, Class<?> keyClass) {
     enum Kind {
       LIST,
+      SET,
       MAP_VALUES,
       OPTIONAL,
     }
@@ -387,6 +471,7 @@ public final class DeepMap {
       if (!(t instanceof ParameterizedType pt)) return null;
       if (!(pt.getRawType() instanceof Class<?> raw)) return null;
       if (raw == List.class) return new ContainerShape(Kind.LIST, pt.getActualTypeArguments()[0], null);
+      if (raw == Set.class) return new ContainerShape(Kind.SET, pt.getActualTypeArguments()[0], null);
       if (raw == Optional.class) return new ContainerShape(Kind.OPTIONAL, pt.getActualTypeArguments()[0], null);
       if (raw == Map.class) {
         final var keyArg = pt.getActualTypeArguments()[0];

--- a/core/src/main/java/io/github/eschizoid/telescope/mapping/MapStep.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/mapping/MapStep.java
@@ -1,0 +1,15 @@
+package io.github.eschizoid.telescope.mapping;
+
+import io.github.eschizoid.telescope.Telescope;
+
+/**
+ * Marker for any row supplied to {@link Telescope#map(Class, Class, MapStep...)} / {@link
+ * Telescope#mapper(Class, Class, MapStep...)} — either a {@link Mapping} (field correspondence) or
+ * a {@link WriteHint} (per-target write-strategy override for the bean path).
+ *
+ * <p>Sealed to the two row kinds so the deep-mapping engine can partition a single varargs into
+ * field overrides and construction hints without runtime cost. Users never name this type — they
+ * static-import the factories on {@code Mapping} and {@code WriteHint} and the compiler upcasts
+ * each row to {@code MapStep} at the call site.
+ */
+public sealed interface MapStep permits Mapping, WriteHint {}

--- a/core/src/main/java/io/github/eschizoid/telescope/mapping/Mapping.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/mapping/Mapping.java
@@ -7,7 +7,7 @@ import io.github.eschizoid.telescope.conversion.Mapper;
 import java.util.function.Function;
 
 /**
- * One field correspondence in a {@link Telescope#map(Class, Class, Mapping[])} call — supplies an
+ * One field correspondence in a {@link Telescope#map(Class, Class, MapStep...)} call — supplies an
  * override for a specific {@code (sourceClass, targetClass)} type pair anywhere in the deep
  * recursive traversal. Build with the static factories ({@link #to}, {@link #via}) — intended to be
  * static-imported so the call site reads as a list of rows.
@@ -27,14 +27,14 @@ import java.util.function.Function;
  *
  * <p><b>Type-pair keying.</b> Each {@link #to to(srcAcc, tgtAcc)} / {@link #via via(srcAcc, tgtAcc,
  * mapper)} row carries the declaring classes of its accessors via {@code SerializedLambda}. {@link
- * Telescope#map(Class, Class, Mapping[])} keys overrides by {@code (sourceClass, targetClass)} so a
- * single row applies wherever the recursion lands on that pair — top level or N levels deep.
+ * Telescope#map(Class, Class, MapStep...)} keys overrides by {@code (sourceClass, targetClass)} so
+ * a single row applies wherever the recursion lands on that pair — top level or N levels deep.
  *
  * <p><b>Permitted impls.</b> Sealed over three package-private records in sibling files in this
  * package — {@link SameTypedTo}, {@link TypedTransformTo}, {@link Via}. Users construct via the
  * static factories below; the record types are not public API.
  */
-public sealed interface Mapping<A, B> permits SameTypedTo, TypedTransformTo, Via {
+public sealed interface Mapping<A, B> extends MapStep permits SameTypedTo, TypedTransformTo, Via {
   /** Same-typed correspondence: {@code src↔tgt}, both with leaf type {@code X}. Identity. */
   static <A, B, X> Mapping<A, B> to(final Accessor<A, X> src, final Accessor<B, X> tgt) {
     return new SameTypedTo<>(src, tgt);
@@ -73,8 +73,8 @@ public sealed interface Mapping<A, B> permits SameTypedTo, TypedTransformTo, Via
 
   /**
    * Source class this row keys against (the declaring class of {@code src}'s accessor, recovered
-   * via {@code SerializedLambda}). Used by {@link Telescope#map(Class, Class, Mapping[])} to decide
-   * which type pairs this override applies to.
+   * via {@code SerializedLambda}). Used by {@link Telescope#map(Class, Class, MapStep...)} to
+   * decide which type pairs this override applies to.
    */
   Class<A> sourceClass();
 

--- a/core/src/main/java/io/github/eschizoid/telescope/mapping/WriteHint.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/mapping/WriteHint.java
@@ -1,0 +1,81 @@
+package io.github.eschizoid.telescope.mapping;
+
+import io.github.eschizoid.telescope.Telescope;
+
+/**
+ * Per-target write-strategy override consumed by {@link Telescope#map(Class, Class, MapStep...)}.
+ * Tells the deep-mapping engine which {@code Beans.BeanWriter} strategy to use when constructing an
+ * instance of {@code B}, overriding the auto-detected strategy from {@code Beans.autoWriter}.
+ *
+ * <p>Closes the gap on immutable all-args-only POJOs (no builder, no no-arg constructor) by letting
+ * the user pin {@link WriteStrategy#CONSTRUCTOR}. Also useful when several strategies apply and the
+ * user wants to force a specific one (e.g., {@link WriteStrategy#FIELDS} over a class that also has
+ * a builder).
+ *
+ * <pre>{@code
+ * import static io.github.eschizoid.telescope.mapping.Mapping.to;
+ * import static io.github.eschizoid.telescope.mapping.WriteHint.writeBean;
+ * import static io.github.eschizoid.telescope.mapping.WriteHint.WriteStrategy.CONSTRUCTOR;
+ *
+ * final Telescope<OrderRecord, OrderPojo> conv = Telescope.map(
+ *     OrderRecord.class, OrderPojo.class,
+ *     writeBean(OrderPojo.class, CONSTRUCTOR),
+ *     to(OrderRecord::sku, OrderPojo::getSku));
+ * }</pre>
+ *
+ * <p><b>Direction of application.</b> The hint is keyed on the class. During recursion, the hint's
+ * writer is used whenever {@code targetClass} appears <em>as the bean side</em> of a constructed
+ * value — which is the target side during {@code Iso.to} and the source side during {@code
+ * Iso.from} ({@code Mapper.backward}, {@code Mapper.patch}). If you map {@code Foo → Foo} or {@code
+ * Foo} appears on both sides of a deep mapping, the single hint governs both directions — which is
+ * almost always the right behavior, since the bean's construction strategy is a property of the
+ * class, not of the direction.
+ *
+ * <p><b>Validation.</b> Hints are validated eagerly at {@code Telescope.map(...)} time:
+ *
+ * <ul>
+ *   <li>Hint target must not be a record (records always rebuild via the canonical constructor)
+ *   <li>No two hints may share the same target class
+ *   <li>The chosen strategy must be applicable to the target class (e.g., {@code BUILDER} requires
+ *       a static {@code builder()} method) — checked by instantiating the writer immediately
+ *   <li>Every hint's target class must be reached at least once during the deep recursion; unused
+ *       hints (typos, refactor stragglers) are reported rather than silently ignored
+ * </ul>
+ */
+public sealed interface WriteHint<B> extends MapStep permits WriteHint.BeanWriteHint {
+  /**
+   * The {@code Beans.BeanWriter} strategies available for explicit selection.
+   *
+   * <ul>
+   *   <li>{@link #BUILDER} — requires a static {@code builder()} method on the target
+   *   <li>{@link #SETTERS} — requires a no-arg constructor and public {@code setX(value)} setters
+   *   <li>{@link #FIELDS} — requires a no-arg constructor; injects values into declared fields
+   *       reflectively (needs {@code opens} under JPMS for private fields)
+   *   <li>{@link #CONSTRUCTOR} — uses the all-args constructor; matches arguments by parameter name
+   *       when compiled with {@code -parameters}, otherwise positional
+   * </ul>
+   */
+  enum WriteStrategy {
+    BUILDER,
+    SETTERS,
+    FIELDS,
+    CONSTRUCTOR,
+  }
+
+  /**
+   * Declare that {@code target} should be constructed via {@code strategy} during deep mapping,
+   * overriding the auto-detected choice.
+   */
+  static <B> WriteHint<B> writeBean(final Class<B> target, final WriteStrategy strategy) {
+    return new BeanWriteHint<>(target, strategy);
+  }
+
+  /** The target class this hint applies to — used to key the per-class strategy lookup. */
+  Class<B> targetClass();
+
+  /** The chosen write strategy for {@link #targetClass()}. */
+  WriteStrategy strategy();
+
+  /** Package-private record impl; users construct via {@link #writeBean}. */
+  record BeanWriteHint<B>(Class<B> targetClass, WriteStrategy strategy) implements WriteHint<B> {}
+}

--- a/core/src/main/java/io/github/eschizoid/telescope/package-info.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/package-info.java
@@ -40,7 +40,7 @@
  * <p>{@code .field(...)} navigation rebuilds via a record's canonical constructor or a bean's
  * auto-detected write strategy. The deep recursive mapping factory {@link
  * io.github.eschizoid.telescope.Telescope#map(Class, Class,
- * io.github.eschizoid.telescope.mapping.Mapping[])} handles record↔record, POJO↔POJO, and any
+ * io.github.eschizoid.telescope.mapping.MapStep...)} handles record↔record, POJO↔POJO, and any
  * cross-paradigm mix at any depth — the per-side {@code Reflective} is picked independently from
  * each class. The annotation {@link io.github.eschizoid.telescope.annotations.Bridge} is the
  * reflection-free, compile-checked counterpart (annotate the record to have the bridge generated

--- a/core/src/test/java/io/github/eschizoid/telescope/DeepMappingTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/DeepMappingTest.java
@@ -2,25 +2,33 @@ package io.github.eschizoid.telescope;
 
 import static io.github.eschizoid.telescope.mapping.Mapping.to;
 import static io.github.eschizoid.telescope.mapping.Mapping.via;
+import static io.github.eschizoid.telescope.mapping.WriteHint.WriteStrategy.BUILDER;
+import static io.github.eschizoid.telescope.mapping.WriteHint.WriteStrategy.CONSTRUCTOR;
+import static io.github.eschizoid.telescope.mapping.WriteHint.WriteStrategy.FIELDS;
+import static io.github.eschizoid.telescope.mapping.WriteHint.writeBean;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.github.eschizoid.telescope.conversion.Mapper;
-import io.github.eschizoid.telescope.mapping.Mapping;
+import io.github.eschizoid.telescope.mapping.MapStep;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 /**
- * Tests for the deep recursive {@link Telescope#map(Class, Class, Mapping[])} / {@link
- * Telescope#mapper(Class, Class, Mapping[])} factories — the "explore the academia boundaries"
+ * Tests for the deep recursive {@link Telescope#map(Class, Class, MapStep...)} / {@link
+ * Telescope#mapper(Class, Class, MapStep...)} factories — the "explore the academia boundaries"
  * shape. Each test exercises a different facet of the recursion: same-name copy, container
- * traversal at multiple depths, renames keyed by type pair applying at any depth, typed transforms,
- * nested mappers via {@code via}, and self-referencing structures (cycle handling).
+ * traversal at multiple depths (List, Set, Map, Optional — N-level nestable), renames keyed by type
+ * pair applying at any depth, typed transforms, nested mappers via {@code via}, per-target {@code
+ * writeBean} construction hints, and self-referencing structures (cycle handling).
  */
 class DeepMappingTest {
 
@@ -395,6 +403,297 @@ class DeepMappingTest {
         )
       );
       assertTrue(ex.getMessage().contains("duplicate"), ex.getMessage());
+    }
+  }
+
+  // ----- writeBean hint fixtures -----
+
+  // Immutable all-args POJO: no setters, no no-arg ctor, no builder. autoWriter without the new
+  // 4th rung would refuse; with the 4th rung (and -parameters compiled in) it auto-detects.
+  static final class ImmutablePojo {
+
+    private final String sku;
+    private final int qty;
+
+    public ImmutablePojo(final String sku, final int qty) {
+      this.sku = sku;
+      this.qty = qty;
+    }
+
+    public String getSku() {
+      return sku;
+    }
+
+    public int getQty() {
+      return qty;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+      return o instanceof ImmutablePojo p && Objects.equals(p.sku, sku) && p.qty == qty;
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(sku, qty);
+    }
+  }
+
+  record OrderRecord(String sku, int qty) {}
+
+  // A bean with both a builder AND a no-arg ctor + fields, so the precedence test
+  // (writeBean FIELDS over the autoWriter-chosen BUILDER) is observable.
+  static final class DualPojo {
+
+    private String name;
+    private int score;
+
+    public DualPojo() {}
+
+    public static Builder builder() {
+      return new Builder();
+    }
+
+    public String getName() {
+      return name;
+    }
+
+    public int getScore() {
+      return score;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+      return o instanceof DualPojo p && Objects.equals(p.name, name) && p.score == score;
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(name, score);
+    }
+
+    static final class Builder {
+
+      // Mark the builder path: the resulting DualPojo's name has "[built]" appended. The fields-
+      // strategy path bypasses this entirely, so a FIELDS-hinted mapping yields "alice" while a
+      // BUILDER-hinted (or autoWriter-default) mapping yields "alice[built]".
+      private String name;
+      private int score;
+
+      public Builder name(final String n) {
+        this.name = n + "[built]";
+        return this;
+      }
+
+      public Builder score(final int s) {
+        this.score = s;
+        return this;
+      }
+
+      public DualPojo build() {
+        final var p = new DualPojo();
+        p.name = name;
+        p.score = score;
+        return p;
+      }
+    }
+  }
+
+  record DualRecord(String name, int score) {}
+
+  // POJO with no builder, no no-arg ctor, and TWO public constructors of matching arity →
+  // autoWriter
+  // CTOR fallback must refuse (ambiguous). With an explicit writeBean(...) hint it could be made to
+  // work — but the simpler test is that autoWriter refuses cleanly without a hint.
+  static final class AmbiguousCtorPojo {
+
+    private final String a;
+    private final String b;
+
+    public AmbiguousCtorPojo(final String a, final String b) {
+      this.a = a;
+      this.b = b;
+    }
+
+    // Decoy ctor of the same arity — auto fallback must reject.
+    public AmbiguousCtorPojo(final String a, final Integer ignoredSentinel) {
+      this.a = a;
+      this.b = String.valueOf(ignoredSentinel);
+    }
+
+    public String getA() {
+      return a;
+    }
+
+    public String getB() {
+      return b;
+    }
+  }
+
+  record AmbiguousRecord(String a, String b) {}
+
+  @Nested
+  @DisplayName("writeBean hints — explicit per-target construction strategy")
+  class WriteHints {
+
+    @Test
+    @DisplayName("CONSTRUCTOR hint constructs an immutable all-args-only POJO round-trip")
+    void constructorHintForImmutablePojo() {
+      final var mapper = Telescope.mapper(
+        OrderRecord.class,
+        ImmutablePojo.class,
+        writeBean(ImmutablePojo.class, CONSTRUCTOR)
+      );
+      final var src = new OrderRecord("SKU-1", 42);
+      final var pojo = mapper.read(src);
+      assertEquals("SKU-1", pojo.getSku());
+      assertEquals(42, pojo.getQty());
+      assertEquals(src, mapper.backward(pojo));
+    }
+
+    @Test
+    @DisplayName("autoWriter constructor fallback handles a same-arity unambiguous immutable POJO without a hint")
+    void autoWriterConstructorFallback() {
+      // No writeBean hint — the new 4th rung in Beans.autoWriter picks ConstructorWriter on its own
+      // because ImmutablePojo has exactly one public 2-arg ctor compiled with -parameters.
+      final var mapper = Telescope.mapper(OrderRecord.class, ImmutablePojo.class);
+      final var pojo = mapper.read(new OrderRecord("SKU-2", 7));
+      assertEquals("SKU-2", pojo.getSku());
+      assertEquals(7, pojo.getQty());
+    }
+
+    @Test
+    @DisplayName("FIELDS hint wins over autoWriter when target also has a builder")
+    void fieldsHintWinsOverBuilder() {
+      // DualPojo has BOTH a builder() (autoWriter would pick BuilderWriter) and writable fields.
+      // The FIELDS hint must bypass the builder entirely — observable because the builder mutates
+      // the name (appends "[built]"), so a fields path yields the raw value.
+      final var mapper = Telescope.mapper(DualRecord.class, DualPojo.class, writeBean(DualPojo.class, FIELDS));
+      final var pojo = mapper.read(new DualRecord("alice", 9));
+      assertEquals("alice", pojo.getName()); // not "alice[built]"
+      assertEquals(9, pojo.getScore());
+    }
+
+    @Test
+    @DisplayName("record-class hint is rejected at resolve time with a descriptive message")
+    void recordClassHintRejected() {
+      final var ex = assertThrows(IllegalArgumentException.class, () ->
+        Telescope.map(ImmutablePojo.class, OrderRecord.class, writeBean(OrderRecord.class, CONSTRUCTOR))
+      );
+      assertTrue(ex.getMessage().contains("record"), ex.getMessage());
+    }
+
+    @Test
+    @DisplayName("duplicate hints for the same target class are rejected at resolve time")
+    void duplicateHintsRejected() {
+      final var ex = assertThrows(IllegalArgumentException.class, () ->
+        Telescope.map(
+          OrderRecord.class,
+          ImmutablePojo.class,
+          writeBean(ImmutablePojo.class, CONSTRUCTOR),
+          writeBean(ImmutablePojo.class, FIELDS)
+        )
+      );
+      assertTrue(ex.getMessage().contains("Duplicate"), ex.getMessage());
+    }
+
+    @Test
+    @DisplayName("BUILDER hint on a class without a static builder() throws eagerly (not at first to())")
+    void incompatibleStrategyEager() {
+      assertThrows(IllegalStateException.class, () ->
+        Telescope.map(OrderRecord.class, ImmutablePojo.class, writeBean(ImmutablePojo.class, BUILDER))
+      );
+    }
+
+    @Test
+    @DisplayName("a hint whose target class is never reached during recursion is reported, not silently dropped")
+    void unusedHintRejected() {
+      final var ex = assertThrows(IllegalArgumentException.class, () ->
+        Telescope.map(OrderRecord.class, ImmutablePojo.class, writeBean(DualPojo.class, FIELDS))
+      );
+      assertTrue(ex.getMessage().contains("Unused"), ex.getMessage());
+    }
+
+    @Test
+    @DisplayName("autoWriter throws cleanly for ambiguous multi-ctor POJO when no hint is supplied")
+    void ambiguousAutoFallbackRefuses() {
+      // resolve() returns successfully — the Iso is built lazily. The throw fires when
+      // Reflective.BEANS.construct runs (first iso.to() call) and Beans.autoWriter can't pick a
+      // strategy.
+      final var mapper = Telescope.mapper(AmbiguousRecord.class, AmbiguousCtorPojo.class);
+      final var ex = assertThrows(IllegalStateException.class, () -> mapper.read(new AmbiguousRecord("x", "y")));
+      assertTrue(
+        ex.getMessage().contains("name-based write strategy") || ex.getMessage().contains("writeBean"),
+        ex.getMessage()
+      );
+    }
+  }
+
+  // ----- Set + deeper-nesting fixtures -----
+
+  record TagE(String name) {}
+
+  record TagD(String name) {}
+
+  record TaggedE(Set<TagE> tags) {}
+
+  record TaggedD(Set<TagD> tags) {}
+
+  record SetOptE(Set<Optional<TagE>> items) {}
+
+  record SetOptD(Set<Optional<TagD>> items) {}
+
+  // List<Map<String, Set<Record>>> — four levels of mixed containers nesting a record leaf.
+  record FourLevelE(List<Map<String, Set<TagE>>> data) {}
+
+  record FourLevelD(List<Map<String, Set<TagD>>> data) {}
+
+  @Nested
+  @DisplayName("Set containers and N-level mixed nesting")
+  class SetAndDeepNesting {
+
+    @Test
+    @DisplayName("Set<Record> round-trips via Iso.liftSet")
+    void setOfRecord() {
+      final var mapper = Telescope.mapper(TaggedE.class, TaggedD.class);
+      final var src = new TaggedE(new LinkedHashSet<>(List.of(new TagE("red"), new TagE("blue"))));
+      final var dto = mapper.read(src);
+      assertEquals(Set.of(new TagD("red"), new TagD("blue")), dto.tags());
+      assertEquals(src, mapper.backward(dto));
+    }
+
+    @Test
+    @DisplayName("Set<Optional<Record>> works at two container levels (Set.equals semantics)")
+    void setOfOptional() {
+      // Set semantics: Optional.empty() is one element regardless of how many empties are added —
+      // the liftSet javadoc documents this. We assert via Set.equals, not multiset semantics.
+      final var mapper = Telescope.mapper(SetOptE.class, SetOptD.class);
+      final var src = new SetOptE(
+        new LinkedHashSet<>(List.of(Optional.of(new TagE("a")), Optional.empty(), Optional.of(new TagE("b"))))
+      );
+      final var dto = mapper.read(src);
+      assertEquals(Set.of(Optional.of(new TagD("a")), Optional.<TagD>empty(), Optional.of(new TagD("b"))), dto.items());
+      assertEquals(src, mapper.backward(dto));
+    }
+
+    @Test
+    @DisplayName("List<Map<K, Set<Record>>> resolves four nested container levels by construction")
+    void fourLevelMixedContainer() {
+      final var mapper = Telescope.mapper(FourLevelE.class, FourLevelD.class);
+      final var src = new FourLevelE(
+        List.of(
+          Map.of(
+            "alpha",
+            new LinkedHashSet<>(List.of(new TagE("x"), new TagE("y"))),
+            "beta",
+            new LinkedHashSet<>(List.of(new TagE("z")))
+          )
+        )
+      );
+      final var dto = mapper.read(src);
+      assertEquals(Set.of(new TagD("x"), new TagD("y")), dto.data().get(0).get("alpha"));
+      assertEquals(Set.of(new TagD("z")), dto.data().get(0).get("beta"));
+      assertEquals(src, mapper.backward(dto));
     }
   }
 }

--- a/core/src/test/java/io/github/eschizoid/telescope/DeepMappingTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/DeepMappingTest.java
@@ -11,7 +11,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.github.eschizoid.telescope.conversion.Mapper;
-import io.github.eschizoid.telescope.mapping.MapStep;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -23,12 +22,14 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 /**
- * Tests for the deep recursive {@link Telescope#map(Class, Class, MapStep...)} / {@link
- * Telescope#mapper(Class, Class, MapStep...)} factories — the "explore the academia boundaries"
- * shape. Each test exercises a different facet of the recursion: same-name copy, container
- * traversal at multiple depths (List, Set, Map, Optional — N-level nestable), renames keyed by type
- * pair applying at any depth, typed transforms, nested mappers via {@code via}, per-target {@code
- * writeBean} construction hints, and self-referencing structures (cycle handling).
+ * Tests for the deep recursive {@link Telescope#map(Class, Class,
+ * io.github.eschizoid.telescope.mapping.MapStep...)} / {@link Telescope#mapper(Class, Class,
+ * io.github.eschizoid.telescope.mapping.MapStep...)} factories — the "explore the academia
+ * boundaries" shape. Each test exercises a different facet of the recursion: same-name copy,
+ * container traversal at multiple depths (List, Set, Map, Optional — N-level nestable), renames
+ * keyed by type pair applying at any depth, typed transforms, nested mappers via {@code via},
+ * per-target {@code writeBean} construction hints, and self-referencing structures (cycle
+ * handling).
  */
 class DeepMappingTest {
 

--- a/core/src/test/java/io/github/eschizoid/telescope/internal/BeansTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/internal/BeansTest.java
@@ -381,7 +381,7 @@ class BeansTest {
     @DisplayName("construct throws IllegalArgumentException for a name without a matching setter")
     void settersMissingSetterThrows() {
       final var writer = Beans.settersWriter(NoArgFields.class); // has fields but no setters
-      assertThrows(RuntimeException.class, () -> writer.construct(new String[] { "name" }, n -> "x"));
+      assertThrows(IllegalArgumentException.class, () -> writer.construct(new String[] { "name" }, n -> "x"));
     }
   }
 
@@ -425,7 +425,7 @@ class BeansTest {
     @DisplayName("construct throws if no setter on the builder matches a given name")
     void builderUnknownSetterThrows() {
       final var writer = Beans.builderWriter(WithBuilder.class);
-      assertThrows(RuntimeException.class, () -> writer.construct(new String[] { "ghost" }, n -> "x"));
+      assertThrows(IllegalArgumentException.class, () -> writer.construct(new String[] { "ghost" }, n -> "x"));
     }
   }
 

--- a/core/src/test/java/io/github/eschizoid/telescope/internal/BeansTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/internal/BeansTest.java
@@ -1,0 +1,577 @@
+package io.github.eschizoid.telescope.internal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Map;
+import java.util.Objects;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests {@link Beans} reflection helpers + the four {@code BeanWriter} strategies + the {@link
+ * Beans#autoWriter} ladder including the 4th-rung constructor fallback. Each test exercises one
+ * surface of the bean machinery so that a regression in any rung surfaces independently from the
+ * end-to-end {@code Telescope.map} / {@code Telescope.ofBean} paths.
+ */
+class BeansTest {
+
+  // ----- Fixtures -----
+
+  static final class WithGetters {
+
+    private final String id;
+    private final boolean active;
+    private final Boolean flag;
+    private final String url;
+
+    WithGetters(final String id, final boolean active, final Boolean flag, final String url) {
+      this.id = id;
+      this.active = active;
+      this.flag = flag;
+      this.url = url;
+    }
+
+    public String getId() {
+      return id;
+    }
+
+    public boolean isActive() {
+      return active;
+    }
+
+    public Boolean isFlag() {
+      return flag;
+    }
+
+    // "URL" — JavaBeans 'two leading caps' rule keeps the property name as "URL", not "uRL".
+    public String getURL() {
+      return url;
+    }
+  }
+
+  static final class NoArgFields {
+
+    private String name;
+    private int score;
+
+    public NoArgFields() {}
+
+    public String getName() {
+      return name;
+    }
+
+    public int getScore() {
+      return score;
+    }
+  }
+
+  static final class NoArgSetters {
+
+    private String name;
+    private int score;
+
+    public NoArgSetters() {}
+
+    public String getName() {
+      return name;
+    }
+
+    public int getScore() {
+      return score;
+    }
+
+    public void setName(final String name) {
+      this.name = name;
+    }
+
+    public void setScore(final int score) {
+      this.score = score;
+    }
+  }
+
+  static final class WithBuilder {
+
+    private final String name;
+    private final int score;
+
+    private WithBuilder(final String name, final int score) {
+      this.name = name;
+      this.score = score;
+    }
+
+    public String getName() {
+      return name;
+    }
+
+    public int getScore() {
+      return score;
+    }
+
+    public static Builder builder() {
+      return new Builder();
+    }
+
+    static final class Builder {
+
+      private String name;
+      private int score;
+
+      // Cover the three setter-name conventions consumed by BuilderWriter: bare name, setX, withX.
+      public Builder name(final String n) {
+        this.name = n;
+        return this;
+      }
+
+      public Builder setScore(final int s) {
+        this.score = s;
+        return this;
+      }
+
+      public WithBuilder build() {
+        return new WithBuilder(name, score);
+      }
+    }
+  }
+
+  static final class WithBuilderWithSetter {
+
+    private final String name;
+
+    private WithBuilderWithSetter(final String name) {
+      this.name = name;
+    }
+
+    public String getName() {
+      return name;
+    }
+
+    public static Builder builder() {
+      return new Builder();
+    }
+
+    static final class Builder {
+
+      private String name;
+
+      // Exercise the "withX" setter-name pattern that BuilderWriter falls through to last.
+      public Builder withName(final String n) {
+        this.name = n;
+        return this;
+      }
+
+      public WithBuilderWithSetter build() {
+        return new WithBuilderWithSetter(name);
+      }
+    }
+  }
+
+  static final class ImmutableCtor {
+
+    private final String label;
+    private final int count;
+
+    public ImmutableCtor(final String label, final int count) {
+      this.label = label;
+      this.count = count;
+    }
+
+    public String getLabel() {
+      return label;
+    }
+
+    public int getCount() {
+      return count;
+    }
+  }
+
+  static final class TwoCtorsSameArity {
+
+    private final String a;
+
+    public TwoCtorsSameArity(final String a) {
+      this.a = a;
+    }
+
+    public TwoCtorsSameArity(final Integer ignored) {
+      this.a = String.valueOf(ignored);
+    }
+
+    public String getA() {
+      return a;
+    }
+  }
+
+  static final class NothingBuildable {
+
+    private final String x;
+
+    private NothingBuildable(final String x) {
+      this.x = x;
+    }
+
+    public String getX() {
+      return x;
+    }
+  }
+
+  static final class NoStaticBuilder {
+
+    private String id;
+
+    public NoStaticBuilder() {}
+
+    public String getId() {
+      return id;
+    }
+
+    public Object builder() {
+      // Instance method, not static — autoWriter's hasStaticBuilder check must reject it.
+      return new Object();
+    }
+  }
+
+  static final class BuilderWithoutBuild {
+
+    private final String id;
+
+    private BuilderWithoutBuild(final String id) {
+      this.id = id;
+    }
+
+    public String getId() {
+      return id;
+    }
+
+    public static Builder builder() {
+      return new Builder();
+    }
+
+    static final class Builder {
+
+      public Builder id(final String id) {
+        return this;
+      }
+      // Deliberately missing build() — BuilderWriter must reject.
+    }
+  }
+
+  // ----- Getter scan / property metadata -----
+
+  @Nested
+  @DisplayName("Getter scanning and property metadata")
+  class GetterScan {
+
+    @Test
+    @DisplayName("getX / isX / boolean and Boolean isX / URL two-caps rule all resolve to expected property names")
+    void propertyNamesCoverConventions() {
+      final var names = java.util.Arrays.asList(Beans.propertyNames(WithGetters.class));
+      assertTrue(names.contains("id"));
+      assertTrue(names.contains("active")); // isActive (boolean)
+      assertTrue(names.contains("flag")); // isFlag (Boolean)
+      assertTrue(names.contains("URL")); // two leading caps preserved
+    }
+
+    @Test
+    @DisplayName("readProperty returns the getter value")
+    void readPropertyHappy() {
+      final var pojo = new WithGetters("u1", true, Boolean.FALSE, "https://x");
+      assertEquals("u1", Beans.readProperty(pojo, "id"));
+      assertEquals(true, Beans.readProperty(pojo, "active"));
+      assertEquals(Boolean.FALSE, Beans.readProperty(pojo, "flag"));
+      assertEquals("https://x", Beans.readProperty(pojo, "URL"));
+    }
+
+    @Test
+    @DisplayName("readProperty throws IllegalArgumentException for a property that has no getter")
+    void readPropertyMissingThrows() {
+      final var pojo = new WithGetters("u1", true, null, "x");
+      final var ex = assertThrows(IllegalArgumentException.class, () -> Beans.readProperty(pojo, "ghost"));
+      assertTrue(ex.getMessage().contains("ghost"), ex.getMessage());
+    }
+
+    @Test
+    @DisplayName("hasProperty reflects scan results")
+    void hasPropertyReflectsScan() {
+      assertTrue(Beans.hasProperty(WithGetters.class, "id"));
+      assertFalse(Beans.hasProperty(WithGetters.class, "ghost"));
+    }
+
+    @Test
+    @DisplayName("propertyType returns the generic return type of the getter")
+    void propertyTypeHappy() {
+      assertEquals(String.class, Beans.propertyType(WithGetters.class, "id"));
+      assertEquals(boolean.class, Beans.propertyType(WithGetters.class, "active"));
+    }
+
+    @Test
+    @DisplayName("propertyType throws when the named property has no getter")
+    void propertyTypeMissingThrows() {
+      assertThrows(IllegalArgumentException.class, () -> Beans.propertyType(WithGetters.class, "ghost"));
+    }
+
+    @Test
+    @DisplayName("propertyOf strips get/is prefix; unknown prefix is returned unchanged")
+    void propertyOfPrefixStripping() {
+      assertEquals("name", Beans.propertyOf("getName"));
+      assertEquals("active", Beans.propertyOf("isActive"));
+      assertEquals("name", Beans.propertyOf("name")); // no prefix → returned as-is
+      assertEquals("URL", Beans.propertyOf("getURL")); // two-caps rule preserved
+    }
+  }
+
+  // ----- FieldsWriter -----
+
+  @Nested
+  @DisplayName("FieldsWriter — no-arg ctor + reflective field injection")
+  class Fields {
+
+    @Test
+    @DisplayName("round-trip via fieldsWriter populates declared fields by name")
+    void fieldsRoundTrip() {
+      final var writer = Beans.fieldsWriter(NoArgFields.class);
+      final var values = Map.<String, Object>of("name", "alice", "score", 9);
+      final var pojo = writer.construct(new String[] { "name", "score" }, values::get);
+      assertEquals("alice", pojo.getName());
+      assertEquals(9, pojo.getScore());
+    }
+
+    @Test
+    @DisplayName("fieldsWriter throws when no no-arg constructor exists")
+    void fieldsRequiresNoArgCtor() {
+      assertThrows(IllegalStateException.class, () -> Beans.fieldsWriter(ImmutableCtor.class));
+    }
+
+    @Test
+    @DisplayName("construct throws when a name has no matching declared field")
+    void fieldsUnknownNameThrows() {
+      final var writer = Beans.fieldsWriter(NoArgFields.class);
+      assertThrows(IllegalArgumentException.class, () -> writer.construct(new String[] { "ghost" }, n -> "x"));
+    }
+  }
+
+  // ----- SettersWriter -----
+
+  @Nested
+  @DisplayName("SettersWriter — no-arg ctor + public setX(value)")
+  class Setters {
+
+    @Test
+    @DisplayName("round-trip via settersWriter invokes setX for each name")
+    void settersRoundTrip() {
+      final var writer = Beans.settersWriter(NoArgSetters.class);
+      final var values = Map.<String, Object>of("name", "bob", "score", 5);
+      final var pojo = writer.construct(new String[] { "name", "score" }, values::get);
+      assertEquals("bob", pojo.getName());
+      assertEquals(5, pojo.getScore());
+    }
+
+    @Test
+    @DisplayName("settersWriter throws when no no-arg constructor exists")
+    void settersRequiresNoArgCtor() {
+      assertThrows(IllegalStateException.class, () -> Beans.settersWriter(ImmutableCtor.class));
+    }
+
+    @Test
+    @DisplayName("construct throws IllegalArgumentException for a name without a matching setter")
+    void settersMissingSetterThrows() {
+      final var writer = Beans.settersWriter(NoArgFields.class); // has fields but no setters
+      assertThrows(RuntimeException.class, () -> writer.construct(new String[] { "name" }, n -> "x"));
+    }
+  }
+
+  // ----- BuilderWriter -----
+
+  @Nested
+  @DisplayName("BuilderWriter — static builder() + named/setX/withX setters + build()")
+  class Builders {
+
+    @Test
+    @DisplayName("round-trip via builderWriter resolves bare-name + setX setters and calls build()")
+    void builderRoundTripMixedSetterStyles() {
+      final var writer = Beans.builderWriter(WithBuilder.class);
+      final var values = Map.<String, Object>of("name", "carol", "score", 7);
+      final var pojo = writer.construct(new String[] { "name", "score" }, values::get);
+      assertEquals("carol", pojo.getName());
+      assertEquals(7, pojo.getScore());
+    }
+
+    @Test
+    @DisplayName("builderWriter resolves the withX setter convention as the last fallback")
+    void builderWithXFallback() {
+      final var writer = Beans.builderWriter(WithBuilderWithSetter.class);
+      final var pojo = writer.construct(new String[] { "name" }, n -> "dora");
+      assertEquals("dora", pojo.getName());
+    }
+
+    @Test
+    @DisplayName("builderWriter throws if class has no static builder() factory")
+    void builderRequiresStaticBuilder() {
+      assertThrows(IllegalStateException.class, () -> Beans.builderWriter(NoArgFields.class));
+    }
+
+    @Test
+    @DisplayName("builderWriter throws if the builder type has no build() method")
+    void builderRequiresBuildMethod() {
+      assertThrows(IllegalStateException.class, () -> Beans.builderWriter(BuilderWithoutBuild.class));
+    }
+
+    @Test
+    @DisplayName("construct throws if no setter on the builder matches a given name")
+    void builderUnknownSetterThrows() {
+      final var writer = Beans.builderWriter(WithBuilder.class);
+      assertThrows(RuntimeException.class, () -> writer.construct(new String[] { "ghost" }, n -> "x"));
+    }
+  }
+
+  // ----- ConstructorWriter -----
+
+  @Nested
+  @DisplayName("ConstructorWriter — all-args ctor (named with -parameters, positional fallback otherwise)")
+  class Constructors {
+
+    @Test
+    @DisplayName("round-trip via constructorWriter populates each ctor arg")
+    void constructorRoundTrip() {
+      final var writer = Beans.constructorWriter(ImmutableCtor.class, 2);
+      final var values = Map.<String, Object>of("label", "x", "count", 11);
+      final var pojo = writer.construct(new String[] { "label", "count" }, values::get);
+      assertEquals("x", pojo.getLabel());
+      assertEquals(11, pojo.getCount());
+    }
+
+    @Test
+    @DisplayName("constructorWriter throws when no constructor of the requested arity exists")
+    void constructorMissingArityThrows() {
+      assertThrows(IllegalStateException.class, () -> Beans.constructorWriter(ImmutableCtor.class, 99));
+    }
+
+    @Test
+    @DisplayName("constructorWriter throws when more than one constructor matches the arity")
+    void constructorAmbiguousArityThrows() {
+      assertThrows(IllegalStateException.class, () -> Beans.constructorWriter(TwoCtorsSameArity.class, 1));
+    }
+  }
+
+  // ----- autoWriter ladder -----
+
+  @Nested
+  @DisplayName("autoWriter — strategy ladder + cache + 4th-rung constructor fallback")
+  class AutoWriter {
+
+    @Test
+    @DisplayName("autoWriter picks BuilderWriter when a static builder() is present")
+    void autoPicksBuilder() {
+      final var writer = Beans.autoWriter(WithBuilder.class);
+      assertEquals("BuilderWriter", writer.getClass().getSimpleName());
+      // Functional confirmation: produces a working instance.
+      final var pojo = writer.construct(new String[] { "name", "score" }, n -> Objects.equals(n, "name") ? "x" : 1);
+      assertNotNull(pojo);
+    }
+
+    @Test
+    @DisplayName("autoWriter picks SettersWriter when no-arg ctor + setters exist (no builder)")
+    void autoPicksSetters() {
+      final var writer = Beans.autoWriter(NoArgSetters.class);
+      final var pojo = writer.construct(new String[] { "name" }, n -> "e");
+      assertEquals("e", pojo.getName());
+    }
+
+    @Test
+    @DisplayName("autoWriter falls back to FieldsWriter when no-arg ctor but no setters")
+    void autoPicksFields() {
+      final var writer = Beans.autoWriter(NoArgFields.class);
+      final var pojo = writer.construct(new String[] { "name" }, n -> "f");
+      assertEquals("f", pojo.getName());
+    }
+
+    @Test
+    @DisplayName("autoWriter 4th-rung: a single public all-args ctor compiled with -parameters works")
+    void autoFourthRungConstructorFallback() {
+      // ImmutableCtor has no builder, no no-arg ctor, exactly one public 2-arg ctor.
+      final var writer = Beans.autoWriter(ImmutableCtor.class);
+      final var values = Map.<String, Object>of("label", "z", "count", 3);
+      final var pojo = writer.construct(new String[] { "label", "count" }, values::get);
+      assertEquals("z", pojo.getLabel());
+      assertEquals(3, pojo.getCount());
+    }
+
+    @Test
+    @DisplayName("autoWriter refuses ambiguous multi-ctor POJO with a descriptive message")
+    void autoRefusesAmbiguousCtor() {
+      final var ex = assertThrows(IllegalStateException.class, () -> Beans.autoWriter(TwoCtorsSameArity.class));
+      assertTrue(ex.getMessage().contains("writeBean") || ex.getMessage().contains("name-based"), ex.getMessage());
+    }
+
+    @Test
+    @DisplayName("autoWriter refuses class with no builder, no no-arg ctor, only a non-public ctor")
+    void autoRefusesUnreachable() {
+      // NothingBuildable has a private ctor only — solePublicConstructor returns null → throws.
+      assertThrows(IllegalStateException.class, () -> Beans.autoWriter(NothingBuildable.class));
+    }
+
+    @Test
+    @DisplayName("autoWriter cache returns the same writer instance on repeated calls")
+    void autoCacheReusesWriter() {
+      final var a = Beans.autoWriter(NoArgSetters.class);
+      final var b = Beans.autoWriter(NoArgSetters.class);
+      assertSame(a, b);
+    }
+
+    @Test
+    @DisplayName("autoWriter ignores a non-static builder() method (uses fields-or-setters instead)")
+    void autoIgnoresNonStaticBuilder() {
+      // NoStaticBuilder declares an INSTANCE builder() (not static). hasStaticBuilder rejects it,
+      // so autoWriter falls through to setters/fields. NoStaticBuilder has a no-arg ctor and no
+      // setters, so it lands on FieldsWriter.
+      final var writer = Beans.autoWriter(NoStaticBuilder.class);
+      assertNotNull(writer);
+      final var pojo = writer.construct(new String[] { "id" }, n -> "ok");
+      assertEquals("ok", pojo.getId());
+    }
+  }
+
+  // ----- lens (single-property Lens) -----
+
+  @Nested
+  @DisplayName("Beans.lens — Lens<P, A> over a single bean property")
+  class LensFactory {
+
+    @Test
+    @DisplayName("get reads via the getter, set rebuilds with the new value, other props carry over")
+    void lensReadWriteRebuild() {
+      final io.github.eschizoid.telescope.internal.optics.Lens<NoArgSetters, String> lens = Beans.lens(
+        NoArgSetters.class,
+        "name",
+        Beans.autoWriter(NoArgSetters.class)
+      );
+      final var base = new NoArgSetters();
+      base.setName("old");
+      base.setScore(42);
+      final var updated = lens.set(base, "new");
+      assertEquals("new", updated.getName());
+      assertEquals(42, updated.getScore()); // off-path value preserved through the rebuild
+      assertEquals("old", base.getName()); // base was not mutated
+    }
+
+    @Test
+    @DisplayName("modify applies a function over the read value")
+    void lensModify() {
+      final io.github.eschizoid.telescope.internal.optics.Lens<NoArgSetters, String> lens = Beans.lens(
+        NoArgSetters.class,
+        "name",
+        Beans.autoWriter(NoArgSetters.class)
+      );
+      final var base = new NoArgSetters();
+      base.setName("alice");
+      base.setScore(1);
+      final var upper = lens.modify(base, String::toUpperCase);
+      assertEquals("ALICE", upper.getName());
+    }
+  }
+}

--- a/core/src/test/java/io/github/eschizoid/telescope/internal/optics/LatticeCoverageTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/internal/optics/LatticeCoverageTest.java
@@ -1,0 +1,572 @@
+package io.github.eschizoid.telescope.internal.optics;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.github.eschizoid.telescope.internal.optics.collections.Traversals;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Direct coverage tests for the optic-lattice primitives — {@link Fold} / {@link Getter} default
+ * views, {@link Iso} lift helpers + composition diamonds, {@link Lens} / {@link Prism} / {@link
+ * Affine} composition arms, {@link Focus} static factories, and {@link Traversals} runtime
+ * dispatch. Complements {@link OpticLawsTest} (which pins the laws); this file pins behavior of the
+ * surface methods rung-by-rung so a regression in any one default or factory surfaces independently
+ * from the end-to-end DSL.
+ */
+class LatticeCoverageTest {
+
+  // ----- Fixtures -----
+
+  record Address(String city, String zip) {}
+
+  record User(String name, int age, Address address) {}
+
+  sealed interface Event permits Created, Updated, Deleted {}
+
+  record Created(String id) implements Event {}
+
+  record Updated(String id, String diff) implements Event {}
+
+  record Deleted(String id) implements Event {}
+
+  static final User ALICE = new User("Alice", 30, new Address("NYC", "10001"));
+
+  static final Lens<User, String> userName = Lens.of(User::name, (u, n) -> new User(n, u.age(), u.address()));
+
+  static final Lens<User, Address> userAddress = Lens.of(User::address, (u, a) -> new User(u.name(), u.age(), a));
+
+  static final Lens<Address, String> addressCity = Lens.of(Address::city, (a, c) -> new Address(c, a.zip()));
+
+  // ----- Fold defaults -----
+
+  @Nested
+  @DisplayName("Fold defaults — toList, findFirst, any, count over a multi-focus")
+  class FoldDefaults {
+
+    @Test
+    @DisplayName("a multi-element Fold yields each focused value through every default method")
+    void multiElementFold() {
+      final Fold<List<Integer>, Integer> all = List::stream;
+      final var src = List.of(1, 2, 3, 4);
+      assertEquals(List.of(1, 2, 3, 4), all.toList(src));
+      assertEquals(Optional.of(3), all.findFirst(src, n -> n > 2));
+      assertEquals(Optional.empty(), all.findFirst(src, n -> n > 99));
+      assertTrue(all.any(src, n -> n == 2));
+      assertFalse(all.any(src, n -> n == 99));
+      assertEquals(4L, all.count(src));
+    }
+
+    @Test
+    @DisplayName("an empty Fold returns empty defaults — no NPE from null source on a non-default Fold")
+    void emptyFold() {
+      final Fold<List<Integer>, Integer> none = src -> java.util.stream.Stream.empty();
+      final var src = List.<Integer>of();
+      assertEquals(List.of(), none.toList(src));
+      assertEquals(Optional.empty(), none.findFirst(src, n -> true));
+      assertFalse(none.any(src, n -> true));
+      assertEquals(0L, none.count(src));
+    }
+  }
+
+  // ----- Getter -----
+
+  @Nested
+  @DisplayName("Getter — single-focus read + Fold view")
+  class GetterTests {
+
+    @Test
+    @DisplayName("get returns the single A; getAll yields a singleton stream")
+    void getAndGetAll() {
+      final Getter<User, String> name = User::name;
+      assertEquals("Alice", name.get(ALICE));
+      assertEquals(List.of("Alice"), name.toList(ALICE));
+      assertEquals(1L, name.count(ALICE));
+      assertTrue(name.any(ALICE, "Alice"::equals));
+    }
+  }
+
+  // ----- Lens composition arms -----
+
+  @Nested
+  @DisplayName("Lens composition — Lens.then(Lens|Iso|Prism)")
+  class LensComposition {
+
+    @Test
+    @DisplayName("Lens.then(Lens) reads through both and writes through both")
+    void lensThenLens() {
+      final Lens<User, String> userCity = userAddress.then(addressCity);
+      assertEquals("NYC", userCity.get(ALICE));
+      assertEquals("SF", userCity.get(userCity.set(ALICE, "SF")));
+      // The set-set law on the composition:
+      assertEquals(userCity.set(ALICE, "B"), userCity.set(userCity.set(ALICE, "A"), "B"));
+    }
+
+    @Test
+    @DisplayName("Lens.then(Iso) lifts the iso through and stays a Lens")
+    void lensThenIso() {
+      final Iso<String, String> reverse = Iso.of(
+        s -> new StringBuilder(s).reverse().toString(),
+        s -> new StringBuilder(s).reverse().toString()
+      );
+      final Lens<User, String> reversedName = userName.then(reverse);
+      assertEquals("ecilA", reversedName.get(ALICE));
+      // Setting through the iso applies the backward direction:
+      assertEquals("Bob", reversedName.set(ALICE, "boB").name());
+    }
+
+    @Test
+    @DisplayName("Lens.then(Prism) widens to Affine — a Prism miss leaves the source untouched")
+    void lensThenPrismIsAffine() {
+      // A Lens<User, Event> via a synthetic event field; compose with a Prism that targets only
+      // Updated.
+      final Lens<Holder, Event> lens = Lens.of(Holder::event, (h, e) -> new Holder(h.id(), e));
+      final Prism<Event, Updated> prism = Prism.downcast(Updated.class);
+      final Affine<Holder, Updated> composed = lens.then(prism);
+      assertInstanceOf(Affine.class, composed);
+
+      final Holder withUpdated = new Holder("h1", new Updated("u1", "diff"));
+      final Holder withCreated = new Holder("h1", new Created("c1"));
+      assertEquals(Optional.of(new Updated("u1", "diff")), composed.getOption(withUpdated));
+      assertEquals(Optional.empty(), composed.getOption(withCreated));
+
+      // miss → source unchanged
+      assertEquals(withCreated, composed.modify(withCreated, u -> new Updated(u.id(), "updated")));
+      // hit → flows through
+      assertEquals(
+        new Holder("h1", new Updated("u1", "new")),
+        composed.modify(withUpdated, u -> new Updated(u.id(), "new"))
+      );
+    }
+  }
+
+  record Holder(String id, Event event) {}
+
+  // ----- Prism composition + behavior -----
+
+  @Nested
+  @DisplayName("Prism — modify on hit/miss, downcast, then(Prism|Iso|Lens)")
+  class PrismTests {
+
+    @Test
+    @DisplayName("downcast Prism returns getOption hit on instance, empty otherwise; reverseGet widens")
+    void downcastBehavior() {
+      final Prism<Event, Updated> p = Prism.downcast(Updated.class);
+      final Event upd = new Updated("u1", "d");
+      final Event crd = new Created("c1");
+      assertEquals(Optional.of(upd), p.getOption(upd));
+      assertEquals(Optional.empty(), p.getOption(crd));
+      assertSame(upd, p.reverseGet((Updated) upd)); // identity widening
+    }
+
+    @Test
+    @DisplayName("modify on a miss returns the source unchanged (the partial round-trip law)")
+    void modifyMiss() {
+      final Prism<Event, Updated> p = Prism.downcast(Updated.class);
+      final Event crd = new Created("c1");
+      assertSame(crd, p.modify(crd, u -> new Updated(u.id(), "x")));
+    }
+
+    @Test
+    @DisplayName("modify on a hit applies the function and rebuilds via reverseGet")
+    void modifyHit() {
+      final Prism<Event, Updated> p = Prism.downcast(Updated.class);
+      final Event upd = new Updated("u1", "d");
+      assertEquals(new Updated("u1", "new"), p.modify(upd, u -> new Updated(u.id(), "new")));
+    }
+
+    @Test
+    @DisplayName("getAll yields a singleton when the prism matches, empty otherwise")
+    void prismGetAll() {
+      final Prism<Event, Updated> p = Prism.downcast(Updated.class);
+      assertEquals(1L, p.getAll(new Updated("u1", "d")).count());
+      assertEquals(0L, p.getAll(new Created("c1")).count());
+    }
+
+    @Test
+    @DisplayName("Prism.then(Prism) composes two narrowings; misses short-circuit")
+    void prismThenPrism() {
+      // Outer Prism: Event → Updated. Inner Prism: Updated → an Updated whose diff is "real".
+      final Prism<Event, Updated> outer = Prism.downcast(Updated.class);
+      final Prism<Updated, Updated> realDiff = Prism.of(
+        u -> "real".equals(u.diff()) ? Optional.of(u) : Optional.empty(),
+        u -> u
+      );
+      final Prism<Event, Updated> composed = outer.then(realDiff);
+      assertEquals(Optional.of(new Updated("u1", "real")), composed.getOption(new Updated("u1", "real")));
+      assertEquals(Optional.empty(), composed.getOption(new Updated("u1", "fake")));
+      assertEquals(Optional.empty(), composed.getOption(new Created("c1")));
+      assertEquals(new Updated("u1", "x"), composed.reverseGet(new Updated("u1", "x")));
+    }
+
+    @Test
+    @DisplayName("Prism.then(Iso) stays a Prism, lifting the iso through both directions")
+    void prismThenIso() {
+      final Prism<Event, Updated> outer = Prism.downcast(Updated.class);
+      final Iso<Updated, String> diffOnly = Iso.of(Updated::diff, d -> new Updated("synth", d));
+      final Prism<Event, String> composed = outer.then(diffOnly);
+      assertEquals(Optional.of("d"), composed.getOption(new Updated("u1", "d")));
+      assertEquals(Optional.empty(), composed.getOption(new Created("c1")));
+      assertEquals(new Updated("synth", "x"), composed.reverseGet("x"));
+    }
+
+    @Test
+    @DisplayName("Prism.then(Lens) widens to Affine — the Lens contributes the read+write half")
+    void prismThenLens() {
+      final Prism<Event, Updated> outer = Prism.downcast(Updated.class);
+      final Lens<Updated, String> diff = Lens.of(Updated::diff, (u, d) -> new Updated(u.id(), d));
+      final Affine<Event, String> composed = outer.then(diff);
+      assertInstanceOf(Affine.class, composed);
+      assertEquals(Optional.of("d"), composed.getOption(new Updated("u1", "d")));
+      assertEquals(Optional.empty(), composed.getOption(new Created("c1")));
+      // hit → modify flows through; miss → unchanged
+      assertEquals(new Updated("u1", "dD"), composed.modify(new Updated("u1", "d"), d -> d + "D"));
+      final Event crd = new Created("c1");
+      assertSame(crd, composed.modify(crd, d -> d + "!"));
+    }
+  }
+
+  // ----- Affine -----
+
+  @Nested
+  @DisplayName("Affine — of(), modify on hit/miss, then(Affine)")
+  class AffineTests {
+
+    @Test
+    @DisplayName("Affine.of getOption + modify behaves as documented (miss = source unchanged)")
+    void affineModifyHitMiss() {
+      final Affine<List<Integer>, Integer> head = Affine.of(
+        xs -> xs.isEmpty() ? Optional.empty() : Optional.of(xs.get(0)),
+        (xs, n) -> {
+          final var c = new ArrayList<>(xs);
+          c.set(0, n);
+          return c;
+        }
+      );
+      assertEquals(Optional.of(1), head.getOption(List.of(1, 2, 3)));
+      assertEquals(List.of(99, 2, 3), head.modify(List.of(1, 2, 3), n -> n + 98));
+      // miss: empty list → source unchanged (and same reference under modify with no-op semantics)
+      final var empty = List.<Integer>of();
+      assertSame(empty, head.modify(empty, n -> n + 1));
+    }
+
+    @Test
+    @DisplayName("Affine.then(Affine) composes hit-then-hit, otherwise misses through")
+    void affineThenAffine() {
+      // Outer: Optional<List<Integer>> → List<Integer> (when present)
+      final Affine<Optional<List<Integer>>, List<Integer>> outer = Affine.of(
+        o -> o,
+        (o, v) -> o.isPresent() ? Optional.of(v) : o
+      );
+      // Inner: List<Integer> → first element (when non-empty)
+      final Affine<List<Integer>, Integer> inner = Affine.of(
+        xs -> xs.isEmpty() ? Optional.empty() : Optional.of(xs.get(0)),
+        (xs, n) -> {
+          final var c = new ArrayList<>(xs);
+          c.set(0, n);
+          return c;
+        }
+      );
+      final Affine<Optional<List<Integer>>, Integer> composed = outer.then(inner);
+      assertEquals(Optional.of(1), composed.getOption(Optional.of(List.of(1, 2))));
+      assertEquals(Optional.empty(), composed.getOption(Optional.empty()));
+      assertEquals(Optional.empty(), composed.getOption(Optional.of(List.of()))); // outer hits, inner misses
+      assertEquals(Optional.of(List.of(7, 2)), composed.modify(Optional.of(List.of(1, 2)), n -> n + 6));
+      // miss path: outer miss → identity
+      assertEquals(Optional.empty(), composed.modify(Optional.empty(), n -> n + 1));
+    }
+  }
+
+  // ----- Iso lift helpers + composition -----
+
+  @Nested
+  @DisplayName("Iso lifts — list/set/optional/map and composition Iso.then(Iso|Lens|Prism)")
+  class IsoLiftsAndComposition {
+
+    static final Iso<Integer, String> intStr = Iso.of(Object::toString, Integer::parseInt);
+
+    @Test
+    @DisplayName("liftList: round-trip preserves order and per-element conversion; null pass-through")
+    void liftList() {
+      final var listIso = Iso.liftList(intStr);
+      assertEquals(List.of("1", "2", "3"), listIso.to(List.of(1, 2, 3)));
+      assertEquals(List.of(1, 2, 3), listIso.from(List.of("1", "2", "3")));
+      assertNull(listIso.to(null));
+      assertNull(listIso.from(null));
+    }
+
+    @Test
+    @DisplayName("liftSet: round-trip preserves Set.equals semantics; null pass-through")
+    void liftSet() {
+      final var setIso = Iso.liftSet(intStr);
+      assertEquals(Set.of("1", "2"), setIso.to(new LinkedHashSet<>(List.of(1, 2))));
+      assertEquals(Set.of(1, 2), setIso.from(new LinkedHashSet<>(List.of("1", "2"))));
+      assertNull(setIso.to(null));
+      assertNull(setIso.from(null));
+    }
+
+    @Test
+    @DisplayName("liftOptional: empty round-trips to empty; null pass-through")
+    void liftOptional() {
+      final var optIso = Iso.liftOptional(intStr);
+      assertEquals(Optional.of("7"), optIso.to(Optional.of(7)));
+      assertEquals(Optional.of(7), optIso.from(Optional.of("7")));
+      assertEquals(Optional.empty(), optIso.to(Optional.empty()));
+      assertEquals(Optional.empty(), optIso.from(Optional.empty()));
+      assertNull(optIso.to(null));
+      assertNull(optIso.from(null));
+    }
+
+    @Test
+    @DisplayName("liftMapValues: keys preserved through both directions; null pass-through")
+    void liftMapValues() {
+      final var mapIso = Iso.<String, Integer, String>liftMapValues(intStr);
+      assertEquals(Map.of("a", "1", "b", "2"), mapIso.to(Map.of("a", 1, "b", 2)));
+      assertEquals(Map.of("a", 1, "b", 2), mapIso.from(Map.of("a", "1", "b", "2")));
+      assertNull(mapIso.to(null));
+      assertNull(mapIso.from(null));
+    }
+
+    @Test
+    @DisplayName("Iso.reverse swaps to and from")
+    void isoReverse() {
+      final var reversed = intStr.reverse();
+      assertEquals(7, reversed.to("7"));
+      assertEquals("7", reversed.from(7));
+    }
+
+    @Test
+    @DisplayName("Iso.then(Iso) composes both directions through the chain")
+    void isoThenIso() {
+      final Iso<String, String> upper = Iso.of(String::toUpperCase, String::toLowerCase);
+      final Iso<Integer, String> composed = intStr.then(upper);
+      assertEquals("7", composed.to(7));
+      assertEquals(7, composed.from("7"));
+    }
+
+    @Test
+    @DisplayName("Iso.then(Lens) drops to a Lens (diamond resolution)")
+    void isoThenLens() {
+      final Iso<User, User> idIso = Iso.identity();
+      final Lens<User, String> composed = idIso.then(userName);
+      assertEquals("Alice", composed.get(ALICE));
+      assertEquals("Bob", composed.get(composed.set(ALICE, "Bob")));
+    }
+
+    @Test
+    @DisplayName("Iso.then(Prism) drops to a Prism (diamond resolution)")
+    void isoThenPrism() {
+      final Iso<Event, Event> idIso = Iso.identity();
+      final Prism<Event, Updated> updPrism = Prism.downcast(Updated.class);
+      final Prism<Event, Updated> composed = idIso.then(updPrism);
+      assertEquals(Optional.of(new Updated("u", "d")), composed.getOption(new Updated("u", "d")));
+      assertEquals(Optional.empty(), composed.getOption(new Created("c")));
+      assertEquals(new Updated("x", "y"), composed.reverseGet(new Updated("x", "y")));
+    }
+
+    @Test
+    @DisplayName("Iso default views match Lens (get/set) and Prism (reverseGet/getOption)")
+    void isoDefaultViews() {
+      assertEquals("7", intStr.get(7));
+      assertEquals(7, intStr.set(7, "7")); // backward(value) ignores source
+      assertEquals(7, intStr.reverseGet("7"));
+      assertEquals(Optional.of("7"), intStr.getOption(7));
+      // modify: lift through to-from
+      assertEquals(8, intStr.modify(7, s -> String.valueOf(Integer.parseInt(s) + 1)));
+      // getAll yields one element
+      assertEquals(1L, intStr.getAll(7).count());
+    }
+  }
+
+  // ----- Focus static factories -----
+
+  @Nested
+  @DisplayName("Focus — aggregator factories")
+  class FocusTests {
+
+    @Test
+    @DisplayName("Focus.lens / prism (downcast & partial) / iso / affine all build a working optic")
+    void focusFactories() {
+      final var lens = Focus.lens(User::name, (u, n) -> new User(n, u.age(), u.address()));
+      assertEquals("Alice", lens.get(ALICE));
+
+      final var prismDown = Focus.prism(Updated.class);
+      assertEquals(Optional.of(new Updated("u", "d")), prismDown.getOption(new Updated("u", "d")));
+
+      final Prism<Event, Updated> prismPartial = Focus.prism(
+        e -> e instanceof Updated u ? Optional.of(u) : Optional.empty(),
+        u -> u
+      );
+      assertEquals(Optional.of(new Updated("u", "d")), prismPartial.getOption(new Updated("u", "d")));
+      assertEquals(Optional.empty(), prismPartial.getOption(new Created("c")));
+
+      final Iso<Integer, String> iso = Focus.iso(Object::toString, Integer::parseInt);
+      assertEquals("7", iso.to(7));
+      assertEquals(7, iso.from("7"));
+
+      final var affine = Focus.affine(
+        (User u) -> Optional.ofNullable(u.address()),
+        (u, a) -> new User(u.name(), u.age(), a)
+      );
+      assertEquals(Optional.of(new Address("NYC", "10001")), affine.getOption(ALICE));
+      final var moved = affine.modify(ALICE, a -> new Address("SF", "94016"));
+      assertEquals("SF", moved.address().city());
+    }
+  }
+
+  // ----- Traversals.eachContainer runtime dispatch -----
+
+  @Nested
+  @DisplayName("Traversals.eachContainer — runtime dispatch over List/Set/Map/Optional/array/null")
+  class EachContainerDispatch {
+
+    @Test
+    @DisplayName("List branch: streams elements and rebuilds via modify")
+    void listBranch() {
+      final Traversal<List<Integer>, Integer> each = Traversals.eachContainer();
+      assertEquals(List.of(1, 2, 3), each.getAll(List.of(1, 2, 3)).toList());
+      assertEquals(List.of(2, 4, 6), each.modify(List.of(1, 2, 3), n -> n * 2));
+    }
+
+    @Test
+    @DisplayName("Set branch: streams and rebuilds into LinkedHashSet (order preserved)")
+    void setBranch() {
+      final Traversal<Set<Integer>, Integer> each = Traversals.eachContainer();
+      final var src = new LinkedHashSet<>(List.of(1, 2, 3));
+      assertEquals(Set.of(1, 2, 3), each.getAll(src).collect(java.util.stream.Collectors.toSet()));
+      assertEquals(Set.of(2, 4, 6), each.modify(src, n -> n * 2));
+    }
+
+    @Test
+    @DisplayName("Map branch: streams values; rebuilds preserving keys")
+    void mapBranch() {
+      final Traversal<Map<String, Integer>, Integer> each = Traversals.eachContainer();
+      final var src = Map.of("a", 1, "b", 2);
+      assertEquals(Set.of(1, 2), each.getAll(src).collect(java.util.stream.Collectors.toSet()));
+      final var out = each.modify(src, n -> n + 10);
+      assertEquals(11, out.get("a"));
+      assertEquals(12, out.get("b"));
+    }
+
+    @Test
+    @DisplayName("Optional branch: present streams one element; modify lifts through")
+    void optionalBranch() {
+      final Traversal<Optional<Integer>, Integer> each = Traversals.eachContainer();
+      assertEquals(List.of(7), each.getAll(Optional.of(7)).toList());
+      assertEquals(Optional.of(8), each.modify(Optional.of(7), n -> n + 1));
+      assertEquals(Optional.empty(), each.modify(Optional.empty(), n -> n + 1));
+    }
+
+    @Test
+    @DisplayName("Array branch: int[] is dispatched via reflection — modify rebuilds an int[]")
+    void arrayPrimitiveBranch() {
+      final Traversal<int[], Integer> each = Traversals.eachContainer();
+      final int[] src = { 1, 2, 3 };
+      assertEquals(List.of(1, 2, 3), each.getAll(src).toList());
+      final int[] doubled = each.modify(src, n -> n * 2);
+      assertArrayEquals(new int[] { 2, 4, 6 }, doubled);
+    }
+
+    @Test
+    @DisplayName("Array branch: Object[] is rebuilt as Object[]")
+    void arrayObjectBranch() {
+      final Traversal<String[], String> each = Traversals.eachContainer();
+      final String[] src = { "a", "b" };
+      assertEquals(List.of("a", "b"), each.getAll(src).toList());
+      final String[] upper = each.modify(src, String::toUpperCase);
+      assertArrayEquals(new String[] { "A", "B" }, upper);
+    }
+
+    @Test
+    @DisplayName("null source streams empty / modify returns null (no NPE)")
+    void nullBranch() {
+      final Traversal<List<Integer>, Integer> each = Traversals.eachContainer();
+      assertEquals(0L, each.getAll(null).count());
+      assertNull(each.modify(null, n -> n + 1));
+    }
+
+    @Test
+    @DisplayName("Unsupported container type throws IllegalArgumentException with a clear message")
+    void unsupportedThrows() {
+      final Traversal<Object, Object> each = Traversals.eachContainer();
+      // Plain Object (not a recognized container, not an array) → throw.
+      final var ex = assertThrows(IllegalArgumentException.class, () ->
+        each.getAll(Objects.requireNonNull("x")).count()
+      );
+      assertTrue(ex.getMessage().contains("each()"), ex.getMessage());
+      final var ex2 = assertThrows(IllegalArgumentException.class, () -> each.modify("x", o -> o));
+      assertTrue(ex2.getMessage().contains("each()"), ex2.getMessage());
+    }
+  }
+
+  // ----- typed Traversals (List/Set/Map/Optional) -----
+
+  @Nested
+  @DisplayName("Typed Traversals — eachList/eachSet/eachMapValue/eachOptional")
+  class TypedTraversals {
+
+    @Test
+    @DisplayName("eachList rebuilds an unmodifiable list with each function applied")
+    void eachList() {
+      final var t = Traversals.<Integer>eachList();
+      assertEquals(List.of(1, 2, 3), t.getAll(List.of(1, 2, 3)).toList());
+      assertEquals(List.of(2, 4, 6), t.modify(List.of(1, 2, 3), n -> n * 2));
+    }
+
+    @Test
+    @DisplayName("eachSet rebuilds an unmodifiable LinkedHashSet preserving insertion order")
+    void eachSet() {
+      final var t = Traversals.<Integer>eachSet();
+      final var src = new LinkedHashSet<>(List.of(1, 2, 3));
+      assertEquals(Set.of(1, 2, 3), t.getAll(src).collect(java.util.stream.Collectors.toSet()));
+      assertEquals(Set.of(2, 4, 6), t.modify(src, n -> n * 2));
+    }
+
+    @Test
+    @DisplayName("eachMapValue rebuilds preserving keys and applying f to each value")
+    void eachMapValue() {
+      final var t = Traversals.<String, Integer>eachMapValue();
+      final var src = Map.of("a", 1, "b", 2);
+      final var out = t.modify(src, n -> n + 10);
+      assertEquals(11, out.get("a"));
+      assertEquals(12, out.get("b"));
+    }
+
+    @Test
+    @DisplayName("eachOptional is an Affine — empty round-trips to empty; present is set")
+    void eachOptional() {
+      final var t = Traversals.<Integer>eachOptional();
+      assertEquals(Optional.of(7), t.getOption(Optional.of(7)));
+      assertEquals(Optional.empty(), t.getOption(Optional.empty()));
+      assertEquals(Optional.of(8), t.modify(Optional.of(7), n -> n + 1));
+      assertEquals(Optional.empty(), t.modify(Optional.empty(), n -> n + 1));
+    }
+  }
+
+  // Suppress the static-fixture unused-field warning for fixtures referenced only inside nested
+  // classes — javac sees them as unread at the outer level, but they're load-bearing inside.
+  @Test
+  @DisplayName("smoke: outer-class fixtures are reachable from nested tests")
+  void smokeFixtures() {
+    assertNotNull(ALICE);
+    assertNotNull(userName);
+    assertNotNull(userAddress);
+    assertNotNull(addressCity);
+  }
+}


### PR DESCRIPTION
## Summary

Three additive capabilities on top of the unified `Telescope.map` factory (shipped in #6) and a major test-coverage lift on the internal substrate.

### DSL additions

- **`WriteHint<B>` + `MapStep` marker.** Pass `writeBean(Class, WriteStrategy)` rows to `Telescope.map` / `Telescope.mapper` to force a specific bean construction strategy (`BUILDER` / `SETTERS` / `FIELDS` / `CONSTRUCTOR`), overriding `Beans.autoWriter` for the keyed class. Closes the gap on immutable all-args-only POJOs (the `viaConstructor()` use case from the old API) and also lets users force a specific strategy when several apply.

  ```java
  import static io.github.eschizoid.telescope.mapping.Mapping.to;
  import static io.github.eschizoid.telescope.mapping.WriteHint.writeBean;
  import static io.github.eschizoid.telescope.mapping.WriteHint.WriteStrategy.CONSTRUCTOR;

  Telescope<OrderRecord, OrderPojo> conv = Telescope.map(
      OrderRecord.class, OrderPojo.class,
      writeBean(OrderPojo.class, CONSTRUCTOR),
      to(OrderRecord::sku, OrderPojo::getSku));
  ```

  Hints are validated **eagerly at resolve time** — duplicate, record-class, incompatible-strategy, and unused-hint cases throw `IllegalArgumentException` / `IllegalStateException` at `Telescope.map(...)` time instead of at first `iso.to()`. No silent corner cases.

- **`Beans.autoWriter` 4th rung.** When no builder / no no-arg ctor exists, fall back to the single public all-args constructor when there's exactly one matching arity **and** the class was compiled with `-parameters`. The auto path refuses positional fallback to avoid silent argument shuffling — for the ambiguous / unparameterized case, the user opts into `writeBean(..., CONSTRUCTOR)` explicitly.

- **Cache.** `Beans.autoWriter` is now backed by a `WeakHashMap` so repeated calls don't re-probe reflection. `WeakHashMap` (vs `ConcurrentHashMap`) avoids classloader leaks under hot-reload (servlet containers / OSGi / JRebel).

- **`Iso.liftSet` + `ContainerShape.Kind.SET` + `autoIso` dispatch arm.** `Set<X>` now participates in deep mapping at N levels of nesting. `List<Map<K, Set<X>>>` and friends resolve by construction. The `liftSet` javadoc documents the lawfulness caveat for element types whose `equals` collapses distinct values (e.g. `Set<Optional<X>>`).

- **`Reflective.beansWithHints(Map)`.** The hint-aware bean reflective is now hoisted to **one allocation per resolution call** and threaded through `populateIso` / `autoIso` via a `beanRefl` parameter — the same anonymous instance is reused across the entire recursion.

### Signature change

`Telescope.map` / `Telescope.mapper` varargs widen from `Mapping<?, ?>...` to `MapStep...` (a sealed marker permitting `Mapping` and `WriteHint`). Existing call sites compile unchanged — `Mapping` rows still flow through identically; `WriteHint` rows are partitioned at runtime in `DeepMap.resolution`. No backward-incompat for any caller that doesn't use the new hint factory.

### Test coverage

- **`BeansTest`** (new, 31 tests): covers every `BeanWriter` strategy, the `autoWriter` ladder including 4th-rung ctor fallback + cache + error paths, the `lens` factory, getter-scan + `propertyOf` helpers. **`Beans.java` instruction coverage: 24.31% → 91%.**
- **`LatticeCoverageTest`** (new, 26 tests): pins `Fold` / `Getter` default views, `Iso` lift helpers + composition diamonds, `Lens` / `Prism` / `Affine` composition arms, `Focus` static factories, and `Traversals.eachContainer` runtime dispatch (`List` / `Set` / `Map` / `Optional` / array / null / unsupported). Lifts `Fold` / `Getter` from 0% → 100%, `Prism` from 28% → 100%, `Iso` / `Focus` to 100%, `Affine` to 74%. Lattice mantra honored.
- **`DeepMappingTest` additions**: `writeBean` round-trip on immutable all-args POJO, hint-wins-over-builder precedence, eager validation throws (record-class hint, duplicate hint, incompatible-strategy hint, unused-hint), `autoWriter` ctor fallback, ambiguous-ctor refusal, `Set<Record>` + `Set<Optional<Record>>` + `List<Map<K, Set<Record>>>` at four container levels.
- **Benchmark fix**: `TelescopeBenchmark` now uses `Telescope.map(...)` instead of the demolished `mapBean()` / `fromBean().viaFields()` chains.

## Test plan

- [x] `./gradlew :core:test` — 244 tests pass (was 187 pre-change)
- [x] `./gradlew build` — full multi-module build green (core + codegen + lombok + benchmarks)
- [x] `./gradlew :core:jacocoTestReport` — `Beans.java` 91%, lattice files 96% package-total
- [x] `./gradlew :benchmarks:compileJmhJava` — benchmark sources compile against the new API
- [x] Spotless / javadoc clean
- [x] Smoke-test the `writeBean` API in a downstream consumer once one exists
- [x] Verify CI green on push