### PR TITLE
chore(core): drop instanceof short-circuit on asList/asSet/asMap/asOptional

### DIFF
--- a/core/src/main/java/io/github/eschizoid/telescope/Telescope.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/Telescope.java
@@ -161,30 +161,26 @@ public sealed class Telescope<
    * final Telescope<Company, Department> elements = Telescope.asList(built).each();
    * }</pre>
    */
-  @SuppressWarnings({ "unchecked", "exports" })
+  @SuppressWarnings("exports")
   public static <S, X> ListPath<S, X> asList(final Telescope<S, List<X>> path) {
-    if (path instanceof ListPath<?, ?> lp) return (ListPath<S, X>) lp;
     return new ListPath<>(path.optic, path.fieldOptics, path.chain);
   }
 
   /** Pre-built-fragment companion to {@link #asList} for {@code Set&lt;X&gt;} paths. */
-  @SuppressWarnings({ "unchecked", "exports" })
+  @SuppressWarnings("exports")
   public static <S, X> SetPath<S, X> asSet(final Telescope<S, java.util.Set<X>> path) {
-    if (path instanceof SetPath<?, ?> sp) return (SetPath<S, X>) sp;
     return new SetPath<>(path.optic, path.fieldOptics, path.chain);
   }
 
   /** Pre-built-fragment companion to {@link #asList} for {@code Map&lt;K, V&gt;} paths. */
-  @SuppressWarnings({ "unchecked", "exports" })
+  @SuppressWarnings("exports")
   public static <S, K, V> MapPath<S, K, V> asMap(final Telescope<S, Map<K, V>> path) {
-    if (path instanceof MapPath<?, ?, ?> mp) return (MapPath<S, K, V>) mp;
     return new MapPath<>(path.optic, path.fieldOptics, path.chain);
   }
 
   /** Pre-built-fragment companion to {@link #asList} for {@code Optional&lt;X&gt;} paths. */
-  @SuppressWarnings({ "unchecked", "exports" })
+  @SuppressWarnings("exports")
   public static <S, X> OptionalPath<S, X> asOptional(final Telescope<S, Optional<X>> path) {
-    if (path instanceof OptionalPath<?, ?> op) return (OptionalPath<S, X>) op;
     return new OptionalPath<>(path.optic, path.fieldOptics, path.chain);
   }
 

--- a/core/src/main/java/io/github/eschizoid/telescope/conversion/Mapper.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/conversion/Mapper.java
@@ -27,9 +27,9 @@ public final class Mapper<A, B> {
    *
    * <p>Declared {@code public} solely so the cross-package {@link
    * io.github.eschizoid.telescope.mapping.DeepMap} engine can construct entries when building a
-   * {@link Mapper} via {@link #Mapper(Iso, Class, Class, Map)}. The raw {@link Function} field is
-   * part of that internal contract; external code must not depend on this record's shape. Treat as
-   * private to the module — it may change or disappear without a deprecation cycle.
+   * {@link Mapper} via {@link Mapper#Mapper(Iso, Class, Class, Map)}. The raw {@link Function}
+   * field is part of that internal contract; external code must not depend on this record's shape.
+   * Treat as private to the module — it may change or disappear without a deprecation cycle.
    */
   public record PatchEntry(String sourceField, Function<Object, Object> backward) {}
 

--- a/core/src/test/java/io/github/eschizoid/telescope/TypedContainerPathTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/TypedContainerPathTest.java
@@ -1,7 +1,6 @@
 package io.github.eschizoid.telescope;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.github.eschizoid.telescope.Telescope.ListPath;
@@ -66,11 +65,14 @@ class TypedContainerPathTest {
     }
 
     @Test
-    @DisplayName("asList on an already-ListPath returns it unchanged (no rewrap)")
-    void asListIdempotent() {
+    @DisplayName("asList on an already-ListPath rewraps to an equivalent ListPath (behavior-preserving)")
+    void asListBehaviorPreserving() {
       final ListPath<TagList, Tag> tags = Telescope.of(TagList.class).list(TagList::tags);
       final ListPath<TagList, Tag> promoted = Telescope.asList(tags);
-      assertSame(tags, promoted);
+      final var src = new TagList("alice", List.of(new Tag("a"), new Tag("b")));
+      assertEquals(tags.read(src), promoted.read(src), "rewrapped ListPath must read identical values");
+      final var updated = promoted.each().update(src, t -> new Tag(t.name().toUpperCase()));
+      assertEquals(List.of(new Tag("A"), new Tag("B")), updated.tags(), "rewrapped ListPath must update identically");
     }
   }
 


### PR DESCRIPTION
## Summary

The four typed-container promotion methods (`asList` / `asSet` / `asMap` / `asOptional` on `Telescope`) carried three `@SuppressWarnings` entries — `"unchecked"`, `"exports"`, `"CastConflictsWithInstanceof"` — because of an `instanceof` short-circuit that re-cast through a wildcard projection:

```java
@SuppressWarnings({ "unchecked", "exports", "CastConflictsWithInstanceof" })
public static <S, X> ListPath<S, X> asList(final Telescope<S, List<X>> path) {
    if (path instanceof ListPath<?, ?> lp) return (ListPath<S, X>) lp;
    return new ListPath<>(path.optic, path.fieldOptics, path.chain);
}
```

In practice the short-circuit almost never fires: `.list(getter)` returns `ListPath` directly, so the only callers of `asList(...)` are promoting a generic `Telescope<S, List<X>>` built from another path — the case that needs the allocation regardless. Dropping the short-circuit shrinks each method to a single `@SuppressWarnings("exports")`. The remaining suppression is genuine (`optic` / `fieldOptics` / `chain` are internal-package types crossing a public constructor boundary).

## Changes

- `Telescope.java` — four `as*` methods shrunk to a single `@SuppressWarnings("exports")` each; instance-cast removed
- `TypedContainerPathTest.java` — `asListIdempotent` (which asserted `assertSame`) replaced by `asListBehaviorPreserving` which round-trips through the rewrapped path. Same semantics; no instance-identity assumption
- `Mapper.java` — folds in the javadoc fix from PR #35 (`{@link #Mapper(...)}` → `{@link Mapper#Mapper(...)}` inside the nested `PatchEntry` record) so this branch passes `./gradlew :core:javadoc` standalone. If #35 lands first this becomes a no-op; if this lands first #35 can close as redundant

## Test plan

- [x] `./gradlew :core:test` — full suite green (including `TypedContainerPathTest`)
- [x] `./gradlew :core:javadoc` — green
- [x] `./gradlew spotlessApply --rerun-tasks` — clean