### PR TITLE
chore(core): clear IntelliJ inspections across :core public surface

### DIFF
--- a/core/src/main/java/io/github/eschizoid/telescope/Telescope.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/Telescope.java
@@ -475,8 +475,9 @@ public sealed class Telescope<
    * {@link MapPath} carrying the map type for later {@link MapPath#values()} navigation.
    *
    * <p>Named {@code mapField} (rather than {@code map}) to disambiguate from the sibling static
-   * deep-conversion factory {@link #map(Class, Class, Mapping[])} — those do conceptually different
-   * things and share the same verb otherwise.
+   * deep-conversion factory {@link #map(Class, Class,
+   * io.github.eschizoid.telescope.mapping.MapStep...)} — those do conceptually different things and
+   * share the same verb otherwise.
    */
   public <K, V> MapPath<S, K, V> mapField(final Accessor<A, Map<K, V>> getter) {
     final Lens<A, Map<K, V>> lens = fieldOptics.lensFor(getter);
@@ -1047,7 +1048,7 @@ public sealed class Telescope<
    * @see #updateEither
    */
   public <E> Validated<E, S> updateValidated(final S source, final Function<? super A, ? extends Validated<E, A>> fn) {
-    return ValidatedK.unbox(optic.modifyF(ValidatedK.<E>forError(), source, a -> ValidatedK.box(fn.apply(a))));
+    return ValidatedK.unbox(optic.modifyF(ValidatedK.forError(), source, a -> ValidatedK.box(fn.apply(a))));
   }
 
   /**
@@ -1060,7 +1061,7 @@ public sealed class Telescope<
    * @see #updateValidated
    */
   public <E> Either<E, S> updateEither(final S source, final Function<? super A, ? extends Either<E, A>> fn) {
-    return EitherK.unbox(optic.modifyF(EitherK.<E>forLeft(), source, a -> EitherK.box(fn.apply(a))));
+    return EitherK.unbox(optic.modifyF(EitherK.forLeft(), source, a -> EitherK.box(fn.apply(a))));
   }
 
   /**

--- a/core/src/main/java/io/github/eschizoid/telescope/internal/Beans.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/internal/Beans.java
@@ -681,7 +681,6 @@ public final class Beans {
    */
   static final class ConstructorWriter<P> implements BeanWriter<P> {
 
-    private final Class<P> cls;
     private final Function<Object, Object> ctorFn;
     // Constructor parameter names when the POJO was compiled with -parameters (enables
     // order-independent name matching); null when names are synthetic, so we fall back to
@@ -690,7 +689,6 @@ public final class Beans {
 
     @SuppressWarnings("unchecked")
     ConstructorWriter(final Class<P> cls, final int arity) {
-      this.cls = cls;
       Constructor<P> found = null;
       for (final var c : cls.getDeclaredConstructors()) {
         if (c.getParameterCount() != arity) continue;
@@ -834,7 +832,7 @@ public final class Beans {
         );
       }
       this.builderSupplier = buildBuilderSupplier(cls, factory);
-      this.buildFn = buildBuildFn(cls, builderType, buildMethod);
+      this.buildFn = buildBuildFn(builderType, buildMethod);
     }
 
     @Override
@@ -985,11 +983,7 @@ public final class Beans {
      * apply(Object)} dispatches directly to {@code build()} on the builder instance.
      */
     @SuppressWarnings("unchecked")
-    private static Function<Object, Object> buildBuildFn(
-      final Class<?> cls,
-      final Class<?> builderType,
-      final Method buildMethod
-    ) {
+    private static Function<Object, Object> buildBuildFn(final Class<?> builderType, final Method buildMethod) {
       // Pin the lookup to `build()`'s declaring class — it may be inherited from a base builder
       // type in a different module than the concrete builderType.
       final var declaringClass = buildMethod.getDeclaringClass();

--- a/core/src/main/java/io/github/eschizoid/telescope/internal/optics/Iso.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/internal/optics/Iso.java
@@ -125,6 +125,7 @@ public interface Iso<A, B> extends Lens<A, B>, Prism<A, B> {
    * Optional reference round-trips to {@code null} (records/beans may legally hold null references
    * and deep mapping treats nulls as pass-through).
    */
+  @SuppressWarnings({ "OptionalAssignedToNull", "OptionalUsedAsFieldOrParameterType" })
   static <X, Y> Iso<Optional<X>, Optional<Y>> liftOptional(final Iso<X, Y> element) {
     return of(ox -> ox == null ? null : ox.map(element::to), oy -> oy == null ? null : oy.map(element::from));
   }

--- a/core/src/main/java/io/github/eschizoid/telescope/mapping/DeepMap.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/mapping/DeepMap.java
@@ -175,7 +175,7 @@ public final class DeepMap {
     for (final var row : overrides) {
       final var internals = internalsOf(row);
       grouped
-        .computeIfAbsent(new TypePair(internals.sourceClass(), internals.targetClass()), k -> new ArrayList<>())
+        .computeIfAbsent(new TypePair(internals.sourceClass(), internals.targetClass()), _ -> new ArrayList<>())
         .add(row);
     }
     return grouped;


### PR DESCRIPTION
## Summary

Sweep of every substantive \`:core\` Java file via \`mcp__idea__get_file_problems\`. Six real findings actioned; the rest are documented false-positives or by-design.

## What changed

1. **\`Telescope.java\` javadoc reference** — \`{@link #map(Class, Class, Mapping[])}\` broke after the internal-leak cleanup moved \`Mapping\` to the package-private \`mapping/\` subpackage. Updated to \`{@link #map(Class, Class, io.github.eschizoid.telescope.mapping.MapStep...)}\`.
2. **\`Telescope.updateValidated\` / \`updateEither\`** — redundant explicit type args \`ValidatedK.<E>forError()\` / \`EitherK.<E>forLeft()\` dropped. The bound \`<E>\` on the surrounding method pins them; inference is enough.
3. **\`Beans.ConstructorWriter.cls\`** — private field assigned in the ctor but never read elsewhere. Dropped both the field and the \`this.cls = cls;\` assignment. The local \`cls\` parameter stays — used in the constructor loop + error messages.
4. **\`Beans.BuilderWriter.buildBuildFn\`** — \`cls\` parameter unused (only mentioned in comments describing what we *don't* use it for). Dropped from the signature; updated the single call site.
5. **\`Iso.liftOptional\`** — \`@SuppressWarnings({\"OptionalAssignedToNull\", \"OptionalUsedAsFieldOrParameterType\"})\` added. The null pass-through behavior is documented in the existing javadoc (records/beans may legally hold null \`Optional\` references; deep mapping treats nulls as pass-through). The warnings flag a real \`Optional\` anti-pattern but one this lift deliberately allows.
6. **\`DeepMap.groupOverridesByPair\`** — \`computeIfAbsent\` unused key lambda parameter renamed \`k\` → \`_\` (Java 22+ unnamed parameter).

## What's deliberately left

- **\`Class<S>\` type-witness parameters** on \`of\`, \`ofBean\`, \`from\`, \`fieldByName\` — common Java idiom; the \`Class\` is used for type inference even when not stored.
- **\`Traversal\` / \`Iso\` \"not exported\"** warnings on documented module-internal seams — \`@SuppressWarnings(\"exports\")\` already in place where needed.
- **\`Validated.isInvalid\` / \`fold\` / \`combine\` \"never used\"** — public sealed-type API surface.
- **\`Records\` / \`Beans\` \`Method#invoke\` javadoc references** — IntelliJ false positive on signature-polymorphic methods; \`javac\` accepts.
- **\`Beans.ClassValue.computeValue\` \`@NotNull\` warnings** — the project doesn't use JetBrains nullness annotations anywhere else.
- **Container-Path inconvertible-types** in \`asList\` / \`asSet\` / \`asMap\` / \`asOptional\` — IntelliJ generic-projection bug; the compiler accepts.
- **\`Iso.liftList\` / \`liftSet\` 4-line duplicated patterns** — intentional; different concrete types, can't share.

## Test plan

- [x] \`./gradlew :core:spotlessApply :core:test :codegen:test :lombok:test\` — green
- [x] No behavior change — substrate-only cleanups
- [x] Pure dead-code removal (3 unused symbols) + 1 documented suppression + 1 javadoc fix + 1 inference cleanup + 1 unnamed-param refresh