### PR TITLE
chore(core,codegen): clear IntelliJ warnings — getFirst, method refs, redundant suppression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,10 +35,10 @@ story.
   `SerializedLambda` decode on user accessor method references.
 - **Phase E.** `<X>Telescope` holders gain a `public static Map<String, Telescope<?, ?>> constants()` method returning
   the name → lens map directly. `MetadataHolderProbe.probe(...)` calls this method as the only path; a holder that's
-  missing the method (out-of-date codegen on the classpath) trips a precise `IllegalStateException` rather than
-  silently falling back. Same posture for the `construct(Function)` method emitted in Phase D — holder presence is a
-  full contract, not a probe of independent optional methods. Cuts the cold-path probe from `~3 + N` reflective ops
-  (N = holder field count) to `3` ops regardless of N. The probe is already `ClassValue`-cached, so this is a
+  missing the method (out-of-date codegen on the classpath) trips a precise `IllegalStateException` rather than silently
+  falling back. Same posture for the `construct(Function)` method emitted in Phase D — holder presence is a full
+  contract, not a probe of independent optional methods. Cuts the cold-path probe from `~3 + N` reflective ops (N =
+  holder field count) to `3` ops regardless of N. The probe is already `ClassValue`-cached, so this is a
   one-shot-per-class improvement, not a hot-path change — but it consolidates the holder's runtime contract into two
   named methods (`constants()` + `construct(Function)`) instead of a contract that depends on field-shape conventions.
   Pre-1.0 stance: no legacy fallback for older codegen output; users re-run the processor.

--- a/README.md
+++ b/README.md
@@ -346,9 +346,9 @@ Multi-edit packing (static factories — see [Multi-edit](#multi-edit)):
 ```java
 final Telescope<User, String> name = Telescope.of(User.class).field(User::name);
 
-name.read(alice);                            // "alice"
-name.set(alice, "Bob");                      // User with name="Bob"
-name.update(alice, String::toUpperCase);     // User with name="ALICE"
+name.read(alice);                        // "alice"
+name.set(alice, "Bob");                  // User with name="Bob"
+name.update(alice, String::toUpperCase); // User with name="ALICE"
 ```
 
 ### Nested fields
@@ -384,8 +384,8 @@ final Telescope<Event, String> updatedDiff = Telescope.of(Event.class)
         .as(Updated.class)
         .field(Updated::diff);
 
-updatedDiff.update(event, s -> s + "!");      // no-op if not Updated
-updatedDiff.find(event);                      // Optional<String>
+updatedDiff.update(event, s -> s + "!"); // no-op if not Updated
+updatedDiff.find(event);                 // Optional<String>
 ```
 
 ### Optional field
@@ -395,7 +395,7 @@ record Profile(String id, Optional<String> nickname) {}
 
 final Telescope<Profile, String> nick = Telescope.of(Profile.class).whenPresent(Profile::nickname);
 
-nick.update(profile, String::toUpperCase);   // no-op if nickname is empty
+nick.update(profile, String::toUpperCase); // no-op if nickname is empty
 ```
 
 ### Map values

--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/AbstractTelescopeProcessor.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/AbstractTelescopeProcessor.java
@@ -805,7 +805,8 @@ public abstract class AbstractTelescopeProcessor extends AbstractProcessor {
     if (props.isEmpty()) {
       out.println("    return Map.of();");
     } else if (props.size() == 1) {
-      out.println("    return Map.of(\"" + props.get(0).name() + "\", " + props.get(0).name() + ");");
+      final var onlyName = props.getFirst().name();
+      out.println("    return Map.of(\"" + onlyName + "\", " + onlyName + ");");
     } else {
       out.println("    return Map.ofEntries(");
       for (var i = 0; i < props.size(); i++) {

--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/FocusProcessor.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/FocusProcessor.java
@@ -177,7 +177,7 @@ public final class FocusProcessor extends AbstractTelescopeProcessor {
           out.println();
         }
         emitRecordConstruct(out, recordName, components);
-        emitRecordConstantsMap(out, recordName, components);
+        emitRecordConstantsMap(out, components);
       }
     );
   }
@@ -211,19 +211,14 @@ public final class FocusProcessor extends AbstractTelescopeProcessor {
   // name → lens table directly, so the runtime probe in MetadataHolderProbe doesn't have to do a
   // `getDeclaredFields()` scan plus N `field.get(null)` reads. Goes from O(N) reflective ops per
   // cold probe to O(1). Legacy holders without this method still fall back to the field-scan path.
-  private void emitRecordConstantsMap(
-    final PrintWriter out,
-    final String recordName,
-    final List<? extends RecordComponentElement> components
-  ) {
+  private void emitRecordConstantsMap(final PrintWriter out, final List<? extends RecordComponentElement> components) {
     out.println("  /** Name -> lens map for the runtime probe to skip the field scan. */");
     out.println("  public static Map<String, Telescope<?, ?>> constants() {");
     if (components.isEmpty()) {
       out.println("    return Map.of();");
     } else if (components.size() == 1) {
-      out.println(
-        "    return Map.of(\"" + components.get(0).getSimpleName() + "\", " + components.get(0).getSimpleName() + ");"
-      );
+      final var onlyName = components.getFirst().getSimpleName();
+      out.println("    return Map.of(\"" + onlyName + "\", " + onlyName + ");");
     } else {
       out.println("    return Map.ofEntries(");
       for (var i = 0; i < components.size(); i++) {

--- a/core/src/main/java/io/github/eschizoid/telescope/internal/Beans.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/internal/Beans.java
@@ -104,7 +104,7 @@ public final class Beans {
     if (reader == null) throw new IllegalArgumentException(
       "No getter for property '" + name + "' on " + beanClass.getName()
     );
-    return source -> reader.apply(source);
+    return reader::apply;
   }
 
   /**

--- a/core/src/main/java/io/github/eschizoid/telescope/internal/Reflective.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/internal/Reflective.java
@@ -168,9 +168,7 @@ public record Reflective(
    * {@link Iso}'s hot map, not inside.
    */
   private static Function<Function<String, Object>, Object> resolveHolderConstructor(final Class<?> cls) {
-    final var maybeHolder = MetadataHolderProbe.probeFor(cls);
-    if (maybeHolder.isEmpty()) return null;
-    return maybeHolder.get().constructor();
+    return MetadataHolderProbe.probeFor(cls).map(MetadataHolderProbe.HolderRef::constructor).orElse(null);
   }
 
   /**

--- a/core/src/main/java/io/github/eschizoid/telescope/internal/optics/Iso.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/internal/optics/Iso.java
@@ -125,7 +125,7 @@ public interface Iso<A, B> extends Lens<A, B>, Prism<A, B> {
    * Optional reference round-trips to {@code null} (records/beans may legally hold null references
    * and deep mapping treats nulls as pass-through).
    */
-  @SuppressWarnings({ "OptionalAssignedToNull", "OptionalUsedAsFieldOrParameterType" })
+  @SuppressWarnings("OptionalAssignedToNull")
   static <X, Y> Iso<Optional<X>, Optional<Y>> liftOptional(final Iso<X, Y> element) {
     return of(ox -> ox == null ? null : ox.map(element::to), oy -> oy == null ? null : oy.map(element::from));
   }

--- a/docs/adr/0006-codegen-runtime-1-1-lookup-via-metadata-holder.md
+++ b/docs/adr/0006-codegen-runtime-1-1-lookup-via-metadata-holder.md
@@ -76,12 +76,12 @@ Phased rollout (each phase is a discrete PR, no public API change):
 - **Phase E — holder constants() eliminates the probe's field scan.** The `<X>Telescope` holder gains a
   `public static Map<String, Telescope<?, ?>> constants()` method that returns the name → lens map directly.
   `MetadataHolderProbe.probe(...)` calls this method as the only path; a holder that's missing the method (out-of-date
-  codegen on the classpath) trips a precise `IllegalStateException` rather than silently falling back. Net effect on
-  the cold-path probe: from `~3 + N` reflective operations per probe (N = number of holder fields) to `3` operations
-  regardless of N. The probe is `ClassValue`-cached, so this is a one-shot-per-class improvement, not a hot-path
-  change — but it consolidates the holder's runtime contract into two named methods (`constants()` +
-  `construct(Function)`) instead of a contract that depends on field-shape conventions. Pre-1.0 stance: no legacy
-  fallback for older codegen output; users re-run the processor.
+  codegen on the classpath) trips a precise `IllegalStateException` rather than silently falling back. Net effect on the
+  cold-path probe: from `~3 + N` reflective operations per probe (N = number of holder fields) to `3` operations
+  regardless of N. The probe is `ClassValue`-cached, so this is a one-shot-per-class improvement, not a hot-path change
+  — but it consolidates the holder's runtime contract into two named methods (`constants()` + `construct(Function)`)
+  instead of a contract that depends on field-shape conventions. Pre-1.0 stance: no legacy fallback for older codegen
+  output; users re-run the processor.
 
 ## Decisions encoded in the design
 


### PR DESCRIPTION
## Summary

Five small cleanups driven by IntelliJ inspection results post-Phase-E. All are net-line-removing or net-zero; no behaviour change.

1. **`Reflective#resolveHolderConstructor`** — collapse the `if (maybeHolder.isEmpty()) return null;` guard + `.get().constructor()` into a single `Optional.map(HolderRef::constructor).orElse(null)` expression
2. **`FocusProcessor#emitRecordConstantsMap`** — drop unused `recordName` parameter (the new emission uses `components.getFirst().getSimpleName()` directly); replace `components.get(0)` with `components.getFirst()` (Java 21+ idiom)
3. **`AbstractTelescopeProcessor#emitBeanConstantsMap`** — replace `props.get(0)` with `props.getFirst()`
4. **`Beans#getter`** — `source -> reader.apply(source)` becomes `reader::apply` (method reference)
5. **`Iso#liftOptional`** — drop redundant `OptionalUsedAsFieldOrParameterType` suppression; the `OptionalAssignedToNull` suppression is the only one that actually fires (verified by post-edit IntelliJ run)

## Intentional flags left alone

- **`{@link Class#forName}` / `Method#invoke` "Symbol inaccessible" errors** — IntelliJ JPMS confusion on `java.base` exports; `:core:javadoc` compiles cleanly
- **Unused type-inference parameters** on `Telescope.of(Class<S>)`, `Telescope.ofBean(Class<P>)`, `From.to(Class<B>)`, `Telescope.fieldByName(String, Class<B>)` — drive `<S>` / `<P>` / `<B>` inference at call sites; documented as such
- **Phantom type parameters** on `Mapping<A, B>` / `Kind<F, A>` / `EitherK<L>` / `ValidatedK<E>` — load-bearing for the sealed-permit and HKT-emulation patterns
- **Unused public-API surface** on `Validated#isInvalid` / `#fold` / `#combine` and `Mapper#asTelescope` — exposed for downstream consumers, may not be called inside the library
- **Duplicated `Iso.liftList` / `liftSet` fragments** — different `Collector` instances per container shape; refactoring would obscure intent
- **`Mapper` constructor + `DeepMap#resolve` "Class Iso<A, B> is not exported"** — both already carry `@SuppressWarnings("exports")`; IntelliJ's separate module-export inspection doesn't honour the javac suppression

## Test plan

- [x] `./gradlew :core:test :codegen:test :lombok:test` all green
- [x] `./gradlew :core:javadoc` green
- [x] `./gradlew spotlessApply --rerun-tasks` clean
- [x] `mcp__idea__get_file_problems` re-run on every changed file shows the targeted warning gone