### PR TITLE
fix(core): LMF inherited-accessor lookup uses declaring class (PR #11 follow-up)

### DIFF
--- a/core/src/main/java/io/github/eschizoid/telescope/internal/Beans.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/internal/Beans.java
@@ -172,41 +172,30 @@ public final class Beans {
     final Map<String, Method> getters
   ) {
     if (getters.isEmpty()) return Map.of();
-    final MethodHandles.Lookup lookup;
-    try {
-      // `privateLookupIn` is needed when the bean's module/package isn't open to the telescope
-      // module; for fully-public types in the same module this is equivalent to a plain
-      // `MethodHandles.lookup()`. Same JPMS constraint as `setAccessible(true)` — no worse than
-      // the previous reflection path.
-      lookup = MethodHandles.privateLookupIn(cls, MethodHandles.lookup());
-    } catch (final IllegalAccessException e) {
-      throw new IllegalStateException(
-        "Cannot access " +
-          cls.getName() +
-          " to build LambdaMetafactory getter invokers. Add 'opens " +
-          cls.getPackageName() +
-          " to io.github.eschizoid.telescope;' to that module's module-info.java.",
-        e
-      );
-    }
+    // Cache one Lookup per declaring class — inherited getters live on a superclass / interface
+    // whose package may be in a different module than `cls`. A single lookup keyed to `cls` would
+    // fail to unreflect an inherited accessor whose declaring package isn't open to telescope.
+    final var lookupByDeclaringClass = new LinkedHashMap<Class<?>, MethodHandles.Lookup>();
     final var invokers = new LinkedHashMap<String, Function<Object, Object>>(getters.size());
     for (final var entry : getters.entrySet()) {
       final var name = entry.getKey();
       final var method = entry.getValue();
+      final var declaringClass = method.getDeclaringClass();
+      final var lookup = lookupByDeclaringClass.computeIfAbsent(declaringClass, dc ->
+        privateLookupOrThrow(dc, cls, "getter")
+      );
       try {
         final var handle = lookup.unreflect(method);
         // SAM signature is `Object apply(Object)`; the instantiatedMethodType pins the actual
         // (declaringClass) -> returnType signature so the metafactory generates the right bridge
-        // — including auto-boxing for primitive returns (`int`, `boolean`, etc). Using
-        // `method.getDeclaringClass()` (not `cls`) keeps the receiver type aligned with the
-        // unreflected handle's leading parameter for getters inherited from a superclass.
+        // — including auto-boxing for primitive returns (`int`, `boolean`, etc).
         final var callSite = LambdaMetafactory.metafactory(
           lookup,
           "apply",
           MethodType.methodType(Function.class),
           MethodType.methodType(Object.class, Object.class),
           handle,
-          MethodType.methodType(method.getReturnType(), method.getDeclaringClass())
+          MethodType.methodType(method.getReturnType(), declaringClass)
         );
         @SuppressWarnings("unchecked")
         final var reader = (Function<Object, Object>) callSite.getTarget().invoke();
@@ -219,6 +208,42 @@ public final class Beans {
       }
     }
     return invokers;
+  }
+
+  /**
+   * Resolve a {@link MethodHandles.Lookup} with private access to {@code declaringClass}, or throw
+   * an {@link IllegalStateException} with a JPMS-opens hint. When {@code declaringClass} is
+   * inherited (i.e. differs from {@code ownerClass}), the message points to the declaring class's
+   * package — that's the one that needs the {@code opens} directive, not the inheritor.
+   */
+  private static MethodHandles.Lookup privateLookupOrThrow(
+    final Class<?> declaringClass,
+    final Class<?> ownerClass,
+    final String accessorKind
+  ) {
+    try {
+      // `privateLookupIn` is needed when the type's module/package isn't open to the telescope
+      // module; for fully-public types in the same module this is equivalent to a plain
+      // `MethodHandles.lookup()`. Same JPMS constraint as `setAccessible(true)` — no worse than
+      // the previous reflection path.
+      return MethodHandles.privateLookupIn(declaringClass, MethodHandles.lookup());
+    } catch (final IllegalAccessException e) {
+      final var inheritedNote =
+        declaringClass == ownerClass
+          ? ""
+          : " (declaring class of an inherited " + accessorKind + " on " + ownerClass.getName() + ")";
+      throw new IllegalStateException(
+        "Cannot access " +
+          declaringClass.getName() +
+          inheritedNote +
+          " to build LambdaMetafactory " +
+          accessorKind +
+          " invokers. Add 'opens " +
+          declaringClass.getPackageName() +
+          " to io.github.eschizoid.telescope;' to that module's module-info.java.",
+        e
+      );
+    }
   }
 
   private static Map<String, Method> scanGetters(final Class<?> cls) {
@@ -761,23 +786,12 @@ public final class Beans {
       if (setter == null) throw new IllegalArgumentException(
         "writeBean(" + cls.getName() + ", SETTERS): no setter '" + set + "'"
       );
-      final MethodHandles.Lookup lookup;
-      try {
-        // `privateLookupIn` is needed when the POJO (or its module's package) isn't open to the
-        // telescope module; for fully-public POJOs in the same module this is equivalent to a
-        // plain `MethodHandles.lookup()`. Same JPMS constraint as `setAccessible(true)` — no
-        // worse than the previous reflection path.
-        lookup = MethodHandles.privateLookupIn(cls, MethodHandles.lookup());
-      } catch (final IllegalAccessException e) {
-        throw new IllegalStateException(
-          "Cannot access " +
-            cls.getName() +
-            " to build LambdaMetafactory setter invoker. Add 'opens " +
-            cls.getPackageName() +
-            " to io.github.eschizoid.telescope;' to that module's module-info.java.",
-          e
-        );
-      }
+      // Use the SETTER's declaring class — inherited setters live on a superclass / interface
+      // whose package may be in a different module than `cls`. Pinning the lookup, the
+      // instantiated receiver type, and the opens-error message to the declaring class keeps all
+      // three consistent.
+      final var declaringClass = setter.getDeclaringClass();
+      final var lookup = privateLookupOrThrow(declaringClass, cls, "setter");
       final var paramType = setter.getParameterTypes()[0];
       final var instantiatedParamType = wrap(paramType);
       try {
@@ -788,7 +802,7 @@ public final class Beans {
           MethodType.methodType(BiConsumer.class),
           MethodType.methodType(void.class, Object.class, Object.class),
           handle,
-          MethodType.methodType(void.class, cls, instantiatedParamType)
+          MethodType.methodType(void.class, declaringClass, instantiatedParamType)
         );
         return (BiConsumer<Object, Object>) callSite.getTarget().invoke();
       } catch (final Throwable t) {

--- a/core/src/test/java/io/github/eschizoid/telescope/internal/BeansTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/internal/BeansTest.java
@@ -86,6 +86,38 @@ class BeansTest {
     }
   }
 
+  // Fixture pair for the inherited-accessor LambdaMetafactory path. ChildBean inherits `getId()`
+  // and `setId(String)` from ParentBean; the LMF cache build must use the setter / getter's
+  // declaring class (ParentBean) for `privateLookupIn` and the instantiated receiver type — using
+  // ChildBean (the inheritor) would still happen to work in the same package but is semantically
+  // wrong, and breaks when the parent lives in a separate module whose package is opened to
+  // telescope (and the child's isn't, or vice-versa).
+  static class ParentBean {
+
+    private String id;
+
+    public String getId() {
+      return id;
+    }
+
+    public void setId(final String id) {
+      this.id = id;
+    }
+  }
+
+  static final class ChildBean extends ParentBean {
+
+    private String name;
+
+    public String getName() {
+      return name;
+    }
+
+    public void setName(final String name) {
+      this.name = name;
+    }
+  }
+
   static final class NoArgFields {
 
     private String name;
@@ -388,6 +420,22 @@ class BeansTest {
       assertEquals(Boolean.class, flagged.getClass());
       assertEquals(Boolean.FALSE, flagged);
     }
+
+    @Test
+    @DisplayName("inherited getter resolves through the parent's declaring class (no cross-class lookup error)")
+    void getterOnInheritedAccessor() {
+      // ChildBean inherits getId() from ParentBean. The LMF cache must build the invoker via a
+      // lookup pinned to ParentBean (the declaring class), not ChildBean — otherwise an
+      // inheritor whose own package isn't open to telescope would fail to bind an accessor whose
+      // declaring package IS open. This pins both the readProperty hot-path and the
+      // lattice-primitive Getter.
+      final var child = new ChildBean();
+      child.setId("inherited-id");
+      child.setName("only-on-child");
+      assertEquals("inherited-id", Beans.readProperty(child, "id"));
+      assertEquals("only-on-child", Beans.readProperty(child, "name"));
+      assertEquals("inherited-id", Beans.<ChildBean>getter(ChildBean.class, "id").get(child));
+    }
   }
 
   // ----- FieldsWriter -----
@@ -447,6 +495,20 @@ class BeansTest {
     void settersMissingSetterThrows() {
       final var writer = Beans.settersWriter(NoArgFields.class); // has fields but no setters
       assertThrows(IllegalArgumentException.class, () -> writer.construct(new String[] { "name" }, n -> "x"));
+    }
+
+    @Test
+    @DisplayName("settersWriter round-trips a value through an inherited setter (declared on a parent class)")
+    void settersOnInheritedSetter() {
+      // ChildBean inherits setId(String) from ParentBean. The LMF builder must use the setter's
+      // declaring class (ParentBean) for privateLookupIn and the instantiated receiver — using
+      // ChildBean's class would fail when the parent and child live in modules with different
+      // opens directives. This test pins the inheritance-correctness contract.
+      final var writer = Beans.settersWriter(ChildBean.class);
+      final var values = Map.<String, Object>of("id", "parent-id", "name", "child-name");
+      final var pojo = writer.construct(new String[] { "id", "name" }, values::get);
+      assertEquals("parent-id", pojo.getId());
+      assertEquals("child-name", pojo.getName());
     }
 
     @Test


### PR DESCRIPTION
## Summary

Post-merge follow-up addressing two Copilot inline comments on [PR #11](https://github.com/eschizoid/telescope/pull/11) about inherited-accessor correctness in the LambdaMetafactory bean dispatch.

Both Phase 2's \`Beans.buildGetterInvokers\` and Phase 3's \`SettersWriter.buildSetterInvoker\` were using \`cls\` (the inheritor's class) for \`MethodHandles.privateLookupIn(...)\` and the JPMS-opens error message. For an accessor inherited from a parent class / interface in a different package or module, the package that needs the \`opens\` directive is the **declaring** class's package, not the inheritor's. Using the inheritor's class for \`privateLookupIn\` would also fail to bind a handle whose declaring package is open to telescope but whose inheritor's package is closed (or vice-versa).

## Changes

1. New private static helper \`Beans.privateLookupOrThrow(declaringClass, ownerClass, accessorKind)\` that throws an \`IllegalStateException\` with a JPMS-opens hint pointing at the **declaring** class's package. When the declaring class differs from the inheritor, the message calls out the inheritance.
2. \`buildGetterInvokers\` now caches one \`Lookup\` per declaring class in a \`HashMap<Class<?>, MethodHandles.Lookup>\` so a single bean with getters spread across multiple declaring classes resolves each correctly. \`instantiatedMethodType\` already used \`getDeclaringClass()\`.
3. \`SettersWriter.buildSetterInvoker\` pins \`privateLookupIn\`, the \`instantiatedMethodType\` receiver, and the error message all to \`setter.getDeclaringClass()\`.

## Tests

New \`ParentBean\` / \`ChildBean extends ParentBean\` fixture pair, plus:

- \`getterOnInheritedAccessor\` — reads inherited \`getId()\` from a \`ChildBean\` through both \`readProperty\` and the lattice-primitive \`Getter\`, plus the child-declared \`getName()\`.
- \`settersOnInheritedSetter\` — round-trip via inherited \`setId(String)\` and child-declared \`setName(String)\`.

## Phases 4 and 5

Their open PRs (#13, #14) carry the same \`cls\`-based pattern in their own LMF code (\`BuilderWriter\`, \`ConstructorWriter\`, \`FieldsWriter\`). I'll forward-port this fix as part of rebasing each onto main.

## Test plan

- [x] \`./gradlew :core:spotlessApply :core:test\` — green (272 tests)
- [x] Two new tests pin inherited-getter and inherited-setter behavior end-to-end
- [x] No public API change