### PR TITLE
perf: short-circuit single-focus Telescope ops + for-loop Iso.lift*

### DIFF
--- a/core/src/main/java/io/github/eschizoid/telescope/Telescope.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/Telescope.java
@@ -8,6 +8,7 @@ import io.github.eschizoid.telescope.internal.Beans;
 import io.github.eschizoid.telescope.internal.LambdaIntrospection;
 import io.github.eschizoid.telescope.internal.MetadataHolderProbe;
 import io.github.eschizoid.telescope.internal.Records;
+import io.github.eschizoid.telescope.internal.optics.Affine;
 import io.github.eschizoid.telescope.internal.optics.Iso;
 import io.github.eschizoid.telescope.internal.optics.Lens;
 import io.github.eschizoid.telescope.internal.optics.Prism;
@@ -666,10 +667,17 @@ public sealed class Telescope<
    * #toList} for every focused value, or {@link #exists} / {@link #count} to test presence.
    */
   public A read(final S source) {
-    return optic
-      .getAll(source)
-      .findFirst()
-      .orElseThrow(() -> new NoSuchElementException("Telescope has no value in this source"));
+    if (optic instanceof final Lens<S, A> lens) {
+      return lens.get(source);
+    }
+    if (optic instanceof final Affine<S, A> affine) {
+      return affine.getOption(source).orElseThrow(Telescope::noValue);
+    }
+    return optic.getAll(source).findFirst().orElseThrow(Telescope::noValue);
+  }
+
+  private static NoSuchElementException noValue() {
+    return new NoSuchElementException("Telescope has no value in this source");
   }
 
   /**
@@ -677,6 +685,12 @@ public sealed class Telescope<
    * non-throwing sibling of {@link #read}.
    */
   public Optional<A> find(final S source) {
+    if (optic instanceof final Lens<S, A> lens) {
+      return Optional.ofNullable(lens.get(source));
+    }
+    if (optic instanceof final Affine<S, A> affine) {
+      return affine.getOption(source);
+    }
     return optic.getAll(source).findFirst();
   }
 
@@ -693,6 +707,12 @@ public sealed class Telescope<
    * <p>See {@link #toListIndexed} to pair each value with its position.
    */
   public List<A> toList(final S source) {
+    if (optic instanceof final Lens<S, A> lens) {
+      return List.of(lens.get(source));
+    }
+    if (optic instanceof final Affine<S, A> affine) {
+      return affine.getOption(source).map(List::of).orElseGet(List::of);
+    }
     return optic.getAll(source).toList();
   }
 
@@ -726,6 +746,12 @@ public sealed class Telescope<
    * nonzero (it stops at the first match).
    */
   public long count(final S source) {
+    if (optic instanceof Lens<S, A>) {
+      return 1L;
+    }
+    if (optic instanceof final Affine<S, A> affine) {
+      return affine.getOption(source).isPresent() ? 1L : 0L;
+    }
     return optic.getAll(source).count();
   }
 
@@ -734,6 +760,12 @@ public sealed class Telescope<
    * #count}.
    */
   public boolean exists(final S source) {
+    if (optic instanceof Lens<S, A>) {
+      return true;
+    }
+    if (optic instanceof final Affine<S, A> affine) {
+      return affine.getOption(source).isPresent();
+    }
     return optic.getAll(source).findAny().isPresent();
   }
 

--- a/internal/src/main/java/io/github/eschizoid/telescope/internal/optics/Iso.java
+++ b/internal/src/main/java/io/github/eschizoid/telescope/internal/optics/Iso.java
@@ -8,7 +8,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
@@ -114,8 +113,18 @@ public interface Iso<A, B> extends Lens<A, B>, Prism<A, B> {
    */
   static <X, Y> Iso<List<X>, List<Y>> liftList(final Iso<X, Y> element) {
     return of(
-      xs -> xs == null ? null : xs.stream().map(element::to).collect(Collectors.toCollection(ArrayList::new)),
-      ys -> ys == null ? null : ys.stream().map(element::from).collect(Collectors.toCollection(ArrayList::new))
+      xs -> {
+        if (xs == null) return null;
+        final var out = new ArrayList<Y>(xs.size());
+        for (final var x : xs) out.add(element.to(x));
+        return out;
+      },
+      ys -> {
+        if (ys == null) return null;
+        final var out = new ArrayList<X>(ys.size());
+        for (final var y : ys) out.add(element.from(y));
+        return out;
+      }
     );
   }
 
@@ -168,8 +177,18 @@ public interface Iso<A, B> extends Lens<A, B>, Prism<A, B> {
    */
   static <X, Y> Iso<Set<X>, Set<Y>> liftSet(final Iso<X, Y> element) {
     return of(
-      xs -> xs == null ? null : xs.stream().map(element::to).collect(Collectors.toCollection(LinkedHashSet::new)),
-      ys -> ys == null ? null : ys.stream().map(element::from).collect(Collectors.toCollection(LinkedHashSet::new))
+      xs -> {
+        if (xs == null) return null;
+        final var out = new LinkedHashSet<Y>(xs.size());
+        for (final var x : xs) out.add(element.to(x));
+        return out;
+      },
+      ys -> {
+        if (ys == null) return null;
+        final var out = new LinkedHashSet<X>(ys.size());
+        for (final var y : ys) out.add(element.from(y));
+        return out;
+      }
     );
   }
 
@@ -182,14 +201,14 @@ public interface Iso<A, B> extends Lens<A, B>, Prism<A, B> {
     return of(
       mx -> {
         if (mx == null) return null;
-        final var out = new LinkedHashMap<K, Y>();
-        mx.forEach((k, x) -> out.put(k, value.to(x)));
+        final var out = new LinkedHashMap<K, Y>(mx.size());
+        for (final var entry : mx.entrySet()) out.put(entry.getKey(), value.to(entry.getValue()));
         return out;
       },
       my -> {
         if (my == null) return null;
-        final var out = new LinkedHashMap<K, X>();
-        my.forEach((k, y) -> out.put(k, value.from(y)));
+        final var out = new LinkedHashMap<K, X>(my.size());
+        for (final var entry : my.entrySet()) out.put(entry.getKey(), value.from(entry.getValue()));
         return out;
       }
     );


### PR DESCRIPTION
Stacked on top of #60. Two zero-API-change perf wins identified by analyzing the dispatch path after the MapStruct comparison landed.

## What changed

### Hotspot `#1` — `Telescope.read/find/count/exists/toList` allocate a Stream pipeline for what should be a direct call

The `optic` field on `Telescope<S, A>` is typed as `Traversal<S, A>`, so every terminal op went through `optic.getAll(s).findFirst()` (or similar) — a Stream allocation + Spliterator + Optional dance, **on every call**, even when the underlying optic is a `Lens` (Iso, `@Bridge`) or `Affine` (Prism narrowing) where the focus count is statically known to be exactly-one or at-most-one.

```java
// Before:
public A read(final S source) {
  return optic.getAll(source).findFirst().orElseThrow(() -> new NoSuchElementException(...));
}

// After:
public A read(final S source) {
  if (optic instanceof final Lens<S, A> lens) return lens.get(source);
  if (optic instanceof final Affine<S, A> affine) return affine.getOption(source).orElseThrow(Telescope::noValue);
  return optic.getAll(source).findFirst().orElseThrow(Telescope::noValue);
}
```

The instanceof check collapses under JIT inlining at monomorphic call sites (every `BRIDGE.read(bean)` site sees the same concrete optic). Same pattern applied to `find`, `toList`, `count`, `exists`.

**Direct evidence this was a hotspot:** the original PR #60 measurements showed forward (read-side) at 15.37 ns/op vs backward (set-side) at 6.85 ns/op on the flat tier. Both go through the same Iso, so the 8.5 ns delta was paid by the Stream pipeline on the read path that the set path skipped (`set` already delegates to `optic.set(s, v)` directly).

### Hotspot #2 — `Iso.liftList/liftSet/liftMapValues` use stream pipelines for typically-tiny lists

The deep-tier conversion composes through two list-lift Isos (`List<Department>`, `List<Team>`), each previously:

```java
xs -> xs == null ? null : xs.stream().map(element::to).collect(Collectors.toCollection(ArrayList::new))
```

Stream + map + collect costs ~30-50 ns of fixed overhead per call (Spliterator alloc, ReferencePipeline chain, ArrayList resize-from-empty), on lists of typically ≤4 elements where the work itself is sub-microsecond.

Replaced with size-presized `ArrayList` / `LinkedHashSet` / `LinkedHashMap` + manual `for (var x : xs) out.add(...)`. Same semantics, no pipeline allocation. `liftMapValues` also dropped a per-call `BiConsumer` lambda allocation (the `forEach((k,v) -> ...)` closure captured the result map per outer invocation).

## What's preserved

- **Public DSL surface: zero changes.** `Telescope.of`, `from/to/using`, `@Bridge`, `.field`, `.each` — identical.
- **Lattice types: zero changes to interfaces.** `Iso`, `Lens`, `Prism`, `Affine`, `Traversal` keep their full signatures. All changes are inside default methods and one instanceof guard on the optic field.
- **No new user-visible abstractions.** The "users never see Lens / Iso" rule holds.

## Test plan

- [x] `./gradlew check -x :benchmarks:jmh` — full multi-module check passes (tests + spotless). All optic-law tests, Telescope DSL tests, codegen processor tests, and Lombok integration tests green.
- [ ] **JMH re-run deferred** — attempted twice. Both runs returned unusable noise: error bars exceeded scores on most rows, **including on MapStruct's unchanged code** (e.g. `flat_mapstruct_forward` 3.66 → 51.75 ns/op between runs, with ±113 ns error). Smoking gun: `uptime` reports load average 64.26 on 12 threads — 5× oversubscribed, seven users logged in, the machine has another heavy workload running. Re-running JMH under that contention measures the scheduler, not the dispatch path.

## How to verify when the machine is quiet

```bash
git fetch && git checkout perf/dispatch-fast-paths
./gradlew :benchmarks:jmh -Pjmh.includes=MapStructComparisonBenchmark --rerun-tasks
```

Expected direction (from the dispatch-path analysis):

| Tier   | Direction       | Before (PR #60) | Expected after |
|--------|-----------------|----------------:|---------------:|
| flat   | bean → record   |          15.37  |           ~7   |
| flat   | record → bean   |           6.85  |           6.85 |
| nested | bean → record   |          17.86  |          ~10   |
| nested | record → bean   |          11.53  |          11.53 |
| deep   | bean → record   |         189.43  |         ~100   |
| deep   | record → bean   |         191.64  |         ~120   |

Forward direction should close the gap with MapStruct from 2-4× to ~1.5-2× on the flat/nested tiers; deep tier should drop ~40-90 ns. Backward direction stays roughly the same (was already fast).

## Why ship without the rerun

The change is mechanical: replace `Stream.findFirst()` with `lens.get()`, replace `stream().collect()` with a `for` loop. Both branches are exercised by existing tests. The perf claim isn't load-bearing for shipping the patch — what we have to defend is that we didn't break anything, and the test suite does that. The number on the README can be updated in a follow-up commit once a quiet-machine rerun lands.
