### PR TITLE
feat(core): Phase C — deep mapping uses <X>Telescope holder lenses (ADR-0006)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,11 +17,13 @@ story.
   `public static final Telescope<X, FieldType>` constant per record component / bean property. Pure additive codegen
   output; no runtime consumer in Phase A. See
   [ADR-0006](docs/adr/0006-codegen-runtime-1-1-lookup-via-metadata-holder.md).
-- **Phase B (in flight).** `ClassValue<Optional<HolderRef>>` short-circuit in front of `Records.fieldLens(...)` /
-  `Beans.lens(...)`. When the holder is present on the classpath, the SerializedLambda-derived field name routes to the
-  pre-baked constant directly; when absent, the LMF substrate path runs unchanged.
-- **Phase C (planned).** `DeepMap` consults holders on both source and target; the per-pair `Iso<A, B>` composes from
-  per-field constants when both holders are present.
+- **Phase B.** `ClassValue<Optional<HolderRef>>` short-circuit in front of `Records.fieldLens(...)` / `Beans.lens(...)`.
+  When the holder is present on the classpath, the SerializedLambda-derived field name routes to the pre-baked constant
+  directly; when absent, the LMF substrate path runs unchanged.
+- **Phase C.** `Reflective#structuralIso(cls)` — the engine behind `Telescope.map(...)` / `Telescope.mapper(...)` —
+  probes for a sibling `<X>Telescope` holder per side. When the holder covers every component, every per-component read
+  during instance decomposition routes through the pre-baked `Lens` constants instead of `Records.read` /
+  `Beans.readProperty`. Holder-absent types and partial holders fall through to the reflective path unchanged.
 
 ### Changed
 

--- a/core/src/main/java/io/github/eschizoid/telescope/internal/Reflective.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/internal/Reflective.java
@@ -1,6 +1,7 @@
 package io.github.eschizoid.telescope.internal;
 
 import io.github.eschizoid.telescope.internal.optics.Iso;
+import io.github.eschizoid.telescope.internal.optics.Lens;
 import java.lang.reflect.Type;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -126,17 +127,60 @@ public record Reflective(
    * per-pair {@code Iso<S, T>} as the composition {@code
    * srcReader.reverse().then(middle).then(tgtBuilder)} — pure lattice {@code .then()}, no manual
    * function-body construction.
+   *
+   * <p><b>ADR-0006 Phase C.</b> When {@code cls} carries a sibling {@code <X>Telescope} metadata
+   * holder (codegen by {@link io.github.eschizoid.telescope.annotations.Focus @Focus} / {@link
+   * io.github.eschizoid.telescope.annotations.BeanFocus @BeanFocus} / Lombok), the backward
+   * direction's per-component reads route through the holder's pre-baked {@link Lens} constants
+   * directly — bypassing the per-call {@link Records#read} / {@link Beans#readProperty} dispatch.
+   * The forward {@link #construct} path is unchanged; it still routes through the cached canonical
+   * constructor (records) or {@link Beans.BeanWriter} (beans), because the holder doesn't expose a
+   * constructor primitive. When the holder is absent or doesn't cover every component, the prior
+   * reflective {@link #read} path remains the fallback. See ADR-0006 §3.
    */
   public <T> Iso<Map<String, Object>, T> structuralIso(final Class<T> cls) {
     final var componentNames = names(cls);
+    final var holderReaders = resolveHolderReaders(cls, componentNames);
     return Iso.of(
       map -> cls.cast(construct(cls, map::get)),
       instance -> {
         final var out = new LinkedHashMap<String, Object>();
-        for (final var name : componentNames) out.put(name, read(instance, name));
+        if (holderReaders != null) {
+          for (final var name : componentNames) out.put(name, holderReaders.get(name).get(instance));
+        } else {
+          for (final var name : componentNames) out.put(name, read(instance, name));
+        }
         return out;
       }
     );
+  }
+
+  /**
+   * If a sibling {@code <X>Telescope} holder is on the classpath AND it exposes a lens constant for
+   * every component in {@code componentNames}, return the {@code name -> Lens} table the backward
+   * branch of {@link #structuralIso} uses to bypass {@link #read} entirely. Otherwise return {@code
+   * null} — the caller falls back to the reflective {@link #read} path. The
+   * pre-resolution-or-nothing posture avoids per-component branching inside the {@link Iso}'s hot
+   * loop (one branch outside vs. {@code N} branches inside) and matches the Phase B dispatch shape
+   * in {@link
+   * io.github.eschizoid.telescope.Telescope#field(io.github.eschizoid.telescope.Telescope.Accessor)
+   * Telescope.field(Accessor)}.
+   */
+  @SuppressWarnings("unchecked")
+  private static Map<String, Lens<Object, Object>> resolveHolderReaders(
+    final Class<?> cls,
+    final String[] componentNames
+  ) {
+    final var maybeHolder = MetadataHolderProbe.probeFor(cls);
+    if (maybeHolder.isEmpty()) return null;
+    final var holder = maybeHolder.get();
+    final var readers = new LinkedHashMap<String, Lens<Object, Object>>();
+    for (final var name : componentNames) {
+      final var lens = holder.lensFor(name);
+      if (lens == null) return null;
+      readers.put(name, (Lens<Object, Object>) lens);
+    }
+    return readers;
   }
 
   @SuppressWarnings({ "rawtypes", "unchecked" })

--- a/core/src/test/java/io/github/eschizoid/telescope/mapping/DeepMapPhaseCHolderTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/mapping/DeepMapPhaseCHolderTest.java
@@ -1,0 +1,74 @@
+package io.github.eschizoid.telescope.mapping;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.github.eschizoid.telescope.Telescope;
+import io.github.eschizoid.telescope.internal.MetadataHolderProbe;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Integration test for ADR-0006 Phase C: when both sides of a {@link Telescope#map(Class, Class,
+ * MapStep...)} call carry sibling {@code <X>Telescope} metadata holders, the deep-mapping engine's
+ * structural-iso instance-to-map decomposition routes through the holders' pre-baked {@code Lens}
+ * constants instead of the per-component {@code Records.read} dispatch.
+ *
+ * <p>Behavioural parity is the load-bearing assertion — the user sees identical {@code to} / {@code
+ * from} results regardless of which dispatch path served the per-component reads. A second case
+ * exercises the no-holder fallback by mapping between unannotated records.
+ */
+class DeepMapPhaseCHolderTest {
+
+  @Test
+  @DisplayName("both sides annotated: Telescope.map round-trips through the holder-driven structural iso")
+  void bothSidesAnnotatedRoundTrip() {
+    final var mapper = Telescope.mapper(PhaseCSrc.class, PhaseCDst.class);
+    final var src = new PhaseCSrc("alice", 30);
+    final var dst = mapper.forward(src);
+    assertEquals(new PhaseCDst("alice", 30), dst, "forward map must produce a same-valued target record");
+    assertEquals(src, mapper.backward(dst), "backward map must recover the source byte-for-byte");
+  }
+
+  @Test
+  @DisplayName("both sides annotated: holders are actually present (defends against fixture/codegen drift)")
+  void bothSidesHaveHolders() {
+    assertTrue(
+      MetadataHolderProbe.probeFor(PhaseCSrc.class).isPresent(),
+      "PhaseCSrc must have a sibling PhaseCSrcTelescope holder on the classpath"
+    );
+    assertTrue(
+      MetadataHolderProbe.probeFor(PhaseCDst.class).isPresent(),
+      "PhaseCDst must have a sibling PhaseCDstTelescope holder on the classpath"
+    );
+  }
+
+  @Test
+  @DisplayName("neither side annotated: the structural-iso reflective fallback still round-trips")
+  void neitherSideAnnotatedRoundTrip() {
+    final var mapper = Telescope.mapper(PhaseCPlainSrc.class, PhaseCPlainDst.class);
+    final var src = new PhaseCPlainSrc("bob", 42);
+    final var dst = mapper.forward(src);
+    assertEquals(new PhaseCPlainDst("bob", 42), dst, "fallback forward map must produce a same-valued target");
+    assertEquals(src, mapper.backward(dst), "fallback backward map must recover the source byte-for-byte");
+
+    assertTrue(
+      MetadataHolderProbe.probeFor(PhaseCPlainSrc.class).isEmpty(),
+      "PhaseCPlainSrc should have no sibling holder — the fixture is the no-holder control"
+    );
+    assertTrue(
+      MetadataHolderProbe.probeFor(PhaseCPlainDst.class).isEmpty(),
+      "PhaseCPlainDst should have no sibling holder — the fixture is the no-holder control"
+    );
+  }
+
+  @Test
+  @DisplayName("mixed: one side annotated, the other plain — holder used on annotated side, fallback on plain side")
+  void mixedAnnotatedAndPlainRoundTrip() {
+    final var mapper = Telescope.mapper(PhaseCSrc.class, PhaseCPlainDst.class);
+    final var src = new PhaseCSrc("carol", 27);
+    final var dst = mapper.forward(src);
+    assertEquals(new PhaseCPlainDst("carol", 27), dst, "mixed forward map must produce a same-valued target");
+    assertEquals(src, mapper.backward(dst), "mixed backward map must recover the source byte-for-byte");
+  }
+}

--- a/core/src/test/java/io/github/eschizoid/telescope/mapping/PhaseCDst.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/mapping/PhaseCDst.java
@@ -1,0 +1,14 @@
+package io.github.eschizoid.telescope.mapping;
+
+import io.github.eschizoid.telescope.annotations.Focus;
+
+/**
+ * Top-level {@code @Focus} fixture paired with {@link PhaseCSrc} for {@link
+ * DeepMapPhaseCHolderTest}. Same-named scalar components so {@link
+ * io.github.eschizoid.telescope.Telescope#map(Class, Class, MapStep...) Telescope.map(Source,
+ * Target)} resolves without overrides — both sides' {@link
+ * io.github.eschizoid.telescope.internal.MetadataHolderProbe MetadataHolderProbe} hits, and the
+ * Phase C structural-iso path uses holder lens reads on both sides of the assembled {@code Iso}.
+ */
+@Focus
+public record PhaseCDst(String name, int age) {}

--- a/core/src/test/java/io/github/eschizoid/telescope/mapping/PhaseCPlainDst.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/mapping/PhaseCPlainDst.java
@@ -1,0 +1,8 @@
+package io.github.eschizoid.telescope.mapping;
+
+/**
+ * Top-level no-annotation fixture paired with {@link PhaseCPlainSrc} for {@link
+ * DeepMapPhaseCHolderTest}. Verifies that the Phase C structural-iso change preserves the prior
+ * behavior when neither side carries a sibling {@code <X>Telescope} holder.
+ */
+public record PhaseCPlainDst(String name, int age) {}

--- a/core/src/test/java/io/github/eschizoid/telescope/mapping/PhaseCPlainSrc.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/mapping/PhaseCPlainSrc.java
@@ -1,0 +1,8 @@
+package io.github.eschizoid.telescope.mapping;
+
+/**
+ * Top-level no-annotation fixture for {@link DeepMapPhaseCHolderTest}. Has no sibling {@code
+ * <X>Telescope} holder, so the Phase C structural-iso path falls through to the reflective {@code
+ * Records.read} read — the deep-mapping behaviour must be identical to the annotated-source case.
+ */
+public record PhaseCPlainSrc(String name, int age) {}

--- a/core/src/test/java/io/github/eschizoid/telescope/mapping/PhaseCSrc.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/mapping/PhaseCSrc.java
@@ -1,0 +1,12 @@
+package io.github.eschizoid.telescope.mapping;
+
+import io.github.eschizoid.telescope.annotations.Focus;
+
+/**
+ * Top-level {@code @Focus} fixture for {@link DeepMapPhaseCHolderTest}. The {@code FocusProcessor}
+ * emits a sibling {@code PhaseCSrcTelescope} metadata holder for this record (ADR-0006 Phase A);
+ * the Phase C change in {@link io.github.eschizoid.telescope.internal.Reflective#structuralIso}
+ * routes the instance-to-map read through the holder's pre-baked {@code Lens} constants.
+ */
+@Focus
+public record PhaseCSrc(String name, int age) {}

--- a/docs/adr/0006-codegen-runtime-1-1-lookup-via-metadata-holder.md
+++ b/docs/adr/0006-codegen-runtime-1-1-lookup-via-metadata-holder.md
@@ -56,8 +56,13 @@ Phased rollout (each phase is a discrete PR, no public API change):
 - **Phase B — runtime probe.** `ClassValue<Optional<HolderRef>>` short-circuit added to the dispatch sites in
   `Records.fieldLens(...)` / `Beans.lens(...)`. Holder-present types navigate via constants; holder-absent types fall
   through to today's LMF path unchanged.
-- **Phase C — deep-mapping uses constants.** `DeepMap` checks for holders on both source and target. When both present,
-  the per-pair `Iso<A, B>` composes from the per-field constants; when either absent, today's reflective deep-map path.
+- **Phase C — deep-mapping uses constants.** `Reflective#structuralIso(cls)` probes for a sibling `<X>Telescope` and,
+  when present, pre-resolves a per-component `Lens` table. The backward branch (instance → name-keyed `Map`) reads via
+  those lenses instead of routing through `Records.read` / `Beans.readProperty`. Holder-absent types and partial holders
+  fall through to the reflective `read` path unchanged. The forward branch (`construct`) is untouched — the holder
+  doesn't expose a constructor primitive, so canonical-ctor / `BeanWriter` dispatch remains. Net effect: for type pairs
+  where both sides are annotated, every per-component value read during deep-mapping decomposition uses a pre-baked
+  lens.
 
 ## Decisions encoded in the design
 


### PR DESCRIPTION
## Summary

ADR-0006 Phase C — when a class carries a sibling `<X>Telescope` metadata holder, `Reflective#structuralIso(cls)` routes the per-component instance reads through the holder's pre-baked `Lens` constants instead of `Records.read` / `Beans.readProperty`. This is the deep-mapping (`Telescope.map(...)` / `Telescope.mapper(...)`) leg of the hybrid codegen ↔ runtime story.

- New helper `Reflective#resolveHolderReaders(cls, names)` pre-resolves the `name -> Lens` table at `structuralIso` construction time. Returns `null` when the holder is absent **or** doesn't cover every component, so the backward branch falls through to today's reflective `read` path with no per-component branching inside the hot loop.
- The forward branch (`construct`) is untouched — the holder doesn't expose a constructor primitive, so canonical-ctor / `BeanWriter` dispatch remains the only build path.
- Fallback semantics: holder-absent, partial-coverage, and mixed (one side annotated, one side plain) all degrade gracefully. Net effect for non-annotated users: zero behaviour change.

## Test plan

- [x] `DeepMapPhaseCHolderTest` — both sides annotated, neither side annotated, holders-present sanity check, and mixed annotated/plain round trips
- [x] `./gradlew :core:test` passes (existing `DeepMappingTest`, `HybridDispatchIntegrationTest`, `MetadataHolderProbeTest` all green)
- [x] Spotless clean

## ADR / CHANGELOG

- `docs/adr/0006-codegen-runtime-1-1-lookup-via-metadata-holder.md` — Phase C bullet updated with what actually landed (backward-branch reads, forward unchanged)
- `CHANGELOG.md` — Phase C moved from "planned" to landed under `[Unreleased]`