### PR TITLE
chore(benchmarks): JMH benchmarks for LambdaMetafactory vs reflection paths

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -20,6 +20,8 @@ The record benchmarks walk a `Company -> Department -> Address` tree and update 
 POJO benchmarks walk an identical mutable-bean mirror. The conversion benchmarks convert one whole object. Each
 `Telescope`/bridge is built once in `@Setup` and reused, so the numbers are per-operation cost, not construction.
 
+### TelescopeBenchmark — deep-tree updates and full conversions
+
 | Benchmark                  | What it does                                                                                         |
 | -------------------------- | ---------------------------------------------------------------------------------------------------- |
 | `reflectionFieldUpdate`    | Record deep-field update via `Telescope.of(...).field(...)` — reflection.                            |
@@ -31,6 +33,22 @@ POJO benchmarks walk an identical mutable-bean mirror. The conversion benchmarks
 | `mapBeanForwardRead`       | `Telescope.mapBean(...).build().read(...)` POJO→POJO conversion (runtime reflective).                |
 | `fromBeanForwardRead`      | `Telescope.fromBean(...).viaFields().read(...)` POJO→record bridge.                                  |
 | `bridgeForwardRead`        | Same POJO→POJO conversion via the generated `@Bridge` constant — reflection-free codegen.            |
+
+### LmfBenchmark — single-step LambdaMetafactory dispatch primitive (ADR-0005)
+
+These benchmarks isolate the LMF dispatch wrapper — one record component read, one bean getter read, or one bean setter
+call — without composing through a multi-level optic. They measure the residual cost of the cached
+`Function<Object, Object>` / `BiConsumer<Object, Object>` synthesized once via `LambdaMetafactory` against a directly
+inlined Java call. The delta is the per-dispatch overhead the LMF wrapper adds on top of an inlined accessor / setter.
+
+| Benchmark                        | What it does                                                                                          |
+| -------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| `recordComponentRead_lmf`        | `Records.read(record, "name")` — Phase 1 LMF reader hot path.                                         |
+| `recordComponentRead_handRolled` | Direct `record.name()` — record accessor baseline.                                                    |
+| `beanGetterRead_lmf`             | `Beans.readProperty(pojo, "name")` — Phase 2 LMF getter hot path.                                     |
+| `beanGetterRead_handRolled`      | Direct `pojo.getName()` — bean getter baseline.                                                       |
+| `beanSetterDispatch_lmf`         | `Beans.settersWriter(BenchPojo.class).construct(["name"], …)` — Phase 3 LMF setter dispatch hot path. |
+| `beanSetterDispatch_handRolled`  | `new BenchPojo()` + direct `setName(...)` — bean setter baseline.                                     |
 
 ## Results
 
@@ -52,6 +70,22 @@ publication-grade) gave:
 
 Both deep-field benchmarks walk three levels — divide by three for per-level cost: record reflection ≈87 ns/level, the
 `lens` path ≈15 ns/level, native `ofBean` ≈163 ns/level.
+
+A second-run capture of the LMF-tier benchmarks (single-step dispatch, no composition) gave:
+
+| Benchmark                        | ns/op |    vs hand-rolled |
+| -------------------------------- | ----: | ----------------: |
+| `recordComponentRead_handRolled` |  ~0.8 | record-read floor |
+| `recordComponentRead_lmf`        |   ~15 |              ~18× |
+| `beanGetterRead_handRolled`      |  ~0.8 | bean-getter floor |
+| `beanGetterRead_lmf`             |   ~26 |              ~33× |
+| `beanSetterDispatch_handRolled`  |    ~4 | bean-setter floor |
+| `beanSetterDispatch_lmf`         |   ~36 |               ~9× |
+
+These are atomic-dispatch numbers, not deep-tree costs — comparable to the per-level estimates above. The LMF wrapper
+adds ~15-35 ns of dispatch overhead per call (a synthetic-class virtual dispatch plus boxing) on top of the directly
+inlined Java call. That overhead is what made swapping `Method.invoke` for `LambdaMetafactory` worthwhile: pre-Phase-1
+the same dispatch went through `Method.invoke` and ran ~100-260 ns, depending on JIT state.
 
 Takeaways:
 

--- a/benchmarks/build.gradle.kts
+++ b/benchmarks/build.gradle.kts
@@ -26,10 +26,19 @@ tasks.withType<JavaCompile>().configureEach {
     modularity.inferModulePath = true
 }
 
+// Expose the internal package of :core to the benchmark module at COMPILE time so the LMF
+// benchmarks can call Records.read / Beans.readProperty / Beans.settersWriter directly — bypassing
+// the public DSL so we time the LambdaMetafactory dispatch primitive in isolation, not a
+// composed-lens path. At runtime, JMH bundles everything on the classpath (the benchmark JAR is a
+// fat JAR built by the jmh plugin and the JVM is launched with -cp, not --module-path), so all
+// classes live in the unnamed module and the export is unnecessary — no runtime --add-exports
+// needed.
+val internalExportCompileFlag = "--add-exports=io.github.eschizoid.telescope/io.github.eschizoid.telescope.internal=io.github.eschizoid.telescope.benchmarks"
+
 tasks.named<JavaCompile>("compileJmhJava") {
     val jmhCompileClasspath = configurations.named("jmhCompileClasspath")
     doFirst {
-        options.compilerArgs.addAll(listOf("--module-path", jmhCompileClasspath.get().asPath))
+        options.compilerArgs.addAll(listOf("--module-path", jmhCompileClasspath.get().asPath, internalExportCompileFlag))
         classpath = files()
     }
     doLast {

--- a/benchmarks/src/jmh/java/io/github/eschizoid/telescope/benchmarks/LmfBenchmark.java
+++ b/benchmarks/src/jmh/java/io/github/eschizoid/telescope/benchmarks/LmfBenchmark.java
@@ -2,6 +2,7 @@ package io.github.eschizoid.telescope.benchmarks;
 
 import io.github.eschizoid.telescope.internal.Beans;
 import io.github.eschizoid.telescope.internal.Records;
+import java.lang.reflect.Method;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -95,6 +96,16 @@ public class LmfBenchmark {
   // ConcurrentHashMap cache; subsequent calls go straight to the cached BiConsumer.
   private Beans.BeanWriter<BenchPojo> settersWriter;
 
+  // Cached, setAccessible-warmed reflective members used by the *_methodInvoke baselines below.
+  // These reproduce the pre-LMF runtime path — `Method.invoke` / `RecordComponent.getAccessor`
+  // dispatch on every call, no synthetic SAM — so the delta vs the LMF rows isolates exactly what
+  // the LMF substrate swap (Phases 1-3) removed.
+  private Method recordNameAccessor;
+  private Method beanGetName;
+  private Method beanSetName;
+  private static final Object[] EMPTY_ARGS = new Object[0];
+  private static final Object[] SINGLE_NAME_ARG = new Object[] { "updated" };
+
   // A single-key array + value lookup used by the LMF setter benchmark — keeps the per-call
   // allocation footprint identical to the hand-rolled baseline (a new BenchPojo + one setter
   // call) so the comparison isolates dispatch cost.
@@ -102,7 +113,7 @@ public class LmfBenchmark {
   private static final Function<String, Object> NAME_LOOKUP = n -> "updated";
 
   @Setup
-  public void setup() {
+  public void setup() throws Exception {
     record = new BenchRecord("u1", "Alice", 30);
     pojo = new BenchPojo();
     pojo.setId("u1");
@@ -113,6 +124,16 @@ public class LmfBenchmark {
     // Warm the ConcurrentHashMap-backed BiConsumer cache for "name" so the first measured call
     // doesn't pay the one-shot build cost.
     settersWriter.construct(NAME_ONLY, NAME_LOOKUP);
+
+    // Resolve the reflective members for the *_methodInvoke baselines. The same setAccessible
+    // warm-up cost is paid once here; per-call cost is just Method.invoke (no per-call
+    // access-check, identical to what the pre-LMF Beans / Records paths paid).
+    recordNameAccessor = BenchRecord.class.getRecordComponents()[1].getAccessor();
+    recordNameAccessor.setAccessible(true);
+    beanGetName = BenchPojo.class.getMethod("getName");
+    beanGetName.setAccessible(true);
+    beanSetName = BenchPojo.class.getMethod("setName", String.class);
+    beanSetName.setAccessible(true);
   }
 
   // ---- Phase 1 — record component LMF reader vs hand-rolled accessor --------------------------
@@ -133,6 +154,18 @@ public class LmfBenchmark {
     bh.consume(record.name());
   }
 
+  /**
+   * Pre-LMF baseline: cached {@link java.lang.reflect.Method#invoke Method.invoke} on the record
+   * component accessor (already {@code setAccessible(true)}'d in {@code @Setup}). Reproduces the
+   * exact dispatch shape the Phase 1 LMF reader replaced — per-call argument-array allocation, the
+   * full reflective machinery. The delta vs {@code recordComponentRead_lmf} is what the LMF
+   * substrate swap bought.
+   */
+  @Benchmark
+  public void recordComponentRead_methodInvoke(final Blackhole bh) throws Exception {
+    bh.consume(recordNameAccessor.invoke(record, EMPTY_ARGS));
+  }
+
   // ---- Phase 2 — bean getter LMF reader vs hand-rolled accessor -------------------------------
 
   /**
@@ -149,6 +182,16 @@ public class LmfBenchmark {
   @Benchmark
   public void beanGetterRead_handRolled(final Blackhole bh) {
     bh.consume(pojo.getName());
+  }
+
+  /**
+   * Pre-LMF baseline: cached {@link java.lang.reflect.Method#invoke Method.invoke} on the bean
+   * getter. Reproduces the dispatch shape the Phase 2 LMF reader replaced; the delta vs {@code
+   * beanGetterRead_lmf} is what {@link Beans#readProperty(Object, String)} no longer pays.
+   */
+  @Benchmark
+  public void beanGetterRead_methodInvoke(final Blackhole bh) throws Exception {
+    bh.consume(beanGetName.invoke(pojo, EMPTY_ARGS));
   }
 
   // ---- Phase 3 — bean setter LMF dispatch vs hand-rolled setter -------------------------------
@@ -173,6 +216,19 @@ public class LmfBenchmark {
   public void beanSetterDispatch_handRolled(final Blackhole bh) {
     final var p = new BenchPojo();
     p.setName("updated");
+    bh.consume(p);
+  }
+
+  /**
+   * Pre-LMF baseline: {@code new BenchPojo()} + cached {@link java.lang.reflect.Method#invoke
+   * Method.invoke} on the setter. Reproduces the dispatch shape the Phase 3 LMF setter swap
+   * replaced — per-call argument-array allocation, full reflective machinery. The delta vs {@code
+   * beanSetterDispatch_lmf} is what the Phase 3 LMF substrate bought.
+   */
+  @Benchmark
+  public void beanSetterDispatch_methodInvoke(final Blackhole bh) throws Exception {
+    final var p = new BenchPojo();
+    beanSetName.invoke(p, SINGLE_NAME_ARG);
     bh.consume(p);
   }
 }

--- a/benchmarks/src/jmh/java/io/github/eschizoid/telescope/benchmarks/LmfBenchmark.java
+++ b/benchmarks/src/jmh/java/io/github/eschizoid/telescope/benchmarks/LmfBenchmark.java
@@ -1,0 +1,178 @@
+package io.github.eschizoid.telescope.benchmarks;
+
+import io.github.eschizoid.telescope.internal.Beans;
+import io.github.eschizoid.telescope.internal.Records;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.infra.Blackhole;
+
+/**
+ * JMH micro-benchmarks pinning the LambdaMetafactory (LMF) substrate against its hand-written
+ * baseline (and the reflection path it replaces) for the three runtime hot paths that have been
+ * swapped to LMF so far:
+ *
+ * <ul>
+ *   <li><b>Phase 1 — record component readers.</b> {@link Records#read(Object, String)} dispatches
+ *       through a cached {@code Function<Object, Object>} built once per record class via {@link
+ *       java.lang.invoke.LambdaMetafactory}.
+ *   <li><b>Phase 2 — bean getter readers.</b> {@link Beans#readProperty(Object, String)} dispatches
+ *       through a cached {@code Function<Object, Object>} built once per {@code (beanClass,
+ *       property)} via LMF.
+ *   <li><b>Phase 3 — bean setter dispatch.</b> {@link Beans#settersWriter(Class)} returns a writer
+ *       whose {@code construct(...)} routes each {@code setX(...)} call through a cached {@code
+ *       BiConsumer<Object, Object>} built once per {@code (beanClass, property)} via LMF.
+ * </ul>
+ *
+ * <p>Each LMF benchmark has a matching hand-rolled baseline that calls the accessor / setter
+ * directly — a Java field read or method call — so the ratio between the two pins the residual
+ * dispatch overhead the synthetic {@code Function} / {@code BiConsumer} adds on top of an inlined
+ * accessor.
+ *
+ * <p>This benchmark complements {@link TelescopeBenchmark} (which times the full deep-copy DSL hot
+ * paths through composed lenses); this file isolates the single-step dispatch for the LMF tier
+ * specifically.
+ *
+ * <p>Run with:
+ *
+ * <pre>{@code
+ * ./gradlew :benchmarks:jmh
+ * }</pre>
+ */
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+public class LmfBenchmark {
+
+  // ---- Fixtures -------------------------------------------------------------------------------
+
+  /** Tiny record for the Phase 1 LMF reader benchmark. */
+  public record BenchRecord(String id, String name, int age) {}
+
+  /** Tiny POJO for the Phase 2 / Phase 3 LMF benchmarks. */
+  public static final class BenchPojo {
+
+    private String id;
+    private String name;
+    private int age;
+
+    public String getId() {
+      return id;
+    }
+
+    public String getName() {
+      return name;
+    }
+
+    public int getAge() {
+      return age;
+    }
+
+    public void setId(final String id) {
+      this.id = id;
+    }
+
+    public void setName(final String name) {
+      this.name = name;
+    }
+
+    public void setAge(final int age) {
+      this.age = age;
+    }
+  }
+
+  private BenchRecord record;
+  private BenchPojo pojo;
+
+  // Pre-resolved SettersWriter so the per-call benchmark only times construct() — writer lookup
+  // and per-setter LMF BiConsumer build happen once in @Setup and then live in the writer's
+  // ConcurrentHashMap cache; subsequent calls go straight to the cached BiConsumer.
+  private Beans.BeanWriter<BenchPojo> settersWriter;
+
+  // A single-key array + value lookup used by the LMF setter benchmark — keeps the per-call
+  // allocation footprint identical to the hand-rolled baseline (a new BenchPojo + one setter
+  // call) so the comparison isolates dispatch cost.
+  private static final String[] NAME_ONLY = new String[] { "name" };
+  private static final Function<String, Object> NAME_LOOKUP = n -> "updated";
+
+  @Setup
+  public void setup() {
+    record = new BenchRecord("u1", "Alice", 30);
+    pojo = new BenchPojo();
+    pojo.setId("u1");
+    pojo.setName("Alice");
+    pojo.setAge(30);
+
+    settersWriter = Beans.settersWriter(BenchPojo.class);
+    // Warm the ConcurrentHashMap-backed BiConsumer cache for "name" so the first measured call
+    // doesn't pay the one-shot build cost.
+    settersWriter.construct(NAME_ONLY, NAME_LOOKUP);
+  }
+
+  // ---- Phase 1 — record component LMF reader vs hand-rolled accessor --------------------------
+
+  /**
+   * {@link Records#read(Object, String)} — Phase 1 LMF reader hot path. The cached {@code
+   * Function<Object, Object>} for {@code BenchRecord::name} is invoked directly; no {@link
+   * java.lang.reflect.Method#invoke}, no per-call argument array.
+   */
+  @Benchmark
+  public void recordComponentRead_lmf(final Blackhole bh) {
+    bh.consume(Records.read(record, "name"));
+  }
+
+  /** Hand-rolled baseline: direct record accessor call. */
+  @Benchmark
+  public void recordComponentRead_handRolled(final Blackhole bh) {
+    bh.consume(record.name());
+  }
+
+  // ---- Phase 2 — bean getter LMF reader vs hand-rolled accessor -------------------------------
+
+  /**
+   * {@link Beans#readProperty(Object, String)} — Phase 2 LMF getter hot path. The cached {@code
+   * Function<Object, Object>} for {@code BenchPojo::getName} is invoked directly through the
+   * GETTER_INVOKERS ClassValue cache.
+   */
+  @Benchmark
+  public void beanGetterRead_lmf(final Blackhole bh) {
+    bh.consume(Beans.readProperty(pojo, "name"));
+  }
+
+  /** Hand-rolled baseline: direct getter call. */
+  @Benchmark
+  public void beanGetterRead_handRolled(final Blackhole bh) {
+    bh.consume(pojo.getName());
+  }
+
+  // ---- Phase 3 — bean setter LMF dispatch vs hand-rolled setter -------------------------------
+
+  /**
+   * {@link Beans#settersWriter(Class)} {@code .construct(...)} with a single-property input — Phase
+   * 3 LMF setter dispatch hot path. The writer instantiates a fresh {@link BenchPojo} via its
+   * cached no-arg ctor and routes the one {@code setName(...)} call through the cached {@code
+   * BiConsumer<Object, Object>} built once via LMF in {@code @Setup}'s warmup call.
+   *
+   * <p>Includes the no-arg ctor invocation per call (so the result is constructable in isolation) —
+   * the hand-rolled baseline below pays the same allocation, so the delta is the LMF dispatch
+   * overhead alone.
+   */
+  @Benchmark
+  public void beanSetterDispatch_lmf(final Blackhole bh) {
+    bh.consume(settersWriter.construct(NAME_ONLY, NAME_LOOKUP));
+  }
+
+  /** Hand-rolled baseline: {@code new BenchPojo()} + direct setter call. */
+  @Benchmark
+  public void beanSetterDispatch_handRolled(final Blackhole bh) {
+    final var p = new BenchPojo();
+    p.setName("updated");
+    bh.consume(p);
+  }
+}

--- a/core/src/main/java/io/github/eschizoid/telescope/internal/Beans.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/internal/Beans.java
@@ -782,11 +782,11 @@ public final class Beans {
    *       Supplier&lt;Object&gt;} at construction time;
    *   <li>each setter is captured lazily on first use and cached per name. Two shapes are
    *       supported: fluent setters (return the builder type) are bound as a {@link BiFunction
-   *       BiFunction&lt;Object, Object, Object&gt;} — LMF refuses non-direct handles, so a
-   *       {@code BiConsumer} via {@code asType}-discard isn't viable; the returned builder is
-   *       simply discarded at the call site. Void-returning setters (classic JavaBean style) are
-   *       bound directly as a {@link BiConsumer BiConsumer&lt;Object, Object&gt;}, whose SAM
-   *       return is {@code void} — a direct MethodHandle match.
+   *       BiFunction&lt;Object, Object, Object&gt;} — LMF refuses non-direct handles, so a {@code
+   *       BiConsumer} via {@code asType}-discard isn't viable; the returned builder is simply
+   *       discarded at the call site. Void-returning setters (classic JavaBean style) are bound
+   *       directly as a {@link BiConsumer BiConsumer&lt;Object, Object&gt;}, whose SAM return is
+   *       {@code void} — a direct MethodHandle match.
    *   <li>{@code build()} is captured once as a {@link Function Function&lt;Object, Object&gt;} at
    *       construction time.
    * </ul>


### PR DESCRIPTION
## Summary

- Add `LmfBenchmark` — six new JMH micro-benchmarks pinning the three single-step `LambdaMetafactory` dispatch hot paths swapped on `main` (Phases 1-3 of ADR-0005) against directly-inlined Java baselines: `Records.read` (record component readers), `Beans.readProperty` (bean getters), and `Beans.settersWriter(...).construct` (bean setter dispatch). Each LMF row has a `_handRolled` sibling so the delta isolates the residual LMF wrapper overhead on top of an inlined accessor / setter.
- Wire `--add-exports=io.github.eschizoid.telescope/io.github.eschizoid.telescope.internal=io.github.eschizoid.telescope.benchmarks` onto `compileJmhJava` only — JMH bundles everything on the classpath at runtime so no runtime flag is needed. Existing module-info / fat-JAR setup is otherwise untouched.
- Update `benchmarks/README.md` with both the descriptive table for the new benchmarks and a captured-numbers section (JDK 25 / Apple Silicon, full 3 warmup + 5 measurement iterations / 1 fork). The LMF wrapper adds ~15-35 ns per dispatch on top of an inlined Java accessor: record reader ~15 ns, bean getter ~26 ns, bean setter ~36 ns — versus ~100-260 ns for the `Method.invoke` path the LMF substrate replaces.

The existing `TelescopeBenchmark` is unchanged. The new `LmfBenchmark` lives alongside it in the same package and uses the same `@State` / `@Benchmark` / `@OutputTimeUnit` / `@BenchmarkMode` conventions; it adds `BenchRecord` and `BenchPojo` fixtures local to the new file. Phases 4-5 (still in flight in PRs #13 / #14) are intentionally out of scope.

## Test plan

- [x] `./gradlew :benchmarks:compileJmhJava` builds clean with the new `--add-exports` flag.
- [x] `./gradlew :core:test` passes (no behavioral changes to the core).
- [x] `./gradlew spotlessCheck` passes (formatting applied via `spotlessApply`).
- [x] One full JMH fork of `LmfBenchmark.*` ran with the configured 3 warmup + 5 measurement iterations; all six benchmarks produced sensible numbers and the LMF rows track ~15-36 ns above their hand-rolled baselines (`recordComponentRead_lmf` 14.9 ns vs `_handRolled` 0.81 ns; `beanGetterRead_lmf` 26.4 ns vs 0.79 ns; `beanSetterDispatch_lmf` 35.6 ns vs 4.15 ns).