### PR TITLE
feat(core): two-arg Mapping.drop(srcAcc, target) for nested pair scope

### DIFF
--- a/core/src/main/java/io/github/eschizoid/telescope/mapping/DeepMap.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/mapping/DeepMap.java
@@ -223,13 +223,14 @@ public final class DeepMap {
     final var grouped = new HashMap<TypePair, List<Mapping<?, ?>>>();
     for (final var row : overrides) {
       final var internals = internalsOf(row);
-      // Drop rows have no target accessor (targetClass() == null). Bind them to the top-level
-      // (source, target) pair the user passed to Telescope.map(...); a Drop row is scoped to the
-      // specific mapper that declares it, not to every pair the recursion lands on.
-      final var key =
-        row instanceof Drop<?, ?, ?>
-          ? new TypePair(internals.sourceClass(), topTarget)
-          : new TypePair(internals.sourceClass(), internals.targetClass());
+      // Drop rows have no target accessor. The single-arg drop(srcAcc) factory binds the row to
+      // the top-level (source, target) pair the user passed to Telescope.map(...); the two-arg
+      // drop(srcAcc, target) factory binds it to whatever nested (source, target) pair the user
+      // names explicitly. Internals.targetClass() returns null for the single-arg form and the
+      // explicit target Class for the two-arg form.
+      final Class<?> effectiveTarget =
+        row instanceof Drop<?, ?, ?> && internals.targetClass() == null ? topTarget : internals.targetClass();
+      final var key = new TypePair(internals.sourceClass(), effectiveTarget);
       grouped.computeIfAbsent(key, _ -> new ArrayList<>()).add(row);
     }
     return grouped;

--- a/core/src/main/java/io/github/eschizoid/telescope/mapping/Drop.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/mapping/Drop.java
@@ -4,29 +4,31 @@ import io.github.eschizoid.telescope.Telescope.Accessor;
 import io.github.eschizoid.telescope.internal.LambdaIntrospection;
 
 /**
- * Drop-source-field row from {@link Mapping#drop(Accessor)}. Marks a single source field as
- * intentionally NOT mapped to the target so the strict deep-mapping factory accepts the pair
- * without requiring a same-name target property. Used when one side of a record↔bean pair carries
- * fields the other shouldn't see (e.g. internal metadata that mustn't leak across a partner-facing
- * boundary).
+ * Drop-source-field row from {@link Mapping#drop(Accessor)} / {@link Mapping#drop(Accessor,
+ * Class)}. Marks a single source field as intentionally NOT mapped to the target so the strict
+ * deep-mapping factory accepts the pair without requiring a same-name target property.
  *
- * <p>Package-private — users construct via {@link Mapping#drop(Accessor)} and never see this type
- * at the call site.
+ * <p>Used when one side of a record↔bean pair carries fields the other shouldn't see (e.g. internal
+ * metadata that mustn't leak across a partner-facing boundary). The single-arg variant scopes the
+ * drop to the top-level mapper; the two-arg variant scopes it to a specific nested pair anywhere in
+ * the recursion (analogous to {@link Via} carrying both accessors).
+ *
+ * <p>Package-private — users construct via the {@link Mapping#drop(Accessor)} / {@link
+ * Mapping#drop(Accessor, Class)} factories and never see this type at the call site.
  */
-record Drop<A, B, X>(Accessor<A, X> src) implements Mapping<A, B>, MappingInternals<A, B> {
+record Drop<A, B, X>(Accessor<A, X> src, Class<B> explicitTarget) implements Mapping<A, B>, MappingInternals<A, B> {
   @Override
   public Class<A> sourceClass() {
     return LambdaIntrospection.implClassOf(src);
   }
 
   /**
-   * No target accessor — a drop row by definition doesn't claim a target field. Returning {@code
-   * null} lets {@link DeepMap} short-circuit the (source, target) type-pair indexing path for this
-   * row.
+   * Explicit target class if the user supplied one (two-arg factory), otherwise {@code null} so
+   * {@link DeepMap} binds the drop to the top-level mapper's target.
    */
   @Override
   public Class<B> targetClass() {
-    return null;
+    return explicitTarget;
   }
 
   @Override

--- a/core/src/main/java/io/github/eschizoid/telescope/mapping/Mapping.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/mapping/Mapping.java
@@ -102,6 +102,32 @@ public sealed interface Mapping<A, B> extends MapStep permits SameTypedTo, Typed
    * the type's default value otherwise — see the source-class's component-default contract).
    */
   static <A, B> Mapping<A, B> drop(final Accessor<A, ?> src) {
-    return new Drop<>(src);
+    return new Drop<>(src, null);
+  }
+
+  /**
+   * Drop a source field scoped to a specific nested {@code (source, target)} pair. Use this when
+   * the field to drop lives on a type the recursion lands on multiple times with different targets
+   * — only the (source, {@code target}) pair gets the field elided; other recursions on the same
+   * source class stay strict.
+   *
+   * <pre>{@code
+   * Telescope.mapper(
+   *     Order.class, PartnerShippingLabel.class,
+   *     to(Order::orderNumber,   PartnerShippingLabel::getTrackingReference),
+   *     via(Order::lineItems,    PartnerShippingLabel::getItems, partnerItemMapper),
+   *     drop(Order::metadata),                       // top-level Order → PartnerShippingLabel
+   *     drop(Customer::tags, PartnerCustomer.class)); // nested Customer → PartnerCustomer
+   * }</pre>
+   *
+   * <p>Symmetrical with {@link #via(Accessor, Accessor, Mapper)} carrying both accessors — the
+   * difference is that there is no target accessor to recover the target class from, so the user
+   * supplies the class directly. Use the single-arg {@link #drop(Accessor)} when the drop scopes to
+   * the top-level mapper.
+   */
+  static <A, B> Mapping<A, B> drop(final Accessor<A, ?> src, final Class<?> target) {
+    @SuppressWarnings("unchecked")
+    final var castTarget = (Class<B>) target;
+    return new Drop<>(src, castTarget);
   }
 }

--- a/core/src/test/java/io/github/eschizoid/telescope/DeepMappingTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/DeepMappingTest.java
@@ -971,5 +971,55 @@ class DeepMappingTest {
       assertTrue(ex.getMessage().contains("metadata"), ex.getMessage());
       assertTrue(ex.getMessage().contains("duplicate"), ex.getMessage());
     }
+
+    // --- two-arg drop(srcAcc, target) — scoped to a nested pair ---
+    record CustomerRich(String name, java.util.Set<String> tags) {}
+
+    record CustomerPartner(String name) {}
+
+    record ShipmentRich(String code, CustomerRich customer) {}
+
+    record ShipmentPartner(String code, CustomerPartner customer) {}
+
+    @Test
+    @DisplayName("two-arg drop scopes the elision to a specific nested (source, target) pair only")
+    void twoArgDropAppliesAtNestedPair() {
+      final var mapper = Telescope.mapper(
+        ShipmentRich.class,
+        ShipmentPartner.class,
+        drop(CustomerRich::tags, CustomerPartner.class)
+      );
+      final var src = new ShipmentRich("S-1", new CustomerRich("alice", Set.of("vip", "newsletter")));
+      final var dst = mapper.forward(src);
+      assertEquals("S-1", dst.code());
+      assertEquals("alice", dst.customer().name());
+    }
+
+    @Test
+    @DisplayName("two-arg drop backward leaves the dropped nested slot null")
+    void twoArgDropBackwardLeavesNull() {
+      final var mapper = Telescope.mapper(
+        ShipmentRich.class,
+        ShipmentPartner.class,
+        drop(CustomerRich::tags, CustomerPartner.class)
+      );
+      final var dst = new ShipmentPartner("S-1", new CustomerPartner("alice"));
+      final var rebuilt = mapper.backward(dst);
+      assertEquals("S-1", rebuilt.code());
+      assertEquals("alice", rebuilt.customer().name());
+      assertNull(rebuilt.customer().tags());
+    }
+
+    @Test
+    @DisplayName("one-arg drop on a nested-source class binds to top target — doesn't reach the nested pair")
+    void oneArgDropOnNestedSourceDoesNotReachNestedPair() {
+      // Without the explicit nested target, the top-level mapper still rejects the unmapped source
+      // because (CustomerRich, CustomerPartner) is the recursion's pair, not (CustomerRich,
+      // top-target).
+      final var ex = assertThrows(IllegalStateException.class, () ->
+        Telescope.mapper(ShipmentRich.class, ShipmentPartner.class, drop(CustomerRich::tags))
+      );
+      assertTrue(ex.getMessage().contains("tags"), ex.getMessage());
+    }
   }
 }


### PR DESCRIPTION
## Summary

Follow-up to PR #54. The single-arg `drop(srcAcc)` scopes the elision to the top-level mapper pair. The nested case — drop a field on a type the recursion lands on with a specific nested target — needs an explicit target class.

## Motivating example (order-jpa demo refactor, in progress)

```java
Telescope.mapper(
    Order.class, PartnerShippingLabel.class,
    to(Order::orderNumber,  PartnerShippingLabel::getTrackingReference),
    via(Order::lineItems,   PartnerShippingLabel::getItems, partnerItemMapper),
    drop(Order::metadata),                       // top-level (PR #54)
    drop(Customer::tags, PartnerCustomer.class));// nested pair (this PR)
```

Without the two-arg overload, the only ways to handle `Customer.tags` in this mapper would be (a) put `tags` on `PartnerCustomer` (semantic leak) or (b) reject the model extension.

## Change

- `Drop` record gains an `explicitTarget: Class<B>` component (nullable to distinguish single-arg vs two-arg).
- New static factory `Mapping.drop(Accessor<A, ?> src, Class<?> target)`.
- `DeepMap.groupOverridesByPair` uses `explicitTarget` when non-null, falls back to the top-level target otherwise. No behavioral change to single-arg call sites.

## Test plan

- [x] 3 new tests under `DeepMappingTest$DropRow`:
  - `twoArgDropAppliesAtNestedPair` — forward elides the nested field
  - `twoArgDropBackwardLeavesNull` — backward leaves the nested slot null
  - `oneArgDropOnNestedSourceDoesNotReachNestedPair` — documents why the two-arg form is needed
- [x] `./gradlew :core:test --tests '*DeepMappingTest*'` green
- [x] spotless clean