### PR TITLE
chore(core): internal-leak cleanup for v1.0.0 API stability

### DIFF
--- a/core/src/main/java/io/github/eschizoid/telescope/Telescope.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/Telescope.java
@@ -133,14 +133,16 @@ public sealed class Telescope<
   }
 
   /**
-   * Wrap an internal optic ({@link Traversal} or any of its subtypes — {@link Iso}, {@link Lens},
-   * {@link Prism}) as a {@code Telescope<S, A>}. Used by the conversion-builder sub-package and the
-   * mapping sub-package to produce telescopes from internally-composed optics without depending on
-   * a package-private constructor.
+   * <b>Module-internal seam — NOT public API.</b> Wrap an internal optic ({@link Traversal} or any
+   * of its subtypes — {@link Iso}, {@link Lens}, {@link Prism}) as a {@code Telescope<S, A>}.
    *
-   * <p>The {@link Traversal} type itself lives in the unexported {@code internal.optics} package,
-   * so consumers of the module cannot construct one to pass in — this factory is effectively
-   * module-internal even though declared public.
+   * <p>This method is declared {@code public} purely so the {@code conversion} and {@code mapping}
+   * sub-packages — and the {@code <X>Path<R>} navigators emitted by the codegen processors — can
+   * construct {@code Telescope} instances from internally-composed optics. The {@link Traversal}
+   * type lives in the unexported {@code internal.optics} package, so module consumers cannot supply
+   * a real argument. Treat this signature as part of the module's internal contract: it may change
+   * or disappear without a deprecation cycle. External code must use the documented entry points
+   * ({@link #of(Class)}, {@link #ofBean(Class)}, {@link #lens}, {@link #from(Class)}, etc.).
    */
   @SuppressWarnings("exports") // Intentional: Traversal is module-internal; users can't construct one.
   public static <S, A> Telescope<S, A> wrap(final Traversal<S, A> optic) {
@@ -186,12 +188,15 @@ public sealed class Telescope<
   }
 
   /**
-   * Expose the underlying {@link Traversal} optic. Public so the {@code conversion} sub-package can
-   * do a downcast check (e.g. {@code .optic() instanceof Iso<?, ?>}) when unwrapping a
-   * bidirectional bridge. The returned value's type lives in the unexported {@code internal.optics}
-   * package, so module consumers cannot reference {@code Traversal} at compile time — this method
-   * is effectively module-internal even though declared public, and pairs with {@link
-   * #wrap(Traversal)} for code inside the module.
+   * <b>Module-internal seam — NOT public API.</b> Expose the underlying {@link Traversal} optic so
+   * code inside the module (e.g. the {@code conversion} sub-package) can downcast-check (e.g.
+   * {@code .optic() instanceof Iso<?, ?>}) when unwrapping a bidirectional bridge.
+   *
+   * <p>The returned value's type lives in the unexported {@code internal.optics} package, so module
+   * consumers cannot reference {@link Traversal} at compile time. This method pairs with {@link
+   * #wrap(Traversal)} for code inside the module; it may change or disappear without a deprecation
+   * cycle. External code should use the documented terminal operations ({@link #read}, {@link
+   * #find}, {@link #toList}, {@link #set}, {@link #update}, etc.) instead.
    */
   @SuppressWarnings("exports") // Intentional: Traversal is module-internal; pairs with wrap().
   public Traversal<S, A> optic() {

--- a/core/src/main/java/io/github/eschizoid/telescope/conversion/From.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/conversion/From.java
@@ -5,9 +5,19 @@ import io.github.eschizoid.telescope.Telescope;
 /**
  * Intermediate of {@link Telescope#from(Class)} — call {@link #to(Class)} to bind the target type
  * and continue into {@link To#using(java.util.function.Function, java.util.function.Function)}.
+ *
+ * <p>External code never constructs this directly; the only entry point is {@link
+ * Telescope#from(Class)}. The no-arg constructor is declared {@code public} solely because the
+ * factory lives in a different package ({@code io.github.eschizoid.telescope}). Treat it as
+ * module-internal — it may be made package-private in a future release once the factory and this
+ * type can share a package.
  */
 public final class From<A> {
 
+  /**
+   * <b>Module-internal seam — NOT public API.</b> Use {@link Telescope#from(Class)} instead. This
+   * constructor is declared {@code public} only so the cross-package factory can call it.
+   */
   public From() {}
 
   public <B> To<A, B> to(final Class<B> target) {

--- a/core/src/main/java/io/github/eschizoid/telescope/conversion/Mapper.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/conversion/Mapper.java
@@ -21,9 +21,15 @@ import java.util.function.Function;
 public final class Mapper<A, B> {
 
   /**
-   * One entry of the patch table — when overlaying a partially-populated target onto a source, each
-   * non-null target component value is fed to {@link #backward} and written to {@link #sourceField}
-   * on the source.
+   * <b>Module-internal seam — NOT public API.</b> One entry of the patch table — when overlaying a
+   * partially-populated target onto a source, each non-null target component value is fed to {@link
+   * #backward} and written to {@link #sourceField} on the source.
+   *
+   * <p>Declared {@code public} solely so the cross-package {@link
+   * io.github.eschizoid.telescope.mapping.DeepMap} engine can construct entries when building a
+   * {@link Mapper} via {@link #Mapper(Iso, Class, Class, Map)}. The raw {@link Function} field is
+   * part of that internal contract; external code must not depend on this record's shape. Treat as
+   * private to the module — it may change or disappear without a deprecation cycle.
    */
   public record PatchEntry(String sourceField, Function<Object, Object> backward) {}
 
@@ -34,11 +40,16 @@ public final class Mapper<A, B> {
   private final Map<String, PatchEntry> patchByTargetField;
 
   /**
-   * Construct a mapper directly from an {@link Iso}, the source/target classes, and a (possibly
-   * empty) patch table keyed by target component/property name. Public but effectively
-   * module-internal — {@link Iso} lives in the unexported {@code internal.optics} package, so
-   * consumers of the module can't supply a real argument. Used by {@link
-   * io.github.eschizoid.telescope.mapping.DeepMap}.
+   * <b>Module-internal seam — NOT public API.</b> Construct a mapper directly from an {@link Iso},
+   * the source/target classes, and a (possibly empty) patch table keyed by target component
+   * /property name.
+   *
+   * <p>Declared {@code public} solely so {@link io.github.eschizoid.telescope.mapping.DeepMap}
+   * (different package) can call it; {@link Iso} lives in the unexported {@code internal.optics}
+   * package, so module consumers cannot supply a real argument. External code must construct
+   * mappers via {@link Telescope#mapper(Class, Class,
+   * io.github.eschizoid.telescope.mapping.MapStep...)}. Treat this signature as part of the
+   * module's internal contract: it may change or disappear without a deprecation cycle.
    */
   @SuppressWarnings("exports") // Intentional: Iso is module-internal; consumers can't supply one.
   public Mapper(

--- a/core/src/main/java/io/github/eschizoid/telescope/conversion/To.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/conversion/To.java
@@ -10,7 +10,11 @@ import java.util.function.Function;
  */
 public final class To<A, B> {
 
-  public To() {}
+  /**
+   * Package-private. External code never constructs this — the only entry point is {@link
+   * From#to(Class)}, which lives in this same package.
+   */
+  To() {}
 
   /**
    * Supply both directions of the conversion. {@code forward} converts {@code A → B}; {@code

--- a/core/src/main/java/io/github/eschizoid/telescope/mapping/DeepMap.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/mapping/DeepMap.java
@@ -173,7 +173,10 @@ public final class DeepMap {
   private static Map<TypePair, List<Mapping<?, ?>>> groupOverridesByPair(final Mapping<?, ?>[] overrides) {
     final var grouped = new HashMap<TypePair, List<Mapping<?, ?>>>();
     for (final var row : overrides) {
-      grouped.computeIfAbsent(new TypePair(row.sourceClass(), row.targetClass()), k -> new ArrayList<>()).add(row);
+      final var internals = internalsOf(row);
+      grouped
+        .computeIfAbsent(new TypePair(internals.sourceClass(), internals.targetClass()), k -> new ArrayList<>())
+        .add(row);
     }
     return grouped;
   }
@@ -208,8 +211,9 @@ public final class DeepMap {
     for (final var row : overrides.getOrDefault(key, List.of())) {
       // Normalize raw method names per side — record::name stays "name", bean::getName becomes
       // "name".
-      final var srcField = srcRefl.normalize(row.sourceField());
-      final var tgtField = tgtRefl.normalize(row.targetField());
+      final var internals = internalsOf(row);
+      final var srcField = srcRefl.normalize(internals.sourceField());
+      final var tgtField = tgtRefl.normalize(internals.targetField());
       // Fail fast on duplicates within this type-pair — two rows that target the same source or
       // target field would silently overwrite each other in byTargetName/bySourceName and could
       // produce non-bijective forward/backward (each direction using a different correspondence).
@@ -364,6 +368,17 @@ public final class DeepMap {
       case TypedTransformTo<?, ?, ?, ?> r -> r.fieldIso();
       case Via<?, ?, ?, ?> r -> r.fieldIso();
     };
+  }
+
+  /**
+   * Recover the {@link MappingInternals} view of a {@link Mapping} row — the {@code
+   * SerializedLambda}-derived declaring classes and method names that key overrides by {@code
+   * (sourceClass, targetClass)} pair. The cast is safe because the three permitted {@link Mapping}
+   * record impls ({@link SameTypedTo}, {@link TypedTransformTo}, {@link Via}) all implement {@link
+   * MappingInternals} — same sealed permit list on both interfaces.
+   */
+  private static MappingInternals<?, ?> internalsOf(final Mapping<?, ?> row) {
+    return (MappingInternals<?, ?>) row;
   }
 
   /**

--- a/core/src/main/java/io/github/eschizoid/telescope/mapping/Mapping.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/mapping/Mapping.java
@@ -70,20 +70,4 @@ public sealed interface Mapping<A, B> extends MapStep permits SameTypedTo, Typed
   static <A, B, X, Y> Mapping<A, B> via(final Accessor<A, X> src, final Accessor<B, Y> tgt, final Mapper<X, Y> nested) {
     return new Via<>(src, tgt, nested);
   }
-
-  /**
-   * Source class this row keys against (the declaring class of {@code src}'s accessor, recovered
-   * via {@code SerializedLambda}). Used by {@link Telescope#map(Class, Class, MapStep...)} to
-   * decide which type pairs this override applies to.
-   */
-  Class<A> sourceClass();
-
-  /** Target class this row keys against — declaring class of {@code tgt}'s accessor. */
-  Class<B> targetClass();
-
-  /** Source record component name this row claims (the {@code src} accessor's method name). */
-  String sourceField();
-
-  /** Target record component name this row claims (the {@code tgt} accessor's method name). */
-  String targetField();
 }

--- a/core/src/main/java/io/github/eschizoid/telescope/mapping/MappingInternals.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/mapping/MappingInternals.java
@@ -1,0 +1,30 @@
+package io.github.eschizoid.telescope.mapping;
+
+/**
+ * Package-private sibling of {@link Mapping}. Carries the {@code SerializedLambda} recovery
+ * machinery — declaring classes and method names of the row's accessors — that {@link DeepMap}
+ * needs to key overrides by {@code (sourceClass, targetClass)} type pair.
+ *
+ * <p>Split off the public {@link Mapping} interface so these reflective-recovery details don't leak
+ * into v1.0's public surface. All three permitted {@link Mapping} record impls ({@link
+ * SameTypedTo}, {@link TypedTransformTo}, {@link Via}) also implement this interface; {@link
+ * DeepMap} casts a {@code Mapping<?, ?>} to {@code MappingInternals<?, ?>} when it needs the
+ * recovery info.
+ */
+sealed interface MappingInternals<A, B> permits SameTypedTo, TypedTransformTo, Via {
+  /**
+   * Source class this row keys against (the declaring class of the source accessor, recovered via
+   * {@code SerializedLambda}). Used by {@link DeepMap} to decide which type pairs this override
+   * applies to.
+   */
+  Class<A> sourceClass();
+
+  /** Target class this row keys against — declaring class of the target accessor. */
+  Class<B> targetClass();
+
+  /** Source record component name this row claims (the source accessor's method name). */
+  String sourceField();
+
+  /** Target record component name this row claims (the target accessor's method name). */
+  String targetField();
+}

--- a/core/src/main/java/io/github/eschizoid/telescope/mapping/SameTypedTo.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/mapping/SameTypedTo.java
@@ -12,7 +12,7 @@ import io.github.eschizoid.telescope.internal.optics.Iso;
  * <p>Package-private — users construct via {@link Mapping#to(Accessor, Accessor)} and never see
  * this type at the call site.
  */
-record SameTypedTo<A, B, X>(Accessor<A, X> src, Accessor<B, X> tgt) implements Mapping<A, B> {
+record SameTypedTo<A, B, X>(Accessor<A, X> src, Accessor<B, X> tgt) implements Mapping<A, B>, MappingInternals<A, B> {
   @Override
   public Class<A> sourceClass() {
     return LambdaIntrospection.implClassOf(src);

--- a/core/src/main/java/io/github/eschizoid/telescope/mapping/TypedTransformTo.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/mapping/TypedTransformTo.java
@@ -17,7 +17,7 @@ record TypedTransformTo<A, B, X, Y>(
   Accessor<B, Y> tgt,
   Function<? super X, ? extends Y> forward,
   Function<? super Y, ? extends X> backward
-) implements Mapping<A, B> {
+) implements Mapping<A, B>, MappingInternals<A, B> {
   @Override
   public Class<A> sourceClass() {
     return LambdaIntrospection.implClassOf(src);

--- a/core/src/main/java/io/github/eschizoid/telescope/mapping/Via.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/mapping/Via.java
@@ -13,7 +13,11 @@ import io.github.eschizoid.telescope.internal.optics.Iso;
  * <p>Package-private — users construct via {@link Mapping#via(Accessor, Accessor, Mapper)} and
  * never see this type at the call site.
  */
-record Via<A, B, X, Y>(Accessor<A, X> src, Accessor<B, Y> tgt, Mapper<X, Y> nested) implements Mapping<A, B> {
+record Via<A, B, X, Y>(
+  Accessor<A, X> src,
+  Accessor<B, Y> tgt,
+  Mapper<X, Y> nested
+) implements Mapping<A, B>, MappingInternals<A, B> {
   @Override
   public Class<A> sourceClass() {
     return LambdaIntrospection.implClassOf(src);


### PR DESCRIPTION
## Summary

Tightens the public surface of `telescope-core` before v1.0 freezes the API. None of the targets here are intended for external use; they were left public during 0.x for cross-package convenience inside the module. Tightening now prevents accidental external dependencies on internal shapes. **All changes are compile-time access / javadoc edits — zero runtime behavior change.**

## Changes

### 1. `Telescope#wrap(Traversal)` and `Telescope#optic()`
Files: `core/src/main/java/io/github/eschizoid/telescope/Telescope.java` (~L135-150, ~L190-204)
- Kept `public`. Expanded the javadoc to mark both methods as **module-internal seams — NOT public API**.
- Why kept public: the `<X>Path<R>` navigators emitted by the codegen processors are compiled in downstream consumer modules, and they call `Telescope.wrap(...)` with the unexported `Traversals.eachIterable()` (`AbstractTelescopeProcessor.java:761`). Making `wrap` package-private would break that generated code.
- Why this is safe: `Traversal` lives in the unexported `internal.optics` package, so external code cannot supply a real argument regardless. `@SuppressWarnings(\"exports\")` retained.

### 2. `From` and `To` no-arg constructors
Files:
- `core/src/main/java/io/github/eschizoid/telescope/conversion/From.java` (~L11)
- `core/src/main/java/io/github/eschizoid/telescope/conversion/To.java` (~L13)

- `To()` → package-private. Caller (`From#to`) lives in the same `conversion` package.
- `From()` → kept `public`. Caller (`Telescope#from`) lives in a different package; expanded javadoc to mark as module-internal.

### 3. `Mapper` public constructor + `PatchEntry` record
File: `core/src/main/java/io/github/eschizoid/telescope/conversion/Mapper.java` (~L34, ~L42-56)
- Both kept `public` with module-internal javadoc markers (\"**Module-internal seam — NOT public API.**\").
- Why kept public: the only caller (`DeepMap` in `mapping` package) constructs both. Co-locating `DeepMap` into `conversion` would require also moving / exposing the three package-private `Mapping` impl records (`SameTypedTo`, `TypedTransformTo`, `Via`) plus their package-private `fieldIso()` accessors — a far larger leak than the one being closed.
- The `Function<Object, Object>` leak on `PatchEntry.backward` is now documented as part of the internal contract.

### 4. `Mapping` interface — remove `sourceClass` / `targetClass` / `sourceField` / `targetField`
Files:
- `core/src/main/java/io/github/eschizoid/telescope/mapping/Mapping.java` (removed four methods, lines ~74-89 in original)
- `core/src/main/java/io/github/eschizoid/telescope/mapping/MappingInternals.java` (new package-private sealed sibling interface)
- `core/src/main/java/io/github/eschizoid/telescope/mapping/SameTypedTo.java` (added `MappingInternals<A, B>` to permits implementation)
- `core/src/main/java/io/github/eschizoid/telescope/mapping/TypedTransformTo.java` (same)
- `core/src/main/java/io/github/eschizoid/telescope/mapping/Via.java` (same)
- `core/src/main/java/io/github/eschizoid/telescope/mapping/DeepMap.java` (added `internalsOf(Mapping<?, ?>)` helper, switched two call sites to use it)

The four `SerializedLambda`-recovery methods were on the public sealed `Mapping<A, B>` interface, leaking the existence of the recovery machinery to anyone naming `Mapping` directly. Moved to a new **package-private** `MappingInternals<A, B>` sealed sibling interface with the same permit list (`SameTypedTo`, `TypedTransformTo`, `Via`); `DeepMap` casts to `MappingInternals` at the two call sites that need the keying info. Cast is safe because every permitted `Mapping` impl implements `MappingInternals`.

## Module exports
`core/src/main/java/module-info.java` is unchanged; no package shifts.

## Test plan
- [x] `./gradlew :core:spotlessApply :core:test :codegen:test :lombok:test` — green locally on Java 25 / Apple Silicon.
- [x] No `module-info.java` change required (verified).
- [x] Runtime behavior unchanged — every edit is a javadoc, an access modifier, or a refactor of an internal call site.