### PR TITLE
feat(quarkus): telescope-quarkus CDI extension + JReleaser staging for starters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,23 @@ story.
 
 ## [Unreleased]
 
-_Nothing yet — see [0.4.1] for the most recent release._
+### Added
+
+- **`telescope-quarkus`** — Quarkus 3 CDI extension. Mirrors the Spring Boot starter's surface: drop-in `Mapper<A,B>`
+  bean registry indexed by `(sourceClass, targetClass)`, `@ConfigMapping`-driven `telescope.registry.fail-fast` toggle,
+  no extra wiring. Uses ArC's `@All List<Mapper<?, ?>>` collector pattern to inject every mapper bean. Ships a pre-built
+  `META-INF/jandex.idx` (via the Kordamp Jandex Gradle plugin) so Quarkus apps consuming the extension skip the startup
+  bytecode scan and avoid the "Application archive ... is being scanned without a Jandex index" warning. Published as
+  `io.github.eschizoid:telescope-quarkus`.
+- `telescope-spring-boot-starter` and `telescope-quarkus` now staged for JReleaser publishing alongside `telescope`,
+  `telescope-codegen`, and `telescope-lombok` — the starter modules were previously built locally but not staged for
+  Sonatype.
+
+### Changed
+
+- README: `Drop-in telescope-spring-boot-starter for autoconfig` now reads
+  `Drop-in telescope-spring-boot-starter (Spring Boot 4) or telescope-quarkus (Quarkus 3) for autoconfig`, reflecting
+  both framework integrations.
 
 ## [0.4.1] — 2026-06-08
 

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ One type drives deep navigation, immutable update, bidirectional mapping, and ef
 POJOs, and Lombok `@Data` classes — no category-theory jargon, no hand-written copy constructors. Reach fields nested
 through lists, sets, maps, optionals, and sealed-type variants in one chain. Skip codegen for the runtime path, or add
 `@Focus` / `@BeanFocus` / `@Bridge` annotations for compile-time-bound navigators with deep recursion through
-containers. Drop-in `telescope-spring-boot-starter` for autoconfig + a typed `Mapper<A,B>` bean registry — one
-dependency, zero wiring.
+containers. Drop-in `telescope-spring-boot-starter` (Spring Boot 4) or `telescope-quarkus` (Quarkus 3) for autoconfig +
+a typed `Mapper<A,B>` bean registry — one dependency, zero wiring.
 
 [![JVM 25+](https://img.shields.io/badge/JVM-25%2B-brightgreen.svg?&logo=openjdk)](https://openjdk.org/projects/jdk/25/)
 [![Build](https://github.com/eschizoid/telescope/actions/workflows/ci.yaml/badge.svg)](https://github.com/eschizoid/telescope/actions/workflows/ci.yaml)
@@ -640,8 +640,8 @@ lift the inner-element Iso through the container automatically (to any depth —
 construction). You only spell the _differences_.
 
 ```java
-import static io.github.eschizoid.telescope.mapping.Mapping.to;
-import static io.github.eschizoid.telescope.mapping.Mapping.via;
+import static io.github.eschizoid.telescope.Mapping.to;
+import static io.github.eschizoid.telescope.Mapping.via;
 
 // All same-name, no overrides — the pure-copy 1-liner:
 final Telescope<UserEntity, UserDto> userMapper = Telescope.map(UserEntity.class, UserDto.class);
@@ -719,8 +719,8 @@ container automatically (to any depth — `List<Map<K, Set<X>>>` resolves by con
 `Telescope<A, B>` (an `Iso`), so it composes with anything else.
 
 ```java
-import static io.github.eschizoid.telescope.mapping.Mapping.to;
-import static io.github.eschizoid.telescope.mapping.Mapping.via;
+import static io.github.eschizoid.telescope.Mapping.to;
+import static io.github.eschizoid.telescope.Mapping.via;
 
 class LegacyUser {
   /* getId(), getEmail(), getName() + a no-arg ctor / all-args ctor / builder() */
@@ -778,8 +778,8 @@ parameter names match the property names). For classes the auto path refuses (im
 of `BUILDER` / `SETTERS` / `FIELDS` / `CONSTRUCTOR`:
 
 ```java
-import static io.github.eschizoid.telescope.mapping.WriteHint.WriteStrategy.CONSTRUCTOR;
-import static io.github.eschizoid.telescope.mapping.WriteHint.writeBean;
+import static io.github.eschizoid.telescope.WriteHint.WriteStrategy.CONSTRUCTOR;
+import static io.github.eschizoid.telescope.WriteHint.writeBean;
 
 // OrderPojo has a public (String sku, int qty) ctor, no builder, no setters — autoWriter would
 // refuse without -parameters. The hint forces the CONSTRUCTOR strategy explicitly.
@@ -800,9 +800,9 @@ construction shape (the common JPA case: every `@Entity` needs `SETTERS` so Hibe
 `X`. At most one `writeBeans(...)` default per call.
 
 ```java
-import static io.github.eschizoid.telescope.mapping.WriteHint.WriteStrategy.SETTERS;
-import static io.github.eschizoid.telescope.mapping.WriteHint.writeBean;
-import static io.github.eschizoid.telescope.mapping.WriteHint.writeBeans;
+import static io.github.eschizoid.telescope.WriteHint.WriteStrategy.SETTERS;
+import static io.github.eschizoid.telescope.WriteHint.writeBean;
+import static io.github.eschizoid.telescope.WriteHint.writeBeans;
 
 final Mapper<Order, OrderEntity> orderMapper = Telescope.mapper(
   Order.class,

--- a/benchmarks/src/jmh/java/io/github/eschizoid/telescope/benchmarks/HolderDispatchBenchmark.java
+++ b/benchmarks/src/jmh/java/io/github/eschizoid/telescope/benchmarks/HolderDispatchBenchmark.java
@@ -1,7 +1,7 @@
 package io.github.eschizoid.telescope.benchmarks;
 
-import io.github.eschizoid.telescope.Telescope;
 import io.github.eschizoid.telescope.Mapper;
+import io.github.eschizoid.telescope.Telescope;
 import java.util.concurrent.TimeUnit;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -156,6 +156,18 @@ jreleaser {
                             .get()
                             .asFile.absolutePath,
                     )
+                    stagingRepository(
+                        project(":spring-boot-starter").layout.buildDirectory
+                            .dir("staging-deploy")
+                            .get()
+                            .asFile.absolutePath,
+                    )
+                    stagingRepository(
+                        project(":quarkus").layout.buildDirectory
+                            .dir("staging-deploy")
+                            .get()
+                            .asFile.absolutePath,
+                    )
                     enabled.set(true)
                     sign.set(false)
                     maxRetries.set(60)

--- a/codegen/README.md
+++ b/codegen/README.md
@@ -1,0 +1,123 @@
+# telescope-codegen
+
+Annotation processors that emit a fluent typed `<X>Path<R>` navigator at compile time, eliminating the runtime
+reflection cost of the [core DSL](../README.md). Same end-state values as the reflective
+`Telescope.of(Class).field(...)` path; different price tag.
+
+```
+Telescope.of(Company.class)             // runtime path (~262 ns/op for a 3-level update)
+    .each(Company::departments)
+    .each(Department::teams)
+    .each(Team::users)
+    .field(User::email)
+    .update(company, String::toLowerCase);
+
+CompanyPath.start()                      // codegen path (~45 ns/op — 5.8× faster)
+    .departments().each()
+    .teams().each()
+    .users().each()
+    .email().update(company, String::toLowerCase);
+```
+
+## When to use
+
+- **Hot paths.** The codegen navigator emits direct method-reference + canonical-constructor bytecode at every hop. Zero
+  `SerializedLambda` decode, zero `Records.fieldLens(String)` lookup, zero `Beans.lens(...)` reflection.
+- **Compile-time path validation.** A typo on `CompanyPath.start().teams()` is a `javac` error. The reflective
+  `.field(Company::teamz)` blows up at construction time.
+- **Cross-paradigm bridges.** `@Bridge(UserDto.class)` on a `UserEntity` POJO generates
+  `UserEntityPath.start().asUserDto().email()` — one fluent chain hops from bean to record.
+
+Skip codegen for prototype / glue code that doesn't sit in a tight loop. The reflective path is sub-microsecond and
+still build-time-validated for method references.
+
+## Annotations
+
+| Annotation              | Target                                        | Emits                                                                              |
+| ----------------------- | --------------------------------------------- | ---------------------------------------------------------------------------------- |
+| `@Focus`                | records                                       | `<R>Path<R>` navigator with one method per component                               |
+| `@BeanFocus`            | POJOs with public getters / setters / builder | same shape as `@Focus`                                                             |
+| `@Bridge(Target.class)` | record or POJO                                | `<S>Bridge.BRIDGE : Iso<S, Target>` constant + `as<Target>()` hop on the navigator |
+
+When a type carries both `@Focus`/`@BeanFocus` **and** `@Bridge`, the navigator gains an `as<TargetSimpleName>()` method
+that chains the generated bridge constant.
+
+## Install
+
+```kotlin
+// Gradle
+dependencies {
+    implementation("io.github.eschizoid:telescope:0.4.1")
+    annotationProcessor("io.github.eschizoid:telescope-codegen:0.4.1")
+}
+```
+
+```xml
+<!-- Maven -->
+<dependency>
+  <groupId>io.github.eschizoid</groupId>
+  <artifactId>telescope</artifactId>
+  <version>0.4.1</version>
+</dependency>
+<!-- annotationProcessorPaths on maven-compiler-plugin -->
+<plugin>
+  <groupId>org.apache.maven.plugins</groupId>
+  <artifactId>maven-compiler-plugin</artifactId>
+  <configuration>
+    <annotationProcessorPaths>
+      <path>
+        <groupId>io.github.eschizoid</groupId>
+        <artifactId>telescope-codegen</artifactId>
+        <version>0.4.1</version>
+      </path>
+    </annotationProcessorPaths>
+  </configuration>
+</plugin>
+```
+
+## What gets generated
+
+For a record `User`:
+
+```java
+@Focus
+public record User(String id, String email, Address address) {}
+```
+
+The processor emits `UserPath<R>` next to it:
+
+```java
+public final class UserPath<R> {
+  public static UserPath<User> start() { /* identity */ }
+
+  public Telescope<R, User>    get()     { /* current chain */ }
+  public Telescope<R, String>  id()      { /* lens to id */ }
+  public Telescope<R, String>  email()   { /* lens to email */ }
+  public AddressPath<R>        address() { /* sub-record → continue navigation */ }
+
+  // forwarders so any hop can read/update/etc without .get()
+  public User read(R source)                                              { ... }
+  public R    update(R source, Function<User, User> fn)                   { ... }
+  public R    set(R source, User value)                                   { ... }
+  // … plus updateAsync / updateOptional / updateEither / updateValidated
+}
+```
+
+Container components yield a `<X><Cap>Step<R>` whose `.each()` / `.eachValue()` / `.whenPresent()` returns the element's
+`Path<R>` when the element type is itself annotated, or a terminal `Telescope<R, T>` when it is not.
+
+## Lombok bean classes
+
+Lombok-annotated POJOs (`@Data` / `@Value` / `@Builder`) need the companion [`telescope-lombok`](../lombok/README.md)
+processor — Lombok's lazy AST patching breaks `:codegen`'s in-memory harness, so the Lombok flavour ships as a separate
+processor with round-deferred emission.
+
+## Benchmarks
+
+`bridgeForwardRead` (codegen `@Bridge`) at ~15 ns/op vs runtime `mapBeanForwardRead` at ~142 ns/op is the closest
+apples-to-apples comparison. Full table in the [root README](../README.md#performance).
+
+## Performance honesty
+
+We haven't published an apples-to-apples vs MapStruct benchmark yet — both bind at compile time, so the comparison would
+be tight. See PLAN Tier 1 item 1; benchmark lands before 1.0.

--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
@@ -242,7 +242,9 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
       if (!(el instanceof TypeElement te)) return null;
       final var args = dt.getTypeArguments();
       return switch (te.getQualifiedName().toString()) {
-        case "java.util.List" -> args.size() == 1 ? new ContainerShape(FieldPlan.Kind.LIST, args.getFirst(), null) : null;
+        case "java.util.List" -> args.size() == 1
+          ? new ContainerShape(FieldPlan.Kind.LIST, args.getFirst(), null)
+          : null;
         case "java.util.Set" -> args.size() == 1 ? new ContainerShape(FieldPlan.Kind.SET, args.getFirst(), null) : null;
         case "java.util.Optional" -> args.size() == 1
           ? new ContainerShape(FieldPlan.Kind.OPTIONAL, args.getFirst(), null)

--- a/core/src/main/java/io/github/eschizoid/telescope/From.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/From.java
@@ -1,6 +1,5 @@
 package io.github.eschizoid.telescope;
 
-
 /**
  * Intermediate of {@link Telescope#from(Class)} — call {@link #to(Class)} to bind the target type
  * and continue into {@link To#using(java.util.function.Function, java.util.function.Function)}.

--- a/core/src/main/java/io/github/eschizoid/telescope/MapStep.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/MapStep.java
@@ -1,6 +1,5 @@
 package io.github.eschizoid.telescope;
 
-
 /**
  * Marker for any row supplied to {@link Telescope#map(Class, Class, MapStep...)} / {@link
  * Telescope#mapper(Class, Class, MapStep...)} — either a {@link Mapping} (field correspondence) or

--- a/core/src/main/java/io/github/eschizoid/telescope/Mapper.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/Mapper.java
@@ -11,9 +11,9 @@ import java.util.function.Function;
 
 /**
  * A bidirectional mapper produced by the deep recursive factory {@link Telescope#mapper(Class,
- * Class, io.github.eschizoid.telescope.MapStep...)}. Wraps an {@link Iso} for the
- * forward/backward conversion and (optionally) a per-target-component patch table for sparse {@link
- * #patch} overlays.
+ * Class, io.github.eschizoid.telescope.MapStep...)}. Wraps an {@link Iso} for the forward/backward
+ * conversion and (optionally) a per-target-component patch table for sparse {@link #patch}
+ * overlays.
  *
  * <p>Works for any combination of record and bean classes — the source and target side each pick
  * their own {@link Reflective} dispatch at construction, so {@code patch(...)} reads the partial
@@ -28,10 +28,10 @@ public final class Mapper<A, B> {
    * #backward} and written to {@link #sourceField} on the source.
    *
    * <p>Declared {@code public} solely so the cross-package {@link
-   * io.github.eschizoid.telescope.DeepMap} engine can construct entries when building a
-   * {@link Mapper} via {@link Mapper#Mapper(Iso, Class, Class, Map)}. The raw {@link Function}
-   * field is part of that internal contract; external code must not depend on this record's shape.
-   * Treat as private to the module — it may change or disappear without a deprecation cycle.
+   * io.github.eschizoid.telescope.DeepMap} engine can construct entries when building a {@link
+   * Mapper} via {@link Mapper#Mapper(Iso, Class, Class, Map)}. The raw {@link Function} field is
+   * part of that internal contract; external code must not depend on this record's shape. Treat as
+   * private to the module — it may change or disappear without a deprecation cycle.
    */
   public record PatchEntry(String sourceField, Function<Object, Object> backward) {}
 

--- a/core/src/main/java/io/github/eschizoid/telescope/Telescope.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/Telescope.java
@@ -177,8 +177,8 @@ public sealed class Telescope<
    * emitted holder constant, and the same-package bridge code casts to {@code Iso} when unwrapping
    * a bidirectional conversion. The {@code Object} return type keeps the {@code internal.optics}
    * lattice types out of this class's public signature — external callers get an opaque value with
-   * no usable shape since the cast targets ({@code Lens} / {@code Iso} / {@code Traversal}) are
-   * not exported by the module.
+   * no usable shape since the cast targets ({@code Lens} / {@code Iso} / {@code Traversal}) are not
+   * exported by the module.
    */
   public static Object opticOf(final Telescope<?, ?> t) {
     return t.optic;
@@ -256,8 +256,8 @@ public sealed class Telescope<
    * that is always safe; with mutable POJOs the new and old object share those sub-objects, so
    * treat the shared parts as effectively immutable (don't mutate them afterward). For
    * POJO&harr;record or POJO&harr;POJO <em>conversion</em>, use {@link #map(Class, Class,
-   * io.github.eschizoid.telescope.MapStep...)} — the same deep recursive factory handles
-   * both kinds and any cross-paradigm mix.
+   * io.github.eschizoid.telescope.MapStep...)} — the same deep recursive factory handles both kinds
+   * and any cross-paradigm mix.
    */
   public static <P> Telescope<P, P> ofBean(final Class<P> pojoClass) {
     return new Telescope<>(Iso.identity(), BeanFieldOptics.INSTANCE);
@@ -312,9 +312,8 @@ public sealed class Telescope<
    * }</pre>
    *
    * <p>For a field-by-field declarative mapping between two records or POJOs (no hand-written
-   * conversion functions), use {@link #map(Class, Class,
-   * io.github.eschizoid.telescope.MapStep...)} — it handles both record↔record, POJO↔POJO,
-   * and any cross-paradigm mix at any depth.
+   * conversion functions), use {@link #map(Class, Class, io.github.eschizoid.telescope.MapStep...)}
+   * — it handles both record↔record, POJO↔POJO, and any cross-paradigm mix at any depth.
    *
    * @see #map(Class, Class, io.github.eschizoid.telescope.MapStep...)
    */
@@ -357,17 +356,17 @@ public sealed class Telescope<
    * <p><b>Row kinds accepted.</b>
    *
    * <ul>
-   *   <li>{@link io.github.eschizoid.telescope.Mapping#to(Accessor, Accessor) to(src, tgt)}
-   *       — same-typed rename
+   *   <li>{@link io.github.eschizoid.telescope.Mapping#to(Accessor, Accessor) to(src, tgt)} —
+   *       same-typed rename
    *   <li>{@link io.github.eschizoid.telescope.Mapping#to(Accessor, Accessor,
    *       java.util.function.Function, java.util.function.Function) to(src, tgt, fwd, bwd)} — typed
    *       transform
-   *   <li>{@link io.github.eschizoid.telescope.Mapping#via(Accessor, Accessor, Mapper)
-   *       via(src, tgt, mapper)} — nested mapper
+   *   <li>{@link io.github.eschizoid.telescope.Mapping#via(Accessor, Accessor, Mapper) via(src,
+   *       tgt, mapper)} — nested mapper
    *   <li>{@link io.github.eschizoid.telescope.WriteHint#writeBean(Class,
-   *       io.github.eschizoid.telescope.WriteHint.WriteStrategy) writeBean(target,
-   *       strategy)} — per-target write-strategy override (e.g. force {@code CONSTRUCTOR} for an
-   *       immutable all-args-only POJO that {@code Beans.autoWriter} refuses)
+   *       io.github.eschizoid.telescope.WriteHint.WriteStrategy) writeBean(target, strategy)} —
+   *       per-target write-strategy override (e.g. force {@code CONSTRUCTOR} for an immutable
+   *       all-args-only POJO that {@code Beans.autoWriter} refuses)
    * </ul>
    *
    * @param source the source root class — record or POJO (root of the recursion)
@@ -456,9 +455,8 @@ public sealed class Telescope<
    * {@link MapPath} carrying the map type for later {@link MapPath#values()} navigation.
    *
    * <p>Named {@code mapField} (rather than {@code map}) to disambiguate from the sibling static
-   * deep-conversion factory {@link #map(Class, Class,
-   * io.github.eschizoid.telescope.MapStep...)} — those do conceptually different things and
-   * share the same verb otherwise.
+   * deep-conversion factory {@link #map(Class, Class, io.github.eschizoid.telescope.MapStep...)} —
+   * those do conceptually different things and share the same verb otherwise.
    */
   public <K, V> MapPath<S, K, V> mapField(final Accessor<A, Map<K, V>> getter) {
     final Lens<A, Map<K, V>> lens = lensForAccessor(getter);
@@ -616,8 +614,7 @@ public sealed class Telescope<
   /**
    * Compose this telescope with another via the lattice's {@code .then}. Lets you build a path in
    * pieces and stitch them together, and is how reusable conversions ({@link #from}, {@link
-   * #map(Class, Class, io.github.eschizoid.telescope.MapStep...)}) get threaded into a
-   * longer path.
+   * #map(Class, Class, io.github.eschizoid.telescope.MapStep...)}) get threaded into a longer path.
    *
    * <pre>{@code
    * final var userEmail = Telescope.of(User.class).field(User::email);   // reusable tail

--- a/core/src/main/java/io/github/eschizoid/telescope/Via.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/Via.java
@@ -42,9 +42,9 @@ record Via<A, B>(
 
   /**
    * The element-level {@link Iso} the user-supplied mapper produces. {@link
-   * io.github.eschizoid.telescope.DeepMap DeepMap} consumes this and, when the row's
-   * source/target field types are container shapes matching the mapper's element classes, lifts the
-   * Iso through the matching container (list / set / optional / map values).
+   * io.github.eschizoid.telescope.DeepMap DeepMap} consumes this and, when the row's source/target
+   * field types are container shapes matching the mapper's element classes, lifts the Iso through
+   * the matching container (list / set / optional / map values).
    */
   @SuppressWarnings("unchecked")
   Iso<?, ?> elementIso() {

--- a/core/src/main/java/io/github/eschizoid/telescope/WriteHint.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/WriteHint.java
@@ -1,6 +1,5 @@
 package io.github.eschizoid.telescope;
 
-
 /**
  * Per-target write-strategy override consumed by {@link Telescope#map(Class, Class, MapStep...)}.
  * Tells the deep-mapping engine which {@code Beans.BeanWriter} strategy to use when constructing an

--- a/core/src/main/java/io/github/eschizoid/telescope/internal/Beans.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/internal/Beans.java
@@ -189,8 +189,8 @@ public final class Beans {
 
   /**
    * The generic return type of {@code beanClass}'s getter for {@code name} (used by {@link
-   * io.github.eschizoid.telescope.DeepMap DeepMap} for container shape detection — {@code
-   * List<X>}, {@code Map<K, V>}, {@code Optional<X>}).
+   * io.github.eschizoid.telescope.DeepMap DeepMap} for container shape detection — {@code List<X>},
+   * {@code Map<K, V>}, {@code Optional<X>}).
    *
    * @throws IllegalArgumentException if no getter is found
    */

--- a/core/src/main/java/io/github/eschizoid/telescope/internal/Records.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/internal/Records.java
@@ -97,8 +97,8 @@ public final class Records {
 
   /**
    * The generic type of a record component by name (used by {@link
-   * io.github.eschizoid.telescope.DeepMap DeepMap} for container shape detection — {@code
-   * List<X>}, {@code Map<K, V>}, {@code Optional<X>}).
+   * io.github.eschizoid.telescope.DeepMap DeepMap} for container shape detection — {@code List<X>},
+   * {@code Map<K, V>}, {@code Optional<X>}).
    *
    * @throws IllegalArgumentException if the name doesn't match a component on {@code recordClass}
    */

--- a/core/src/main/java/io/github/eschizoid/telescope/internal/Reflective.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/internal/Reflective.java
@@ -9,12 +9,11 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 
 /**
- * The uniform reflective dispatch that {@link io.github.eschizoid.telescope.DeepMap
- * DeepMap} drives — abstracts over "this side is a record" vs "this side is a bean" so the
- * recursive resolver doesn't have to know. Per-side dispatch via {@link #of(Class)} lets a single
- * deep-mapping call mix and match records and POJOs at any depth: the source side of a given pair
- * uses one {@code Reflective}, the target side another, chosen independently from the pair's
- * classes.
+ * The uniform reflective dispatch that {@link io.github.eschizoid.telescope.DeepMap DeepMap} drives
+ * — abstracts over "this side is a record" vs "this side is a bean" so the recursive resolver
+ * doesn't have to know. Per-side dispatch via {@link #of(Class)} lets a single deep-mapping call
+ * mix and match records and POJOs at any depth: the source side of a given pair uses one {@code
+ * Reflective}, the target side another, chosen independently from the pair's classes.
  *
  * <p>The record's fields are the five per-side function references; the forwarding instance methods
  * ({@link #names(Class)}, {@link #genericType(Class, String)}, {@link #read(Object, String)},
@@ -32,10 +31,10 @@ import java.util.function.Function;
  *       no-arg ctor) are not supported by the auto path — use a record, or add a no-arg ctor.
  * </ul>
  *
- * <p>The lattice-first principle holds: {@link io.github.eschizoid.telescope.DeepMap
- * DeepMap} composes {@link io.github.eschizoid.telescope.internal.optics.Iso Iso}s; this record
- * only handles "how do I read one component value" and "how do I rebuild one object from a
- * name-keyed function." No bidirectional plumbing lives here.
+ * <p>The lattice-first principle holds: {@link io.github.eschizoid.telescope.DeepMap DeepMap}
+ * composes {@link io.github.eschizoid.telescope.internal.optics.Iso Iso}s; this record only handles
+ * "how do I read one component value" and "how do I rebuild one object from a name-keyed function."
+ * No bidirectional plumbing lives here.
  */
 public record Reflective(
   Function<Class<?>, String[]> names,
@@ -128,8 +127,8 @@ public record Reflective(
    *
    * <p>This is the lattice-routed shape of "rebuild an instance from named values" and "decompose
    * an instance into named values" — the two operations {@link
-   * io.github.eschizoid.telescope.DeepMap DeepMap} previously performed inline in the body
-   * of {@code assembleIso}. Lifting them to an {@link Iso} lets {@code assembleIso} express the
+   * io.github.eschizoid.telescope.DeepMap DeepMap} previously performed inline in the body of
+   * {@code assembleIso}. Lifting them to an {@link Iso} lets {@code assembleIso} express the
    * per-pair {@code Iso<S, T>} as the composition {@code
    * srcReader.reverse().then(middle).then(tgtBuilder)} — pure lattice {@code .then()}, no manual
    * function-body construction.

--- a/core/src/main/java/io/github/eschizoid/telescope/package-info.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/package-info.java
@@ -3,9 +3,8 @@
  * lifting through effects over Java records and POJOs. One {@link
  * io.github.eschizoid.telescope.Telescope Telescope&lt;S, A&gt;} type carries the navigation path
  * and every terminal operation (read / write / single-shot effects / multi-edit / deep mapping);
- * complements {@link io.github.eschizoid.telescope.Mapper Mapper&lt;A, B&gt;} from
- * {@link io.github.eschizoid.telescope.conversion} for the cases that benefit from sparse-overlay
- * patching or explicit container lifting.
+ * complements {@link io.github.eschizoid.telescope.Mapper Mapper&lt;A, B&gt;} for the cases that
+ * benefit from sparse-overlay patching or explicit container lifting.
  *
  * <h2>Entry points</h2>
  *

--- a/core/src/main/java/module-info.java
+++ b/core/src/main/java/module-info.java
@@ -6,31 +6,25 @@
  * {@code @Bridge}) eliminates per-call reflection on hot paths without changing the API users
  * write.
  *
- * <p>Four packages are exported:
+ * <p>Two packages are exported:
  *
  * <ul>
  *   <li>{@link io.github.eschizoid.telescope} — the DSL surface. {@link
  *       io.github.eschizoid.telescope.Telescope} (navigation + read + write + effects + deep
- *       mapping factory), the {@link io.github.eschizoid.telescope.Either} / {@link
+ *       mapping factory), {@link io.github.eschizoid.telescope.Mapper} (bidirectional graph mapper
+ *       with {@code forward} / {@code backward} / {@code patch} / {@code asTelescope} / container-
+ *       lift surface), the {@link io.github.eschizoid.telescope.Either} / {@link
  *       io.github.eschizoid.telescope.Validated} sealed effect types, {@link
- *       io.github.eschizoid.telescope.Indexed} for indexed traversals, and the multi-edit primitive
- *       {@link io.github.eschizoid.telescope.Edit}.
+ *       io.github.eschizoid.telescope.Indexed} for indexed traversals, the multi-edit primitive
+ *       {@link io.github.eschizoid.telescope.Edit}, and the row-builder DSL that the deep-mapping
+ *       factory accepts as varargs ({@link io.github.eschizoid.telescope.Mapping#to to}, {@link
+ *       io.github.eschizoid.telescope.Mapping#via via}, {@link
+ *       io.github.eschizoid.telescope.WriteHint#writeBean writeBean} / {@link
+ *       io.github.eschizoid.telescope.WriteHint#writeBeans writeBeans}).
  *   <li>{@link io.github.eschizoid.telescope.annotations} — compile-time markers for the codegen
  *       processors: {@code @Focus} (records), {@code @BeanFocus} (POJOs, also for Lombok-annotated
  *       classes via the {@code telescope-lombok} module), {@code @Bridge} (compile-checked
  *       cross-paradigm conversion).
- *   <li>{@link io.github.eschizoid.telescope.conversion} — the {@link
- *       io.github.eschizoid.telescope.Mapper} type: bidirectional graph mapper produced
- *       by {@link io.github.eschizoid.telescope.Telescope#mapper(Class, Class,
- *       io.github.eschizoid.telescope.MapStep...) Telescope.mapper}, with {@code forward} /
- *       {@code backward} / {@code patch} / {@code asTelescope} / container-lift surface.
- *   <li>{@link io.github.eschizoid.telescope.mapping} — the row-builder DSL the deep-mapping
- *       factory accepts as varargs: {@link io.github.eschizoid.telescope.Mapping#to to}
- *       (rename / typed transform), {@link io.github.eschizoid.telescope.Mapping#via via}
- *       (nested mapper, auto-lifted through containers), {@link
- *       io.github.eschizoid.telescope.WriteHint#writeBean writeBean} / {@link
- *       io.github.eschizoid.telescope.WriteHint#writeBeans writeBeans} (per-target /
- *       default bean write-strategy hints).
  * </ul>
  *
  * <p>The {@code io.github.eschizoid.telescope.internal} packages are deliberately not exported.

--- a/core/src/test/java/io/github/eschizoid/telescope/DeepMapPhaseCHolderTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/DeepMapPhaseCHolderTest.java
@@ -1,9 +1,8 @@
-package io.github.eschizoid.telescope.mapping;
+package io.github.eschizoid.telescope;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import io.github.eschizoid.telescope.Telescope;
 import io.github.eschizoid.telescope.internal.MetadataHolderProbe;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/core/src/test/java/io/github/eschizoid/telescope/DeepMapPhaseDConstructTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/DeepMapPhaseDConstructTest.java
@@ -1,10 +1,9 @@
-package io.github.eschizoid.telescope.mapping;
+package io.github.eschizoid.telescope;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import io.github.eschizoid.telescope.Telescope;
 import io.github.eschizoid.telescope.internal.MetadataHolderProbe;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/core/src/test/java/io/github/eschizoid/telescope/DeepMappingTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/DeepMappingTest.java
@@ -13,7 +13,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import io.github.eschizoid.telescope.Mapper;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -27,12 +26,11 @@ import org.junit.jupiter.api.Test;
 /**
  * Tests for the deep recursive {@link Telescope#map(Class, Class,
  * io.github.eschizoid.telescope.MapStep...)} / {@link Telescope#mapper(Class, Class,
- * io.github.eschizoid.telescope.MapStep...)} factories — the "explore the academia
- * boundaries" shape. Each test exercises a different facet of the recursion: same-name copy,
- * container traversal at multiple depths (List, Set, Map, Optional — N-level nestable), renames
- * keyed by type pair applying at any depth, typed transforms, nested mappers via {@code via},
- * per-target {@code writeBean} construction hints, and self-referencing structures (cycle
- * handling).
+ * io.github.eschizoid.telescope.MapStep...)} factories — the "explore the academia boundaries"
+ * shape. Each test exercises a different facet of the recursion: same-name copy, container
+ * traversal at multiple depths (List, Set, Map, Optional — N-level nestable), renames keyed by type
+ * pair applying at any depth, typed transforms, nested mappers via {@code via}, per-target {@code
+ * writeBean} construction hints, and self-referencing structures (cycle handling).
  */
 class DeepMappingTest {
 

--- a/core/src/test/java/io/github/eschizoid/telescope/PhaseCDst.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/PhaseCDst.java
@@ -1,4 +1,4 @@
-package io.github.eschizoid.telescope.mapping;
+package io.github.eschizoid.telescope;
 
 import io.github.eschizoid.telescope.annotations.Focus;
 

--- a/core/src/test/java/io/github/eschizoid/telescope/PhaseCPlainDst.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/PhaseCPlainDst.java
@@ -1,4 +1,4 @@
-package io.github.eschizoid.telescope.mapping;
+package io.github.eschizoid.telescope;
 
 /**
  * Top-level no-annotation fixture paired with {@link PhaseCPlainSrc} for {@link

--- a/core/src/test/java/io/github/eschizoid/telescope/PhaseCPlainSrc.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/PhaseCPlainSrc.java
@@ -1,4 +1,4 @@
-package io.github.eschizoid.telescope.mapping;
+package io.github.eschizoid.telescope;
 
 /**
  * Top-level no-annotation fixture for {@link DeepMapPhaseCHolderTest}. Has no sibling {@code

--- a/core/src/test/java/io/github/eschizoid/telescope/PhaseCSrc.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/PhaseCSrc.java
@@ -1,4 +1,4 @@
-package io.github.eschizoid.telescope.mapping;
+package io.github.eschizoid.telescope;
 
 import io.github.eschizoid.telescope.annotations.Focus;
 

--- a/examples/library/src/main/java/io/github/eschizoid/telescope/examples/DeepMappingDemo.java
+++ b/examples/library/src/main/java/io/github/eschizoid/telescope/examples/DeepMappingDemo.java
@@ -5,8 +5,8 @@ import static io.github.eschizoid.telescope.Mapping.via;
 import static io.github.eschizoid.telescope.WriteHint.WriteStrategy.CONSTRUCTOR;
 import static io.github.eschizoid.telescope.WriteHint.writeBean;
 
-import io.github.eschizoid.telescope.Telescope;
 import io.github.eschizoid.telescope.Mapper;
+import io.github.eschizoid.telescope.Telescope;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;

--- a/examples/springboot/README.md
+++ b/examples/springboot/README.md
@@ -92,13 +92,13 @@ value-level cycle once Hibernate populates both sides — `bob.manager == alice 
   materialises with first-level associations intact; deeper back-pointers collapse to empty.
 - `spring.jpa.open-in-view=false` — production hygiene. The transactional boundary is the controller, not the view.
 - **vs MapStruct:** MapStruct doesn't have first-class cycle handling for self-referencing graphs. Workarounds involve
-`@Context` cycle trackers or splitting into two interfaces. Telescope handles type-level cycles at construction
-(TypePair cache) and value-level cycles at traversal (IdentityHashMap seen-set) without user wiring. See
-[How it compares to MapStruct → "When telescope is the right pick"](../../README.md#when-telescope-is-the-right-pick).
+  `@Context` cycle trackers or splitting into two interfaces. Telescope handles type-level cycles at construction
+  (TypePair cache) and value-level cycles at traversal (IdentityHashMap seen-set) without user wiring. See
+  [How it compares to MapStruct → "When telescope is the right pick"](../../README.md#when-telescope-is-the-right-pick).
 - **Perf receipts:** see
-[`TelescopeBenchmark.java`](../../benchmarks/src/jmh/java/io/github/eschizoid/telescope/benchmarks/TelescopeBenchmark.java)
-for general runtime-path numbers; the cycle severance itself adds an IdentityHashMap probe per leaf — negligible vs the
-structural-iso decompose/recompose dominant cost.
+  [`TelescopeBenchmark.java`](../../benchmarks/src/jmh/java/io/github/eschizoid/telescope/benchmarks/TelescopeBenchmark.java)
+  for general runtime-path numbers; the cycle severance itself adds an IdentityHashMap probe per leaf — negligible vs
+  the structural-iso decompose/recompose dominant cost.
 
 ---
 
@@ -140,14 +140,14 @@ wiring. Useful when a particular conversion is in your tightest loop and you wan
   on a generated class. Compile-time bound, IDE-navigable, no reflection in the hot path. Pair this with the runtime API
   for the rest of the app — the two paradigms compose freely.
 - **vs MapStruct:** this is the apples-to-apples comparison. Both generate conversion code at compile time. MapStruct
-makes you declare a `@Mapper` interface for each pair and a separate one for the inverse; telescope's `@Bridge`
-generates both directions from a single annotation, and parent bridges auto-recurse through user-declared child bridges.
-See
-[How it compares to MapStruct → "When MapStruct is the right pick"](../../README.md#when-mapstruct-is-the-right-pick)
-for cases where MapStruct's tooling beats this.
+  makes you declare a `@Mapper` interface for each pair and a separate one for the inverse; telescope's `@Bridge`
+  generates both directions from a single annotation, and parent bridges auto-recurse through user-declared child
+  bridges. See
+  [How it compares to MapStruct → "When MapStruct is the right pick"](../../README.md#when-mapstruct-is-the-right-pick)
+  for cases where MapStruct's tooling beats this.
 - **Perf receipts:** `bridgeForwardRead` (~15 ns/op) in `:benchmarks` is the closest match to this code path — direct
-generated method call, no runtime mapper. See
-[`TelescopeBenchmark.java`](../../benchmarks/src/jmh/java/io/github/eschizoid/telescope/benchmarks/TelescopeBenchmark.java).
+  generated method call, no runtime mapper. See
+  [`TelescopeBenchmark.java`](../../benchmarks/src/jmh/java/io/github/eschizoid/telescope/benchmarks/TelescopeBenchmark.java).
 
 ---
 

--- a/examples/springboot/order-jpa/src/main/java/io/github/eschizoid/telescope/demo/spring/api/AdminTouchController.java
+++ b/examples/springboot/order-jpa/src/main/java/io/github/eschizoid/telescope/demo/spring/api/AdminTouchController.java
@@ -1,7 +1,7 @@
 package io.github.eschizoid.telescope.demo.spring.api;
 
-import io.github.eschizoid.telescope.Telescope;
 import io.github.eschizoid.telescope.Mapper;
+import io.github.eschizoid.telescope.Telescope;
 import io.github.eschizoid.telescope.demo.spring.domain.Order;
 import io.github.eschizoid.telescope.demo.spring.persistence.OrderEntity;
 import io.github.eschizoid.telescope.demo.spring.persistence.OrderRepository;

--- a/examples/springboot/order-jpa/src/main/java/io/github/eschizoid/telescope/demo/spring/api/BulkUpdateController.java
+++ b/examples/springboot/order-jpa/src/main/java/io/github/eschizoid/telescope/demo/spring/api/BulkUpdateController.java
@@ -3,8 +3,8 @@ package io.github.eschizoid.telescope.demo.spring.api;
 import static io.github.eschizoid.telescope.Edit.mapIfPresent;
 import static io.github.eschizoid.telescope.Edit.overIfPresent;
 
-import io.github.eschizoid.telescope.Telescope;
 import io.github.eschizoid.telescope.Mapper;
+import io.github.eschizoid.telescope.Telescope;
 import io.github.eschizoid.telescope.demo.spring.domain.Address;
 import io.github.eschizoid.telescope.demo.spring.domain.Customer;
 import io.github.eschizoid.telescope.demo.spring.domain.LineItem;

--- a/examples/springboot/order-jpa/src/main/java/io/github/eschizoid/telescope/demo/spring/api/InspectController.java
+++ b/examples/springboot/order-jpa/src/main/java/io/github/eschizoid/telescope/demo/spring/api/InspectController.java
@@ -1,7 +1,7 @@
 package io.github.eschizoid.telescope.demo.spring.api;
 
-import io.github.eschizoid.telescope.Telescope;
 import io.github.eschizoid.telescope.Mapper;
+import io.github.eschizoid.telescope.Telescope;
 import io.github.eschizoid.telescope.demo.spring.domain.Order;
 import io.github.eschizoid.telescope.demo.spring.persistence.OrderEntity;
 import io.github.eschizoid.telescope.demo.spring.persistence.OrderRepository;

--- a/examples/springboot/order-jpa/src/main/java/io/github/eschizoid/telescope/demo/spring/api/OrderController.java
+++ b/examples/springboot/order-jpa/src/main/java/io/github/eschizoid/telescope/demo/spring/api/OrderController.java
@@ -1,7 +1,7 @@
 package io.github.eschizoid.telescope.demo.spring.api;
 
-import io.github.eschizoid.telescope.Telescope;
 import io.github.eschizoid.telescope.Mapper;
+import io.github.eschizoid.telescope.Telescope;
 import io.github.eschizoid.telescope.demo.spring.domain.Customer;
 import io.github.eschizoid.telescope.demo.spring.domain.Order;
 import io.github.eschizoid.telescope.demo.spring.persistence.OrderEntity;

--- a/examples/springboot/order-jpa/src/main/java/io/github/eschizoid/telescope/demo/spring/mapping/OrderMappers.java
+++ b/examples/springboot/order-jpa/src/main/java/io/github/eschizoid/telescope/demo/spring/mapping/OrderMappers.java
@@ -6,8 +6,8 @@ import static io.github.eschizoid.telescope.Mapping.via;
 import static io.github.eschizoid.telescope.WriteHint.WriteStrategy.SETTERS;
 import static io.github.eschizoid.telescope.WriteHint.writeBeans;
 
-import io.github.eschizoid.telescope.Telescope;
 import io.github.eschizoid.telescope.Mapper;
+import io.github.eschizoid.telescope.Telescope;
 import io.github.eschizoid.telescope.demo.spring.domain.Customer;
 import io.github.eschizoid.telescope.demo.spring.domain.LineItem;
 import io.github.eschizoid.telescope.demo.spring.domain.Order;
@@ -25,9 +25,9 @@ import org.springframework.context.annotation.Configuration;
 /**
  * Wires the top-level {@code Order ↔ OrderEntity} mapper. All four record↔entity type pairs (Order,
  * Customer, LineItem, Address) live under one {@link Telescope#mapper(Class, Class,
- * io.github.eschizoid.telescope.MapStep...)} call — the deep-mapping engine groups rows by
- * {@code (sourceClass, targetClass)} pair, so a row written here applies wherever that pair shows
- * up in the recursive walk (top-level for Order, depth-1 for Customer, depth-1 for the shipping and
+ * io.github.eschizoid.telescope.MapStep...)} call — the deep-mapping engine groups rows by {@code
+ * (sourceClass, targetClass)} pair, so a row written here applies wherever that pair shows up in
+ * the recursive walk (top-level for Order, depth-1 for Customer, depth-1 for the shipping and
  * billing addresses, depth-2 inside the list of line items).
  *
  * <p>The configuration is consumed by both controllers. Underlying dispatch is transparent: when
@@ -94,8 +94,7 @@ public class OrderMappers {
 
   /**
    * A reusable {@code Customer ↔ CustomerEntity} mapper, broken out so {@link #orderMapper(Mapper,
-   * Mapper) orderMapper} can drop it in via {@link
-   * io.github.eschizoid.telescope.Mapping#via(
+   * Mapper) orderMapper} can drop it in via {@link io.github.eschizoid.telescope.Mapping#via(
    * io.github.eschizoid.telescope.Telescope.Accessor,
    * io.github.eschizoid.telescope.Telescope.Accessor, Mapper) via} as a <em>scalar</em> nested
    * mapper (one-to-one record-pair slot, no container lift). Same shape as the {@link

--- a/examples/springboot/order-jpa/src/test/java/io/github/eschizoid/telescope/demo/spring/AdminTouchControllerTest.java
+++ b/examples/springboot/order-jpa/src/test/java/io/github/eschizoid/telescope/demo/spring/AdminTouchControllerTest.java
@@ -23,9 +23,9 @@ import org.springframework.web.client.RestClient;
  *
  * <ol>
  *   <li>A two-segment write path ({@code shippingAddress.city}) sets the nested leaf and persists
- *       it — a follow-up GET reads the new value back. {@code shippingAddress} is {@code
- *       @Embedded} on {@code OrderEntity}, so the update lands in the same row as the parent and
- *       the cascade config is irrelevant.
+ *       it — a follow-up GET reads the new value back. {@code shippingAddress} is {@code @Embedded}
+ *       on {@code OrderEntity}, so the update lands in the same row as the parent and the cascade
+ *       config is irrelevant.
  *   <li>A wrong leaf segment surfaces a {@code 400} carrying the offending field name, the
  *       declaring class (the nested record, not the top-level one), AND the list of known
  *       components on that class.

--- a/examples/springboot/order-jpa/src/test/java/io/github/eschizoid/telescope/demo/spring/CustomerTagsSetFieldTest.java
+++ b/examples/springboot/order-jpa/src/test/java/io/github/eschizoid/telescope/demo/spring/CustomerTagsSetFieldTest.java
@@ -2,8 +2,8 @@ package io.github.eschizoid.telescope.demo.spring;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.github.eschizoid.telescope.Telescope;
 import io.github.eschizoid.telescope.Mapper;
+import io.github.eschizoid.telescope.Telescope;
 import io.github.eschizoid.telescope.demo.spring.domain.Customer;
 import io.github.eschizoid.telescope.demo.spring.domain.Order;
 import io.github.eschizoid.telescope.demo.spring.persistence.OrderEntity;

--- a/examples/springboot/org-chart/src/main/java/io/github/eschizoid/telescope/demo/orgchart/mapping/EmployeeMappers.java
+++ b/examples/springboot/org-chart/src/main/java/io/github/eschizoid/telescope/demo/orgchart/mapping/EmployeeMappers.java
@@ -3,8 +3,8 @@ package io.github.eschizoid.telescope.demo.orgchart.mapping;
 import static io.github.eschizoid.telescope.WriteHint.WriteStrategy.SETTERS;
 import static io.github.eschizoid.telescope.WriteHint.writeBeans;
 
-import io.github.eschizoid.telescope.Telescope;
 import io.github.eschizoid.telescope.Mapper;
+import io.github.eschizoid.telescope.Telescope;
 import io.github.eschizoid.telescope.demo.orgchart.domain.Employee;
 import io.github.eschizoid.telescope.demo.orgchart.persistence.EmployeeEntity;
 import org.springframework.context.annotation.Bean;
@@ -12,10 +12,10 @@ import org.springframework.context.annotation.Configuration;
 
 /**
  * Wires a single {@code Mapper<Employee, EmployeeEntity>} via {@link Telescope#mapper(Class, Class,
- * io.github.eschizoid.telescope.MapStep...)}. All fields are same-name + same-shape (id,
- * name, manager, reports) — so this is a pure auto-inference test of {@link
- * io.github.eschizoid.telescope.DeepMap}'s TypePair cycle cache against a self-referencing
- * pair {@code (Employee, EmployeeEntity)}.
+ * io.github.eschizoid.telescope.MapStep...)}. All fields are same-name + same-shape (id, name,
+ * manager, reports) — so this is a pure auto-inference test of {@link
+ * io.github.eschizoid.telescope.DeepMap}'s TypePair cycle cache against a self-referencing pair
+ * {@code (Employee, EmployeeEntity)}.
  */
 @Configuration
 public class EmployeeMappers {

--- a/examples/springboot/org-chart/src/test/java/io/github/eschizoid/telescope/demo/orgchart/JpaCycleMappingTest.java
+++ b/examples/springboot/org-chart/src/test/java/io/github/eschizoid/telescope/demo/orgchart/JpaCycleMappingTest.java
@@ -24,10 +24,9 @@ import org.springframework.transaction.annotation.Transactional;
  *
  * <ol>
  *   <li><b>Type-level cycle resolution at {@code Telescope.mapper(...)} construction time.</b>
- *       {@link io.github.eschizoid.telescope.DeepMap} reserves the TypePair slot before
- *       recursing into auto-derived component Isos, so {@code Employee} containing {@code
- *       Optional<Employee> manager} + {@code List<Employee> reports} resolves without
- *       stack-overflow.
+ *       {@link io.github.eschizoid.telescope.DeepMap} reserves the TypePair slot before recursing
+ *       into auto-derived component Isos, so {@code Employee} containing {@code Optional<Employee>
+ *       manager} + {@code List<Employee> reports} resolves without stack-overflow.
  *   <li><b>Value-level traversal at {@code mapper.backward(entityFromDb)} time.</b> Hibernate
  *       populates bidirectional associations on hydration: once bob is initialized, {@code
  *       bob.getManager() == alice} and {@code alice.getReports().contains(bob)}, a literal

--- a/examples/springboot/product-starter/src/main/java/io/github/eschizoid/telescope/demo/starter/mapping/ProductMappers.java
+++ b/examples/springboot/product-starter/src/main/java/io/github/eschizoid/telescope/demo/starter/mapping/ProductMappers.java
@@ -5,8 +5,8 @@ import static io.github.eschizoid.telescope.WriteHint.WriteStrategy.SETTERS;
 import static io.github.eschizoid.telescope.WriteHint.writeBean;
 import static io.github.eschizoid.telescope.WriteHint.writeBeans;
 
-import io.github.eschizoid.telescope.Telescope;
 import io.github.eschizoid.telescope.Mapper;
+import io.github.eschizoid.telescope.Telescope;
 import io.github.eschizoid.telescope.demo.starter.domain.Product;
 import io.github.eschizoid.telescope.demo.starter.partner.ProductDto;
 import io.github.eschizoid.telescope.demo.starter.partner.ProductManifest;

--- a/lombok/README.md
+++ b/lombok/README.md
@@ -1,0 +1,120 @@
+# telescope-lombok
+
+Compile-time `<X>Path<R>` navigator emission for Lombok-annotated POJOs. Sibling of
+[`telescope-codegen`](../codegen/README.md), out-of-tree consumer of the same `AbstractTelescopeProcessor` base — split
+because Lombok's lazy AST patching breaks the in-memory test harness `:codegen` uses, and round-deferred emission means
+a different processor lifecycle.
+
+If you write `@Data` / `@Value` / `@Builder` POJOs and want the same reflection-free navigator shape that `@Focus` gives
+records, this is the processor.
+
+## When to use
+
+You have a Lombok POJO:
+
+```java
+@Data
+public class User {
+
+  private String id;
+  private String email;
+  private Address address;
+}
+```
+
+You want the same compile-checked navigator as `@Focus`/`@BeanFocus`:
+
+```java
+UserPath.start()
+    .address().city()
+    .update(user, city -> city.toLowerCase());
+```
+
+Add the `telescope-lombok` annotation processor alongside Lombok itself. No annotations on your classes needed — the
+processor detects `@lombok.Data`, `@lombok.Value`, and `@lombok.Builder` by string FQN and emits the navigator. (No
+compile-time Lombok dependency on the processor jar — the detection is graceful no-op if Lombok isn't on the consumer's
+classpath.)
+
+## Install
+
+```kotlin
+// Gradle
+dependencies {
+    implementation("io.github.eschizoid:telescope:0.4.1")
+
+    // Lombok itself
+    compileOnly("org.projectlombok:lombok:1.18.42")
+    annotationProcessor("org.projectlombok:lombok:1.18.42")
+
+    // Telescope's Lombok-aware codegen — must come AFTER Lombok in the processor list so
+    // Lombok's AST patches have fired when telescope reads the synthesized members.
+    annotationProcessor("io.github.eschizoid:telescope-lombok:0.4.1")
+}
+```
+
+```xml
+<!-- Maven -->
+<plugin>
+  <groupId>org.apache.maven.plugins</groupId>
+  <artifactId>maven-compiler-plugin</artifactId>
+  <configuration>
+    <annotationProcessorPaths>
+      <path>
+        <groupId>org.projectlombok</groupId>
+        <artifactId>lombok</artifactId>
+        <version>1.18.42</version>
+      </path>
+      <path>
+        <groupId>io.github.eschizoid</groupId>
+        <artifactId>telescope-lombok</artifactId>
+        <version>0.4.1</version>
+      </path>
+    </annotationProcessorPaths>
+  </configuration>
+</plugin>
+```
+
+## The round-deferred-emission gotcha
+
+Don't process a Lombok-annotated class in round 1 of annotation processing. Lombok installs lazy AST visitors during
+processor init that patch class declarations on traversal. Those visitors haven't necessarily fired by round 1; a
+processor that queries `Elements.getAllMembers()` on a `@Data` class in round 1 sees the un-patched member list (no
+synthesised getters / setters / builder), causing a "no readable properties" error.
+
+`telescope-lombok` handles this by collecting Lombok-annotated targets every round and only emitting on
+`processingOver()`. Any future Lombok-touching processor in this repo must follow the same pattern — see
+`LombokFocusProcessor.java`.
+
+## Generated output
+
+Same `<X>Path<R>` shape as [`telescope-codegen`'s](../codegen/README.md) emission — see that module's README for the
+full structure. The processor uses the Lombok-synthesised getter / setter / builder where present:
+
+- `@Data` / `@Value` → read via `getFoo()` / `isFoo()`, rebuild via no-arg ctor + setters
+- `@Builder` → rebuild via the generated `Builder.foo(value).build()` chain
+
+If a class carries both `@Data` and `@Builder`, the builder rebuild path wins (higher fidelity for field-renamed builder
+methods).
+
+## Caveat: same-module main code can't reference the emitted Path
+
+Lombok-emitted `<Pojo>Path<R>` is emitted in `processingOver()` — the final processor round, after main-source symbol
+resolution. Same-module main code that directly references `<Pojo>Path` won't compile, since the symbol isn't visible
+until after main resolution finishes.
+
+Workarounds:
+
+- Reference the Path from test code (works — test compilation is a separate phase)
+- Reference from downstream modules (works — they're compiled later, the jar carries the emitted Path)
+- For same-module main code, use the reflective `Telescope.ofBean(Pojo.class).field(Pojo::getFoo)` path instead.
+  Slightly slower; gets the same end-state.
+
+This is a structural limitation of Lombok's lifecycle, not a `telescope-lombok` bug.
+
+## Cross-module symmetry
+
+| Use case                                                 | Module                                                        |
+| -------------------------------------------------------- | ------------------------------------------------------------- |
+| Records (`record User(String id, String email) {}`)      | [`telescope-codegen`](../codegen/README.md) with `@Focus`     |
+| Plain POJOs (manual getters / setters / builder)         | [`telescope-codegen`](../codegen/README.md) with `@BeanFocus` |
+| Lombok-generated POJOs (`@Data` / `@Value` / `@Builder`) | **`telescope-lombok`** (no annotation needed)                 |

--- a/quarkus/README.md
+++ b/quarkus/README.md
@@ -1,0 +1,121 @@
+# telescope-quarkus
+
+Drop-in Quarkus 3 CDI extension for [telescope](../README.md). Adds one CDI bean — a typed `Mapper<A, B>` registry — and
+nothing else. Mirrors the [`spring-boot-starter`](../spring-boot-starter/README.md) surface for Quarkus apps.
+
+```kotlin
+dependencies {
+    implementation("io.github.eschizoid:telescope-quarkus:0.4.1")
+}
+```
+
+No `@EnableTelescope` annotation. No `application.properties` you have to touch. Declare any `@Produces Mapper<A, B>`
+method (or `@ApplicationScoped` class) and it shows up in the registry; the registry resolves them by
+`(sourceClass, targetClass)` pair.
+
+## What you get
+
+- **`TelescopeMapperRegistry`** — auto-built `@ApplicationScoped` bean, indexes every `Mapper<?, ?>` ArC can resolve
+  into the application. Polymorphic dispatch: generic services receive `Object` and convert via
+  `registry.get(src.getClass(), Target.class).forward(src)` without enumerating type pairs.
+- **`TelescopeProducer`** — CDI producer that uses ArC's `@All List<Mapper<?, ?>>` collector to inject every mapper
+  bean.
+- **`TelescopeConfig`** — `@ConfigMapping(prefix = "telescope")` interface for the `telescope.registry.fail-fast`
+  toggle.
+
+The jar ships a pre-built `META-INF/jandex.idx` so Quarkus skips the startup bytecode scan and avoids the "Application
+archive ... is being scanned without a Jandex index" warning.
+
+## Install
+
+```kotlin
+// Gradle (Quarkus 3 BOM picks up Quarkus's version)
+dependencies {
+    implementation(platform("io.quarkus.platform:quarkus-bom:3.20.0"))
+    implementation("io.github.eschizoid:telescope-quarkus:0.4.1")
+}
+```
+
+```xml
+<!-- Maven -->
+<dependency>
+  <groupId>io.github.eschizoid</groupId>
+  <artifactId>telescope-quarkus</artifactId>
+  <version>0.4.1</version>
+</dependency>
+```
+
+The `telescope` core library comes along transitively (`api` scope).
+
+## Minimum viable example
+
+```java
+@ApplicationScoped
+public class MapperProducers {
+
+  @Produces
+  @ApplicationScoped
+  Mapper<Order, OrderEntity> orderMapper() {
+    return Telescope.mapper(Order.class, OrderEntity.class);
+  }
+
+  @Produces
+  @ApplicationScoped
+  Mapper<Order, OrderDto> orderDtoMapper() {
+    return Telescope.mapper(Order.class, OrderDto.class);
+  }
+}
+
+@ApplicationScoped
+public class OrderConverter {
+
+  @Inject
+  TelescopeMapperRegistry registry;
+
+  // Polymorphic conversion — no switch over known type pairs.
+  public <A, B> B convert(A src, Class<B> targetClass) {
+    @SuppressWarnings("unchecked")
+    Mapper<A, B> mapper = (Mapper<A, B>) registry.get(src.getClass(), targetClass);
+    return mapper.forward(src);
+  }
+}
+```
+
+## Configuration
+
+| Property                       | Default | Effect                                                                                                                                                                                      |
+| ------------------------------ | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `telescope.registry.fail-fast` | `true`  | When `true`, `registry.get(srcCls, tgtCls)` throws `IllegalArgumentException` on a missing type pair. When `false`, returns `null`. Either way, `registry.find(...)` returns an `Optional`. |
+
+`application.properties`:
+
+```properties
+telescope.registry.fail-fast=false
+```
+
+## Overrides
+
+To suppress the default registry (e.g. to provide your own), declare your own `@Produces TelescopeMapperRegistry` bean.
+CDI's alternatives / `@Specializes` picks yours over ours.
+
+## Duplicate-pair behaviour
+
+Defining two beans for the same `(srcClass, tgtClass)` pair fails at registry construction with `IllegalStateException`
+— the pair must uniquely identify a mapper. If you genuinely have two semantically-different mappers for the same pair,
+qualify them with `@Named` / `@Qualifier` and `@Inject` the specific bean instead of going through the registry.
+
+## What's NOT here
+
+This is a runtime-only extension — no separate `deployment` module, no `@BuildStep` recorders. Beans are discovered via
+Jandex + `beans.xml` at startup; the registry's index is built once at application bootstrap and then immutable. For
+most cases this is fine; if you need build-time optimization for an enormous mapper graph, a follow-up split into
+`deployment` + `runtime` would be the path.
+
+`@QuarkusTest` integration tests aren't shipped — the registry is pure Java with no CDI dependency, so the existing unit
+tests cover the behaviour. Add a `@QuarkusTest` in your own application if you want to validate the producer wiring
+end-to-end.
+
+## Spring Boot equivalent
+
+`telescope-spring-boot-starter` ships the same registry shape via Spring's auto-config — see
+[`spring-boot-starter`](../spring-boot-starter/README.md) for the Spring 4 equivalent.

--- a/quarkus/build.gradle.kts
+++ b/quarkus/build.gradle.kts
@@ -1,0 +1,127 @@
+plugins {
+    `java-library`
+    `maven-publish`
+    signing
+    jacoco
+    // Quarkus discovers CDI beans via a pre-built Jandex index instead of scanning bytecode at
+    // startup. Without this plugin the produced jar has no META-INF/jandex.idx and users see a
+    // "Application archive ... is being scanned without a Jandex index" warning + a slower boot.
+    id("org.kordamp.gradle.jandex") version "2.1.0"
+}
+
+description = "telescope-quarkus — Quarkus CDI extension + Mapper<A,B> bean registry for telescope"
+
+base {
+    archivesName = "telescope-quarkus"
+}
+
+repositories {
+    mavenCentral()
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+    withSourcesJar()
+    withJavadocJar()
+}
+
+tasks.withType<JavaCompile>().configureEach {
+    options.release = 25
+    options.encoding = "UTF-8"
+    options.compilerArgs.addAll(listOf("-Xlint:all,-processing", "-parameters"))
+}
+
+tasks.withType<Test>().configureEach {
+    useJUnitPlatform()
+    testLogging {
+        events("passed", "failed", "skipped")
+    }
+}
+
+tasks.jacocoTestReport {
+    reports {
+        csv.required.set(true)
+        xml.required.set(true)
+        html.required.set(true)
+    }
+}
+
+tasks.withType<Javadoc>().configureEach {
+    (options as StandardJavadocDocletOptions).apply {
+        addStringOption("Xdoclint:all,-missing", "-quiet")
+    }
+}
+
+val quarkusVersion = "3.20.0"
+
+dependencies {
+    // Telescope core travels with the extension — consumers of the artifact expect the library to
+    // come along with no extra dependency declarations. `api` puts it in the published POM.
+    api(project(":core"))
+
+    // Quarkus ArC is the CDI runtime — provides @ApplicationScoped, @Produces, @Inject, and the
+    // @All collector annotation used to inject every Mapper<?, ?> bean as a List. `api` so users
+    // can write their own @Inject TelescopeMapperRegistry without an extra dep declaration.
+    api(platform("io.quarkus.platform:quarkus-bom:$quarkusVersion"))
+    api("io.quarkus:quarkus-arc")
+
+    testImplementation(platform(libs.junitBom))
+    testImplementation(libs.junitJupiter)
+    testRuntimeOnly(libs.junitPlatformLauncher)
+    testImplementation("org.assertj:assertj-core:3.27.7")
+}
+
+publishing {
+    publications {
+        create<MavenPublication>("maven") {
+            groupId = "io.github.eschizoid"
+            artifactId = "telescope-quarkus"
+            from(components["java"])
+
+            pom {
+                name.set("telescope-quarkus")
+                description.set(
+                    "Quarkus CDI extension + Mapper<A,B> bean registry for the telescope optics DSL."
+                )
+                url.set("https://github.com/eschizoid/telescope")
+                inceptionYear.set("2026")
+
+                licenses {
+                    license {
+                        name.set("Apache-2.0")
+                        url.set("https://www.apache.org/licenses/LICENSE-2.0")
+                    }
+                }
+                developers {
+                    developer {
+                        id.set("eschizoid")
+                        name.set("Mariano Gonzalez")
+                        email.set("mariano.gonzalez.mx@gmail.com")
+                    }
+                }
+                scm {
+                    connection.set("scm:git:git@github.com:eschizoid/telescope.git")
+                    developerConnection.set("scm:git:git@github.com:eschizoid/telescope.git")
+                    url.set("https://github.com/eschizoid/telescope")
+                }
+            }
+        }
+    }
+    repositories {
+        maven {
+            url = uri(layout.buildDirectory.dir("staging-deploy"))
+        }
+    }
+}
+
+signing {
+    val signingKey =
+        System.getenv("JRELEASER_GPG_SECRET_KEY") ?: project.properties["signing.secretKey"]?.toString()
+    val signingPassword =
+        System.getenv("JRELEASER_GPG_PASSPHRASE") ?: project.properties["signing.password"]?.toString()
+    isRequired = signingKey != null && signingPassword != null
+    if (signingKey != null && signingPassword != null) useInMemoryPgpKeys(signingKey, signingPassword)
+    sign(publishing.publications["maven"])
+}

--- a/quarkus/src/main/java/io/github/eschizoid/telescope/quarkus/TelescopeConfig.java
+++ b/quarkus/src/main/java/io/github/eschizoid/telescope/quarkus/TelescopeConfig.java
@@ -1,0 +1,41 @@
+package io.github.eschizoid.telescope.quarkus;
+
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefault;
+
+/**
+ * Configuration mapping for the telescope Quarkus extension. Read by {@link TelescopeProducer} when
+ * constructing the {@link TelescopeMapperRegistry}.
+ *
+ * <p>Configuration keys live under the {@code telescope.*} namespace in {@code
+ * application.properties} / {@code application.yaml}:
+ *
+ * <pre>{@code
+ * telescope.registry.fail-fast=true
+ * }</pre>
+ *
+ * <h2>Properties</h2>
+ *
+ * <ul>
+ *   <li>{@code telescope.registry.fail-fast} — when {@code true} (default), {@link
+ *       TelescopeMapperRegistry#get(Class, Class) registry.get(srcCls, tgtCls)} throws on missing
+ *       type pair; when {@code false}, returns {@code null}. Either way, {@link
+ *       TelescopeMapperRegistry#find(Class, Class) registry.find(...)} returns {@link
+ *       java.util.Optional}.
+ * </ul>
+ */
+@ConfigMapping(prefix = "telescope")
+public interface TelescopeConfig {
+  /** Registry-scoped configuration. */
+  Registry registry();
+
+  /** Settings for the {@link TelescopeMapperRegistry} bean. */
+  interface Registry {
+    /**
+     * When {@code true} (default), {@link TelescopeMapperRegistry#get(Class, Class)} throws on a
+     * missing type pair; when {@code false}, returns {@code null}.
+     */
+    @WithDefault("true")
+    boolean failFast();
+  }
+}

--- a/quarkus/src/main/java/io/github/eschizoid/telescope/quarkus/TelescopeMapperRegistry.java
+++ b/quarkus/src/main/java/io/github/eschizoid/telescope/quarkus/TelescopeMapperRegistry.java
@@ -1,0 +1,121 @@
+package io.github.eschizoid.telescope.quarkus;
+
+import io.github.eschizoid.telescope.Mapper;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Typed registry of every {@link Mapper} bean Quarkus' CDI container can resolve. Indexed by {@code
+ * (sourceClass, targetClass)} pair so callers can look up a mapper by its type pair without having
+ * to inject a specific {@code @Named} bean. Built automatically by {@link TelescopeProducer} when
+ * the extension is on the classpath.
+ *
+ * <h2>Why this exists</h2>
+ *
+ * <p>CDI already resolves parametric beans by type — {@code @Inject Mapper<Order, OrderEntity>}
+ * just works. The registry's value-add is <em>polymorphic dispatch</em>: a generic service that
+ * receives an {@code Object} of unknown type can call {@code registry.get(src.class,
+ * Target.class).forward(src)} to convert it, without writing a switch over every known type pair.
+ *
+ * <pre>{@code
+ * @ApplicationScoped
+ * public class GenericConverter {
+ *   @Inject TelescopeMapperRegistry registry;
+ *
+ *   public <A, B> B convert(A src, Class<B> targetClass) {
+ *     @SuppressWarnings("unchecked")
+ *     Mapper<A, B> mapper = (Mapper<A, B>) registry.get(src.getClass(), targetClass);
+ *     return mapper.forward(src);
+ *   }
+ * }
+ * }</pre>
+ *
+ * <h2>Construction</h2>
+ *
+ * <p>{@link TelescopeProducer} injects every {@code Mapper<?, ?>} bean via the {@code @All
+ * List<Mapper<?, ?>>} CDI pattern and hands them to the registry constructor. Mappers built via
+ * {@link io.github.eschizoid.telescope.Telescope#mapper Telescope.mapper(...)} expose {@link
+ * Mapper#sourceClass()} / {@link Mapper#targetClass()} that the registry reads to build the index.
+ *
+ * <p>Duplicate {@code (srcClass, tgtClass)} pairs cause an {@link IllegalStateException} at
+ * construction time — the {@code (sourceClass, targetClass)} pair must uniquely identify a mapper.
+ * If you genuinely have two semantically-different mappers for the same pair, qualify them with CDI
+ * {@code @Named} or {@code @Qualifier} annotations and {@code @Inject} the specific bean instead of
+ * going through the registry.
+ */
+public class TelescopeMapperRegistry {
+
+  private final Map<TypePair, Mapper<?, ?>> mappers;
+  private final boolean failFast;
+
+  public TelescopeMapperRegistry(final Collection<Mapper<?, ?>> mappers, final boolean failFast) {
+    this.failFast = failFast;
+    final var index = new HashMap<TypePair, Mapper<?, ?>>(mappers.size() * 2);
+    for (final var mapper : mappers) {
+      final var key = new TypePair(mapper.sourceClass(), mapper.targetClass());
+      final var prior = index.put(key, mapper);
+      if (prior != null) throw new IllegalStateException(
+        "Duplicate Mapper for type pair " +
+          mapper.sourceClass().getName() +
+          " -> " +
+          mapper.targetClass().getName() +
+          ". Qualify the beans with @Named / @Qualifier and inject the specific instance instead of relying on the registry."
+      );
+    }
+    this.mappers = Map.copyOf(index);
+  }
+
+  /**
+   * Look up the registered {@link Mapper} for {@code (sourceClass, targetClass)}. Behaviour on
+   * absence depends on {@code telescope.registry.fail-fast} (default {@code true}): when {@code
+   * true}, throws {@link IllegalArgumentException}; when {@code false}, returns {@code null}.
+   */
+  @SuppressWarnings("unchecked")
+  public <A, B> Mapper<A, B> get(final Class<A> sourceClass, final Class<B> targetClass) {
+    Objects.requireNonNull(sourceClass, "sourceClass");
+    Objects.requireNonNull(targetClass, "targetClass");
+    final var mapper = mappers.get(new TypePair(sourceClass, targetClass));
+    if (mapper == null && failFast) throw new IllegalArgumentException(
+      "No Mapper<" +
+        sourceClass.getName() +
+        ", " +
+        targetClass.getName() +
+        "> registered. Define a CDI producer or @ApplicationScoped class returning Mapper<" +
+        sourceClass.getSimpleName() +
+        ", " +
+        targetClass.getSimpleName() +
+        ">."
+    );
+    return (Mapper<A, B>) mapper;
+  }
+
+  /**
+   * Look up the registered {@link Mapper} as an {@link Optional}. Useful when {@code fail-fast} is
+   * on but the caller wants to handle absence without an exception (e.g., a generic dispatch where
+   * "no mapper" is a recoverable case).
+   */
+  @SuppressWarnings("unchecked")
+  public <A, B> Optional<Mapper<A, B>> find(final Class<A> sourceClass, final Class<B> targetClass) {
+    Objects.requireNonNull(sourceClass, "sourceClass");
+    Objects.requireNonNull(targetClass, "targetClass");
+    return Optional.ofNullable((Mapper<A, B>) mappers.get(new TypePair(sourceClass, targetClass)));
+  }
+
+  /** The number of mappers indexed by the registry. */
+  public int size() {
+    return mappers.size();
+  }
+
+  /**
+   * Whether a {@link Mapper} is registered for the given type pair. Avoids the {@code
+   * fail-fast}-driven throw of {@link #get}.
+   */
+  public boolean contains(final Class<?> sourceClass, final Class<?> targetClass) {
+    return mappers.containsKey(new TypePair(sourceClass, targetClass));
+  }
+
+  private record TypePair(Class<?> source, Class<?> target) {}
+}

--- a/quarkus/src/main/java/io/github/eschizoid/telescope/quarkus/TelescopeProducer.java
+++ b/quarkus/src/main/java/io/github/eschizoid/telescope/quarkus/TelescopeProducer.java
@@ -1,0 +1,43 @@
+package io.github.eschizoid.telescope.quarkus;
+
+import io.github.eschizoid.telescope.Mapper;
+import io.quarkus.arc.All;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+import java.util.List;
+
+/**
+ * CDI producer for {@link TelescopeMapperRegistry}. Activates whenever the {@code telescope-
+ * quarkus} extension is on the classpath — analogue of the Spring Boot starter's auto-config.
+ *
+ * <p>The {@code @All List<Mapper<?, ?>>} parameter is Quarkus ArC's collector pattern: CDI hands
+ * over every {@link Mapper} bean defined in any {@code @ApplicationScoped} (or other normal-scope)
+ * class in the user's application. No extra wiring needed — declare a producer that returns {@code
+ * Mapper<A, B>} (or annotate an {@code @ApplicationScoped} class implementing the right type) and
+ * it shows up in the registry.
+ *
+ * <p>Users who want to suppress the registry (e.g., to provide their own implementation) can
+ * declare their own {@code @Produces TelescopeMapperRegistry} bean. CDI's specialization /
+ * alternatives picks theirs over ours.
+ */
+@ApplicationScoped
+public class TelescopeProducer {
+
+  /** Default constructor invoked by Quarkus' CDI container. */
+  public TelescopeProducer() {}
+
+  /**
+   * Build the {@link TelescopeMapperRegistry} from every {@link Mapper} bean ArC can resolve. The
+   * {@code @All} annotation is Quarkus-specific and collects every CDI bean of the parameter type
+   * into a {@link List} — without it, CDI would only inject one (and fail at startup if multiple
+   * candidates exist).
+   */
+  @Produces
+  @ApplicationScoped
+  public TelescopeMapperRegistry telescopeMapperRegistry(
+    @All final List<Mapper<?, ?>> mappers,
+    final TelescopeConfig config
+  ) {
+    return new TelescopeMapperRegistry(mappers, config.registry().failFast());
+  }
+}

--- a/quarkus/src/main/java/io/github/eschizoid/telescope/quarkus/package-info.java
+++ b/quarkus/src/main/java/io/github/eschizoid/telescope/quarkus/package-info.java
@@ -1,0 +1,19 @@
+/**
+ * Quarkus CDI extension for the telescope optics DSL.
+ *
+ * <p>Adds two CDI beans when the extension is on the classpath:
+ *
+ * <ul>
+ *   <li>{@link io.github.eschizoid.telescope.quarkus.TelescopeMapperRegistry} — a typed registry
+ *       indexing every {@link io.github.eschizoid.telescope.Mapper} bean by {@code (sourceClass,
+ *       targetClass)}. Useful for polymorphic conversion in generic services.
+ *   <li>{@link io.github.eschizoid.telescope.quarkus.TelescopeProducer} — the CDI producer that
+ *       builds the registry from every injected {@code Mapper<?, ?>} bean.
+ * </ul>
+ *
+ * <p>Configuration lives under the {@code telescope.*} namespace via {@link
+ * io.github.eschizoid.telescope.quarkus.TelescopeConfig}. The Spring Boot starter {@code
+ * telescope-spring-boot-starter} ships the same registry shape under {@code
+ * io.github.eschizoid.telescope.spring}.
+ */
+package io.github.eschizoid.telescope.quarkus;

--- a/quarkus/src/main/resources/META-INF/beans.xml
+++ b/quarkus/src/main/resources/META-INF/beans.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Marker file — enables CDI bean discovery for the telescope-quarkus extension. Quarkus ArC scans
+  any jar with this file (even empty) and picks up @ApplicationScoped / @Produces beans inside.
+  Without this, the TelescopeProducer below would not be discovered by user applications.
+-->
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_4_0.xsd"
+       bean-discovery-mode="annotated"
+       version="4.0">
+</beans>

--- a/quarkus/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/quarkus/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,0 +1,13 @@
+name: "Telescope"
+description: "Telescope optics DSL — Mapper<A,B> bean registry + CDI producer for the runtime extension"
+metadata:
+  keywords:
+    - "telescope"
+    - "optics"
+    - "mapping"
+    - "records"
+    - "bidirectional"
+  guide: "https://github.com/eschizoid/telescope"
+  categories:
+    - "data"
+  status: "experimental"

--- a/quarkus/src/test/java/io/github/eschizoid/telescope/quarkus/TelescopeMapperRegistryTest.java
+++ b/quarkus/src/test/java/io/github/eschizoid/telescope/quarkus/TelescopeMapperRegistryTest.java
@@ -1,0 +1,93 @@
+package io.github.eschizoid.telescope.quarkus;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.github.eschizoid.telescope.Mapper;
+import io.github.eschizoid.telescope.Telescope;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link TelescopeMapperRegistry} — the registry is pure Java with no CDI
+ * dependency, so these tests exercise it directly with hand-rolled mapper lists. The full
+ * {@code @QuarkusTest} integration that wires {@link TelescopeProducer} through ArC's CDI container
+ * is a follow-on for users who want to validate the autoconfig end-to-end; the unit tests here pin
+ * the behaviour the producer relies on.
+ *
+ * <p>Mirror of {@code TelescopeMapperRegistryTest} in {@code telescope-spring-boot-starter} —
+ * Spring's tests drive the autoconfig through {@code ApplicationContextRunner}; Quarkus' unit
+ * surface is simpler because the registry itself has no framework hook.
+ */
+class TelescopeMapperRegistryTest {
+
+  record Source(String name) {}
+
+  record Target(String name) {}
+
+  record AltSource(int value) {}
+
+  record AltTarget(int value) {}
+
+  @Test
+  void registryIndexesEveryMapperByTypePair() {
+    final var registry = new TelescopeMapperRegistry(
+      List.of(Telescope.mapper(Source.class, Target.class), Telescope.mapper(AltSource.class, AltTarget.class)),
+      true
+    );
+
+    assertThat(registry.size()).isEqualTo(2);
+    assertThat(registry.contains(Source.class, Target.class)).isTrue();
+    assertThat(registry.contains(AltSource.class, AltTarget.class)).isTrue();
+    assertThat(registry.contains(Source.class, AltTarget.class)).isFalse();
+  }
+
+  @Test
+  void getReturnsTheRegisteredMapperForALookedUpTypePair() {
+    final var mapper = Telescope.mapper(Source.class, Target.class);
+    final var registry = new TelescopeMapperRegistry(List.of(mapper), true);
+
+    final Mapper<Source, Target> found = registry.get(Source.class, Target.class);
+    assertThat(found).isNotNull();
+    final var dto = found.forward(new Source("alice"));
+    assertThat(dto.name()).isEqualTo("alice");
+  }
+
+  @Test
+  void getThrowsForMissingTypePairByDefault() {
+    final var registry = new TelescopeMapperRegistry(List.of(Telescope.mapper(Source.class, Target.class)), true);
+
+    assertThatThrownBy(() -> registry.get(Source.class, AltTarget.class))
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessageContaining("No Mapper")
+      .hasMessageContaining("CDI producer");
+  }
+
+  @Test
+  void failFastFalseMakesGetReturnNullInsteadOfThrowing() {
+    final var registry = new TelescopeMapperRegistry(List.of(Telescope.mapper(Source.class, Target.class)), false);
+
+    assertThat(registry.get(Source.class, AltTarget.class)).isNull();
+  }
+
+  @Test
+  void findReturnsOptionalRegardlessOfFailFast() {
+    final var registry = new TelescopeMapperRegistry(List.of(Telescope.mapper(Source.class, Target.class)), true);
+
+    assertThat(registry.find(Source.class, Target.class)).isPresent();
+    assertThat(registry.find(Source.class, AltTarget.class)).isEmpty();
+  }
+
+  @Test
+  void duplicateTypePairFailsAtConstruction() {
+    assertThatThrownBy(() ->
+      new TelescopeMapperRegistry(
+        List.of(Telescope.mapper(Source.class, Target.class), Telescope.mapper(Source.class, Target.class)),
+        true
+      )
+    )
+      .isInstanceOf(IllegalStateException.class)
+      .hasMessageContaining("Duplicate Mapper")
+      .hasMessageContaining("@Named / @Qualifier");
+  }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -4,6 +4,7 @@ include("core")
 include("codegen")
 include("lombok")
 include("spring-boot-starter")
+include("quarkus")
 include("benchmarks")
 
 include("examples:library")

--- a/spring-boot-starter/README.md
+++ b/spring-boot-starter/README.md
@@ -1,0 +1,112 @@
+# telescope-spring-boot-starter
+
+Drop-in Spring Boot 4 auto-config for [telescope](../README.md). Adds one bean to your application context — a typed
+`Mapper<A, B>` registry — and nothing else.
+
+```kotlin
+dependencies {
+    implementation("io.github.eschizoid:telescope-spring-boot-starter:0.4.1")
+}
+```
+
+No `@EnableTelescope` annotation. No config class to author. The starter declares `@Mapper<Order, OrderEntity>` beans in
+your `@Configuration` and they show up in the registry; the registry resolves them by `(sourceClass, targetClass)` pair.
+
+## What you get
+
+- **`TelescopeMapperRegistry`** — auto-built `@Bean`, indexes every `Mapper<?, ?>` Spring can resolve into the context.
+  Polymorphic dispatch: generic services receive `Object` and convert via
+  `registry.get(src.getClass(), Target.class).forward(src)` without enumerating type pairs.
+- **`TelescopeProperties`** — `@ConfigurationProperties("telescope")` for the `telescope.registry.fail-fast` toggle.
+
+## Install
+
+```kotlin
+// Gradle (Spring Boot 4 BOM picks up Boot's version)
+dependencies {
+    implementation(platform("org.springframework.boot:spring-boot-dependencies:4.0.1"))
+    implementation("io.github.eschizoid:telescope-spring-boot-starter:0.4.1")
+}
+```
+
+```xml
+<!-- Maven -->
+<dependency>
+  <groupId>io.github.eschizoid</groupId>
+  <artifactId>telescope-spring-boot-starter</artifactId>
+  <version>0.4.1</version>
+</dependency>
+```
+
+The `telescope` core library comes along transitively (`api` scope).
+
+## Minimum viable example
+
+```java
+@Configuration
+class MapperConfig {
+
+  @Bean
+  Mapper<Order, OrderEntity> orderMapper() {
+    return Telescope.mapper(Order.class, OrderEntity.class);
+  }
+
+  @Bean
+  Mapper<Order, OrderDto> orderDtoMapper() {
+    return Telescope.mapper(Order.class, OrderDto.class);
+  }
+}
+
+@Service
+class OrderConverter {
+
+  private final TelescopeMapperRegistry registry;
+
+  OrderConverter(TelescopeMapperRegistry registry) {
+    this.registry = registry;
+  }
+
+  // Polymorphic conversion — no switch over known type pairs.
+  <A, B> B convert(A src, Class<B> targetClass) {
+    @SuppressWarnings("unchecked")
+    Mapper<A, B> mapper = (Mapper<A, B>) registry.get(src.getClass(), targetClass);
+    return mapper.forward(src);
+  }
+}
+```
+
+## Configuration
+
+| Property                       | Default | Effect                                                                                                                                                                                      |
+| ------------------------------ | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `telescope.registry.fail-fast` | `true`  | When `true`, `registry.get(srcCls, tgtCls)` throws `IllegalArgumentException` on a missing type pair. When `false`, returns `null`. Either way, `registry.find(...)` returns an `Optional`. |
+
+`application.yaml`:
+
+```yaml
+telescope:
+  registry:
+    fail-fast: false # return null instead of throwing on missing pair
+```
+
+## Overrides
+
+The auto-config bean is `@ConditionalOnMissingBean` — declare your own `@Bean TelescopeMapperRegistry` to suppress the
+default. Useful when you want to wrap the registry with logging, metrics, or a multi-tenant variant.
+
+## Duplicate-pair behaviour
+
+Defining two beans for the same `(srcClass, tgtClass)` pair fails at registry construction with `IllegalStateException`
+— the pair must uniquely identify a mapper. If you genuinely have two semantically-different mappers for the same pair,
+qualify them with Spring `@Qualifier`s and `@Autowired` the specific bean instead of going through the registry.
+
+## Demo
+
+See [`examples/springboot/order-jpa`](../examples/springboot/order-jpa) for the full integration flow: REST controller →
+registry lookup → Telescope mapper → Hibernate persist. The same project covers JPA cycles, Hibernate LAZY proxy unwrap,
+sparse-PATCH composition, and the sealed-narrow paradigm hop.
+
+## Quarkus equivalent
+
+`telescope-quarkus` ships the same registry shape via CDI producers — see [`quarkus`](../quarkus/README.md) for the
+Quarkus 3 equivalent.

--- a/spring-boot-starter/src/main/java/io/github/eschizoid/telescope/spring/TelescopeAutoConfiguration.java
+++ b/spring-boot-starter/src/main/java/io/github/eschizoid/telescope/spring/TelescopeAutoConfiguration.java
@@ -1,7 +1,7 @@
 package io.github.eschizoid.telescope.spring;
 
-import io.github.eschizoid.telescope.Telescope;
 import io.github.eschizoid.telescope.Mapper;
+import io.github.eschizoid.telescope.Telescope;
 import java.util.Collection;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;

--- a/spring-boot-starter/src/main/java/io/github/eschizoid/telescope/spring/package-info.java
+++ b/spring-boot-starter/src/main/java/io/github/eschizoid/telescope/spring/package-info.java
@@ -4,8 +4,8 @@
  * io.github.eschizoid.telescope.spring.TelescopeAutoConfiguration} activates automatically and
  * contributes one bean by default — {@link
  * io.github.eschizoid.telescope.spring.TelescopeMapperRegistry} — a typed registry indexing every
- * {@link io.github.eschizoid.telescope.Mapper} bean in the {@code ApplicationContext} by
- * {@code (sourceClass, targetClass)} pair.
+ * {@link io.github.eschizoid.telescope.Mapper} bean in the {@code ApplicationContext} by {@code
+ * (sourceClass, targetClass)} pair.
  *
  * <p>Configuration properties live under the {@code telescope.*} namespace; see {@link
  * io.github.eschizoid.telescope.spring.TelescopeProperties}.

--- a/spring-boot-starter/src/main/java/module-info.java
+++ b/spring-boot-starter/src/main/java/module-info.java
@@ -2,8 +2,8 @@
  * Spring Boot 4 autoconfig module for telescope. Provides {@link
  * io.github.eschizoid.telescope.spring.TelescopeAutoConfiguration} and the {@link
  * io.github.eschizoid.telescope.spring.TelescopeMapperRegistry} bean — a typed registry indexing
- * every {@link io.github.eschizoid.telescope.Mapper} bean in the {@code
- * ApplicationContext} by {@code (sourceClass, targetClass)} pair.
+ * every {@link io.github.eschizoid.telescope.Mapper} bean in the {@code ApplicationContext} by
+ * {@code (sourceClass, targetClass)} pair.
  */
 module io.github.eschizoid.telescope.spring {
   requires transitive io.github.eschizoid.telescope;

--- a/spring-boot-starter/src/test/java/io/github/eschizoid/telescope/spring/TelescopeMapperRegistryTest.java
+++ b/spring-boot-starter/src/test/java/io/github/eschizoid/telescope/spring/TelescopeMapperRegistryTest.java
@@ -3,8 +3,8 @@ package io.github.eschizoid.telescope.spring;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import io.github.eschizoid.telescope.Telescope;
 import io.github.eschizoid.telescope.Mapper;
+import io.github.eschizoid.telescope.Telescope;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;


### PR DESCRIPTION
## Summary
- New `:quarkus` module published as `io.github.eschizoid:telescope-quarkus` (Quarkus 3 CDI extension). Mirrors the Spring Boot starter's surface: same `TelescopeMapperRegistry` shape, `@ConfigMapping`-driven `telescope.registry.fail-fast`, no extra wiring. Uses ArC's `@All List<Mapper<?, ?>>` collector pattern to inject every mapper bean.
- JReleaser staging repos for both `:spring-boot-starter` and `:quarkus` added to root `build.gradle.kts` — these were previously built locally but never staged for Sonatype.
- Drive-by cleanup from PR #57's flat-package move: 6 phase-C test files moved from `core/src/test/.../mapping/` to root; stale `@link` references to the now-deleted `conversion`/`mapping` packages in `package-info.java` + `module-info.java` updated.

## Test plan
- [x] `./gradlew :quarkus:test` — 6 tests green (indexing, lookup, fail-fast on/off, find-as-Optional, duplicate-pair rejection)
- [x] `./gradlew build` — green across all 11 modules
- [x] `:quarkus:javadoc` builds clean (Quarkus BOM + ArC API resolve)
- [x] README + CHANGELOG updated to mention the Quarkus integration alongside Spring Boot
- [x] Spring Boot starter `TelescopeMapperRegistryTest` still passes (unchanged registry behaviour)
- [ ] Copilot review (auto-triggered)