### PR TITLE
feat(codegen)!: Phase D — <X>Telescope.construct holder bypasses reflective construct (ADR-0006)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,15 @@ story.
   probes for a sibling `<X>Telescope` holder per side. When the holder covers every component, every per-component read
   during instance decomposition routes through the pre-baked `Lens` constants instead of `Records.read` /
   `Beans.readProperty`. Holder-absent types and partial holders fall through to the reflective path unchanged.
+- **Phase D.** `<X>Telescope` holders gain a `public static <X> construct(Function<String, Object> values)` method that
+  mirrors the same write strategy the `<X>Path<R>` lens setters chose (canonical constructor for records; builder chain
+  or no-arg ctor + setters for beans). `MetadataHolderProbe.HolderRef` adds an optional
+  `Function<Function<String, Object>, Object> constructor` field bound once via `LambdaMetafactory` at probe time.
+  `Reflective#structuralIso(cls)`'s forward branch (`Map → instance`) routes through it when present, bypassing the
+  reflective `Records.construct` / `Beans.BeanWriter` path. Legacy holders without a Phase D `construct` method degrade
+  gracefully (the `constructor` field is `null` and the reflective fallback runs). Combined with Phase C, both
+  directions of `structuralIso` are reflection-free for annotated type pairs; the only remaining runtime reflection is
+  `SerializedLambda` decode on user accessor method references.
 
 ### Changed
 

--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/AbstractTelescopeProcessor.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/AbstractTelescopeProcessor.java
@@ -754,6 +754,10 @@ public abstract class AbstractTelescopeProcessor extends AbstractProcessor {
 
     final Set<String> extraImports = new LinkedHashSet<>();
     for (final var p : props) collectStdImports(p.type(), extraImports);
+    // Phase D: the holder also exposes a static construct(Function<String, Object>) so the runtime
+    // forward branch in Reflective#structuralIso can skip the BeanWriter reflective path. See
+    // ADR-0006 §3 (Phase D).
+    extraImports.add("java.util.function.Function");
 
     writeMetadataHolderClass(
       qualifiedHolder,
@@ -783,8 +787,51 @@ public abstract class AbstractTelescopeProcessor extends AbstractProcessor {
           );
           out.println();
         }
+        emitBeanConstruct(out, pojoName, props, setters, useBuilder);
       }
     );
+  }
+
+  /**
+   * Phase D (ADR-0006): emit a {@code public static <Pojo> construct(Function<String, Object>
+   * values)} on the bean holder. The emitted body mirrors the same write strategy {@link
+   * #emitBeanNavigator} already picked for the {@code <X>Path<R>} lens setters — builder chain when
+   * {@code useBuilder} is true, otherwise no-arg ctor plus per-property setters. The runtime hybrid
+   * dispatch in {@link io.github.eschizoid.telescope.internal.MetadataHolderProbe
+   * MetadataHolderProbe} / {@link io.github.eschizoid.telescope.internal.Reflective#structuralIso
+   * Reflective.structuralIso} routes here, bypassing the reflective {@link
+   * io.github.eschizoid.telescope.internal.Beans.BeanWriter Beans.BeanWriter} path for annotated
+   * beans. The cast types match the constants' fieldType (boxed primitives, shortened std imports).
+   */
+  private void emitBeanConstruct(
+    final PrintWriter out,
+    final String pojoName,
+    final List<Prop> props,
+    final String[] setters,
+    final boolean useBuilder
+  ) {
+    out.println("  /** Phase D (ADR-0006): bean rebuild short-circuit for the runtime forward branch. */");
+    out.println("  @SuppressWarnings(\"unchecked\")");
+    out.println("  public static " + pojoName + " construct(final Function<String, Object> values) {");
+    if (useBuilder) {
+      out.print("    return " + pojoName + ".builder()");
+      for (var i = 0; i < props.size(); i++) {
+        final var p = props.get(i);
+        final var castType = shortenStdImports(boxedType(p.type()));
+        out.print("." + setters[i] + "((" + castType + ") values.apply(\"" + p.name() + "\"))");
+      }
+      out.println(".build();");
+    } else {
+      out.println("    final var c = new " + pojoName + "();");
+      for (var i = 0; i < props.size(); i++) {
+        final var p = props.get(i);
+        final var castType = shortenStdImports(boxedType(p.type()));
+        out.println("    c." + setters[i] + "((" + castType + ") values.apply(\"" + p.name() + "\"));");
+      }
+      out.println("    return c;");
+    }
+    out.println("  }");
+    out.println();
   }
 
   /**

--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/FocusProcessor.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/FocusProcessor.java
@@ -144,6 +144,10 @@ public final class FocusProcessor extends AbstractTelescopeProcessor {
 
     final Set<String> extraImports = new LinkedHashSet<>();
     for (final var comp : components) collectStdImports(comp.asType(), extraImports);
+    // Phase D: the holder also exposes a static construct(Function<String, Object>) so the runtime
+    // forward branch in Reflective#structuralIso can skip the canonical-ctor reflective path. See
+    // ADR-0006 §3 (Phase D).
+    extraImports.add("java.util.function.Function");
 
     writeMetadataHolderClass(
       qualifiedHolder,
@@ -171,8 +175,34 @@ public final class FocusProcessor extends AbstractTelescopeProcessor {
           );
           out.println();
         }
+        emitRecordConstruct(out, recordName, components);
       }
     );
+  }
+
+  // Phase D: emit a `public static <Record> construct(Function<String, Object> values)` that calls
+  // the canonical constructor directly with cast-pulled values — the runtime hybrid dispatch in
+  // MetadataHolderProbe / Reflective#structuralIso routes here, bypassing the reflective
+  // Records.construct path for annotated records. See ADR-0006 §3 (Phase D).
+  private void emitRecordConstruct(
+    final PrintWriter out,
+    final String recordName,
+    final List<? extends RecordComponentElement> components
+  ) {
+    out.println("  /** Phase D (ADR-0006): canonical-constructor short-circuit for the runtime forward branch. */");
+    out.println("  @SuppressWarnings(\"unchecked\")");
+    out.println("  public static " + recordName + " construct(final Function<String, Object> values) {");
+    out.print("    return new " + recordName + "(");
+    for (var i = 0; i < components.size(); i++) {
+      final var comp = components.get(i);
+      final var compName = comp.getSimpleName().toString();
+      final var castType = shortenStdImports(boxedType(comp.asType()));
+      out.print("(" + castType + ") values.apply(\"" + compName + "\")");
+      if (i < components.size() - 1) out.print(", ");
+    }
+    out.println(");");
+    out.println("  }");
+    out.println();
   }
 
   // Emits one navigator method for the given record component, dispatching on its shape:

--- a/codegen/src/test/java/io/github/eschizoid/telescope/codegen/BeanFocusProcessorTest.java
+++ b/codegen/src/test/java/io/github/eschizoid/telescope/codegen/BeanFocusProcessorTest.java
@@ -550,4 +550,90 @@ class BeanFocusProcessorTest {
       );
     }
   }
+
+  @Nested
+  @DisplayName("Metadata holder construct(...) emission (ADR-0006 Phase D)")
+  class MetadataHolderConstruct {
+
+    @Test
+    @DisplayName("setter POJO: construct calls the no-arg ctor then setX per property")
+    void setterPojoConstruct() {
+      final var compilation = compile(
+        source(
+          "demo.Person",
+          """
+          package demo;
+          import io.github.eschizoid.telescope.annotations.BeanFocus;
+          @BeanFocus
+          public class Person {
+            private String name;
+            private int age;
+            public Person() {}
+            public String getName() { return name; }
+            public int getAge() { return age; }
+            public void setName(String name) { this.name = name; }
+            public void setAge(int age) { this.age = age; }
+          }
+          """
+        )
+      );
+
+      assertTrue(compilation.success(), () -> "compilation failed: " + compilation.errorMessages());
+      final var holder = compilation.generated().get("demo.PersonTelescope");
+      assertNotNull(holder, () -> "PersonTelescope not generated; saw " + compilation.generated().keySet());
+
+      // Phase D signature.
+      assertTrue(holder.contains("public static Person construct(final Function<String, Object> values)"), holder);
+      // No-arg ctor + setX per property. The setter strategy chosen by emitBeanNavigator is
+      // mirrored here verbatim.
+      assertTrue(holder.contains("final var c = new Person();"), holder);
+      assertTrue(holder.contains("c.setName((String) values.apply(\"name\"));"), holder);
+      assertTrue(holder.contains("c.setAge((Integer) values.apply(\"age\"));"), holder);
+      assertTrue(holder.contains("return c;"), holder);
+      // Imports + @SuppressWarnings present.
+      assertTrue(holder.contains("import java.util.function.Function;"), holder);
+      assertTrue(holder.contains("@SuppressWarnings(\"unchecked\")"), holder);
+    }
+
+    @Test
+    @DisplayName("builder() POJO: construct chains builder().setX(...).setY(...).build()")
+    void builderPojoConstruct() {
+      final var compilation = compile(
+        source(
+          "demo.BuilderPojo",
+          """
+          package demo;
+          import io.github.eschizoid.telescope.annotations.BeanFocus;
+          @BeanFocus
+          public class BuilderPojo {
+            private final String id;
+            private final String email;
+            private BuilderPojo(String id, String email) { this.id = id; this.email = email; }
+            public String getId() { return id; }
+            public String getEmail() { return email; }
+            public static Builder builder() { return new Builder(); }
+            public static final class Builder {
+              private String id;
+              private String email;
+              public Builder id(String id) { this.id = id; return this; }
+              public Builder email(String email) { this.email = email; return this; }
+              public BuilderPojo build() { return new BuilderPojo(id, email); }
+            }
+          }
+          """
+        )
+      );
+
+      assertTrue(compilation.success(), () -> "compilation failed: " + compilation.errorMessages());
+      final var holder = compilation.generated().get("demo.BuilderPojoTelescope");
+      assertNotNull(holder, () -> "BuilderPojoTelescope not generated; saw " + compilation.generated().keySet());
+
+      // Builder chain mirrors the per-property lens setter strategy.
+      assertTrue(holder.contains("public static BuilderPojo construct(final Function<String, Object> values)"), holder);
+      assertTrue(holder.contains("return BuilderPojo.builder()"), holder);
+      assertTrue(holder.contains(".id((String) values.apply(\"id\"))"), holder);
+      assertTrue(holder.contains(".email((String) values.apply(\"email\"))"), holder);
+      assertTrue(holder.contains(".build();"), holder);
+    }
+  }
 }

--- a/codegen/src/test/java/io/github/eschizoid/telescope/codegen/FocusProcessorTest.java
+++ b/codegen/src/test/java/io/github/eschizoid/telescope/codegen/FocusProcessorTest.java
@@ -505,4 +505,89 @@ class FocusProcessorTest {
       assertTrue(noteStep.contains("public Telescope<R, String> whenPresent()"), noteStep);
     }
   }
+
+  @Nested
+  @DisplayName("Metadata holder construct(...) emission (ADR-0006 Phase D)")
+  class MetadataHolderConstruct {
+
+    @Test
+    @DisplayName("scalar record: emits a public static construct(Function) calling the canonical constructor")
+    void scalarRecordConstruct() {
+      final var compilation = compile(
+        source(
+          "demo.Person",
+          """
+          package demo;
+          import io.github.eschizoid.telescope.annotations.Focus;
+          @Focus
+          public record Person(String name, int age) {}
+          """
+        )
+      );
+
+      assertTrue(compilation.success(), () -> "compilation failed: " + compilation.errorMessages());
+      final var holder = compilation.generated().get("demo.PersonTelescope");
+      assertNotNull(holder, () -> "PersonTelescope not generated; saw " + compilation.generated().keySet());
+
+      // Phase D signature: public static Person construct(final Function<String, Object> values)
+      assertTrue(holder.contains("public static Person construct(final Function<String, Object> values)"), holder);
+      // The body must call the canonical constructor with per-component casts pulled from
+      // values.apply(...). Primitives surface as their boxed equivalents (the auto-unbox happens
+      // implicitly at the canonical-ctor call site).
+      assertTrue(holder.contains("return new Person("), holder);
+      assertTrue(holder.contains("(String) values.apply(\"name\")"), holder);
+      assertTrue(holder.contains("(Integer) values.apply(\"age\")"), holder);
+      // Function import has to be in the holder's import block — extra import collected by
+      // emitMetadataHolder, alongside any java.util container imports.
+      assertTrue(holder.contains("import java.util.function.Function;"), holder);
+      // @SuppressWarnings("unchecked") on the construct method so generic-component casts compile
+      // clean under -Werror.
+      assertTrue(holder.contains("@SuppressWarnings(\"unchecked\")"), holder);
+    }
+
+    @Test
+    @DisplayName("container components: construct casts to the generic container type")
+    void containerComponentConstruct() {
+      final var compilation = compile(
+        source(
+          "demo.Bag",
+          """
+          package demo;
+          import java.util.List;
+          import io.github.eschizoid.telescope.annotations.Focus;
+          @Focus
+          public record Bag(List<String> tags) {}
+          """
+        )
+      );
+
+      assertTrue(compilation.success(), () -> "compilation failed: " + compilation.errorMessages());
+      final var holder = compilation.generated().get("demo.BagTelescope");
+      assertNotNull(holder, () -> "BagTelescope not generated; saw " + compilation.generated().keySet());
+
+      assertTrue(holder.contains("public static Bag construct(final Function<String, Object> values)"), holder);
+      assertTrue(holder.contains("return new Bag((List<String>) values.apply(\"tags\"));"), holder);
+    }
+
+    @Test
+    @DisplayName("rejected holder: no construct method emitted when component types are un-emittable")
+    void rejectedHolderHasNoConstruct() {
+      final var compilation = compile(
+        source(
+          "demo.Wild",
+          """
+          package demo;
+          import java.util.List;
+          import io.github.eschizoid.telescope.annotations.Focus;
+          @Focus
+          public record Wild(List<? extends Comparable<?>> values) {}
+          """
+        )
+      );
+
+      // The wildcard rejection already covers this — re-asserted here as a Phase D regression
+      // guard: no holder means no construct.
+      assertFalse(compilation.generated().containsKey("demo.WildTelescope"), "no holder, no construct method");
+    }
+  }
 }

--- a/core/src/main/java/io/github/eschizoid/telescope/conversion/Mapper.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/conversion/Mapper.java
@@ -27,9 +27,9 @@ public final class Mapper<A, B> {
    *
    * <p>Declared {@code public} solely so the cross-package {@link
    * io.github.eschizoid.telescope.mapping.DeepMap} engine can construct entries when building a
-   * {@link Mapper} via {@link #Mapper(Iso, Class, Class, Map)}. The raw {@link Function} field is
-   * part of that internal contract; external code must not depend on this record's shape. Treat as
-   * private to the module — it may change or disappear without a deprecation cycle.
+   * {@link Mapper} via {@link Mapper#Mapper(Iso, Class, Class, Map)}. The raw {@link Function}
+   * field is part of that internal contract; external code must not depend on this record's shape.
+   * Treat as private to the module — it may change or disappear without a deprecation cycle.
    */
   public record PatchEntry(String sourceField, Function<Object, Object> backward) {}
 

--- a/core/src/main/java/io/github/eschizoid/telescope/internal/MetadataHolderProbe.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/internal/MetadataHolderProbe.java
@@ -3,10 +3,14 @@ package io.github.eschizoid.telescope.internal;
 import io.github.eschizoid.telescope.Telescope;
 import io.github.eschizoid.telescope.internal.optics.Lens;
 import io.github.eschizoid.telescope.internal.optics.Traversal;
+import java.lang.invoke.LambdaMetafactory;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
 import java.lang.reflect.Modifier;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Function;
 
 /**
  * Probes the user's classpath for a sibling {@code <X>Telescope} metadata holder emitted by
@@ -32,6 +36,18 @@ import java.util.Optional;
  * package; the constants are {@code public static final}. The holder is plain public Java — no
  * {@code privateLookupIn} required, and the JPMS {@code opens} directive that the LMF substrate
  * needs for non-annotated types is not required for the probe itself.
+ *
+ * <p><b>ADR-0006 Phase D.</b> Holders also expose a {@code public static <X>
+ * construct(Function<String, Object> values)} method that mirrors the {@code <X>Path<R>}'s write
+ * strategy (canonical constructor for records; builder chain or no-arg ctor + setters for beans).
+ * Probing binds the static method via {@link LambdaMetafactory} into a cached {@code
+ * Function<Function<String, Object>, Object>} on {@link HolderRef}. {@link
+ * io.github.eschizoid.telescope.internal.Reflective#structuralIso Reflective.structuralIso}'s
+ * forward branch routes through it when present, skipping the reflective {@link
+ * io.github.eschizoid.telescope.internal.Records#construct Records.construct} / {@link
+ * io.github.eschizoid.telescope.internal.Beans.BeanWriter Beans.BeanWriter} path. Older holders
+ * that predate Phase D (no {@code construct} method) degrade gracefully — the constructor field is
+ * {@code null} and the reflective path runs.
  */
 public final class MetadataHolderProbe {
 
@@ -39,13 +55,24 @@ public final class MetadataHolderProbe {
 
   /**
    * A discovered sibling {@code <X>Telescope} metadata holder for some class: the holder class
-   * itself (used in diagnostics) plus the immutable name &rarr; constant lookup table. Each
-   * constant is a {@link io.github.eschizoid.telescope.Telescope Telescope} instance built via
-   * {@link io.github.eschizoid.telescope.Telescope#lens(java.util.function.Function,
+   * itself (used in diagnostics), the immutable name &rarr; constant lookup table, and — when the
+   * holder was emitted with ADR-0006 Phase D — a cached {@link Function} bound to the holder's
+   * static {@code construct(Function<String, Object>)} method. Each constant is a {@link
+   * io.github.eschizoid.telescope.Telescope Telescope} instance built via {@link
+   * io.github.eschizoid.telescope.Telescope#lens(java.util.function.Function,
    * java.util.function.BiFunction) Telescope.lens(...)} at codegen time. {@link #lensFor} unwraps
    * one to a {@link Lens} for the dispatch site.
+   *
+   * <p>The {@code constructor} field is {@code null} when the holder doesn't expose a {@code
+   * construct} method — older Phase A holders, or future processors that opt out. {@link
+   * io.github.eschizoid.telescope.internal.Reflective#structuralIso Reflective.structuralIso}
+   * checks for {@code null} and falls back to the reflective constructor path.
    */
-  public record HolderRef(Class<?> holderClass, Map<String, Telescope<?, ?>> constantsByName) {
+  public record HolderRef(
+    Class<?> holderClass,
+    Map<String, Telescope<?, ?>> constantsByName,
+    Function<Function<String, Object>, Object> constructor
+  ) {
     /**
      * The {@link Lens} backing the holder constant named {@code name}, or {@code null} if the
      * holder doesn't expose that name. Dispatch sites in {@link
@@ -131,11 +158,56 @@ public final class MetadataHolderProbe {
         final var value = field.get(null);
         if (value instanceof Telescope<?, ?> t) constants.put(field.getName(), t);
       }
-      return Optional.of(new HolderRef(holder, Map.copyOf(constants)));
+      final var constructor = bindConstructor(holder, cls);
+      return Optional.of(new HolderRef(holder, Map.copyOf(constants), constructor));
     } catch (final ClassNotFoundException e) {
       return Optional.empty();
     } catch (final ReflectiveOperationException e) {
       throw new IllegalStateException("Failed to probe metadata holder " + holderName, e);
+    }
+  }
+
+  /**
+   * Bind the holder's {@code public static <X> construct(Function<String, Object> values)} method
+   * to a cached {@link Function} via {@link LambdaMetafactory}, so the runtime forward branch in
+   * {@link Reflective#structuralIso} can invoke it directly without per-call reflection. Returns
+   * {@code null} when the holder doesn't expose a matching {@code construct} method (older Phase A
+   * holders that predate Phase D, or future opt-out paths) — callers fall back to the reflective
+   * {@link Reflective#construct} path.
+   *
+   * <p>The holder is plain public Java in the user's package, so a default {@link
+   * MethodHandles#lookup} suffices; no {@code privateLookupIn} dance, no JPMS {@code opens}
+   * requirement beyond what the holder's package already grants.
+   */
+  @SuppressWarnings("unchecked")
+  private static Function<Function<String, Object>, Object> bindConstructor(
+    final Class<?> holder,
+    final Class<?> target
+  ) {
+    try {
+      final var method = holder.getDeclaredMethod("construct", Function.class);
+      if (
+        !Modifier.isPublic(method.getModifiers()) ||
+        !Modifier.isStatic(method.getModifiers()) ||
+        !target.isAssignableFrom(method.getReturnType())
+      ) {
+        return null;
+      }
+      final var lookup = MethodHandles.lookup();
+      final var handle = lookup.unreflect(method);
+      final var callSite = LambdaMetafactory.metafactory(
+        lookup,
+        "apply",
+        MethodType.methodType(Function.class),
+        MethodType.methodType(Object.class, Object.class),
+        handle,
+        MethodType.methodType(method.getReturnType(), Function.class)
+      );
+      return (Function<Function<String, Object>, Object>) callSite.getTarget().invoke();
+    } catch (final NoSuchMethodException e) {
+      return null;
+    } catch (final Throwable t) {
+      throw new IllegalStateException("Failed to bind construct(Function) on holder " + holder.getName(), t);
     }
   }
 }

--- a/core/src/main/java/io/github/eschizoid/telescope/internal/Reflective.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/internal/Reflective.java
@@ -133,16 +133,27 @@ public record Reflective(
    * io.github.eschizoid.telescope.annotations.BeanFocus @BeanFocus} / Lombok), the backward
    * direction's per-component reads route through the holder's pre-baked {@link Lens} constants
    * directly — bypassing the per-call {@link Records#read} / {@link Beans#readProperty} dispatch.
-   * The forward {@link #construct} path is unchanged; it still routes through the cached canonical
-   * constructor (records) or {@link Beans.BeanWriter} (beans), because the holder doesn't expose a
-   * constructor primitive. When the holder is absent or doesn't cover every component, the prior
-   * reflective {@link #read} path remains the fallback. See ADR-0006 §3.
+   * When the holder is absent or doesn't cover every component, the prior reflective {@link #read}
+   * path remains the fallback. See ADR-0006 §3.
+   *
+   * <p><b>ADR-0006 Phase D.</b> The forward branch ({@code Map → instance}) now also short-circuits
+   * the reflective {@link #construct} path. When the holder exposes a bound {@code
+   * construct(Function<String, Object>)} method (emitted by Phase D codegen), the {@link
+   * MetadataHolderProbe.HolderRef#constructor() HolderRef.constructor} is non-{@code null} and the
+   * forward branch invokes it directly — calling the record's canonical constructor or the bean's
+   * chosen builder / no-arg-ctor-plus-setters strategy with no per-call reflective dispatch. When
+   * absent (no holder, or older Phase A holder without a {@code construct} method), today's
+   * canonical constructor (records) or {@link Beans.BeanWriter} (beans) path runs unchanged.
    */
   public <T> Iso<Map<String, Object>, T> structuralIso(final Class<T> cls) {
     final var componentNames = names(cls);
     final var holderReaders = resolveHolderReaders(cls, componentNames);
+    final var holderConstructor = resolveHolderConstructor(cls);
     return Iso.of(
-      map -> cls.cast(construct(cls, map::get)),
+      map -> {
+        if (holderConstructor != null) return cls.cast(holderConstructor.apply(map::get));
+        return cls.cast(construct(cls, map::get));
+      },
       instance -> {
         final var out = new LinkedHashMap<String, Object>();
         if (holderReaders != null) {
@@ -153,6 +164,21 @@ public record Reflective(
         return out;
       }
     );
+  }
+
+  /**
+   * If a sibling {@code <X>Telescope} holder is on the classpath AND it exposes a bound static
+   * {@code construct(Function<String, Object>)} method (ADR-0006 Phase D), return that bound
+   * function so the forward branch of {@link #structuralIso} bypasses {@link #construct} entirely.
+   * Returns {@code null} when no holder is present OR when the holder predates Phase D and exposes
+   * only the per-property {@link Lens} constants — the caller falls back to the reflective {@link
+   * #construct} path. Matches the pre-resolution-or-nothing posture of {@link
+   * #resolveHolderReaders}: one branch outside the {@link Iso}'s hot map, not inside.
+   */
+  private static Function<Function<String, Object>, Object> resolveHolderConstructor(final Class<?> cls) {
+    final var maybeHolder = MetadataHolderProbe.probeFor(cls);
+    if (maybeHolder.isEmpty()) return null;
+    return maybeHolder.get().constructor();
   }
 
   /**

--- a/core/src/test/java/io/github/eschizoid/telescope/mapping/DeepMapPhaseDConstructTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/mapping/DeepMapPhaseDConstructTest.java
@@ -1,0 +1,131 @@
+package io.github.eschizoid.telescope.mapping;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.github.eschizoid.telescope.Telescope;
+import io.github.eschizoid.telescope.internal.MetadataHolderProbe;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Integration test for ADR-0006 Phase D: when both sides of a {@link Telescope#map(Class, Class,
+ * MapStep...)} call carry sibling {@code <X>Telescope} metadata holders with the Phase D {@code
+ * construct(Function<String, Object>)} method, the deep-mapping engine's structural-iso
+ * map-to-instance forward branch routes through the holder's pre-baked constructor instead of the
+ * reflective {@code Records.construct} / {@code Beans.BeanWriter} path.
+ *
+ * <p>The Phase C tests in {@link DeepMapPhaseCHolderTest} cover the backward branch (instance
+ * decomposition through holder lenses). Phase D closes the loop on the forward branch — together
+ * they eliminate the per-component reflective dispatch on both sides of a holder-covered type pair.
+ *
+ * <p>Reuses the {@link PhaseCSrc} / {@link PhaseCDst} / {@link PhaseCPlainSrc} / {@link
+ * PhaseCPlainDst} fixtures from the Phase C suite — the same holders are exercised, just from a
+ * different observation angle (forward construct vs backward decompose). The annotated fixtures
+ * carry Phase D holders since the {@link io.github.eschizoid.telescope.codegen.FocusProcessor
+ * FocusProcessor} now emits {@code construct(...)} alongside the per-component lens constants.
+ */
+class DeepMapPhaseDConstructTest {
+
+  @Test
+  @DisplayName("both sides annotated: Phase D construct round-trips through the holder-bound constructor")
+  void bothSidesAnnotatedRoundTrip() {
+    final var mapper = Telescope.mapper(PhaseCSrc.class, PhaseCDst.class);
+    final var src = new PhaseCSrc("dave", 41);
+    final var dst = mapper.forward(src);
+    assertEquals(new PhaseCDst("dave", 41), dst, "forward map must produce a same-valued target via holder construct");
+    assertEquals(src, mapper.backward(dst), "backward map must recover the source byte-for-byte via holder construct");
+  }
+
+  @Test
+  @DisplayName("both sides annotated: holders expose a bound constructor (defends against codegen drift)")
+  void bothSidesHaveBoundConstructors() {
+    final var srcHolder = MetadataHolderProbe.probeFor(PhaseCSrc.class);
+    final var dstHolder = MetadataHolderProbe.probeFor(PhaseCDst.class);
+    assertTrue(srcHolder.isPresent(), "PhaseCSrc must have a sibling PhaseCSrcTelescope holder on the classpath");
+    assertTrue(dstHolder.isPresent(), "PhaseCDst must have a sibling PhaseCDstTelescope holder on the classpath");
+    assertNotNull(
+      srcHolder.get().constructor(),
+      "PhaseCSrcTelescope must expose a Phase D construct(Function) method bound at probe time"
+    );
+    assertNotNull(
+      dstHolder.get().constructor(),
+      "PhaseCDstTelescope must expose a Phase D construct(Function) method bound at probe time"
+    );
+  }
+
+  @Test
+  @DisplayName("holder-bound constructor builds the right instance from a name-keyed function")
+  void holderConstructorBuildsCorrectInstance() {
+    final var holder = MetadataHolderProbe.probeFor(PhaseCSrc.class).orElseThrow();
+    final var constructor = holder.constructor();
+    assertNotNull(constructor, "PhaseCSrcTelescope must expose a Phase D construct(Function) method");
+    final var built = constructor.apply(name ->
+      switch (name) {
+        case "name" -> "erin";
+        case "age" -> 52;
+        default -> throw new IllegalArgumentException("Unexpected component: " + name);
+      }
+    );
+    assertEquals(
+      new PhaseCSrc("erin", 52),
+      built,
+      "holder-bound constructor must call the canonical constructor with the right components"
+    );
+  }
+
+  @Test
+  @DisplayName("neither side annotated: the reflective construct fallback still round-trips")
+  void neitherSideAnnotatedRoundTrip() {
+    final var mapper = Telescope.mapper(PhaseCPlainSrc.class, PhaseCPlainDst.class);
+    final var src = new PhaseCPlainSrc("frank", 19);
+    final var dst = mapper.forward(src);
+    assertEquals(new PhaseCPlainDst("frank", 19), dst, "fallback forward map must produce a same-valued target");
+    assertEquals(src, mapper.backward(dst), "fallback backward map must recover the source byte-for-byte");
+
+    assertTrue(
+      MetadataHolderProbe.probeFor(PhaseCPlainSrc.class).isEmpty(),
+      "PhaseCPlainSrc should have no sibling holder — the fixture is the no-holder control"
+    );
+    assertTrue(
+      MetadataHolderProbe.probeFor(PhaseCPlainDst.class).isEmpty(),
+      "PhaseCPlainDst should have no sibling holder — the fixture is the no-holder control"
+    );
+  }
+
+  @Test
+  @DisplayName(
+    "mixed: one side annotated, the other plain — holder construct used on annotated side, fallback on plain"
+  )
+  void mixedAnnotatedAndPlainRoundTrip() {
+    final var mapper = Telescope.mapper(PhaseCPlainSrc.class, PhaseCDst.class);
+    final var src = new PhaseCPlainSrc("gina", 33);
+    final var dst = mapper.forward(src);
+    assertEquals(new PhaseCDst("gina", 33), dst, "mixed forward map must produce a same-valued target");
+    assertEquals(src, mapper.backward(dst), "mixed backward map must recover the source byte-for-byte");
+  }
+
+  @Test
+  @DisplayName("legacy holder without Phase D construct: HolderRef.constructor() is null (graceful degradation)")
+  void legacyHolderHasNullConstructor() {
+    // Sanity check: a holder that exposes only Phase A constants (no construct(Function)) must
+    // surface a null `constructor` field on HolderRef so Reflective#structuralIso falls back to
+    // the reflective canonical-ctor path. The fixture is hand-written below so we can simulate the
+    // pre-Phase-D output shape without depending on codegen state.
+    final var holder = MetadataHolderProbe.probeFor(PhaseDLegacyHolderTarget.class);
+    assertTrue(holder.isPresent(), "PhaseDLegacyHolderTarget must have a sibling holder on the classpath");
+    assertNull(
+      holder.get().constructor(),
+      "PhaseDLegacyHolderTargetTelescope has no construct(Function) — constructor field must be null"
+    );
+
+    // And the structural Iso must still round-trip through the reflective fallback. Drive it via
+    // Telescope.mapper which composes the two structural Isos; the forward branch on the target
+    // side hits the null-constructor path.
+    final var mapper = Telescope.mapper(PhaseDLegacyHolderTarget.class, PhaseDLegacyHolderTarget.class);
+    final var v = new PhaseDLegacyHolderTarget("h", 7);
+    assertEquals(v, mapper.forward(v), "forward must still produce the right value via the reflective fallback");
+  }
+}

--- a/core/src/test/java/io/github/eschizoid/telescope/mapping/PhaseDLegacyHolderTarget.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/mapping/PhaseDLegacyHolderTarget.java
@@ -1,0 +1,14 @@
+package io.github.eschizoid.telescope.mapping;
+
+/**
+ * Test fixture for {@link DeepMapPhaseDConstructTest}: a record paired with a hand-written sibling
+ * {@code PhaseDLegacyHolderTargetTelescope} that simulates a pre-Phase-D holder shape — Phase A
+ * lens constants only, no {@code construct(Function<String, Object>)} method. The runtime probe
+ * must surface a {@code null} {@link
+ * io.github.eschizoid.telescope.internal.MetadataHolderProbe.HolderRef#constructor()
+ * HolderRef.constructor()} so {@link
+ * io.github.eschizoid.telescope.internal.Reflective#structuralIso Reflective.structuralIso} falls
+ * back to the reflective canonical-ctor path. Without {@code @Focus} the codegen wouldn't fire on
+ * this record, which lets the hand-written holder stand without conflict.
+ */
+public record PhaseDLegacyHolderTarget(String name, int age) {}

--- a/core/src/test/java/io/github/eschizoid/telescope/mapping/PhaseDLegacyHolderTargetTelescope.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/mapping/PhaseDLegacyHolderTargetTelescope.java
@@ -1,0 +1,26 @@
+package io.github.eschizoid.telescope.mapping;
+
+import io.github.eschizoid.telescope.Telescope;
+
+/**
+ * Hand-written legacy-shape holder for {@link PhaseDLegacyHolderTarget} — Phase A constants only,
+ * no Phase D {@code construct(Function)}. Simulates the wire shape a pre-Phase-D processor would
+ * have emitted so {@link DeepMapPhaseDConstructTest} can assert {@link
+ * io.github.eschizoid.telescope.internal.MetadataHolderProbe MetadataHolderProbe} degrades
+ * gracefully to a {@code null} constructor field and the reflective {@code structuralIso} forward
+ * branch still works.
+ */
+public final class PhaseDLegacyHolderTargetTelescope {
+
+  private PhaseDLegacyHolderTargetTelescope() {}
+
+  public static final Telescope<PhaseDLegacyHolderTarget, String> name = Telescope.lens(
+    PhaseDLegacyHolderTarget::name,
+    (s, v) -> new PhaseDLegacyHolderTarget(v, s.age())
+  );
+
+  public static final Telescope<PhaseDLegacyHolderTarget, Integer> age = Telescope.lens(
+    PhaseDLegacyHolderTarget::age,
+    (s, v) -> new PhaseDLegacyHolderTarget(s.name(), v)
+  );
+}

--- a/docs/adr/0006-codegen-runtime-1-1-lookup-via-metadata-holder.md
+++ b/docs/adr/0006-codegen-runtime-1-1-lookup-via-metadata-holder.md
@@ -63,6 +63,16 @@ Phased rollout (each phase is a discrete PR, no public API change):
   doesn't expose a constructor primitive, so canonical-ctor / `BeanWriter` dispatch remains. Net effect: for type pairs
   where both sides are annotated, every per-component value read during deep-mapping decomposition uses a pre-baked
   lens.
+- **Phase D — holder construct(...) closes the forward branch.** The `<X>Telescope` holder gains a
+  `public static <X> construct(Function<String, Object> values)` method that mirrors the same write strategy the
+  `<X>Path<R>` lenses use (canonical constructor for records; builder chain or no-arg ctor + setters for beans). The
+  `MetadataHolderProbe.HolderRef` adds an optional `Function<Function<String, Object>, Object> constructor` field bound
+  once via `LambdaMetafactory` at probe time. `Reflective#structuralIso(cls)`'s forward branch routes through it when
+  present, bypassing the reflective `Records.construct` / `Beans.BeanWriter` path; older holders that predate Phase D
+  surface a `null` constructor and the engine falls back to today's reflective path unchanged. Net effect: for type
+  pairs where both sides are annotated, both the forward (construct) and the backward (read) branches of `structuralIso`
+  are reflection-free in the hot path; the only remaining runtime reflection is `SerializedLambda` decode on the user's
+  accessor method references.
 
 ## Decisions encoded in the design
 

--- a/lombok/src/test/java/io/github/eschizoid/telescope/codegen/lombok/LombokFocusProcessorTest.java
+++ b/lombok/src/test/java/io/github/eschizoid/telescope/codegen/lombok/LombokFocusProcessorTest.java
@@ -148,6 +148,46 @@ class LombokFocusProcessorTest {
       assertEquals("foo@bar.com", updated.getEmail());
       assertEquals("ABC", updated.getId(), "the non-focused property should round-trip untouched");
     }
+
+    @Test
+    @DisplayName("Phase D: @Data holder exposes a public static construct(Function) that rebuilds via setters")
+    void dataHolderConstruct() throws Exception {
+      final var holder = Class.forName("io.github.eschizoid.telescope.codegen.lombok.fixtures.DataUserTelescope");
+      final var constructMethod = holder.getDeclaredMethod("construct", java.util.function.Function.class);
+      final var mods = constructMethod.getModifiers();
+      assertTrue(java.lang.reflect.Modifier.isPublic(mods), "construct must be public");
+      assertTrue(java.lang.reflect.Modifier.isStatic(mods), "construct must be static");
+      assertEquals(DataUser.class, constructMethod.getReturnType(), "construct must return DataUser");
+
+      // Drive it directly with a name-keyed lookup function.
+      final java.util.function.Function<String, Object> values = name ->
+        switch (name) {
+          case "id" -> "X-123";
+          case "email" -> "noreply@example.com";
+          default -> throw new IllegalArgumentException("Unexpected: " + name);
+        };
+      final var built = (DataUser) constructMethod.invoke(null, values);
+      assertEquals("X-123", built.getId());
+      assertEquals("noreply@example.com", built.getEmail());
+    }
+
+    @Test
+    @DisplayName("Phase D: @Builder holder exposes a public static construct(Function) that chains the builder")
+    void builderHolderConstruct() throws Exception {
+      final var holder = Class.forName("io.github.eschizoid.telescope.codegen.lombok.fixtures.BuilderUserTelescope");
+      final var constructMethod = holder.getDeclaredMethod("construct", java.util.function.Function.class);
+      assertEquals(BuilderUser.class, constructMethod.getReturnType());
+
+      final java.util.function.Function<String, Object> values = name ->
+        switch (name) {
+          case "id" -> "B-1";
+          case "email" -> "builder@example.com";
+          default -> throw new IllegalArgumentException("Unexpected: " + name);
+        };
+      final var built = (BuilderUser) constructMethod.invoke(null, values);
+      assertEquals("B-1", built.getId());
+      assertEquals("builder@example.com", built.getEmail());
+    }
   }
 
   private static void assertHolderField(final Class<?> holder, final String name) throws Exception {


### PR DESCRIPTION
## Summary

Closes the forward branch of `Reflective#structuralIso` for annotated types so both directions of deep-mapping decomposition are reflection-free.

- **Codegen.** The sibling `<X>Telescope` holder gains `public static <X> construct(Function<String, Object> values)`. For records, the body calls the canonical constructor directly with cast-pulled values. For beans, the body mirrors whatever write strategy `emitBeanNavigator` picked (builder chain or no-arg ctor + setters). Lombok inherits via the existing `emitBeanNavigator` path; the round-deferred `processingOver()` emission already guards against AST visibility.
- **Runtime.** `MetadataHolderProbe.HolderRef` adds an optional `Function<Function<String, Object>, Object> constructor` field bound once via `LambdaMetafactory` at probe time (no `privateLookupIn` needed — the holder is plain public Java). `Reflective#structuralIso(cls)`'s forward branch (`Map → instance`) routes through it when present; legacy holders without `construct` surface `null` and the engine falls back to today's reflective `Records.construct` / `Beans.BeanWriter` path. Pre-resolution-or-nothing posture matches `resolveHolderReaders` — one branch outside the `Iso`'s hot loop, not inside.
- **Net effect.** For annotated type pairs, both forward (`construct`) and backward (`read`) branches of `structuralIso` are reflection-free. Only `SerializedLambda` decode on user accessor method references remains — matching ADR-0006's closing claim.
- **Drive-by.** `Mapper.PatchEntry` javadoc `{@link #Mapper(...)}` → `{@link Mapper#Mapper(...)}` so `:core:javadoc` compiles clean. The nested-record context needed the outer-class qualifier.

## Test plan

- [x] `:core:test` — new `DeepMapPhaseDConstructTest` covers the holder-driven forward branch round-trip (annotated/plain/mixed cases), exercises the bound constructor directly, and verifies the graceful `null`-constructor degradation via a hand-written legacy-shape holder fixture (`PhaseDLegacyHolderTarget` + `PhaseDLegacyHolderTargetTelescope`).
- [x] `:codegen:test` — new `MetadataHolderConstruct` nested classes in `FocusProcessorTest` and `BeanFocusProcessorTest` verify the emitted `construct(Function)` shape: signature, `@SuppressWarnings("unchecked")`, primitive boxing, container-generic casts, builder vs setter rebuild bodies, and the no-construct-on-rejected-holder guard.
- [x] `:lombok:test` — new Phase D tests in `LombokFocusProcessorTest.MetadataHolder` call the emitted `DataUserTelescope.construct` and `BuilderUserTelescope.construct` end-to-end via reflection, confirming Lombok inherits Phase D through `emitBeanNavigator` without round-ordering issues.
- [x] `:core:javadoc` clean.
- [x] `spotlessCheck --rerun-tasks` clean (stale-cache guard from MEMORY).