### PR TITLE
docs(core): qualify Mapper constructor link in PatchEntry javadoc

### DIFF
--- a/core/src/main/java/io/github/eschizoid/telescope/conversion/Mapper.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/conversion/Mapper.java
@@ -27,9 +27,9 @@ public final class Mapper<A, B> {
    *
    * <p>Declared {@code public} solely so the cross-package {@link
    * io.github.eschizoid.telescope.mapping.DeepMap} engine can construct entries when building a
-   * {@link Mapper} via {@link #Mapper(Iso, Class, Class, Map)}. The raw {@link Function} field is
-   * part of that internal contract; external code must not depend on this record's shape. Treat as
-   * private to the module — it may change or disappear without a deprecation cycle.
+   * {@link Mapper} via {@link Mapper#Mapper(Iso, Class, Class, Map)}. The raw {@link Function}
+   * field is part of that internal contract; external code must not depend on this record's shape.
+   * Treat as private to the module — it may change or disappear without a deprecation cycle.
    */
   public record PatchEntry(String sourceField, Function<Object, Object> backward) {}
 


### PR DESCRIPTION
## Summary

`./gradlew :core:javadoc` was failing with `reference not found` on `Mapper.java:30`:

```
* {@link Mapper} via {@link #Mapper(Iso, Class, Class, Map)}. The raw {@link Function} field is
                               ^
```

The `{@link #Mapper(Iso, Class, Class, Map)}` reference sits inside the nested `PatchEntry` record, so `#Mapper(...)` resolves against `PatchEntry` (which has no such constructor) instead of the enclosing `Mapper` class. Qualifying the link as `Mapper#Mapper(Iso, Class, Class, Map)` points it at the actual constructor.

## Test plan

- [x] `./gradlew :core:javadoc` passes
- [x] `./gradlew javadoc` (all modules) passes
- [x] Spotless clean