### PR TITLE
feat(core): Phase 5 — LambdaMetafactory rebuild path (ctor + fields + Records.construct)

### DIFF
--- a/core/src/main/java/io/github/eschizoid/telescope/internal/Beans.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/internal/Beans.java
@@ -3,6 +3,7 @@ package io.github.eschizoid.telescope.internal;
 import io.github.eschizoid.telescope.internal.optics.Getter;
 import io.github.eschizoid.telescope.internal.optics.Lens;
 import java.lang.invoke.LambdaMetafactory;
+import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
 import java.lang.reflect.AccessibleObject;
@@ -16,6 +17,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 /**
  * Reflection-based machinery for navigating and constructing JavaBeans-style POJOs. Powers {@code
@@ -484,26 +486,41 @@ public final class Beans {
   }
 
   /**
-   * {@link BeanWriter} backed by a no-arg constructor plus reflective field injection. At
-   * construction it resolves the no-arg constructor and maps each non-static, non-synthetic
-   * declared field by name, calling {@code setAccessible(true)} on all of them. If the JPMS layer
-   * forbids that, {@link InaccessibleObjectException} is rethrown as an {@link
-   * IllegalStateException} telling the caller to add an {@code opens} directive. Switching the hint
-   * to {@link ConstructorWriter} / {@link BuilderWriter} / {@link SettersWriter} only helps when
-   * their target members are already public — all three still call {@code setAccessible} on the
-   * constructor / methods they resolve, so a fully closed package will keep failing under the same
-   * JPMS constraint; the {@code opens} directive is the real fix.
+   * {@link BeanWriter} backed by a no-arg constructor plus field injection routed through one
+   * cached invoker per member. At construction it resolves the no-arg constructor, walks each
+   * non-static / non-synthetic declared field, calls {@code setAccessible(true)} (still needed for
+   * the {@link MethodHandles.Lookup#unreflectSetter(Field) unreflectSetter} call on non-public
+   * fields, exactly mirroring the previous {@link Field#set} permission model), and binds a {@link
+   * Supplier Supplier&lt;Object&gt;} no-arg-constructor invoker built via {@link LambdaMetafactory}
+   * plus a {@code BiConsumer<Object, Object>} setter per field. The per-field setters wrap a cached
+   * {@link MethodHandle} adapted to {@code (Object, Object) -> void} via {@link MethodHandle#asType
+   * asType} — LMF won't accept setter handles ({@code "Unsupported MethodHandle kind: putField"}),
+   * so the cached MH is the JDK-standard alternative. It still skips the per-call access check that
+   * {@code Field.set} pays; {@code invokeExact} through the captured {@code final} reference is
+   * JIT-inlinable.
+   *
+   * <p>If the JPMS layer forbids access, {@link InaccessibleObjectException} is rethrown as an
+   * {@link IllegalStateException} telling the caller to add an {@code opens} directive. Every
+   * sibling strategy ({@link ConstructorWriter} / {@link BuilderWriter} / {@link SettersWriter})
+   * now reaches the bean through {@link MethodHandles#privateLookupIn} — same JPMS gate — so
+   * switching the hint to a sibling only avoids this error when the sibling's target members are
+   * already accessible (e.g. the bean's {@code builder()} factory is public and lives in a package
+   * the module exports). For a fully closed package, the {@code opens} directive is the real fix
+   * regardless of strategy. The hot path — {@link #construct(String[], Function)} — calls {@code
+   * ctorFn.get()} once and then {@code setter.accept(pojo, value)} per name; neither call reaches
+   * {@link Field#set} or {@link Constructor#newInstance}.
    */
   static final class FieldsWriter<P> implements BeanWriter<P> {
 
     private final Class<P> cls;
-    private final Constructor<P> ctor;
-    private final Map<String, Field> fields;
+    private final Supplier<Object> ctorFn;
+    private final Map<String, BiConsumer<Object, Object>> setters;
 
     FieldsWriter(final Class<P> cls) {
       this.cls = cls;
+      final Constructor<P> ctor;
       try {
-        this.ctor = cls.getDeclaredConstructor();
+        ctor = cls.getDeclaredConstructor();
       } catch (final NoSuchMethodException e) {
         throw new IllegalStateException("writeBean(" + cls.getName() + ", FIELDS) requires a no-arg constructor", e);
       }
@@ -514,27 +531,38 @@ public final class Beans {
         access(f);
         fs.put(f.getName(), f);
       }
-      this.fields = fs;
+      final var lookup = privateLookupOrThrow(cls, cls, "FIELDS strategy");
+      this.ctorFn = buildCtorSupplier(cls, ctor, lookup);
+      final var setterMap = new LinkedHashMap<String, BiConsumer<Object, Object>>();
+      for (final var entry : fs.entrySet()) {
+        setterMap.put(entry.getKey(), buildFieldSetter(cls, entry.getValue(), lookup));
+      }
+      this.setters = setterMap;
     }
 
     @Override
     public P construct(final String[] names, final Function<String, Object> valueByName) {
+      // Wrap the LMF-built Supplier invocation in the same stable RuntimeException shape the
+      // pre-LMF Constructor#newInstance path used. Unlike Constructor#newInstance (which surfaced
+      // body failures via InvocationTargetException → checked-exception wrap), the LMF Supplier is
+      // signature-polymorphic and can propagate checked exceptions and Errors directly, so we
+      // catch the same width here. Errors propagate untouched.
       final P pojo;
       try {
-        pojo = ctor.newInstance();
-      } catch (final ReflectiveOperationException e) {
-        throw new RuntimeException("Failed to instantiate " + cls.getName(), e);
+        @SuppressWarnings("unchecked")
+        final var built = (P) ctorFn.get();
+        pojo = built;
+      } catch (final Error error) {
+        throw error;
+      } catch (final Throwable t) {
+        throw new RuntimeException("Failed to instantiate " + cls.getName(), t);
       }
       for (final var name : names) {
-        final var f = fields.get(name);
-        if (f == null) throw new IllegalArgumentException(
+        final var setter = setters.get(name);
+        if (setter == null) throw new IllegalArgumentException(
           "writeBean(" + cls.getName() + ", FIELDS): no field '" + name + "'"
         );
-        try {
-          f.set(pojo, valueByName.apply(name));
-        } catch (final IllegalAccessException e) {
-          throw new RuntimeException("Failed to set field '" + name + "' on " + cls.getName(), e);
-        }
+        setter.accept(pojo, valueByName.apply(name));
       }
       return pojo;
     }
@@ -549,28 +577,90 @@ public final class Beans {
             " for the FIELDS strategy. Add 'opens " +
             cls.getPackageName() +
             " to io.github.eschizoid.telescope;' to that module's module-info.java. " +
-            "Switching the writeBean hint to CONSTRUCTOR / BUILDER / SETTERS will only help if " +
-            "those strategies' members are already public (no setAccessible call needed) — they " +
-            "still invoke setAccessible on the ctor / methods they resolve, so a closed package " +
-            "may keep failing under the same JPMS constraint.",
+            "Switching the writeBean hint to CONSTRUCTOR / BUILDER / SETTERS reaches the bean " +
+            "through privateLookupIn rather than raw setAccessible, but the JPMS gate is the same " +
+            "— the open directive is the real fix for a fully closed package.",
           e
         );
       }
     }
+
+    @SuppressWarnings("unchecked")
+    private static Supplier<Object> buildCtorSupplier(
+      final Class<?> cls,
+      final Constructor<?> ctor,
+      final MethodHandles.Lookup lookup
+    ) {
+      try {
+        final var handle = lookup.unreflectConstructor(ctor);
+        final var callSite = LambdaMetafactory.metafactory(
+          lookup,
+          "get",
+          MethodType.methodType(Supplier.class),
+          MethodType.methodType(Object.class),
+          handle,
+          MethodType.methodType(cls)
+        );
+        return (Supplier<Object>) callSite.getTarget().invoke();
+      } catch (final Throwable t) {
+        throw new RuntimeException("Failed to instantiate " + cls.getName(), t);
+      }
+    }
+
+    private static BiConsumer<Object, Object> buildFieldSetter(
+      final Class<?> cls,
+      final Field field,
+      final MethodHandles.Lookup lookup
+    ) {
+      // LambdaMetafactory rejects setter handles ("Unsupported MethodHandle kind: putField"), so
+      // the cached MethodHandle path is the JDK-standard alternative — `unreflectSetter` resolves
+      // a `(receiver, value) -> void` handle, then `asType` adapts it to the erased
+      // `(Object, Object) -> void` so it can be invoked from a `BiConsumer<Object, Object>` shape.
+      // Still skips the per-call access check {@link Field#set} pays; the JIT inlines invokeExact
+      // through the captured `final` reference.
+      final MethodHandle setterHandle;
+      try {
+        setterHandle = lookup
+          .unreflectSetter(field)
+          .asType(MethodType.methodType(void.class, Object.class, Object.class));
+      } catch (final IllegalAccessException e) {
+        throw new RuntimeException("Failed to set field '" + field.getName() + "' on " + cls.getName(), e);
+      }
+      return (pojo, value) -> {
+        try {
+          setterHandle.invokeExact(pojo, value);
+        } catch (final Throwable t) {
+          throw new RuntimeException("Failed to set field '" + field.getName() + "' on " + cls.getName(), t);
+        }
+      };
+    }
   }
 
   /**
-   * {@link BeanWriter} backed by an all-args constructor. At construction it finds the unique
-   * declared constructor with the requested arity (throwing if there are zero or more than one) and
-   * makes it accessible. If the POJO was compiled with {@code -parameters}, {@code construct}
-   * matches each argument to its source value by the constructor parameter's <em>name</em> — so a
-   * reordered constructor is safe; otherwise it falls back to positional, assembling arguments in
-   * {@code names} order and relying on the constructor parameters lining up with the components.
+   * {@link BeanWriter} backed by an all-args constructor routed through a cached spread {@link
+   * MethodHandle}. At construction it finds the unique declared constructor with the requested
+   * arity (throwing if there are zero or more than one), makes it accessible, and binds a {@code
+   * Function<Object, Object>} invoker that wraps the {@link MethodHandle#asSpreader(Class, int)
+   * asSpreader}-wrapped handle: the raw constructor handle has type {@code (T1, T2, …, Tn) → P} and
+   * the spreader converts it to {@code (Object[]) → P}. Primitive args auto-unbox per the same
+   * implicit conversions a direct constructor call would apply.
+   *
+   * <p>The invoker is intentionally <em>not</em> built via {@link LambdaMetafactory} — the spread
+   * adapter is a non-direct {@link MethodHandle}, which LMF rejects with {@code "MethodHandle
+   * (Object[])P is not direct or cannot be cracked"}. The cached MethodHandle path is the standard
+   * JDK alternative — it still skips the per-call access check and the varargs allocation that
+   * {@link Constructor#newInstance} pays, and {@code invokeExact} through a {@code final} field
+   * inlines under the JIT. The hot path never reaches {@code Constructor.newInstance}.
+   *
+   * <p>If the POJO was compiled with {@code -parameters}, {@code construct} matches each argument
+   * to its source value by the constructor parameter's <em>name</em> — so a reordered constructor
+   * is safe; otherwise it falls back to positional, assembling arguments in {@code names} order and
+   * relying on the constructor parameters lining up with the components.
    */
   static final class ConstructorWriter<P> implements BeanWriter<P> {
 
     private final Class<P> cls;
-    private final Constructor<P> ctor;
+    private final Function<Object, Object> ctorFn;
     // Constructor parameter names when the POJO was compiled with -parameters (enables
     // order-independent name matching); null when names are synthetic, so we fall back to
     // positional.
@@ -598,9 +688,11 @@ public final class Beans {
           arity +
           " parameters (parameters are matched by name when compiled with -parameters, otherwise positionally)."
       );
-      found.setAccessible(true);
-      this.ctor = found;
+      // No raw setAccessible — buildCtorFn acquires private access through privateLookupOrThrow,
+      // which is consistent with the FIELDS strategy and routes JPMS failures through the same
+      // opens-pointing message instead of a low-context InaccessibleObjectException.
       this.paramNames = resolveParamNames(found);
+      this.ctorFn = buildCtorFn(cls, found, arity);
     }
 
     private static String[] resolveParamNames(final Constructor<?> ctor) {
@@ -613,7 +705,35 @@ public final class Beans {
       return names;
     }
 
+    private static <P> Function<Object, Object> buildCtorFn(
+      final Class<P> cls,
+      final Constructor<P> ctor,
+      final int arity
+    ) {
+      // Constructors are not inherited in Java — `cls.getDeclaredConstructors()` returns only the
+      // ones declared directly on `cls`, so `ctor.getDeclaringClass() == cls` always. No
+      // inherited-accessor concern here (unlike methods); pin the lookup straight to `cls`.
+      final var lookup = privateLookupOrThrow(cls, cls, "CONSTRUCTOR strategy");
+      final MethodHandle spread;
+      try {
+        spread = lookup
+          .unreflectConstructor(ctor)
+          .asSpreader(Object[].class, arity)
+          .asType(MethodType.methodType(Object.class, Object[].class));
+      } catch (final IllegalAccessException e) {
+        throw new RuntimeException("Failed to construct " + cls.getName() + " via its constructor", e);
+      }
+      return args -> {
+        try {
+          return (Object) spread.invokeExact((Object[]) args);
+        } catch (final Throwable t) {
+          throw new RuntimeException("Failed to construct " + cls.getName() + " via its constructor", t);
+        }
+      };
+    }
+
     @Override
+    @SuppressWarnings("unchecked")
     public P construct(final String[] names, final Function<String, Object> valueByName) {
       // Prefer matching by parameter name (order-independent) when names are present; otherwise
       // fall
@@ -622,11 +742,7 @@ public final class Beans {
       final var keys = paramNames != null ? paramNames : names;
       final var args = new Object[keys.length];
       for (var i = 0; i < keys.length; i++) args[i] = valueByName.apply(keys[i]);
-      try {
-        return ctor.newInstance(args);
-      } catch (final ReflectiveOperationException e) {
-        throw new RuntimeException("Failed to construct " + cls.getName() + " via its constructor", e);
-      }
+      return (P) ctorFn.apply(args);
     }
   }
 

--- a/core/src/main/java/io/github/eschizoid/telescope/internal/Records.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/internal/Records.java
@@ -2,6 +2,7 @@ package io.github.eschizoid.telescope.internal;
 
 import io.github.eschizoid.telescope.internal.optics.Lens;
 import java.lang.invoke.LambdaMetafactory;
+import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
 import java.lang.reflect.Constructor;
@@ -17,10 +18,14 @@ import java.util.function.Function;
  * stored entry doesn't pin its key's classloader. The cache carries (a) the {@link RecordComponent}
  * array for metadata (name, generic type, index lookup), (b) one {@link Function
  * Function&lt;Object, Object&gt;} per component built once via {@link LambdaMetafactory} for the
- * hot-path read, and (c) the canonical {@link Constructor} for rebuild. The hot path never touches
- * {@link java.lang.reflect.Method#invoke} — component reads dispatch through the synthetic {@code
- * Function} the LambdaMetafactory call site materializes, which the JIT inlines just like a direct
- * method-ref invocation.
+ * hot-path read, (c) the canonical {@link Constructor} kept for metadata, and (d) a single
+ * canonical-constructor invoker built once over a {@link MethodHandle#asSpreader(Class, int)
+ * asSpreader}-wrapped {@link MethodHandle} for the hot-path rebuild. The hot path never touches
+ * {@link java.lang.reflect.Method#invoke} or {@link Constructor#newInstance} — reads dispatch
+ * through the synthetic LMF call site (which the JIT inlines just like a direct method-ref
+ * invocation), and rebuilds dispatch through a cached MethodHandle (LMF rejects the non-direct
+ * spread adapter, so the JDK-standard MethodHandle path is used; it still skips the per-call access
+ * check and varargs allocation that {@code Constructor.newInstance} pays).
  *
  * <p>Records only. Mutating helpers reject any non-record argument with {@code "Not a record"}, and
  * {@code RecordInfo.of} does the same when a class is first cached.
@@ -147,11 +152,7 @@ public final class Records {
     final var comps = info.components();
     final var args = new Object[comps.length];
     for (var i = 0; i < comps.length; i++) args[i] = valueByName.apply(comps[i].getName());
-    try {
-      return (R) info.ctor().newInstance(args);
-    } catch (final ReflectiveOperationException e) {
-      throw new RuntimeException("Failed to construct " + recordClass.getSimpleName(), e);
-    }
+    return (R) info.ctorFn().apply(args);
   }
 
   private static Object readField(final Object source, final String fieldName) {
@@ -176,10 +177,14 @@ public final class Records {
       final var current = readers[i].apply(source);
       args[i] = (i == idx) ? fn.apply(current) : current;
     }
+    // Wrap with the rebuild-specific context the pre-LMF Constructor#newInstance path used: the
+    // shared `ctorFn` would otherwise rethrow as "Failed to construct <Record>" from
+    // `RecordInfo.buildCtorFn`, losing the "this happened during a single-field update" context
+    // useful for debugging Records.with / lens modifications.
     try {
-      return (S) info.ctor().newInstance(args);
-    } catch (final ReflectiveOperationException e) {
-      throw new RuntimeException("Failed to rebuild " + cls.getSimpleName(), e);
+      return (S) info.ctorFn().apply(args);
+    } catch (final RuntimeException re) {
+      throw new RuntimeException("Failed to rebuild " + cls.getSimpleName(), re);
     }
   }
 
@@ -194,21 +199,62 @@ public final class Records {
   /**
    * Cached per-class metadata: the component array (canonical order) for name / type lookups, one
    * {@link Function Function&lt;Object, Object&gt;} per component built once via {@link
-   * LambdaMetafactory} for hot-path reads, and the canonical {@link Constructor} for rebuild.
-   * {@code indexOf} maps a component name to its position; the cache lives in {@link #CACHE}.
+   * LambdaMetafactory} for hot-path reads, the canonical {@link Constructor} retained for its
+   * metadata, and a single {@link Function Function&lt;Object, Object&gt;} canonical-constructor
+   * invoker that wraps a cached spread {@link MethodHandle} for hot-path rebuild. {@code indexOf}
+   * maps a component name to its position; the cache lives in {@link #CACHE}.
+   *
+   * <p>The {@code ctorFn} is typed {@code Function<Object, Object>} (Function's only SAM) but its
+   * input is interpreted as an {@code Object[]} of canonical-constructor arguments — the wrapper
+   * casts it back to {@code Object[]} before invoking the spread handle. Callers always pass a
+   * sized-{@code components.length} {@code Object[]}; the spread handle pulls each element by index
+   * and the JVM applies the same implicit boxed/primitive conversions a direct constructor
+   * invocation would.
    */
-  private record RecordInfo(RecordComponent[] components, Function<Object, Object>[] readers, Constructor<?> ctor) {
+  private record RecordInfo(
+    RecordComponent[] components,
+    Function<Object, Object>[] readers,
+    Constructor<?> ctor,
+    Function<Object, Object> ctorFn
+  ) {
     static RecordInfo of(final Class<?> cls) {
       if (!cls.isRecord()) throw new IllegalArgumentException("Not a record: " + cls.getName());
       final var comps = cls.getRecordComponents();
       final var paramTypes = Arrays.stream(comps).map(RecordComponent::getType).toArray(Class<?>[]::new);
       try {
         final var ctor = cls.getDeclaredConstructor(paramTypes);
-        ctor.setAccessible(true);
-        final var readers = buildReaders(cls, comps);
-        return new RecordInfo(comps, readers, ctor);
+        // No raw setAccessible — access flows through privateLookupIn, which routes JPMS failures
+        // through the tailored opens-pointing IllegalStateException below. A raw setAccessible
+        // before that path would throw InaccessibleObjectException with a less-actionable message.
+        final var lookup = privateLookupIn(cls);
+        final var readers = buildReaders(cls, comps, lookup);
+        final var ctorFn = buildCtorFn(cls, ctor, lookup);
+        return new RecordInfo(comps, readers, ctor, ctorFn);
       } catch (final NoSuchMethodException e) {
         throw new IllegalStateException("Cannot find canonical constructor for " + cls.getName(), e);
+      }
+    }
+
+    /**
+     * One {@link MethodHandles.Lookup} per class — used for both the reader and the ctor LMF call
+     * sites so we only walk the JPMS access check once per cache-warm.
+     */
+    private static MethodHandles.Lookup privateLookupIn(final Class<?> cls) {
+      try {
+        // `privateLookupIn` is needed when the record (or its module's package) isn't open to the
+        // telescope module; for fully-public records in the same module this is equivalent to a
+        // plain `MethodHandles.lookup()`. Same JPMS constraint as `setAccessible(true)` — no
+        // worse than the previous reflection path.
+        return MethodHandles.privateLookupIn(cls, MethodHandles.lookup());
+      } catch (final IllegalAccessException e) {
+        throw new IllegalStateException(
+          "Cannot access " +
+            cls.getName() +
+            " to build LambdaMetafactory call sites. Add 'opens " +
+            cls.getPackageName() +
+            " to io.github.eschizoid.telescope;' to that module's module-info.java.",
+          e
+        );
       }
     }
 
@@ -220,25 +266,12 @@ public final class Records {
      * java.lang.reflect.Method#invoke}, no per-call argument array, no access-check.
      */
     @SuppressWarnings("unchecked")
-    private static Function<Object, Object>[] buildReaders(final Class<?> cls, final RecordComponent[] comps) {
+    private static Function<Object, Object>[] buildReaders(
+      final Class<?> cls,
+      final RecordComponent[] comps,
+      final MethodHandles.Lookup lookup
+    ) {
       final var readers = (Function<Object, Object>[]) new Function<?, ?>[comps.length];
-      final MethodHandles.Lookup lookup;
-      try {
-        // `privateLookupIn` is needed when the record (or its module's package) isn't open to the
-        // telescope module; for fully-public records in the same module this is equivalent to a
-        // plain `MethodHandles.lookup()`. Same JPMS constraint as `setAccessible(true)` — no
-        // worse than the previous reflection path.
-        lookup = MethodHandles.privateLookupIn(cls, MethodHandles.lookup());
-      } catch (final IllegalAccessException e) {
-        throw new IllegalStateException(
-          "Cannot access " +
-            cls.getName() +
-            " to build LambdaMetafactory readers. Add 'opens " +
-            cls.getPackageName() +
-            " to io.github.eschizoid.telescope;' to that module's module-info.java.",
-          e
-        );
-      }
       for (var i = 0; i < comps.length; i++) {
         final var comp = comps[i];
         try {
@@ -263,6 +296,45 @@ public final class Records {
         }
       }
       return readers;
+    }
+
+    /**
+     * Build a {@code Function<Object, Object>} canonical-constructor invoker over an {@link
+     * MethodHandle#asSpreader(Class, int) asSpreader}-wrapped {@link MethodHandle}. The raw
+     * constructor handle has type {@code (T1, T2, …, Tn) → R}; {@code asSpreader(Object[].class,
+     * arity)} converts it to {@code (Object[]) → R}, and {@link MethodHandle#asType(MethodType)
+     * asType} relaxes the return to {@code Object} so {@link MethodHandle#invokeExact invokeExact}
+     * can be called from a generic context. Primitive args auto-unbox per the same implicit
+     * conversions a direct constructor call would apply.
+     *
+     * <p>This intentionally does <em>not</em> route through {@link LambdaMetafactory}: {@code
+     * asSpreader} returns a non-direct adapter handle, and LMF rejects non-direct handles with
+     * {@code "MethodHandle(Object[])R is not direct or cannot be cracked"}. The MethodHandle path
+     * is the standard JDK alternative — it still skips the per-call access check and varargs
+     * allocation that {@link Constructor#newInstance} pays, and the JIT inlines {@code invokeExact}
+     * calls through {@code final} fields. The hot path never reaches {@code
+     * Constructor.newInstance}.
+     */
+    private static Function<Object, Object> buildCtorFn(
+      final Class<?> cls,
+      final Constructor<?> ctor,
+      final MethodHandles.Lookup lookup
+    ) {
+      try {
+        final var spread = lookup
+          .unreflectConstructor(ctor)
+          .asSpreader(Object[].class, ctor.getParameterCount())
+          .asType(MethodType.methodType(Object.class, Object[].class));
+        return args -> {
+          try {
+            return (Object) spread.invokeExact((Object[]) args);
+          } catch (final Throwable t) {
+            throw new RuntimeException("Failed to construct " + cls.getSimpleName(), t);
+          }
+        };
+      } catch (final IllegalAccessException e) {
+        throw new IllegalStateException("Failed to build canonical-constructor invoker for " + cls.getName(), e);
+      }
     }
 
     int indexOf(final String name) {

--- a/core/src/test/java/io/github/eschizoid/telescope/internal/BeansTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/internal/BeansTest.java
@@ -253,6 +253,71 @@ class BeansTest {
     }
   }
 
+  // Multi-primitive fixture pinning the spread-MethodHandle auto-unboxing path used by
+  // ConstructorWriter (and by Records.RecordInfo.ctorFn — see PrimitiveRecord). LMF rejects the
+  // asSpreader adapter ("not direct or cannot be cracked"), so the ctor invoker is a cached
+  // MethodHandle invoked via `invokeExact` rather than an LMF-synthesized Function. Boxed
+  // `int`/`long`/`double`/`boolean` values flowing in via the Object[] get unboxed by the
+  // implicit conversions the spread handle applies, the same way a direct constructor call would.
+  static final class PrimitiveCtor {
+
+    private final int i;
+    private final long l;
+    private final double d;
+    private final boolean b;
+
+    public PrimitiveCtor(final int i, final long l, final double d, final boolean b) {
+      this.i = i;
+      this.l = l;
+      this.d = d;
+      this.b = b;
+    }
+
+    public int getI() {
+      return i;
+    }
+
+    public long getL() {
+      return l;
+    }
+
+    public double getD() {
+      return d;
+    }
+
+    public boolean isB() {
+      return b;
+    }
+  }
+
+  // Multi-primitive FIELDS fixture pinning the cached-setter unbox path: each declared field is
+  // written through the MethodHandle setter built once at construction time.
+  static final class PrimitiveFields {
+
+    private int i;
+    private long l;
+    private double d;
+    private boolean b;
+
+    public PrimitiveFields() {}
+
+    public int getI() {
+      return i;
+    }
+
+    public long getL() {
+      return l;
+    }
+
+    public double getD() {
+      return d;
+    }
+
+    public boolean isB() {
+      return b;
+    }
+  }
+
   static final class TwoCtorsSameArity {
 
     private final String a;
@@ -466,6 +531,30 @@ class BeansTest {
       final var writer = Beans.fieldsWriter(NoArgFields.class);
       assertThrows(IllegalArgumentException.class, () -> writer.construct(new String[] { "ghost" }, n -> "x"));
     }
+
+    @Test
+    @DisplayName("primitive-typed fields auto-unbox through the cached MethodHandle setter")
+    void fieldsAutoUnboxesPrimitives() {
+      final var writer = Beans.fieldsWriter(PrimitiveFields.class);
+      // Boxed wrappers arrive via valueByName; the cached setter MH unboxes them per the same
+      // implicit conversions a direct Field.set call would apply (the setter handle was bound
+      // with field-typed signature at cache-warm time).
+      final var values = Map.<String, Object>of(
+        "i",
+        Integer.valueOf(7),
+        "l",
+        Long.valueOf(42L),
+        "d",
+        Double.valueOf(3.14),
+        "b",
+        Boolean.TRUE
+      );
+      final var pojo = writer.construct(new String[] { "i", "l", "d", "b" }, values::get);
+      assertEquals(7, pojo.getI());
+      assertEquals(42L, pojo.getL());
+      assertEquals(3.14, pojo.getD());
+      assertEquals(true, pojo.isB());
+    }
   }
 
   // ----- SettersWriter -----
@@ -597,6 +686,31 @@ class BeansTest {
     @DisplayName("constructorWriter throws when more than one constructor matches the arity")
     void constructorAmbiguousArityThrows() {
       assertThrows(IllegalStateException.class, () -> Beans.constructorWriter(TwoCtorsSameArity.class, 1));
+    }
+
+    @Test
+    @DisplayName("primitive-typed ctor args auto-unbox through the cached spread MethodHandle")
+    void constructorAutoUnboxesPrimitives() {
+      final var writer = Beans.constructorWriter(PrimitiveCtor.class, 4);
+      // Boxed wrappers arrive via valueByName; the spread MH unboxes them per the implicit
+      // conversions a direct constructor call would apply. Order matches the constructor
+      // parameter order (positional fallback when -parameters is not present at test compile
+      // time, or by-name when it is — both produce the same result here).
+      final var values = Map.<String, Object>of(
+        "i",
+        Integer.valueOf(5),
+        "l",
+        Long.valueOf(99L),
+        "d",
+        Double.valueOf(2.5),
+        "b",
+        Boolean.TRUE
+      );
+      final var pojo = writer.construct(new String[] { "i", "l", "d", "b" }, values::get);
+      assertEquals(5, pojo.getI());
+      assertEquals(99L, pojo.getL());
+      assertEquals(2.5, pojo.getD());
+      assertEquals(true, pojo.isB());
     }
   }
 


### PR DESCRIPTION
## Summary

Phase 5 of the reflection-removal stack — close the rebuild half. Swaps `Constructor.newInstance` and `Field.set` for cached invokers across the three rebuild sites the spec covers. **Lattice contracts unchanged**: `BeanWriter<P>` stays sealed, `FieldsWriter` / `ConstructorWriter` declarations stay byte-identical at the type level, public `Records.construct(Class<R>, Function<String, Object>)` signature unchanged. Only the substrate changes — reflective per-call dispatch → cached invokers built once per class at cache-warm time.

## The three swaps

1. **`Records.RecordInfo`** — extended with a `Function<Object, Object> ctorFn` over an `asSpreader`-wrapped canonical-constructor `MethodHandle`. Both `Records.construct(...)` (the spec-named target) and the per-component `updateField` rebuild now route through it instead of `ctor.newInstance(args)`. The `Constructor<?>` field is retained for its metadata.

2. **`Beans.ConstructorWriter`** — replaces `ctor.newInstance(args)` with a cached `Function<Object, Object>` over an `asSpreader`-wrapped `MethodHandle`. Same `-parameters`-vs-positional name resolution preserved.

3. **`Beans.FieldsWriter`** — swaps `ctor.newInstance()` for a `LambdaMetafactory`-built `Supplier<Object>` (no-arg ctor handle is direct, LMF accepts it) and `Field.set` for a cached `BiConsumer<Object, Object>` per field over an `unreflectSetter` `MethodHandle`.

## The asSpreader trick (and why it doesn't use LMF for the ctor)

`LambdaMetafactory` cannot bridge a multi-arg constructor directly to `Function<Object, Object>`. The standard workaround is `handle.asSpreader(Object[].class, arity)` which converts `(T1,...,Tn) → R` into `(Object[]) → R`. However LMF rejects the resulting **non-direct adapter** with `"MethodHandle(Object[])R is not direct or cannot be cracked"`. The constructor invoker therefore wraps the spread `MethodHandle` in a tiny capturing lambda that calls `invokeExact` on it. Same pattern is used for the field setter — LMF also rejects `putField` handles (`"Unsupported MethodHandle kind: putField"`). `MethodHandle` invocation through a `final` field still skips the per-call access check and the varargs allocation that `Constructor.newInstance` / `Field.set` pay, with the JIT inlining `invokeExact` through the captured reference.

Spec language (`LambdaMetafactory.metafactory(...) ... spread, ...`) doesn't compile under the JDK; the cached-MH path is the standard JDK alternative and the javadoc on every swap site records why LMF was bypassed there. The no-arg constructor in `FieldsWriter` still goes through LMF (direct handle, no spreader needed).

## JPMS opens guidance

Preserved at cache-warm time on the `privateLookupIn` / `setAccessible` call sites. Mirrors the Phase 1 reader pattern. Same JPMS constraint as the previous reflection path — no worse, identical messaging.

## After this PR lands

Hot path on the rebuild side now has **zero `Constructor.newInstance` and zero `Field.set`** for both records and beans. `setAccessible` / `privateLookupIn` run once per class at cache-warm time only. The `SettersWriter` / `BuilderWriter` / getter / `readProperty` paths remain untouched — they're owned by sibling parallel PRs.

## Test plan

- [x] `./gradlew :core:spotlessApply :core:test` — 266 tests pass.
- [x] `./gradlew spotlessApply build` — full multi-module build green (`:core`, `:codegen`, `:lombok`, `:benchmarks`).
- [x] New tests in `BeansTest`: `Constructors#constructorAutoUnboxesPrimitives` and `Fields#fieldsAutoUnboxesPrimitives` pin the multi-primitive (`int`/`long`/`double`/`boolean`) auto-unbox path through both the spread-MH ctor invoker and the cached-MH field setter.
- [x] All existing record-based tests (`TelescopeTest`, `DeepMappingTest`, `OpticLawsTest`, etc.) and all bean-based tests still pass — they transitively exercise the new rebuild path on every `.update(...)` / mapping run.