### PR TITLE
fix(core): rename Edit.overIfPresent(BiFunction) → Edit.mapIfPresent

### DIFF
--- a/core/src/main/java/io/github/eschizoid/telescope/Edit.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/Edit.java
@@ -83,10 +83,15 @@ public interface Edit<S> {
    * delta or an instruction rather than a replacement.
    *
    * <pre>{@code
-   * Edit.overIfPresent(LINE_ITEM_QUANTITIES, req.quantityDelta(), (delta, q) -> q + delta)
+   * Edit.mapIfPresent(LINE_ITEM_QUANTITIES, req.quantityDelta(), (delta, q) -> q + delta)
    * }</pre>
+   *
+   * <p>Distinct name from {@link #overIfPresent(Telescope, Object, Function)} so the lambda's arity
+   * does not need to disambiguate the overload at the call site — pick {@code overIfPresent} when
+   * the value alone yields the new leaf; pick {@code mapIfPresent} when the new leaf depends on
+   * both the value and the current leaf.
    */
-  static <S, X, V> Edit<S> overIfPresent(
+  static <S, X, V> Edit<S> mapIfPresent(
     final Telescope<S, X> path,
     final V value,
     final BiFunction<V, X, X> transform

--- a/core/src/test/java/io/github/eschizoid/telescope/AllOverTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/AllOverTest.java
@@ -5,7 +5,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 
 import java.util.List;
-import java.util.function.Function;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -211,13 +210,25 @@ class AllOverTest {
     }
 
     @Test
-    @DisplayName("BiFunction form lets the carried value steer per-leaf transformation")
-    void biFunctionFormCombinesValueWithLeaf() {
+    @DisplayName("mapIfPresent — value steers per-leaf transformation")
+    void mapIfPresentCombinesValueWithLeaf() {
       final var company = sample();
       final var out = Telescope.all(
-        Edit.overIfPresent(EMAILS, "@DOMAIN", (suffix, email) -> email + suffix.toLowerCase())
+        Edit.mapIfPresent(EMAILS, "@DOMAIN", (suffix, email) -> email + suffix.toLowerCase())
       ).apply(company);
       assertEquals("ALICE@ACME.COM@domain", out.departments().getFirst().teams().getFirst().users().getFirst().email());
+    }
+
+    @Test
+    @DisplayName("mapIfPresent — null value short-circuits without invoking the transform")
+    void mapIfPresentNullSkips() {
+      final var company = sample();
+      final var out = Telescope.all(
+        Edit.<Company, String, String>mapIfPresent(EMAILS, null, (suffix, email) -> {
+          throw new IllegalStateException("transform must not run for null value");
+        })
+      ).apply(company);
+      assertSame(company, out);
     }
 
     @Test
@@ -227,8 +238,8 @@ class AllOverTest {
       final var out = Telescope.all(
         Edit.<Company, String>overIfPresent(DEPT_NAMES, null),
         Edit.overIfPresent(TEAM_NAMES, "Renamed"),
-        Edit.<Company, String, String>overIfPresent(USER_NAMES, null, (Function<String, String>) String::toUpperCase),
-        Edit.overIfPresent(EMAILS, "!", (bang, email) -> email + bang)
+        Edit.<Company, String, String>overIfPresent(USER_NAMES, null, String::toUpperCase),
+        Edit.mapIfPresent(EMAILS, "!", (bang, email) -> email + bang)
       ).apply(company);
       assertEquals(company.departments().getFirst().name(), out.departments().getFirst().name());
       assertEquals("Renamed", out.departments().getFirst().teams().getFirst().name());


### PR DESCRIPTION
## Summary

Quick follow-up to PR #52. While wiring \`Edit.overIfPresent(...)\` into the order-jpa \`BulkUpdateController\` I hit a real overload-resolution ambiguity at the call site:

\`\`\`java
// fails to compile: "reference to overIfPresent is ambiguous"
overIfPresent(LINE_ITEM_QUANTITIES, req.lineItemQuantityDelta(), (delta, q) -> q + delta)
\`\`\`

Even though only the \`BiFunction\` form has the right arity, Java's overload resolution can't pick between the two same-name 3-arg overloads while target-typing the lambda. Casting the lambda to \`BiFunction\` works but defeats the "reads clean" goal of the DSL.

## Change

Rename the BiFunction form from \`overIfPresent\` to \`mapIfPresent\`. The two read-modes are now distinguished by name, not by lambda arity:

| Method | Use when |
|---|---|
| \`overIfPresent(path, value)\` | DTO field type matches the leaf — direct replace |
| \`overIfPresent(path, value, mapper)\` | DTO type differs — map then replace |
| \`mapIfPresent(path, value, transform)\` | New leaf depends on the current leaf + carried value |

Mnemonic: **over** = the value yields the new leaf; **map** = the new leaf depends on the current leaf.

## Behavior

Unchanged. Same identity-on-null short-circuit, same lazy mapper invocation.

## Test plan

- [x] AllOverTest renames the BiFunction cases to \`mapIfPresent\`, adds a null-skip test for the new name
- [x] \`./gradlew :core:test\` green