### PR TITLE
fix(ci): compute next version explicitly via -Prelease.forceVersion

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -45,15 +45,33 @@ jobs:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.GPG_PASSPHRASE }}
 
+      - name: Compute next version
+        id: nextver
+        run: |
+          # axion-release's auto-incrementer (`-Prelease.incrementer=<patch|minor|major>`) was
+          # silently skipping the bump on this repo — `release` kept resolving the current version
+          # to the latest tag (e.g. `v0.3.0`) and tried to recreate it. Compute the next version
+          # explicitly from `latest-tag + dropdown selection` and pass it via
+          # `-Prelease.forceVersion`, which axion honours unconditionally.
+          LATEST=$(git tag --sort=-version:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1 | sed 's/^v//')
+          IFS='.' read -r MAJ MIN PATCH <<< "$LATEST"
+          case "${{ inputs.releaseType }}" in
+            patch) NEXT="$MAJ.$MIN.$((PATCH+1))" ;;
+            minor) NEXT="$MAJ.$((MIN+1)).0" ;;
+            major) NEXT="$((MAJ+1)).0.0" ;;
+            *) echo "Unknown release type: ${{ inputs.releaseType }}"; exit 1 ;;
+          esac
+          echo "Latest tag: v$LATEST → next: v$NEXT (${{ inputs.releaseType }})"
+          echo "next=$NEXT" >> "$GITHUB_OUTPUT"
+
       - name: Update Version and Create Tag
         id: version
         run: |
-          # axion-release bumps the version per the chosen incrementer, creates the v* tag,
-          # commits the SNAPSHOT bump-back, and pushes both. -Prelease.disableChecks skips the
-          # uncommitted-changes guard so the release commit itself isn't rejected.
-          ./gradlew release -Prelease.incrementer=${{ inputs.releaseType }} -Prelease.disableChecks -x test
+          # axion-release creates the v* tag at `forceVersion` and pushes it. -Prelease.disableChecks
+          # skips the uncommitted-changes guard so the release commit itself isn't rejected.
+          ./gradlew release -Prelease.forceVersion=${{ steps.nextver.outputs.next }} -Prelease.disableChecks -x test
 
-          RAW_VERSION=$(./gradlew currentVersion -q -Prelease.quiet)
+          RAW_VERSION="${{ steps.nextver.outputs.next }}"
           TAG_VERSION="v$RAW_VERSION"
           echo "version=$RAW_VERSION" >> "$GITHUB_OUTPUT"
           echo "tagName=$TAG_VERSION" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

axion-release 1.18.7's `-Prelease.incrementer=<patch|minor|major>` flag is being silently ignored on telescope's main branch — the `release` task resolves the current version to the latest tag (`v0.3.0`) instead of bumping per the incrementer, then tries to recreate that tag and crashes:

```
> Task :release FAILED
Creating tag: v0.3.0
> RefAlreadyExistsException: tag '...tag v0.3.0...' already exists
```

Two consecutive Release workflow runs (runs `27111925151` and `27112719174`) hit the same failure. The first three releases (v0.1.0, v0.2.0, v0.3.0) used the same workflow and command and succeeded — so this is plausibly an axion-release edge case on `0.x` versions or on a specific git state past the last tag. The sibling kpipe repo with identical config also still works for it. Diagnosis is incomplete; what's certain is that telescope's `release -Prelease.incrementer=minor` no longer increments.

## What changes

- **New `Compute next version` step** parses `git tag --sort=-version:refname` to find the latest `vMAJ.MIN.PATCH`, then applies the dropdown selection (`patch` / `minor` / `major`) to produce the next version explicitly.
- **`Update Version and Create Tag` step** now passes that version via `-Prelease.forceVersion=$NEXT` — axion-release honours this flag unconditionally and tags at the literal version.
- `RAW_VERSION` is now sourced from the computed value rather than `./gradlew currentVersion` (which was returning `0.3.0-SNAPSHOT`, the source of the original mistag).

## Trade-off

The workflow no longer depends on axion-release's auto-increment logic; the dropdown selection drives the version computation deterministically. Slight loss: axion-specific incrementer customisation (e.g. branch-specific incrementers configured in `scmVersion {}`) is bypassed. For this repo's main-only release flow that's not a concern.

## Test plan

- [x] Workflow YAML is syntactically valid
- [x] Shell snippet matches `vMAJ.MIN.PATCH` (regex-anchored) — won't pick up `v0.1.0-rc1` or similar
- [ ] **Re-trigger Release workflow after merge** with `releaseType=minor`; expect a successful tag at `v0.4.0`