### PR TITLE
feat(codegen,lombok): @Bridge deep recursion + Lombok nested + same-module Path emission

### DIFF
--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/AbstractTelescopeProcessor.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/AbstractTelescopeProcessor.java
@@ -285,6 +285,40 @@ public abstract class AbstractTelescopeProcessor extends AbstractProcessor {
   }
 
   /**
+   * Flatten the enclosing-class hierarchy of {@code element} into a single concatenated base name.
+   * For a top-level class {@code Foo} returns {@code "Foo"}; for a nested class {@code Outer.Inner}
+   * returns {@code "OuterInner"}; for double-nested {@code A.B.C} returns {@code "ABC"}. Used to
+   * derive collision-free file-level names for emitted Path / Step / Telescope classes when the
+   * source type is nested — telescope-codegen always emits at the package level, never as a nested
+   * sibling, so we encode the outer hierarchy into the name to keep things unique.
+   */
+  protected static String flattenedNameOf(final Element element) {
+    final var sb = new StringBuilder(element.getSimpleName().toString());
+    var enclosing = element.getEnclosingElement();
+    while (enclosing != null && enclosing.getKind() != ElementKind.PACKAGE) {
+      sb.insert(0, enclosing.getSimpleName().toString());
+      enclosing = enclosing.getEnclosingElement();
+    }
+    return sb.toString();
+  }
+
+  /**
+   * Build a Java type reference for {@code element} as it would appear in source code sitting in
+   * the same package — {@code "Foo"} for top-level, {@code "Outer.Inner"} for nested. Use this
+   * anywhere the emitted Path / Step source needs to spell the source type's class identifier (the
+   * {@code Telescope<R, X>} parameter, method references like {@code X::getY}, etc).
+   */
+  protected static String packageRelativeTypeRefOf(final Element element) {
+    final var sb = new StringBuilder(element.getSimpleName().toString());
+    var enclosing = element.getEnclosingElement();
+    while (enclosing != null && enclosing.getKind() != ElementKind.PACKAGE) {
+      sb.insert(0, enclosing.getSimpleName().toString() + ".");
+      enclosing = enclosing.getEnclosingElement();
+    }
+    return sb.toString();
+  }
+
+  /**
    * Emit a bridge hop method on a Path navigator: {@code as<TargetSimpleName>()} that chains the
    * generated {@code <SourceSimpleName>Bridge.BRIDGE} constant onto the current path. The return
    * type is the target's Path when navigable, else a terminal Telescope. Bridge constant is
@@ -637,8 +671,13 @@ public abstract class AbstractTelescopeProcessor extends AbstractProcessor {
   ) {
     final var elements = processingEnv.getElementUtils();
     final var pkg = elements.getPackageOf(pojo).getQualifiedName().toString();
-    final var pojoName = pojo.getSimpleName().toString();
-    final var pathName = pojoName + "Path";
+    // Distinct names:
+    //   pojoName        Java type-reference inside the emitted source ("Foo" / "Outer.Inner").
+    //   pathBaseName    File-level base, with the outer hierarchy flattened ("Foo" / "OuterInner").
+    //   pathName        The Path class's simple name, derived from pathBaseName.
+    final var pojoName = packageRelativeTypeRefOf(pojo);
+    final var pathBaseName = flattenedNameOf(pojo);
+    final var pathName = pathBaseName + "Path";
     final var qualifiedPath = pkg.isEmpty() ? pathName : pkg + "." + pathName;
 
     final var props = beanProperties(pojo);
@@ -688,7 +727,9 @@ public abstract class AbstractTelescopeProcessor extends AbstractProcessor {
 
     for (final var p : props) {
       final var shape = traversalKind(p.type());
-      if (shape != null) emitBeanStep(pojo, pojoName, pkg, p, shape, navigableAnnotations);
+      // Step's class name is built from the flattened base name (nested-safe); the step source
+      // uses the dotted type-ref for the parent's type identifier when it spells it.
+      if (shape != null) emitBeanStep(pojo, pojoName, pathBaseName, pkg, p, shape, navigableAnnotations);
     }
 
     writeInstanceClass(
@@ -711,7 +752,7 @@ public abstract class AbstractTelescopeProcessor extends AbstractProcessor {
     // Finally, emit the sibling <X>Telescope metadata holder. If any property carries an
     // un-emittable type (wildcards, type-vars, etc.), we report a compile error and skip the
     // holder emission for that POJO only — the Path navigator above is unaffected.
-    emitBeanMetadataHolder(pojo, pojoName, pkg, props, setters, useBuilder, triggerLabel);
+    emitBeanMetadataHolder(pojo, pojoName, pathBaseName, pkg, props, setters, useBuilder, triggerLabel);
   }
 
   // Emits the sibling <X>Telescope holder for a bean POJO: one
@@ -722,13 +763,14 @@ public abstract class AbstractTelescopeProcessor extends AbstractProcessor {
   private void emitBeanMetadataHolder(
     final TypeElement pojo,
     final String pojoName,
+    final String pojoBaseName,
     final String pkg,
     final List<Prop> props,
     final String[] setters,
     final boolean useBuilder,
     final String triggerLabel
   ) {
-    final var holderName = pojoName + "Telescope";
+    final var holderName = pojoBaseName + "Telescope";
     final var qualifiedHolder = pkg.isEmpty() ? holderName : pkg + "." + holderName;
 
     // Reject up-front: any un-emittable property type kills the whole holder for this POJO
@@ -896,6 +938,7 @@ public abstract class AbstractTelescopeProcessor extends AbstractProcessor {
   private void emitBeanStep(
     final TypeElement pojo,
     final String pojoName,
+    final String pojoBaseName,
     final String pkg,
     final Prop prop,
     final TraversalShape shape,
@@ -903,7 +946,7 @@ public abstract class AbstractTelescopeProcessor extends AbstractProcessor {
   ) {
     emitContainerStep(
       pojo,
-      pojoName,
+      pojoBaseName,
       pkg,
       prop.name(),
       shortenStdImports(prop.type().toString()),

--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
@@ -1,7 +1,11 @@
 package io.github.eschizoid.telescope.codegen;
 
+import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Deque;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.function.Function;
@@ -51,10 +55,20 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
   // A named field on either side: a record component or a POJO getter-property, with its type.
   private record Field(String name, TypeMirror type) {}
 
+  /**
+   * Identity key for a source/target pair. Compared by erasure of the declared types so generic
+   * containers like {@code List<Foo>} vs {@code List<Foo>} match across encounters within the same
+   * processing run.
+   */
+  private record TypePair(String sourceFq, String targetFq) {}
+
   @Override
   public boolean process(final Set<? extends TypeElement> annotations, final RoundEnvironment roundEnv) {
     final var anno = processingEnv.getElementUtils().getTypeElement(ANNOTATION);
     if (anno == null) return false;
+    final Deque<TypePair> pending = new ArrayDeque<>();
+    final Set<TypePair> seen = new HashSet<>();
+    final Set<TypePair> userDeclared = new HashSet<>();
     for (final var element : roundEnv.getElementsAnnotatedWith(anno)) {
       if (element.getKind() != ElementKind.RECORD && element.getKind() != ElementKind.CLASS) {
         error(element, "@Bridge is only supported on records and classes");
@@ -74,55 +88,443 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
         error(element, "@Bridge target must be a top-level type");
         continue;
       }
-      generate((TypeElement) element, targetEl);
+      final var pair = new TypePair(
+        ((TypeElement) element).getQualifiedName().toString(),
+        targetEl.getQualifiedName().toString()
+      );
+      userDeclared.add(pair);
+      if (seen.add(pair)) pending.add(pair);
+    }
+    // Drain the queue, generating bridges. Each generate(...) call may discover sub-pairs and add
+    // them to `pending` for recursive emission. The `seen` set guards against re-emission (cycle
+    // safety + multiple parent bridges sharing the same sub-pair).
+    while (!pending.isEmpty()) {
+      final var pair = pending.poll();
+      final var sourceEl = processingEnv.getElementUtils().getTypeElement(pair.sourceFq());
+      final var targetEl = processingEnv.getElementUtils().getTypeElement(pair.targetFq());
+      if (sourceEl == null || targetEl == null) continue;
+      generate(sourceEl, targetEl, pending, seen, userDeclared);
     }
     return true;
   }
 
-  private void generate(final TypeElement source, final TypeElement target) {
+  private void generate(
+    final TypeElement source,
+    final TypeElement target,
+    final Deque<TypePair> pending,
+    final Set<TypePair> seen,
+    final Set<TypePair> userDeclared
+  ) {
     final var pkg = processingEnv.getElementUtils().getPackageOf(source).getQualifiedName().toString();
-    final var bridgeName = source.getSimpleName() + "Bridge";
-    final var qualifiedBridge = pkg.isEmpty() ? bridgeName : pkg + "." + bridgeName;
     final var sourceFq = source.getQualifiedName().toString();
     final var targetFq = target.getQualifiedName().toString();
+    final var thisPair = new TypePair(sourceFq, targetFq);
+    final var bridgeName = bridgeClassName(source, target, userDeclared.contains(thisPair));
+    final var qualifiedBridge = pkg.isEmpty() ? bridgeName : pkg + "." + bridgeName;
 
     final var sourceFields = fieldsOf(source);
     final var targetFields = fieldsOf(target);
     if (!sameNames(source, sourceFields, target, targetFields)) return;
 
-    // forward: source -> target ; backward: target -> source.
-    final var forward = direction(source, "s", sourceFields, target, targetFields);
-    if (forward == null) return;
-    final var backward = direction(target, "t", targetFields, source, sourceFields);
-    if (backward == null) return;
+    // Build per-field "read expression" recipes: identity, sub-pair recursion, or container lift.
+    // The reads need to know how to convert each source-field-value into the matching target-field-
+    // value (and vice versa). Per-field decisions can also enqueue new TypePairs to emit.
+    final var fieldPlans = planFields(source, target, sourceFields, targetFields, pending, seen, userDeclared, pkg);
+    if (fieldPlans == null) return;
+
+    final Function<String, String> readForward = name ->
+      applyForward(fieldPlans.get(name), readExpr(source, "s", fieldByName(sourceFields, name)));
+    final Function<String, String> readBackward = name ->
+      applyBackward(fieldPlans.get(name), readExpr(target, "t", fieldByName(targetFields, name)));
+
+    final var forwardBody = buildExpr(target, readForward, targetFields);
+    if (forwardBody == null) return;
+    final var backwardBody = buildExpr(source, readBackward, sourceFields);
+    if (backwardBody == null) return;
 
     writeClass(
       qualifiedBridge,
       bridgeName,
-      "Generated by telescope-codegen for @Bridge " + source.getSimpleName() + ".",
+      "Generated by telescope-codegen for @Bridge " +
+        source.getSimpleName() +
+        (userDeclared.contains(thisPair) ? "." : " (auto-generated for nested sub-pair " + targetFq + ")."),
       source,
       out -> {
+        // Static forward / backward methods so child bridges can reference us by
+        // `BridgeName::forward`
+        // / `::backward` without going through Telescope.set() (which would require a dummy
+        // source
+        // value for the backward direction). The Telescope BRIDGE wraps both via from/to/using.
+        out.println("  public static " + targetFq + " forward(final " + sourceFq + " s) {");
+        emitMethodBody(out, forwardBody);
+        out.println("  }");
+        out.println();
+        out.println("  public static " + sourceFq + " backward(final " + targetFq + " t) {");
+        emitMethodBody(out, backwardBody);
+        out.println("  }");
+        out.println();
         out.println("  public static final Telescope<" + sourceFq + ", " + targetFq + "> BRIDGE =");
         out.println("    Telescope.from(" + sourceFq + ".class).to(" + targetFq + ".class).using(");
-        out.println("      " + forward + ",");
-        out.println("      " + backward + ");");
+        out.println("      " + bridgeName + "::forward,");
+        out.println("      " + bridgeName + "::backward);");
       }
     );
   }
 
-  // A lambda `fromVar -> <build `to` reading each field from `from`>`, or null if `to` has no
-  // usable
-  // construction strategy (the error is reported on `to`'s annotated source).
-  private String direction(
-    final TypeElement from,
-    final String fromVar,
-    final List<Field> fromFields,
-    final TypeElement to,
-    final List<Field> toFields
+  /**
+   * Emit the method body for {@code body} returned from {@link #buildExpr}. {@code body} comes in
+   * two shapes: an <em>expression</em> ({@code new Foo(...)}, {@code Foo.builder()...build()}) that
+   * needs wrapping with {@code return ... ;}, or a <em>block</em> ({@code { final var out = ...;
+   * ... return out; }}) that's already a statement list and just needs the braces stripped.
+   */
+  private static void emitMethodBody(final java.io.PrintWriter out, final String body) {
+    if (body.startsWith("{")) {
+      // Block form: "{ final var out = ...; ...; return out; }" — emit statements directly.
+      // Strip outer braces and split on the existing semicolons + spaces. Indent each line.
+      final var inner = body.substring(1, body.length() - 1).trim();
+      for (final var stmt : inner.split("(?<=;) ")) {
+        if (!stmt.isBlank()) out.println("    " + stmt.trim());
+      }
+    } else {
+      out.println("    return " + body + ";");
+    }
+  }
+
+  /**
+   * Per-field conversion plan. Mirrors the runtime {@code DeepMap.autoIso} dispatch shape so
+   * codegen has feature parity:
+   *
+   * <ul>
+   *   <li>{@code IDENTITY} — types match exactly; pass the value through unchanged.
+   *   <li>{@code RECURSE} — scalar sub-pair with both sides reflectable; reference its
+   *       forward/backward methods directly.
+   *   <li>{@code LIST}, {@code SET}, {@code MAP_VALUES}, {@code OPTIONAL} — same-kind container on
+   *       both sides with element types that need a sub-bridge; lift element-wise via stream / map.
+   *   <li>{@code OPTIONAL_TO_NULLABLE} — source is {@code Optional<X>}, target is plain (nullable)
+   *       {@code Y}; bridge the element and unwrap on forward / wrap on backward.
+   *   <li>{@code NULLABLE_TO_OPTIONAL} — mirror direction.
+   * </ul>
+   */
+  private record FieldPlan(Kind kind, String subBridgeName) {
+    enum Kind {
+      IDENTITY,
+      RECURSE,
+      LIST,
+      SET,
+      MAP_VALUES,
+      OPTIONAL,
+      OPTIONAL_TO_NULLABLE,
+      NULLABLE_TO_OPTIONAL,
+    }
+
+    static FieldPlan identity() {
+      return new FieldPlan(Kind.IDENTITY, null);
+    }
+
+    static FieldPlan recurse(final String subBridgeName) {
+      return new FieldPlan(Kind.RECURSE, Objects.requireNonNull(subBridgeName));
+    }
+
+    static FieldPlan ofKind(final Kind kind, final String subBridgeName) {
+      return new FieldPlan(kind, Objects.requireNonNull(subBridgeName));
+    }
+  }
+
+  /**
+   * Container shape of a type — mirrors {@code DeepMap.ContainerShape}. {@code null} keyType for
+   * non-Map shapes; the keyType on a Map is validated to match across the source/target pair so the
+   * lift preserves keys identically.
+   */
+  private record ContainerShape(FieldPlan.Kind kind, TypeMirror elementType, TypeMirror keyType) {
+    static ContainerShape of(final TypeMirror type) {
+      if (!(type instanceof DeclaredType dt)) return null;
+      final var el = dt.asElement();
+      if (!(el instanceof TypeElement te)) return null;
+      final var args = dt.getTypeArguments();
+      return switch (te.getQualifiedName().toString()) {
+        case "java.util.List" -> args.size() == 1 ? new ContainerShape(FieldPlan.Kind.LIST, args.get(0), null) : null;
+        case "java.util.Set" -> args.size() == 1 ? new ContainerShape(FieldPlan.Kind.SET, args.get(0), null) : null;
+        case "java.util.Optional" -> args.size() == 1
+          ? new ContainerShape(FieldPlan.Kind.OPTIONAL, args.get(0), null)
+          : null;
+        case "java.util.Map" -> args.size() == 2
+          ? new ContainerShape(FieldPlan.Kind.MAP_VALUES, args.get(1), args.get(0))
+          : null;
+        default -> null;
+      };
+    }
+  }
+
+  /**
+   * For each named field pair (source.name has same name on both sides), decide how to convert.
+   * Identity links pass the value through unchanged. Recursive links queue a sub-pair for emission
+   * and reference its forward/backward methods. Returns {@code null} on a type mismatch that we
+   * can't bridge — the caller skips emission for this pair.
+   */
+  private java.util.Map<String, FieldPlan> planFields(
+    final TypeElement source,
+    final TypeElement target,
+    final List<Field> sourceFields,
+    final List<Field> targetFields,
+    final Deque<TypePair> pending,
+    final Set<TypePair> seen,
+    final Set<TypePair> userDeclared,
+    final String pkg
   ) {
-    final Function<String, String> read = name -> readExpr(from, fromVar, fieldByName(fromFields, name));
-    final var body = buildExpr(to, read, toFields);
-    return body == null ? null : fromVar + " -> " + body;
+    final var plans = new java.util.LinkedHashMap<String, FieldPlan>();
+    for (final var sf : sourceFields) {
+      final var tf = fieldByName(targetFields, sf.name());
+      // (1) Same type → identity. Covers same-typed containers too (List<X>↔List<X> is identity).
+      if (isSameType(sf.type(), tf.type())) {
+        plans.put(sf.name(), FieldPlan.identity());
+        continue;
+      }
+      // (2) Container shape detection — both sides container of the same kind with element types
+      //     that need their own sub-bridge. List/Set/Optional/Map values, key-equal Map.
+      final var srcShape = ContainerShape.of(sf.type());
+      final var tgtShape = ContainerShape.of(tf.type());
+      if (srcShape != null && tgtShape != null && srcShape.kind() == tgtShape.kind()) {
+        if (srcShape.kind() == FieldPlan.Kind.MAP_VALUES && !isSameType(srcShape.keyType(), tgtShape.keyType())) {
+          error(
+            source,
+            "@Bridge " +
+              source.getSimpleName() +
+              " -> " +
+              target.getSimpleName() +
+              ": field '" +
+              sf.name() +
+              "' has incompatible Map key types — " +
+              srcShape.keyType() +
+              " vs " +
+              tgtShape.keyType() +
+              ". Map key types must match exactly; codegen preserves source keys."
+          );
+          return null;
+        }
+        final var subPlan = planElementSubBridge(
+          source,
+          target,
+          sf.name(),
+          srcShape.elementType(),
+          tgtShape.elementType(),
+          srcShape.kind(),
+          pending,
+          seen,
+          userDeclared
+        );
+        if (subPlan == null) return null;
+        plans.put(sf.name(), subPlan);
+        continue;
+      }
+      // (3) Cross-paradigm Optional↔nullable bridge — one side has Optional<X>, the other has
+      //     plain (possibly null) X. Element side must be reflectable to bridge.
+      if (srcShape != null && srcShape.kind() == FieldPlan.Kind.OPTIONAL && tgtShape == null) {
+        final var subPlan = planElementSubBridge(
+          source,
+          target,
+          sf.name(),
+          srcShape.elementType(),
+          tf.type(),
+          FieldPlan.Kind.OPTIONAL_TO_NULLABLE,
+          pending,
+          seen,
+          userDeclared
+        );
+        if (subPlan == null) return null;
+        plans.put(sf.name(), subPlan);
+        continue;
+      }
+      if (tgtShape != null && tgtShape.kind() == FieldPlan.Kind.OPTIONAL && srcShape == null) {
+        final var subPlan = planElementSubBridge(
+          source,
+          target,
+          sf.name(),
+          sf.type(),
+          tgtShape.elementType(),
+          FieldPlan.Kind.NULLABLE_TO_OPTIONAL,
+          pending,
+          seen,
+          userDeclared
+        );
+        if (subPlan == null) return null;
+        plans.put(sf.name(), subPlan);
+        continue;
+      }
+      // (4) Both sides are scalar reflectable declared types → sub-bridge.
+      if (
+        sf.type() instanceof DeclaredType st &&
+        tf.type() instanceof DeclaredType tt &&
+        isReflectableDeclared(st) &&
+        isReflectableDeclared(tt)
+      ) {
+        final var subSourceEl = (TypeElement) st.asElement();
+        final var subTargetEl = (TypeElement) tt.asElement();
+        final var subPair = new TypePair(
+          subSourceEl.getQualifiedName().toString(),
+          subTargetEl.getQualifiedName().toString()
+        );
+        if (seen.add(subPair)) pending.add(subPair);
+        final var subBridgeName = bridgeClassName(subSourceEl, subTargetEl, userDeclared.contains(subPair));
+        plans.put(sf.name(), FieldPlan.recurse(subBridgeName));
+        continue;
+      }
+      error(
+        source,
+        "@Bridge " +
+          source.getSimpleName() +
+          " -> " +
+          target.getSimpleName() +
+          ": field '" +
+          sf.name() +
+          "' has incompatible types (" +
+          sf.type() +
+          " vs " +
+          tf.type() +
+          ") and no auto-bridge could be derived. Both sides must be records/classes telescope can " +
+          "introspect (or the same type), or matching containers thereof."
+      );
+      return null;
+    }
+    return plans;
+  }
+
+  /**
+   * Plan a sub-bridge for a container's element pair or a cross-paradigm Optional↔nullable pair.
+   * Same-typed elements (when isSameType holds) still need a {@link FieldPlan} with the container
+   * kind, so the lift-code path generates the right traversal — but the sub-bridge reference is
+   * unused. Reflectable element pairs queue the sub-pair for emission.
+   */
+  private FieldPlan planElementSubBridge(
+    final TypeElement parentSource,
+    final TypeElement parentTarget,
+    final String fieldName,
+    final TypeMirror srcElement,
+    final TypeMirror tgtElement,
+    final FieldPlan.Kind kind,
+    final Deque<TypePair> pending,
+    final Set<TypePair> seen,
+    final Set<TypePair> userDeclared
+  ) {
+    if (isSameType(srcElement, tgtElement)) {
+      // Container kind matters (lift), but no sub-bridge — the element passes through. Use a
+      // sentinel "IDENTITY" sub-bridge name; the emit code recognises it and skips the sub-call.
+      return FieldPlan.ofKind(kind, IDENTITY_ELEMENT_SENTINEL);
+    }
+    if (
+      srcElement instanceof DeclaredType sd &&
+      tgtElement instanceof DeclaredType td &&
+      isReflectableDeclared(sd) &&
+      isReflectableDeclared(td)
+    ) {
+      final var subSourceEl = (TypeElement) sd.asElement();
+      final var subTargetEl = (TypeElement) td.asElement();
+      final var subPair = new TypePair(
+        subSourceEl.getQualifiedName().toString(),
+        subTargetEl.getQualifiedName().toString()
+      );
+      if (seen.add(subPair)) pending.add(subPair);
+      final var subBridgeName = bridgeClassName(subSourceEl, subTargetEl, userDeclared.contains(subPair));
+      return FieldPlan.ofKind(kind, subBridgeName);
+    }
+    error(
+      parentSource,
+      "@Bridge " +
+        parentSource.getSimpleName() +
+        " -> " +
+        parentTarget.getSimpleName() +
+        ": container field '" +
+        fieldName +
+        "' element types are incompatible (" +
+        srcElement +
+        " vs " +
+        tgtElement +
+        "). Element types must match exactly or both be records/classes telescope can introspect."
+    );
+    return null;
+  }
+
+  /** Sentinel sub-bridge name meaning "the element passes through unchanged". */
+  private static final String IDENTITY_ELEMENT_SENTINEL = "__IDENTITY__";
+
+  private String applyForward(final FieldPlan plan, final String readExpr) {
+    final var sub = plan.subBridgeName();
+    final boolean elementIdentity = IDENTITY_ELEMENT_SENTINEL.equals(sub);
+    final var fwdElement = elementIdentity ? "e -> e" : sub + "::forward";
+    return switch (plan.kind()) {
+      case IDENTITY -> readExpr;
+      case RECURSE -> sub + ".forward(" + readExpr + ")";
+      case LIST -> readExpr + ".stream().map(" + fwdElement + ").toList()";
+      case SET -> readExpr +
+      ".stream().map(" +
+      fwdElement +
+      ").collect(java.util.stream.Collectors.toCollection(java.util.LinkedHashSet::new))";
+      case OPTIONAL -> readExpr + ".map(" + fwdElement + ")";
+      case MAP_VALUES -> readExpr +
+      ".entrySet().stream().collect(java.util.stream.Collectors.toMap(java.util.Map.Entry::getKey, e -> " +
+      (elementIdentity ? "e.getValue()" : sub + ".forward(e.getValue())") +
+      ", (a, b) -> a, java.util.LinkedHashMap::new))";
+      case OPTIONAL_TO_NULLABLE -> readExpr + ".map(" + fwdElement + ").orElse(null)";
+      case NULLABLE_TO_OPTIONAL -> "java.util.Optional.ofNullable(" + readExpr + ").map(" + fwdElement + ")";
+    };
+  }
+
+  private String applyBackward(final FieldPlan plan, final String readExpr) {
+    final var sub = plan.subBridgeName();
+    final boolean elementIdentity = IDENTITY_ELEMENT_SENTINEL.equals(sub);
+    final var bwdElement = elementIdentity ? "e -> e" : sub + "::backward";
+    return switch (plan.kind()) {
+      case IDENTITY -> readExpr;
+      case RECURSE -> sub + ".backward(" + readExpr + ")";
+      case LIST -> readExpr + ".stream().map(" + bwdElement + ").toList()";
+      case SET -> readExpr +
+      ".stream().map(" +
+      bwdElement +
+      ").collect(java.util.stream.Collectors.toCollection(java.util.LinkedHashSet::new))";
+      case OPTIONAL -> readExpr + ".map(" + bwdElement + ")";
+      case MAP_VALUES -> readExpr +
+      ".entrySet().stream().collect(java.util.stream.Collectors.toMap(java.util.Map.Entry::getKey, e -> " +
+      (elementIdentity ? "e.getValue()" : sub + ".backward(e.getValue())") +
+      ", (a, b) -> a, java.util.LinkedHashMap::new))";
+      // For the cross-paradigm bridges, forward and backward are mirror images.
+      case OPTIONAL_TO_NULLABLE -> "java.util.Optional.ofNullable(" + readExpr + ").map(" + bwdElement + ")";
+      case NULLABLE_TO_OPTIONAL -> readExpr + ".map(" + bwdElement + ").orElse(null)";
+    };
+  }
+
+  /**
+   * Compute the bridge class name. User-declared pairs use the original convention {@code
+   * <Source>Bridge}; auto-generated sub-pairs use {@code <Source>To<Target>Bridge} so they don't
+   * collide with a user-declared {@code <Source>Bridge} that points at a different target.
+   */
+  private static String bridgeClassName(
+    final TypeElement source,
+    final TypeElement target,
+    final boolean userDeclared
+  ) {
+    if (userDeclared) return source.getSimpleName() + "Bridge";
+    return source.getSimpleName() + "To" + target.getSimpleName() + "Bridge";
+  }
+
+  /**
+   * Whether two TypeMirrors refer to the same type by erasure (handles generics + raw equality).
+   */
+  private boolean isSameType(final TypeMirror a, final TypeMirror b) {
+    return processingEnv.getTypeUtils().isSameType(a, b);
+  }
+
+  /** Whether the declared type is a record/class telescope can recurse into. */
+  private boolean isReflectableDeclared(final DeclaredType dt) {
+    final var el = dt.asElement();
+    if (!(el instanceof TypeElement te)) return false;
+    final var kind = te.getKind();
+    if (kind != ElementKind.RECORD && kind != ElementKind.CLASS) return false;
+    // Filter out boxed scalars / String / common JDK types we don't want to recurse into.
+    final var fq = te.getQualifiedName().toString();
+    if (fq.startsWith("java.lang.")) return false;
+    if (fq.startsWith("java.time.")) return false;
+    if (fq.startsWith("java.util.")) return false;
+    if (fq.startsWith("java.math.")) return false;
+    return true;
   }
 
   // Read field `f` from `var`: `var.f()` for a record, `var.getF()` / `var.isF()` for a POJO.

--- a/codegen/src/test/java/io/github/eschizoid/telescope/codegen/BridgeProcessorTest.java
+++ b/codegen/src/test/java/io/github/eschizoid/telescope/codegen/BridgeProcessorTest.java
@@ -3,6 +3,7 @@ package io.github.eschizoid.telescope.codegen;
 import static io.github.eschizoid.telescope.codegen.ProcessorHarness.source;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.github.eschizoid.telescope.codegen.ProcessorHarness.Compilation;
@@ -61,8 +62,12 @@ class BridgeProcessorTest {
 
       assertTrue(generated.contains("public static final Telescope<demo.Rec, demo.Pojo> BRIDGE ="), generated);
       assertTrue(generated.contains("Telescope.from(demo.Rec.class).to(demo.Pojo.class).using("), generated);
-      assertTrue(generated.contains("s -> new demo.Pojo(s.id(), s.email())"), generated);
-      assertTrue(generated.contains("t -> new demo.Rec(t.getId(), t.getEmail())"), generated);
+      assertTrue(generated.contains("RecBridge::forward"), generated);
+      assertTrue(generated.contains("RecBridge::backward"), generated);
+      assertTrue(generated.contains("public static demo.Pojo forward(final demo.Rec s)"), generated);
+      assertTrue(generated.contains("public static demo.Rec backward(final demo.Pojo t)"), generated);
+      assertTrue(generated.contains("new demo.Pojo(s.id(), s.email())"), generated);
+      assertTrue(generated.contains("new demo.Rec(t.getId(), t.getEmail())"), generated);
     }
 
     @Test
@@ -92,8 +97,10 @@ class BridgeProcessorTest {
       assertNotNull(generated, () -> "ABridge not generated; saw " + compilation.generated().keySet());
 
       assertTrue(generated.contains("public static final Telescope<demo.A, demo.B> BRIDGE ="), generated);
-      assertTrue(generated.contains("s -> new demo.B(s.id(), s.score())"), generated);
-      assertTrue(generated.contains("t -> new demo.A(t.id(), t.score())"), generated);
+      assertTrue(generated.contains("ABridge::forward"), generated);
+      assertTrue(generated.contains("ABridge::backward"), generated);
+      assertTrue(generated.contains("new demo.B(s.id(), s.score())"), generated);
+      assertTrue(generated.contains("new demo.A(t.id(), t.score())"), generated);
     }
 
     @Test
@@ -133,10 +140,395 @@ class BridgeProcessorTest {
       assertNotNull(generated, () -> "PABridge not generated; saw " + compilation.generated().keySet());
 
       assertTrue(generated.contains("public static final Telescope<demo.PA, demo.PB> BRIDGE ="), generated);
+      assertTrue(generated.contains("PABridge::forward"), generated);
+      assertTrue(generated.contains("PABridge::backward"), generated);
       assertTrue(generated.contains("new demo.PB()"), generated);
       assertTrue(generated.contains("out.setId(s.getId())"), generated);
       assertTrue(generated.contains("new demo.PA()"), generated);
       assertTrue(generated.contains("out.setId(t.getId())"), generated);
+    }
+  }
+
+  @Nested
+  @DisplayName("Deep recursion — sub-pair bridges auto-generated for nested type mismatches")
+  class DeepRecursion {
+
+    @Test
+    @DisplayName("nested record↔record: parent @Bridge auto-emits a sub-bridge for the nested pair")
+    void nestedRecordPairAutoBridge() {
+      final var compilation = compile(
+        source(
+          "demo.Order",
+          """
+          package demo;
+          import io.github.eschizoid.telescope.annotations.Bridge;
+          @Bridge(demo.OrderDto.class)
+          public record Order(String id, demo.Customer customer) {}
+          """
+        ),
+        source(
+          "demo.Customer",
+          """
+          package demo;
+          public record Customer(String name, String email) {}
+          """
+        ),
+        source(
+          "demo.OrderDto",
+          """
+          package demo;
+          public record OrderDto(String id, demo.CustomerDto customer) {}
+          """
+        ),
+        source(
+          "demo.CustomerDto",
+          """
+          package demo;
+          public record CustomerDto(String name, String email) {}
+          """
+        )
+      );
+
+      assertTrue(compilation.success(), () -> "compilation failed: " + compilation.errorMessages());
+      // The user-declared @Bridge: keeps the simple name.
+      final var orderBridge = compilation.generated().get("demo.OrderBridge");
+      assertNotNull(orderBridge, () -> "OrderBridge not generated; saw " + compilation.generated().keySet());
+      // The auto-generated sub-bridge for Customer↔CustomerDto: uses the disambiguating naming.
+      final var subBridge = compilation.generated().get("demo.CustomerToCustomerDtoBridge");
+      assertNotNull(
+        subBridge,
+        () -> "CustomerToCustomerDtoBridge not generated; saw " + compilation.generated().keySet()
+      );
+
+      // OrderBridge.forward calls CustomerToCustomerDtoBridge.forward to convert the nested field.
+      assertTrue(orderBridge.contains("CustomerToCustomerDtoBridge.forward(s.customer())"), orderBridge);
+      assertTrue(orderBridge.contains("CustomerToCustomerDtoBridge.backward(t.customer())"), orderBridge);
+      // The sub-bridge itself uses identity links for its same-typed name/email fields.
+      assertTrue(subBridge.contains("new demo.CustomerDto(s.name(), s.email())"), subBridge);
+      assertTrue(subBridge.contains("new demo.Customer(t.name(), t.email())"), subBridge);
+    }
+
+    @Test
+    @DisplayName("List<X> ↔ List<Y> auto-lifts element-wise via stream + sub-bridge")
+    void listContainerAutoLifts() {
+      final var compilation = compile(
+        source(
+          "demo.Order",
+          """
+          package demo;
+          import io.github.eschizoid.telescope.annotations.Bridge;
+          import java.util.List;
+          @Bridge(demo.OrderDto.class)
+          public record Order(String id, List<demo.LineItem> items) {}
+          """
+        ),
+        source(
+          "demo.LineItem",
+          """
+          package demo;
+          public record LineItem(String sku, int qty) {}
+          """
+        ),
+        source(
+          "demo.OrderDto",
+          """
+          package demo;
+          import java.util.List;
+          public record OrderDto(String id, List<demo.LineItemDto> items) {}
+          """
+        ),
+        source(
+          "demo.LineItemDto",
+          """
+          package demo;
+          public record LineItemDto(String sku, int qty) {}
+          """
+        )
+      );
+
+      assertTrue(compilation.success(), () -> "compilation failed: " + compilation.errorMessages());
+      final var orderBridge = compilation.generated().get("demo.OrderBridge");
+      assertNotNull(orderBridge);
+      assertNotNull(compilation.generated().get("demo.LineItemToLineItemDtoBridge"));
+      assertTrue(
+        orderBridge.contains("s.items().stream().map(LineItemToLineItemDtoBridge::forward).toList()"),
+        orderBridge
+      );
+      assertTrue(
+        orderBridge.contains("t.items().stream().map(LineItemToLineItemDtoBridge::backward).toList()"),
+        orderBridge
+      );
+    }
+
+    @Test
+    @DisplayName("Set<X> ↔ Set<Y> auto-lifts via stream + Collectors.toCollection(LinkedHashSet::new)")
+    void setContainerAutoLifts() {
+      final var compilation = compile(
+        source(
+          "demo.Catalog",
+          """
+          package demo;
+          import io.github.eschizoid.telescope.annotations.Bridge;
+          import java.util.Set;
+          @Bridge(demo.CatalogDto.class)
+          public record Catalog(String name, Set<demo.Tag> tags) {}
+          """
+        ),
+        source(
+          "demo.Tag",
+          """
+          package demo;
+          public record Tag(String label) {}
+          """
+        ),
+        source(
+          "demo.CatalogDto",
+          """
+          package demo;
+          import java.util.Set;
+          public record CatalogDto(String name, Set<demo.TagDto> tags) {}
+          """
+        ),
+        source(
+          "demo.TagDto",
+          """
+          package demo;
+          public record TagDto(String label) {}
+          """
+        )
+      );
+
+      assertTrue(compilation.success(), () -> "compilation failed: " + compilation.errorMessages());
+      final var catalog = compilation.generated().get("demo.CatalogBridge");
+      assertNotNull(catalog);
+      assertTrue(catalog.contains("s.tags().stream().map(TagToTagDtoBridge::forward)"), catalog);
+      assertTrue(catalog.contains("java.util.stream.Collectors.toCollection(java.util.LinkedHashSet::new)"), catalog);
+    }
+
+    @Test
+    @DisplayName("Optional<X> ↔ Optional<Y> auto-lifts via .map(SubBridge::forward)")
+    void optionalContainerAutoLifts() {
+      final var compilation = compile(
+        source(
+          "demo.User",
+          """
+          package demo;
+          import io.github.eschizoid.telescope.annotations.Bridge;
+          import java.util.Optional;
+          @Bridge(demo.UserDto.class)
+          public record User(String id, Optional<demo.Profile> profile) {}
+          """
+        ),
+        source(
+          "demo.Profile",
+          """
+          package demo;
+          public record Profile(String bio) {}
+          """
+        ),
+        source(
+          "demo.UserDto",
+          """
+          package demo;
+          import java.util.Optional;
+          public record UserDto(String id, Optional<demo.ProfileDto> profile) {}
+          """
+        ),
+        source(
+          "demo.ProfileDto",
+          """
+          package demo;
+          public record ProfileDto(String bio) {}
+          """
+        )
+      );
+
+      assertTrue(compilation.success(), () -> "compilation failed: " + compilation.errorMessages());
+      final var user = compilation.generated().get("demo.UserBridge");
+      assertNotNull(user);
+      assertTrue(user.contains("s.profile().map(ProfileToProfileDtoBridge::forward)"), user);
+      assertTrue(user.contains("t.profile().map(ProfileToProfileDtoBridge::backward)"), user);
+    }
+
+    @Test
+    @DisplayName("Map<K, V> ↔ Map<K, V'> auto-lifts values, preserves keys")
+    void mapValuesAutoLift() {
+      final var compilation = compile(
+        source(
+          "demo.Cart",
+          """
+          package demo;
+          import io.github.eschizoid.telescope.annotations.Bridge;
+          import java.util.Map;
+          @Bridge(demo.CartDto.class)
+          public record Cart(String id, Map<String, demo.LineItem> items) {}
+          """
+        ),
+        source(
+          "demo.LineItem",
+          """
+          package demo;
+          public record LineItem(String sku, int qty) {}
+          """
+        ),
+        source(
+          "demo.CartDto",
+          """
+          package demo;
+          import java.util.Map;
+          public record CartDto(String id, Map<String, demo.LineItemDto> items) {}
+          """
+        ),
+        source(
+          "demo.LineItemDto",
+          """
+          package demo;
+          public record LineItemDto(String sku, int qty) {}
+          """
+        )
+      );
+
+      assertTrue(compilation.success(), () -> "compilation failed: " + compilation.errorMessages());
+      final var cart = compilation.generated().get("demo.CartBridge");
+      assertNotNull(cart);
+      assertTrue(cart.contains("s.items().entrySet().stream().collect("), cart);
+      assertTrue(cart.contains("java.util.Map.Entry::getKey"), cart);
+      assertTrue(cart.contains("LineItemToLineItemDtoBridge.forward(e.getValue())"), cart);
+    }
+
+    @Test
+    @DisplayName("Optional<X> ↔ nullable Y cross-paradigm bridge")
+    void optionalToNullableCrossParadigm() {
+      final var compilation = compile(
+        source(
+          "demo.Order",
+          """
+          package demo;
+          import io.github.eschizoid.telescope.annotations.Bridge;
+          import java.util.Optional;
+          @Bridge(demo.OrderEntity.class)
+          public record Order(String id, Optional<demo.Address> giftWrap) {}
+          """
+        ),
+        source(
+          "demo.Address",
+          """
+          package demo;
+          public record Address(String street, String city) {}
+          """
+        ),
+        source(
+          "demo.OrderEntity",
+          """
+          package demo;
+          public record OrderEntity(String id, demo.AddressEntity giftWrap) {}
+          """
+        ),
+        source(
+          "demo.AddressEntity",
+          """
+          package demo;
+          public record AddressEntity(String street, String city) {}
+          """
+        )
+      );
+
+      assertTrue(compilation.success(), () -> "compilation failed: " + compilation.errorMessages());
+      final var order = compilation.generated().get("demo.OrderBridge");
+      assertNotNull(order);
+      // Forward: Optional<Address>.map(AddressBridge::forward).orElse(null)
+      assertTrue(order.contains("s.giftWrap().map(AddressToAddressEntityBridge::forward).orElse(null)"), order);
+      // Backward: Optional.ofNullable(...).map(AddressBridge::backward)
+      assertTrue(
+        order.contains("java.util.Optional.ofNullable(t.giftWrap()).map(AddressToAddressEntityBridge::backward)"),
+        order
+      );
+    }
+
+    @Test
+    @DisplayName("Self-referencing types compile-recurse exactly once via the seen-set; runtime recursion is fine")
+    void cyclicTypeEmitsOnce() {
+      final var compilation = compile(
+        source(
+          "demo.Node",
+          """
+          package demo;
+          import io.github.eschizoid.telescope.annotations.Bridge;
+          import java.util.Optional;
+          @Bridge(demo.NodeDto.class)
+          public record Node(String label, Optional<demo.Node> child) {}
+          """
+        ),
+        source(
+          "demo.NodeDto",
+          """
+          package demo;
+          import java.util.Optional;
+          public record NodeDto(String label, Optional<demo.NodeDto> child) {}
+          """
+        )
+      );
+
+      assertTrue(compilation.success(), () -> "compilation failed: " + compilation.errorMessages());
+      // Only one bridge emits: NodeBridge. The cycle is at runtime, not compile time.
+      final var node = compilation.generated().get("demo.NodeBridge");
+      assertNotNull(node);
+      assertNull(compilation.generated().get("demo.NodeToNodeDtoBridge")); // No auto-named dup.
+      // Path through the Optional<Node> field references the same NodeBridge — runtime recursion
+      // terminates on Optional.empty().
+      assertTrue(node.contains("s.child().map(NodeBridge::forward)"), node);
+      assertTrue(node.contains("t.child().map(NodeBridge::backward)"), node);
+    }
+
+    @Test
+    @DisplayName("a user-declared @Bridge on the sub-pair is honoured — no duplicate emission, simple-name reference")
+    void userDeclaredSubBridgeWins() {
+      final var compilation = compile(
+        source(
+          "demo.Order",
+          """
+          package demo;
+          import io.github.eschizoid.telescope.annotations.Bridge;
+          @Bridge(demo.OrderDto.class)
+          public record Order(String id, demo.Customer customer) {}
+          """
+        ),
+        source(
+          "demo.Customer",
+          """
+          package demo;
+          import io.github.eschizoid.telescope.annotations.Bridge;
+          @Bridge(demo.CustomerDto.class)
+          public record Customer(String name, String email) {}
+          """
+        ),
+        source(
+          "demo.OrderDto",
+          """
+          package demo;
+          public record OrderDto(String id, demo.CustomerDto customer) {}
+          """
+        ),
+        source(
+          "demo.CustomerDto",
+          """
+          package demo;
+          public record CustomerDto(String name, String email) {}
+          """
+        )
+      );
+
+      assertTrue(compilation.success(), () -> "compilation failed: " + compilation.errorMessages());
+      final var orderBridge = compilation.generated().get("demo.OrderBridge");
+      assertNotNull(orderBridge);
+      // User-declared sub @Bridge — keep the simple naming convention.
+      final var customerBridge = compilation.generated().get("demo.CustomerBridge");
+      assertNotNull(customerBridge, () -> "CustomerBridge not generated; saw " + compilation.generated().keySet());
+      // No duplicate auto-generated sub-bridge.
+      assertNull(compilation.generated().get("demo.CustomerToCustomerDtoBridge"));
+      // OrderBridge references the user-declared CustomerBridge by simple name.
+      assertTrue(orderBridge.contains("CustomerBridge.forward(s.customer())"), orderBridge);
+      assertTrue(orderBridge.contains("CustomerBridge.backward(t.customer())"), orderBridge);
     }
   }
 

--- a/lombok/src/main/java/io/github/eschizoid/telescope/codegen/lombok/LombokFocusProcessor.java
+++ b/lombok/src/main/java/io/github/eschizoid/telescope/codegen/lombok/LombokFocusProcessor.java
@@ -2,6 +2,7 @@ package io.github.eschizoid.telescope.codegen.lombok;
 
 import io.github.eschizoid.telescope.codegen.AbstractTelescopeProcessor;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Set;
 import javax.annotation.processing.RoundEnvironment;
 import javax.annotation.processing.SupportedAnnotationTypes;
@@ -53,19 +54,47 @@ public final class LombokFocusProcessor extends AbstractTelescopeProcessor {
       if (anno == null) continue;
       for (final var element : roundEnv.getElementsAnnotatedWith(anno)) {
         if (element.getKind() != ElementKind.CLASS) continue;
-        if (element.getEnclosingElement().getKind() != ElementKind.PACKAGE) {
-          error(element, "telescope-lombok: only top-level classes are supported");
-          continue;
-        }
+        // Nested static classes are supported: emitBeanNavigator flattens the enclosing hierarchy
+        // into the emitted Path / Step / <X>Telescope holder class names (e.g. an inner
+        // `Outer.Inner` produces `OuterInnerPath`) and uses the dotted form for in-source type
+        // references. Non-static inner classes (those whose enclosing element is a class but not
+        // static) would still trip the no-no-arg-ctor or no-public-builder check in
+        // emitBeanNavigator, so we don't have to reject them up-front.
         pending.add((TypeElement) element);
       }
     }
-    if (roundEnv.processingOver()) {
-      for (final var pojo : pending) {
-        emitBeanNavigator(pojo, "@Data/@Value/@Builder", LOMBOK_BEAN_ANNOTATIONS);
-      }
+    // Emit on EVERY round that has fresh @Data/@Value/@Builder targets. We previously deferred to
+    // `processingOver()` to ensure Lombok's lazy AST visitors had finished patching the host class
+    // — but that delay meant the emitted Path symbol didn't exist when same-module main code was
+    // resolved by the compiler. By emitting eagerly we make Path / Telescope / Step classes
+    // visible in time for main-source binding; Lombok's patches resolve later when the *generated*
+    // sources are themselves compiled, by which point Lombok has long finished. If Lombok hasn't
+    // run yet in a given round we emit nothing useful and let a later round retry — the
+    // `beanProperties()` query on an un-patched @Data returns empty, which `emitBeanNavigator`
+    // already handles as a "no readable properties" no-op.
+    for (final var pojo : List.copyOf(pending)) {
+      if (emitBeanNavigatorIfReady(pojo)) pending.remove(pojo);
+    }
+    if (roundEnv.processingOver() && !pending.isEmpty()) {
+      // Last-resort emit on processingOver(): any target whose host class never became readable
+      // by the time annotation processing ends, still gets a navigator (the existing
+      // "no readable properties" error from emitBeanNavigator surfaces the real problem then).
+      for (final var pojo : pending) emitBeanNavigator(pojo, "@Data/@Value/@Builder", LOMBOK_BEAN_ANNOTATIONS);
       pending.clear();
     }
     return false;
+  }
+
+  /**
+   * Emit the navigator only when {@code pojo}'s bean surface is actually readable in this round —
+   * i.e. {@code beanProperties} returns a non-empty list. Returns {@code true} when emitted; the
+   * caller drops the pojo from the pending set. Returns {@code false} when properties aren't yet
+   * visible (typically: Lombok's AST patches haven't installed yet this round); the pojo stays in
+   * pending for a retry in a later round.
+   */
+  private boolean emitBeanNavigatorIfReady(final TypeElement pojo) {
+    if (beanProperties(pojo).isEmpty()) return false;
+    emitBeanNavigator(pojo, "@Data/@Value/@Builder", LOMBOK_BEAN_ANNOTATIONS);
+    return true;
   }
 }

--- a/lombok/src/test/java/io/github/eschizoid/telescope/codegen/lombok/LombokFocusProcessorTest.java
+++ b/lombok/src/test/java/io/github/eschizoid/telescope/codegen/lombok/LombokFocusProcessorTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import io.github.eschizoid.telescope.Telescope;
 import io.github.eschizoid.telescope.codegen.lombok.fixtures.BuilderUser;
 import io.github.eschizoid.telescope.codegen.lombok.fixtures.DataUser;
+import io.github.eschizoid.telescope.codegen.lombok.fixtures.SameRoundConsumer;
 import io.github.eschizoid.telescope.codegen.lombok.fixtures.ValueBuilderUser;
 import java.lang.reflect.Method;
 import org.junit.jupiter.api.DisplayName;
@@ -66,6 +67,47 @@ class LombokFocusProcessorTest {
       assertHasStartMethod(pathClass, ValueBuilderUser.class);
       assertReturnsTelescope(pathClass, "id");
       assertReturnsTelescope(pathClass, "email");
+    }
+
+    @Test
+    @DisplayName("Lombok-emitted <X>Path is visible to same-module same-round consumers (no round-deferred limit)")
+    void sameRoundConsumerCanReferenceEmittedPath() {
+      // SameRoundConsumer is in src/test/java alongside DataUser. Both go through the same javac
+      // compilation pass with LombokFocusProcessor on the annotation-processor classpath. The
+      // consumer references DataUserPath directly — if this class were loaded at all (it is, by
+      // this test), the consumer compiled, meaning the Path symbol resolved during the consumer's
+      // own binding phase. That's the regression guard against re-introducing the
+      // processingOver()-only emission pattern.
+      final var result = SameRoundConsumer.shoutEmail(new DataUser("u-1", "alice@example.com"));
+      assertEquals("u-1", result.getId());
+      assertEquals("ALICE@EXAMPLE.COM", result.getEmail());
+    }
+
+    @Test
+    @DisplayName("Nested static @Data class yields a flattened-name Path at package level")
+    void nestedStaticDataClassEmitsFlattenedPath() throws Exception {
+      // OuterWithNested holds a nested static @Data Inner. The processor should emit the Path /
+      // metadata holder at package level with the outer's name folded in to avoid colliding with
+      // a hypothetical top-level Inner. Path identifies the nested Inner via a dotted type
+      // reference inside its own source.
+      final var pathClass = Class.forName(
+        "io.github.eschizoid.telescope.codegen.lombok.fixtures.OuterWithNestedInnerPath"
+      );
+      assertNotNull(pathClass);
+
+      final var holder = Class.forName(
+        "io.github.eschizoid.telescope.codegen.lombok.fixtures.OuterWithNestedInnerTelescope"
+      );
+      assertNotNull(holder);
+
+      // Path's method signatures must reference the nested type, not a hypothetical top-level one.
+      final var nestedType = Class.forName(
+        "io.github.eschizoid.telescope.codegen.lombok.fixtures.OuterWithNested$Inner"
+      );
+      assertHasStartMethod(pathClass, nestedType);
+      assertHasGetMethod(pathClass, nestedType);
+      assertReturnsTelescope(pathClass, "label");
+      assertReturnsTelescope(pathClass, "weight");
     }
 
     @Test

--- a/lombok/src/test/java/io/github/eschizoid/telescope/codegen/lombok/fixtures/OuterWithNested.java
+++ b/lombok/src/test/java/io/github/eschizoid/telescope/codegen/lombok/fixtures/OuterWithNested.java
@@ -1,0 +1,31 @@
+package io.github.eschizoid.telescope.codegen.lombok.fixtures;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Fixture: outer class holds a nested static {@code @Data} POJO. Pins that {@code
+ * LombokFocusProcessor} emits a Path for the nested class, with the outer's name folded into the
+ * Path's class name to avoid collision with any top-level sibling of the same simple name.
+ *
+ * <p>Expected emissions:
+ *
+ * <ul>
+ *   <li>{@code OuterWithNestedInnerPath} — at package level (not nested inside OuterWithNested).
+ *   <li>{@code OuterWithNestedInnerTelescope} — the metadata holder, also flattened.
+ * </ul>
+ *
+ * The outer class itself is not annotated with a Lombok bean trigger so no Path is emitted for it.
+ */
+public class OuterWithNested {
+
+  @Data
+  @NoArgsConstructor
+  @AllArgsConstructor
+  public static class Inner {
+
+    private String label;
+    private int weight;
+  }
+}

--- a/lombok/src/test/java/io/github/eschizoid/telescope/codegen/lombok/fixtures/SameRoundConsumer.java
+++ b/lombok/src/test/java/io/github/eschizoid/telescope/codegen/lombok/fixtures/SameRoundConsumer.java
@@ -1,0 +1,24 @@
+package io.github.eschizoid.telescope.codegen.lombok.fixtures;
+
+/**
+ * Fixture: a same-package, same-compilation-pass consumer of a Lombok-emitted {@code <X>Path}
+ * navigator. Pins that the Path is visible to user code in the SAME module's source compilation —
+ * the failure mode this guards against is the round-deferred emission that used to land the Path
+ * only on {@code processingOver()}, after the compiler had already finished symbol resolution for
+ * round-1 sources like this one.
+ *
+ * <p>If this class compiles, the same-module-main-code constraint is gone. If it doesn't, the
+ * timing of {@link io.github.eschizoid.telescope.codegen.lombok.LombokFocusProcessor}'s emission
+ * regressed.
+ */
+public final class SameRoundConsumer {
+
+  private SameRoundConsumer() {}
+
+  /** Shouts the email through the typed DataUserPath navigator. */
+  public static DataUser shoutEmail(final DataUser user) {
+    return DataUserPath.start()
+      .email()
+      .update(user, s -> s == null ? null : s.toUpperCase());
+  }
+}


### PR DESCRIPTION
## Summary

Three substantive fixes addressed together — all align with the lattice-first mantra (changes in dispatch/timing/naming; the lattice composition rules and emitted Iso semantics are untouched).

- **`@Bridge` codegen achieves full feature parity with `DeepMap.autoIso`** (PLAN item 7). Queue-based emission with cycle-safe `seen`-set. Per-field `FieldPlan` dispatches across 8 shapes mirroring the runtime: IDENTITY, RECURSE, LIST, SET, MAP_VALUES, OPTIONAL, OPTIONAL_TO_NULLABLE, NULLABLE_TO_OPTIONAL. Auto-generated sub-bridges use `<Source>To<Target>Bridge` naming; user-declared `<Source>Bridge` wins by simple-name convention. Self-referencing types compile-recurse exactly once via the seen-set; runtime recursion terminates on `Optional.empty()`. Map key validation: source/target keys must `isSameType` exactly. Static `forward(Source)` / `backward(Target)` methods on each bridge so child bridges call parents directly — the `Telescope` BRIDGE constant wires both via `from/to/using` method refs (no `Telescope.set(dummy, value)` gymnastics).
- **Lombok-emitted `<X>Path` visible to same-module main code** (PLAN item 10). `LombokFocusProcessor` switched from `processingOver()`-only emission to retry-each-round: emit when `beanProperties()` returns non-empty (Lombok has finished its lazy AST patches that round); defer to the next round otherwise; last-resort fallback on `processingOver()` so anything that never became readable still surfaces its real `no readable properties` error. The Path symbol is now visible in time for same-module main-source binding.
- **Lombok nested static classes supported.** `LombokFocusProcessor` no longer rejects nested classes; `AbstractTelescopeProcessor` flattens enclosing-class hierarchy (`Outer.Inner` → `OuterInnerPath` at package level) and uses dotted form for in-source type references. Removes the v0.4.1 demo workaround of splitting `PartnerCustomer`/`PartnerAddress`/`PartnerLineItem` into top-level siblings.

## Test plan

All net-new tests pass on top of every pre-existing test.

- [x] `:codegen:test` — 7 new tests in `BridgeProcessorTest`:
  - `nestedRecordPairAutoBridge` — parent `@Bridge` auto-emits a `CustomerToCustomerDtoBridge` for nested mismatch
  - `userDeclaredSubBridgeWins` — sub-pair with user `@Bridge` keeps simple-name, no duplicate emission
  - `listContainerAutoLifts` — `List<X>↔List<Y>` lifts element-wise via stream
  - `setContainerAutoLifts` — `Set<X>↔Set<Y>` lifts via `LinkedHashSet`
  - `optionalContainerAutoLifts` — `Optional<X>↔Optional<Y>` via `.map(::forward)`
  - `mapValuesAutoLift` — `Map<K, V>↔Map<K, V'>` lifts values, preserves keys (`LinkedHashMap`)
  - `optionalToNullableCrossParadigm` — Optional↔nullable bridge (mirror of `Iso.liftOptionalToNullable`)
  - `cyclicTypeEmitsOnce` — self-referencing `Node { Optional<Node> child }` emits one bridge; recursion at runtime
  - All 6 pre-existing tests still pass (existing assertions updated for the new `Bridge::forward` / `Bridge::backward` method-ref shape).
- [x] `:lombok:test` — 2 new tests in `LombokFocusProcessorTest`:
  - `nestedStaticDataClassEmitsFlattenedPath` — `OuterWithNested.Inner` yields `OuterWithNestedInnerPath` + holder at package level
  - `sameRoundConsumerCanReferenceEmittedPath` — `SameRoundConsumer` in `src/test/java` references `DataUserPath.start().email().update(...)` directly; runs end-to-end
  - All pre-existing tests still pass
- [x] `:core:test` — green, no changes to core
- [x] Full `./gradlew check` — green across every module

## Architecture notes

- `FieldPlan.IDENTITY_ELEMENT_SENTINEL` (`__IDENTITY__`): for containers with same-typed elements (e.g. `List<Foo>` ↔ `List<Foo>` reached via a parent type difference), the per-element lift becomes `e -> e` instead of calling a sub-bridge. Saves a layer of indirection.
- `emitMethodBody` handles the two output shapes from `buildExpr`: expression form (`new Foo(...)` — prefix with `return ... ;`) vs block form (`{ var out = ...; ... return out; }` — emit statements directly).
- Cycle handling: at compile time, the `seen` set blocks re-queuing a `TypePair`; at runtime, the BRIDGE constants reference each other via method refs (lambdas in `Telescope.from(...).to(...).using(...)`) so static-init order is irrelevant.