### PR TITLE
chore: post-merge follow-up on PR #8 Copilot review

### DIFF
--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/AbstractTelescopeProcessor.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/AbstractTelescopeProcessor.java
@@ -744,14 +744,16 @@ public abstract class AbstractTelescopeProcessor extends AbstractProcessor {
       case "set" -> "Telescope.<R, " + elementType + ">asSet(path).each()";
       case "optional" -> "Telescope.<R, " + elementType + ">asOptional(path).present()";
       case "map" -> "Telescope.asMap(path).values()";
-      // Iterable case: declared leaf is some `? extends Iterable<E>` shape (e.g. Iterable<E>,
-      // Collection<E>, a custom user iterable). Java's type inference can't always work
-      // backward
-      // from path's leaf type to `eachIterable()`'s bounded type parameter, so we pin both type
-      // arguments to `Telescope.wrap(...)` explicitly — that way the produced
-      // `Telescope<containerType, elementType>` matches the `path.then(...)` left side
-      // regardless
-      // of whether the declared container is `Iterable`, `Collection`, or any other subtype.
+      // Iterable case: declared leaf is some `? extends Iterable<E>` shape that isn't List,
+      // Set,
+      // Map, or Optional (e.g. bare `Iterable<E>` or `Collection<E>`). Pin both type arguments
+      // on `Telescope.wrap(...)` explicitly so the produced `Telescope<containerType,
+      // elementType>` matches the `path.then(...)` left side regardless of the exact declared
+      // container subtype. NOTE: `Traversals.eachIterable()` only safely rebuilds List and Set
+      // sources — other Iterable subtypes (Queue, Deque, custom iterables) trigger a runtime
+      // IllegalArgumentException at update time. The generated step still compiles; if your
+      // model uses Queue/Deque, re-declare the leaf as `List<E>` or `Set<E>` at the source so
+      // the codegen lands on the typed `list`/`set` branches above instead.
       default -> "path.then(Telescope.<" +
       containerType +
       ", " +

--- a/core/src/main/java/io/github/eschizoid/telescope/internal/Beans.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/internal/Beans.java
@@ -26,7 +26,9 @@ import java.util.function.Function;
  * ({@code Introspector} lives in the {@code java.desktop} module). The discovered getter map is
  * cached per class via {@link ClassValue}. The lattice-primitive read for one property is {@link
  * #getter(Class, String)} — a {@link Getter Getter&lt;P, Object&gt;} backed by the cached {@link
- * Method}; {@link #readProperty} is a thin convenience over it.
+ * Method} that allocates a capturing lambda per call (the lattice-shape entry for composing the
+ * read with other optics). {@link #readProperty} is the hot-path shortcut that invokes the same
+ * cached {@link Method} directly, skipping the lambda allocation — preferred from inner loops.
  *
  * <p><b>Write direction (Map/record &rarr; POJO).</b> Four strategies behind the sealed {@link
  * BeanWriter} — {@link BuilderWriter}, {@link SettersWriter}, {@link FieldsWriter}, {@link
@@ -377,8 +379,11 @@ public final class Beans {
    * construction it resolves the no-arg constructor and maps each non-static, non-synthetic
    * declared field by name, calling {@code setAccessible(true)} on all of them. If the JPMS layer
    * forbids that, {@link InaccessibleObjectException} is rethrown as an {@link
-   * IllegalStateException} telling the caller to add an {@code opens} directive or switch to {@link
-   * ConstructorWriter} / {@link BuilderWriter} (which touch public members only).
+   * IllegalStateException} telling the caller to add an {@code opens} directive. Switching the hint
+   * to {@link ConstructorWriter} / {@link BuilderWriter} / {@link SettersWriter} only helps when
+   * their target members are already public — all three still call {@code setAccessible} on the
+   * constructor / methods they resolve, so a fully closed package will keep failing under the same
+   * JPMS constraint; the {@code opens} directive is the real fix.
    */
   static final class FieldsWriter<P> implements BeanWriter<P> {
 

--- a/core/src/main/java/io/github/eschizoid/telescope/internal/Beans.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/internal/Beans.java
@@ -58,17 +58,17 @@ public final class Beans {
   };
 
   /**
-   * The lattice-primitive read for one bean property — a {@link Getter Getter&lt;P, Object&gt;}
-   * over the {@code getX()} / {@code isX()} accessor. Built once per {@code (beanClass, name)} pair
-   * (the underlying {@link Method} comes from the {@link #GETTERS} ClassValue cache, so the Getter
-   * is a thin wrapper around an already-resolved method reference).
+   * The lattice-primitive form of "read one bean property" — a {@link Getter Getter&lt;P,
+   * Object&gt;} over the {@code getX()} / {@code isX()} accessor. The underlying {@link Method} is
+   * resolved from the {@link #GETTERS} ClassValue cache (so the per-class probe is one-shot), but
+   * each call to {@code getter(...)} <em>does</em> allocate a fresh capturing lambda — this is the
+   * lattice-shape entry point for callers that want to compose a {@code Getter} into other optics.
+   * Hot paths that just want the value (e.g. {@link
+   * io.github.eschizoid.telescope.internal.Reflective Reflective}'s bean-side {@code read}) should
+   * call {@link #readProperty(Object, String)} instead; it invokes the cached {@link Method}
+   * directly without the lambda allocation.
    *
    * <p>Throws {@link IllegalArgumentException} at build time if the named property has no getter.
-   *
-   * <p>{@link #readProperty(Object, String)} is the convenience caller; {@code
-   * io.github.eschizoid.telescope.internal.Reflective.BEANS#read} delegates here so the read side
-   * of {@code DeepMap} stays routed through the lattice rather than through bare {@code
-   * Method.invoke}.
    */
   public static <P> Getter<P, Object> getter(final Class<P> beanClass, final String name) {
     final var method = getters(beanClass).get(name);
@@ -434,8 +434,11 @@ public final class Beans {
             cls.getName() +
             " for the FIELDS strategy. Add 'opens " +
             cls.getPackageName() +
-            " to io.github.eschizoid.telescope;' to that module's module-info.java, or switch the writeBean " +
-            "hint to CONSTRUCTOR / BUILDER (which use public members only).",
+            " to io.github.eschizoid.telescope;' to that module's module-info.java. " +
+            "Switching the writeBean hint to CONSTRUCTOR / BUILDER / SETTERS will only help if " +
+            "those strategies' members are already public (no setAccessible call needed) — they " +
+            "still invoke setAccessible on the ctor / methods they resolve, so a closed package " +
+            "may keep failing under the same JPMS constraint.",
           e
         );
       }

--- a/core/src/main/java/io/github/eschizoid/telescope/internal/optics/collections/Traversals.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/internal/optics/collections/Traversals.java
@@ -26,7 +26,9 @@ import java.util.stream.Stream;
  * <p>{@link #eachIterable()} is the polymorphic {@code Iterable<E>} variant used by the typed
  * {@code Telescope.each(Accessor)} form when the declared leaf type is {@code Iterable<E>} rather
  * than a specific {@code List}/{@code Set}. It dispatches once on the runtime class to pick the
- * concrete rebuild shape (List → ArrayList, Set → LinkedHashSet, other → ArrayList fallback).
+ * concrete rebuild shape (List → ArrayList, Set → LinkedHashSet). Other {@code Iterable} subtypes
+ * (Queue, Deque, custom iterables) are rejected at {@code modify} time — see {@link
+ * #eachIterable()} for the rationale.
  */
 public final class Traversals {
 
@@ -97,15 +99,22 @@ public final class Traversals {
   }
 
   /**
-   * A {@link Traversal} over any {@link Iterable} container ({@code List}, {@code Set}, any custom
-   * {@code Iterable}). Streams via {@link Iterable#iterator()} and rebuilds via the concrete
-   * container's typed {@code Traversals.each*} primitive when the actual class is known (List →
-   * {@code ArrayList}, Set → {@code LinkedHashSet}); other Iterables rebuild as unmodifiable lists.
+   * A {@link Traversal} over an {@link Iterable} container — rebuilds {@link List} sources as an
+   * unmodifiable {@code ArrayList}-backed list, {@link Set} sources as an unmodifiable {@link
+   * LinkedHashSet}-backed set.
    *
-   * <p>Used by the typed {@code Telescope.each(Accessor<A, ? extends Iterable<E>>)} form on
-   * Telescope, which declares the leaf as Iterable to accept either List or Set without locking the
-   * caller into one concrete shape. Arrays are NOT supported — wrap as a List or Set if your model
-   * uses arrays.
+   * <p><b>Supported shapes are List and Set only.</b> Used by the typed {@code
+   * Telescope.each(Accessor<A, ? extends Iterable<E>>)} form on Telescope so a getter declared as
+   * {@code Iterable<E>} accepts either concrete kind without locking the call site to one. Any
+   * other {@code Iterable} subtype ({@link java.util.Queue Queue}, {@link java.util.Deque Deque}, a
+   * custom {@code FooIterable}) is rejected at {@code modify(...)} time with a {@link
+   * ClassCastException}-equivalent {@link IllegalArgumentException} — the rebuild can only preserve
+   * container identity (i.e. honor the {@code C} type parameter without a downstream cast failure)
+   * for {@code List} and {@code Set}. If your model uses {@code Queue}/{@code Deque} /custom
+   * iterables, declare the getter as {@code List<E>} or {@code Set<E>} and explicitly convert at
+   * the boundary instead.
+   *
+   * <p>Arrays are NOT supported — wrap as a List or Set if your model uses arrays.
    */
   @SuppressWarnings({ "unchecked", "cast" })
   public static <C extends Iterable<E>, E> Traversal<C, E> eachIterable() {
@@ -129,11 +138,15 @@ public final class Traversals {
           for (final var e : source) out.add(f.apply(e));
           return (C) Collections.unmodifiableSet(out);
         }
-        // Other Iterable shapes — rebuild as an immutable List (best-effort; the typed leaf
-        // .each(Accessor<A, List<X>>) or .each(Accessor<A, Set<X>>) preserves the original shape).
-        final var out = new ArrayList<E>();
-        for (final var e : source) out.add(f.apply(e));
-        return (C) Collections.unmodifiableList(out);
+        // No safe rebuild for other Iterable shapes — the (C) cast would succeed on a List but
+        // throw ClassCastException downstream when callers store it into a field typed as e.g.
+        // Queue<E>. Refuse upfront with a clear message instead of fabricating an unsafe cast.
+        throw new IllegalArgumentException(
+          "Traversals.eachIterable() supports only List and Set sources; got " +
+            source.getClass().getName() +
+            ". Declare your record component / bean property as List<E> or Set<E>, " +
+            "not the raw Iterable subtype, so the rebuild can preserve container identity."
+        );
       }
     };
   }

--- a/core/src/test/java/io/github/eschizoid/telescope/internal/optics/LatticeCoverageTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/internal/optics/LatticeCoverageTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.github.eschizoid.telescope.internal.optics.collections.Traversals;
@@ -457,6 +458,17 @@ class LatticeCoverageTest {
       final Traversal<Iterable<Integer>, Integer> each = Traversals.eachIterable();
       assertEquals(0L, each.getAll(null).count());
       assertNull(each.modify(null, n -> n + 1));
+    }
+
+    @Test
+    @DisplayName("non-List / non-Set Iterable source: modify rejects with IllegalArgumentException")
+    void nonListNonSetRejected() {
+      final Traversal<Iterable<Integer>, Integer> each = Traversals.eachIterable();
+      // Plain Iterable<Integer> that is neither List nor Set — e.g. a Queue. We can't safely
+      // rebuild Queue (the C cast would lie), so modify must throw.
+      final Iterable<Integer> src = new java.util.ArrayDeque<>(List.of(1, 2, 3));
+      final var ex = assertThrows(IllegalArgumentException.class, () -> each.modify(src, n -> n + 1));
+      assertTrue(ex.getMessage().contains("List and Set"), ex.getMessage());
     }
   }
 


### PR DESCRIPTION
## Summary

Copilot fired on PR #8 **two minutes after merge** with 5 actionable comments that landed too late to be addressed in the original PR. This PR addresses all 5.

## Fixes

1. **`Beans.getter(...)` javadoc** — dropped the misleading \"built once per (beanClass, name) pair\" claim. The method allocates a capturing lambda per call by design (it's the lattice-shape entry point for composing a `Getter` into other optics). Reworded to point hot-path callers at `readProperty` (no lambda alloc — invokes the cached `Method` directly). Also removed the stale \"Reflective.BEANS#read delegates here\" line; round-1 of PR #8 inlined that path for exactly the alloc reason.

2. **`Beans.FieldsWriter` access() exception message** — toned down the \"switch to CONSTRUCTOR / BUILDER (which use public members only)\" guidance. CONSTRUCTOR / BUILDER / SETTERS all still invoke `setAccessible(true)` on their resolved members, so a closed package keeps failing for them too. Updated to make this explicit.

3. **`Traversals.eachIterable` cast safety** — refuse non-List / non-Set Iterable sources upfront with a clear `IllegalArgumentException` instead of fabricating an unsafe `(C)` cast. The previous \"rebuild as unmodifiable List, cast to C\" fallback was a latent ClassCastException hazard: if the caller's `C` was `Queue<E>` or any other non-`List` Iterable, the cast succeeded here but threw downstream. Class-level + method-level javadoc updated to record the supported-shapes constraint.

4. **`AbstractTelescopeProcessor` codegen comment** — removed the \"any custom user iterable\" claim from the Iterable-case branch. Replaced with an accurate description that notes the runtime rejection for `Queue`/`Deque`/custom iterables and tells users to re-declare such leaves as `List<E>` or `Set<E>` at the source so the codegen lands on the typed `list`/`set` branches instead.

5. **`LatticeCoverageTest.EachIterable`** — new test pinning the non-List/non-Set rejection behavior with an `ArrayDeque` source.

## Test plan

- [x] `./gradlew :core:test` — 267 tests pass (was 266; +1 for the new rejection test)
- [x] `./gradlew build` — full multi-module build green
- [x] Spotless / javadoc clean