### PR TITLE
feat(core): Mapping.drop(srcAccessor) — explicit source-field exclusion

### DIFF
--- a/core/src/main/java/io/github/eschizoid/telescope/mapping/DeepMap.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/mapping/DeepMap.java
@@ -93,7 +93,7 @@ public final class DeepMap {
       hintMap.isEmpty() && defaultWriterFactory == null
         ? Reflective.BEANS
         : Reflective.beansWithHints(hintMap, defaultWriterFactory);
-    final var overrideTable = groupOverridesByPair(overrides.toArray(Mapping<?, ?>[]::new));
+    final var overrideTable = groupOverridesByPair(overrides.toArray(Mapping<?, ?>[]::new), source, target);
     final var cache = new HashMap<TypePair, Iso<?, ?>>();
     final var topSteps = new LinkedHashMap<String, FieldStep>();
     populateIso(source, target, overrideTable, beanRefl, cache, topSteps);
@@ -215,13 +215,22 @@ public final class DeepMap {
 
   // ---------- Override grouping ----------
 
-  private static Map<TypePair, List<Mapping<?, ?>>> groupOverridesByPair(final Mapping<?, ?>[] overrides) {
+  private static Map<TypePair, List<Mapping<?, ?>>> groupOverridesByPair(
+    final Mapping<?, ?>[] overrides,
+    final Class<?> topSource,
+    final Class<?> topTarget
+  ) {
     final var grouped = new HashMap<TypePair, List<Mapping<?, ?>>>();
     for (final var row : overrides) {
       final var internals = internalsOf(row);
-      grouped
-        .computeIfAbsent(new TypePair(internals.sourceClass(), internals.targetClass()), _ -> new ArrayList<>())
-        .add(row);
+      // Drop rows have no target accessor (targetClass() == null). Bind them to the top-level
+      // (source, target) pair the user passed to Telescope.map(...); a Drop row is scoped to the
+      // specific mapper that declares it, not to every pair the recursion lands on.
+      final var key =
+        row instanceof Drop<?, ?, ?>
+          ? new TypePair(internals.sourceClass(), topTarget)
+          : new TypePair(internals.sourceClass(), internals.targetClass());
+      grouped.computeIfAbsent(key, _ -> new ArrayList<>()).add(row);
     }
     return grouped;
   }
@@ -258,6 +267,25 @@ public final class DeepMap {
       // "name".
       final var internals = internalsOf(row);
       final var srcField = srcRefl.normalize(internals.sourceField());
+      // Drop rows claim a source field with no target counterpart — they exist to satisfy the
+      // strict source-must-be-claimed pass below when one side carries fields the other doesn't.
+      if (row instanceof Drop<?, ?, ?>) {
+        if (!claimedSrc.add(srcField)) throw new IllegalArgumentException(
+          "Deep map " +
+            source.getSimpleName() +
+            " → " +
+            target.getSimpleName() +
+            ": duplicate override row for source field '" +
+            srcField +
+            "'. Each (source, target) type pair may declare at most one row per source field."
+        );
+        // Register a backward-only step under the source name so the source-reconstructor
+        // (assembleIso's bySourceName loop) produces a placeholder value (null) for the dropped
+        // field. The step is NOT registered under byTargetName, so the forward direction omits
+        // the source field from the target map entirely.
+        bySourceName.put(srcField, new FieldStep(srcField, null, NULLING_ISO));
+        continue;
+      }
       final var tgtField = tgtRefl.normalize(internals.targetField());
       // Fail fast on duplicates within this type-pair — two rows that target the same source or
       // target field would silently overwrite each other in byTargetName/bySourceName and could
@@ -435,6 +463,10 @@ public final class DeepMap {
       case SameTypedTo<?, ?, ?> r -> r.fieldIso();
       case TypedTransformTo<?, ?, ?, ?> r -> r.fieldIso();
       case Via<?, ?> r -> liftViaIfNeeded(r, srcType, tgtType);
+      // Drop rows never reach this method — populateIso short-circuits on `instanceof Drop` before
+      // calling fieldIsoOf. The case is here only to make the switch exhaustive for the sealed
+      // hierarchy; reaching it indicates a routing bug above.
+      case Drop<?, ?, ?> _ -> throw new IllegalStateException("Drop row should not reach fieldIsoOf");
     };
   }
 
@@ -677,6 +709,13 @@ public final class DeepMap {
    * One per-component step: source/target field names + the {@link Iso} between their leaf types.
    */
   private record FieldStep(String sourceName, String targetName, Iso<?, ?> iso) {}
+
+  /**
+   * Placeholder Iso used by {@code Mapping.drop(srcAccessor)}'s backward pass — both directions
+   * return {@code null}. Only ever invoked in the {@link #remapIso} backward loop for source-only
+   * fields that have no target counterpart; the forward direction skips the field entirely.
+   */
+  private static final Iso<Object, Object> NULLING_ISO = Iso.of(_ -> null, _ -> null);
 
   /**
    * Bundled return from {@link #resolution(Class, Class, MapStep...)} — the Iso and the patch

--- a/core/src/main/java/io/github/eschizoid/telescope/mapping/Drop.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/mapping/Drop.java
@@ -1,0 +1,42 @@
+package io.github.eschizoid.telescope.mapping;
+
+import io.github.eschizoid.telescope.Telescope.Accessor;
+import io.github.eschizoid.telescope.internal.LambdaIntrospection;
+
+/**
+ * Drop-source-field row from {@link Mapping#drop(Accessor)}. Marks a single source field as
+ * intentionally NOT mapped to the target so the strict deep-mapping factory accepts the pair
+ * without requiring a same-name target property. Used when one side of a record↔bean pair carries
+ * fields the other shouldn't see (e.g. internal metadata that mustn't leak across a partner-facing
+ * boundary).
+ *
+ * <p>Package-private — users construct via {@link Mapping#drop(Accessor)} and never see this type
+ * at the call site.
+ */
+record Drop<A, B, X>(Accessor<A, X> src) implements Mapping<A, B>, MappingInternals<A, B> {
+  @Override
+  public Class<A> sourceClass() {
+    return LambdaIntrospection.implClassOf(src);
+  }
+
+  /**
+   * No target accessor — a drop row by definition doesn't claim a target field. Returning {@code
+   * null} lets {@link DeepMap} short-circuit the (source, target) type-pair indexing path for this
+   * row.
+   */
+  @Override
+  public Class<B> targetClass() {
+    return null;
+  }
+
+  @Override
+  public String sourceField() {
+    return LambdaIntrospection.methodNameOf(src);
+  }
+
+  /** No target field — distinguishes a drop row from {@link SameTypedTo} / {@link Via}. */
+  @Override
+  public String targetField() {
+    return null;
+  }
+}

--- a/core/src/main/java/io/github/eschizoid/telescope/mapping/Mapping.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/mapping/Mapping.java
@@ -30,11 +30,11 @@ import java.util.function.Function;
  * Telescope#map(Class, Class, MapStep...)} keys overrides by {@code (sourceClass, targetClass)} so
  * a single row applies wherever the recursion lands on that pair — top level or N levels deep.
  *
- * <p><b>Permitted impls.</b> Sealed over three package-private records in sibling files in this
- * package — {@link SameTypedTo}, {@link TypedTransformTo}, {@link Via}. Users construct via the
- * static factories below; the record types are not public API.
+ * <p><b>Permitted impls.</b> Sealed over four package-private records in sibling files in this
+ * package — {@link SameTypedTo}, {@link TypedTransformTo}, {@link Via}, {@link Drop}. Users
+ * construct via the static factories below; the record types are not public API.
  */
-public sealed interface Mapping<A, B> extends MapStep permits SameTypedTo, TypedTransformTo, Via {
+public sealed interface Mapping<A, B> extends MapStep permits SameTypedTo, TypedTransformTo, Via, Drop {
   /** Same-typed correspondence: {@code src↔tgt}, both with leaf type {@code X}. Identity. */
   static <A, B, X> Mapping<A, B> to(final Accessor<A, X> src, final Accessor<B, X> tgt) {
     return new SameTypedTo<>(src, tgt);
@@ -80,5 +80,28 @@ public sealed interface Mapping<A, B> extends MapStep permits SameTypedTo, Typed
     final Mapper<?, ?> elementMapper
   ) {
     return new Via<>(src, tgt, elementMapper);
+  }
+
+  /**
+   * Drop a source field — declare it intentionally NOT mapped to the target so the strict deep-map
+   * factory accepts the pair without requiring a same-name target property. Use this when one side
+   * of a cross-paradigm pair carries fields the other side shouldn't (or doesn't) see — e.g.
+   * internal {@code metadata} that mustn't leak to a partner-facing DTO.
+   *
+   * <pre>{@code
+   * Telescope.mapper(
+   *     Order.class, PartnerShippingLabel.class,
+   *     to(Order::orderNumber, PartnerShippingLabel::getTrackingReference),
+   *     via(Order::lineItems,  PartnerShippingLabel::getItems, partnerItemMapper),
+   *     drop(Order::metadata));   // PartnerShippingLabel has no metadata field; this is OK
+   * }</pre>
+   *
+   * <p>The dropped field is read-side-only: {@code forward(order)} simply does not propagate it to
+   * the target, and {@code backward(label)} reconstructs the record with the field set to whatever
+   * the source-side reflection chooses (typically {@code null} for nullable record components, or
+   * the type's default value otherwise — see the source-class's component-default contract).
+   */
+  static <A, B> Mapping<A, B> drop(final Accessor<A, ?> src) {
+    return new Drop<>(src);
   }
 }

--- a/core/src/main/java/io/github/eschizoid/telescope/mapping/MappingInternals.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/mapping/MappingInternals.java
@@ -11,7 +11,7 @@ package io.github.eschizoid.telescope.mapping;
  * DeepMap} casts a {@code Mapping<?, ?>} to {@code MappingInternals<?, ?>} when it needs the
  * recovery info.
  */
-sealed interface MappingInternals<A, B> permits SameTypedTo, TypedTransformTo, Via {
+sealed interface MappingInternals<A, B> permits SameTypedTo, TypedTransformTo, Via, Drop {
   /**
    * Source class this row keys against (the declaring class of the source accessor, recovered via
    * {@code SerializedLambda}). Used by {@link DeepMap} to decide which type pairs this override

--- a/core/src/test/java/io/github/eschizoid/telescope/DeepMappingTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/DeepMappingTest.java
@@ -1,5 +1,6 @@
 package io.github.eschizoid.telescope;
 
+import static io.github.eschizoid.telescope.mapping.Mapping.drop;
 import static io.github.eschizoid.telescope.mapping.Mapping.to;
 import static io.github.eschizoid.telescope.mapping.Mapping.via;
 import static io.github.eschizoid.telescope.mapping.WriteHint.WriteStrategy.BUILDER;
@@ -904,6 +905,71 @@ class DeepMappingTest {
       assertEquals(Set.of(new TagD("x"), new TagD("y")), dto.data().get(0).get("alpha"));
       assertEquals(Set.of(new TagD("z")), dto.data().get(0).get("beta"));
       assertEquals(src, mapper.backward(dto));
+    }
+  }
+
+  @Nested
+  @DisplayName("drop(srcAccessor) — intentionally exclude a source field from the strict mapper")
+  class DropRow {
+
+    record OrderRich(String orderNumber, String customer, String metadata) {}
+
+    record OrderPartner(String orderNumber, String customer) {}
+
+    @Test
+    @DisplayName("without drop — strict mapper rejects the unmapped source field with a usable hint")
+    void strictModeRejectsUnmappedSource() {
+      final var ex = assertThrows(IllegalStateException.class, () ->
+        Telescope.mapper(OrderRich.class, OrderPartner.class)
+      );
+      assertTrue(ex.getMessage().contains("metadata"), ex.getMessage());
+      assertTrue(ex.getMessage().contains("no same-name target"), ex.getMessage());
+    }
+
+    @Test
+    @DisplayName("with drop(OrderRich::metadata) — mapper builds; forward omits the field")
+    void dropMakesForwardOmitTheField() {
+      final var mapper = Telescope.mapper(OrderRich.class, OrderPartner.class, drop(OrderRich::metadata));
+      final var src = new OrderRich("ORD-1", "alice", "secret-internal");
+      final var dst = mapper.forward(src);
+      assertEquals("ORD-1", dst.orderNumber());
+      assertEquals("alice", dst.customer());
+    }
+
+    @Test
+    @DisplayName("with drop — backward reconstructs the source with a null in the dropped slot")
+    void dropMakesBackwardLeaveDroppedFieldNull() {
+      final var mapper = Telescope.mapper(OrderRich.class, OrderPartner.class, drop(OrderRich::metadata));
+      final var dst = new OrderPartner("ORD-1", "alice");
+      final var rebuilt = mapper.backward(dst);
+      assertEquals("ORD-1", rebuilt.orderNumber());
+      assertEquals("alice", rebuilt.customer());
+      assertNull(rebuilt.metadata());
+    }
+
+    @Test
+    @DisplayName("drop composes with to(...) renames in the same mapper")
+    void dropComposesWithRename() {
+      final var mapper = Telescope.mapper(
+        OrderRich.class,
+        OrderPartner.class,
+        to(OrderRich::customer, OrderPartner::customer),
+        drop(OrderRich::metadata)
+      );
+      final var src = new OrderRich("ORD-1", "alice", "metadata-value");
+      final var dst = mapper.forward(src);
+      assertEquals("alice", dst.customer());
+      assertEquals("ORD-1", dst.orderNumber());
+    }
+
+    @Test
+    @DisplayName("duplicate drop on the same source field — same fail-fast guard as a duplicate to(...) row")
+    void duplicateDropRejected() {
+      final var ex = assertThrows(IllegalArgumentException.class, () ->
+        Telescope.mapper(OrderRich.class, OrderPartner.class, drop(OrderRich::metadata), drop(OrderRich::metadata))
+      );
+      assertTrue(ex.getMessage().contains("metadata"), ex.getMessage());
+      assertTrue(ex.getMessage().contains("duplicate"), ex.getMessage());
     }
   }
 }


### PR DESCRIPTION
## Summary

Adds a fourth row type to the deep-mapper varargs: `drop(srcAccessor)`. Claims a single source field with no target counterpart so the strict deep-mapping factory accepts the pair without requiring a same-name target property.

## Motivating example (from the order-jpa demo refactor)

```java
Telescope.mapper(
    Order.class, PartnerShippingLabel.class,
    to(Order::orderNumber, PartnerShippingLabel::getTrackingReference),
    via(Order::lineItems,  PartnerShippingLabel::getItems, partnerItemMapper),
    drop(Order::metadata));   // Order has internal metadata that
                              // mustn't leak to the partner DTO
```

Without `drop`, adding any field to the source side breaks every consumer mapper that doesn't have a target for it — wrong direction of pressure for a deep-mapping DSL.

## Behavior

- **Forward** (`mapper.forward(src)`): the dropped field is omitted from the target — no entry in `byTargetName`, the structural-iso never sees it.
- **Backward** (`mapper.backward(dst)`): the source-reconstructor produces `null` for the dropped slot. If your source records `null`-reject in their canonical ctor, you'll see that surface here.
- **Scoping**: a drop row applies only to the specific (source, target) pair the user passed to `Telescope.mapper(...)`. Drops on the same source class don't bleed across to other mappers.
- **Duplicate guard**: two `drop(src)` rows on the same source field fail-fast with the same `IllegalArgumentException` the duplicate-`to(...)` guard produces.

## Implementation

- New package-private `Drop<A, B, X>` record implements `Mapping<A, B>` + `MappingInternals<A, B>`. Carries only the src accessor; `targetClass()` and `targetField()` return `null` to mark "no target counterpart."
- `Mapping` sealed permits + `MappingInternals` sealed permits widen to include `Drop`.
- `DeepMap.groupOverridesByPair` binds `Drop` rows to the top-level `(source, target)` `TypePair` the user passed to `Telescope.map(...)`; a drop is scoped to the specific mapper that declares it, not every pair the recursion lands on.
- `DeepMap.populateIso` short-circuits on `row instanceof Drop` — adds the source field to `claimedSrc` (satisfying the strict-source pass) and registers a backward-only `FieldStep` that produces `null` in the source-reconstructor under the source-field key.
- `DeepMap.fieldIsoOf` gets a `Drop` case that throws — `Drop` never reaches `fieldIsoOf`, but the switch needs exhaustiveness for the sealed hierarchy.

## Test plan

- [x] 5 new `DropRow` cases under `DeepMappingTest`:
  - strict mode rejects unmapped source without `drop`
  - `drop` makes forward omit the field
  - `drop` makes backward leave the source slot `null`
  - `drop` composes with `to(...)` renames in the same mapper
  - duplicate `drop` is rejected with the same fail-fast guard as duplicate `to(...)`
- [x] `./gradlew :core:check` green
- [x] spotless clean