### PR TITLE
feat(core): Edit.overIfPresent — sparse-PATCH DSL ergonomics

### DIFF
--- a/core/src/main/java/io/github/eschizoid/telescope/Edit.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/Edit.java
@@ -1,5 +1,6 @@
 package io.github.eschizoid.telescope;
 
+import java.util.function.BiFunction;
 import java.util.function.Function;
 
 /**
@@ -43,6 +44,63 @@ public interface Edit<S> {
    */
   static <S, X> Edit<S> over(final Telescope<S, X> path, final Function<X, X> fn) {
     return new EditImpl<>(path, fn);
+  }
+
+  /**
+   * Conditional edit — directly replace the focused leaf with {@code value} when it is non-null,
+   * otherwise do nothing. The ergonomic shape for sparse-PATCH controllers where each request DTO
+   * field is nullable and you want to land it 1:1 on the domain.
+   *
+   * <pre>{@code
+   * Telescope.all(
+   *     Edit.overIfPresent(ORDER_NUMBER,  req.orderNumber()),
+   *     Edit.overIfPresent(SHIPPING_CITY, req.shippingCity()))
+   * }</pre>
+   *
+   * <p>If {@code value} is {@code null}, the returned edit is identity — the surrounding {@link
+   * Telescope#all(Edit[])} composition still runs, but this slot contributes no change.
+   */
+  static <S, X> Edit<S> overIfPresent(final Telescope<S, X> path, final X value) {
+    return value == null ? identity() : new EditImpl<>(path, _ -> value);
+  }
+
+  /**
+   * Conditional edit — replace the focused leaf with {@code mapper.apply(value)} when {@code value}
+   * is non-null, otherwise do nothing. Use this when the leaf type differs from the DTO type (e.g.
+   * lower-case the incoming email before it lands).
+   *
+   * <pre>{@code
+   * Edit.overIfPresent(CUSTOMER_EMAIL, req.customerEmail(), String::toLowerCase)
+   * }</pre>
+   */
+  static <S, X, V> Edit<S> overIfPresent(final Telescope<S, X> path, final V value, final Function<V, X> mapper) {
+    return value == null ? identity() : new EditImpl<>(path, _ -> mapper.apply(value));
+  }
+
+  /**
+   * Conditional edit — when {@code value} is non-null, transform each focused leaf via {@code
+   * transform.apply(value, currentLeaf)}; otherwise do nothing. Use this when the patch carries a
+   * delta or an instruction rather than a replacement.
+   *
+   * <pre>{@code
+   * Edit.overIfPresent(LINE_ITEM_QUANTITIES, req.quantityDelta(), (delta, q) -> q + delta)
+   * }</pre>
+   */
+  static <S, X, V> Edit<S> overIfPresent(
+    final Telescope<S, X> path,
+    final V value,
+    final BiFunction<V, X, X> transform
+  ) {
+    return value == null ? identity() : new EditImpl<>(path, x -> transform.apply(value, x));
+  }
+
+  /**
+   * Identity edit — returns its input unchanged. Used internally by the {@code overIfPresent}
+   * factories when the carried value is {@code null}, so a sparse-PATCH composition can keep its
+   * slot count visible without each null check distorting the surrounding shape.
+   */
+  static <S> Edit<S> identity() {
+    return s -> s;
   }
 
   /**

--- a/core/src/test/java/io/github/eschizoid/telescope/AllOverTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/AllOverTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 
 import java.util.List;
+import java.util.function.Function;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -166,6 +167,76 @@ class AllOverTest {
         .update(DEPT_NAMES, String::trim)
         .apply(company);
       assertEquals(viaChain, viaAll);
+    }
+  }
+
+  @Nested
+  @DisplayName("overIfPresent — sparse-PATCH ergonomics")
+  class OverIfPresent {
+
+    @Test
+    @DisplayName("non-null direct value replaces the focused leaf")
+    void directNonNullReplaces() {
+      final var company = sample();
+      final var out = Telescope.all(Edit.overIfPresent(DEPT_NAMES, "Engineering")).apply(company);
+      assertEquals("Engineering", out.departments().getFirst().name());
+    }
+
+    @Test
+    @DisplayName("null direct value short-circuits to identity — source returned unchanged")
+    void directNullIsIdentity() {
+      final var company = sample();
+      final var out = Telescope.all(Edit.<Company, String>overIfPresent(DEPT_NAMES, null)).apply(company);
+      assertSame(company, out);
+    }
+
+    @Test
+    @DisplayName("non-null with mapper applies the mapper to the carried value before replacing")
+    void mapperFormApplies() {
+      final var company = sample();
+      final var out = Telescope.all(Edit.overIfPresent(DEPT_NAMES, "  trimmed  ", String::trim)).apply(company);
+      assertEquals("trimmed", out.departments().getFirst().name());
+    }
+
+    @Test
+    @DisplayName("null with mapper does not invoke the mapper and returns identity")
+    void mapperNullSkips() {
+      final var company = sample();
+      final var out = Telescope.all(
+        Edit.<Company, String, String>overIfPresent(DEPT_NAMES, null, v -> {
+          throw new IllegalStateException("mapper must not run for null value");
+        })
+      ).apply(company);
+      assertSame(company, out);
+    }
+
+    @Test
+    @DisplayName("BiFunction form lets the carried value steer per-leaf transformation")
+    void biFunctionFormCombinesValueWithLeaf() {
+      final var company = sample();
+      final var out = Telescope.all(
+        Edit.overIfPresent(EMAILS, "@DOMAIN", (suffix, email) -> email + suffix.toLowerCase())
+      ).apply(company);
+      assertEquals("ALICE@ACME.COM@domain", out.departments().getFirst().teams().getFirst().users().getFirst().email());
+    }
+
+    @Test
+    @DisplayName("Mixed PATCH composition — some null, some not — only the non-null slots land")
+    void sparsePatchCompositionLandsOnlyPresentSlots() {
+      final var company = sample();
+      final var out = Telescope.all(
+        Edit.<Company, String>overIfPresent(DEPT_NAMES, null),
+        Edit.overIfPresent(TEAM_NAMES, "Renamed"),
+        Edit.<Company, String, String>overIfPresent(USER_NAMES, null, (Function<String, String>) String::toUpperCase),
+        Edit.overIfPresent(EMAILS, "!", (bang, email) -> email + bang)
+      ).apply(company);
+      assertEquals(company.departments().getFirst().name(), out.departments().getFirst().name());
+      assertEquals("Renamed", out.departments().getFirst().teams().getFirst().name());
+      assertEquals(
+        company.departments().getFirst().teams().getFirst().users().getFirst().name(),
+        out.departments().getFirst().teams().getFirst().users().getFirst().name()
+      );
+      assertEquals("ALICE@ACME.COM!", out.departments().getFirst().teams().getFirst().users().getFirst().email());
     }
   }
 }


### PR DESCRIPTION
## Summary

Three new overloads on `Edit` + an `identity()` helper, all returning `Edit<S>` so they slot directly into `Telescope.all(...)`. The point is to collapse the if-ladder pattern PATCH/partial-update controllers otherwise hand-roll around `over(...)`.

## Before / after

```java
// before — manual builder, ArrayList, if-ladder
final List<Edit<Order>> edits = new ArrayList<>();
if (req.orderNumber() != null) edits.add(over(ORDER_NUMBER, _ -> req.orderNumber()));
if (req.shippingCity() != null) edits.add(over(SHIPPING_CITY, _ -> req.shippingCity()));
if (req.customerEmail() != null) edits.add(over(CUSTOMER_EMAIL, _ -> req.customerEmail().toLowerCase()));
if (req.quantityDelta() != null) edits.add(over(LINE_ITEM_QUANTITIES, q -> q + req.quantityDelta()));
final Telescope<Order, Order> bundle = Telescope.all(edits.toArray(new Edit[0]));

// after — declarative, slot count visible, no ArrayList
final Telescope<Order, Order> bundle = Telescope.all(
    overIfPresent(ORDER_NUMBER,         req.orderNumber()),
    overIfPresent(SHIPPING_CITY,        req.shippingCity()),
    overIfPresent(CUSTOMER_EMAIL,       req.customerEmail(),  String::toLowerCase),
    overIfPresent(LINE_ITEM_QUANTITIES, req.quantityDelta(),  (delta, q) -> q + delta));
```

## Overloads

| Signature | Use when |
|---|---|
| `overIfPresent(Telescope<S, X>, X value)` | The DTO field type matches the leaf type — direct replace |
| `overIfPresent(Telescope<S, X>, V value, Function<V, X> mapper)` | DTO type differs — map then replace |
| `overIfPresent(Telescope<S, X>, V value, BiFunction<V, X, X> transform)` | The patch carries a delta — combine with current leaf |

In all three, a `null` value short-circuits to `Edit.identity()` and the mapper/transform is **not** invoked.

## Test plan

- [x] Six new tests under `AllOverTest$OverIfPresent` covering: direct non-null replace, direct null identity, mapper applies, null skips mapper, BiFunction combines value+leaf, mixed-PATCH composition where some slots short-circuit and others apply
- [x] `./gradlew :core:check` green
- [x] spotless clean