### PR TITLE
perf(lattice): .then() composition uses concrete inner classes

### DIFF
--- a/internal/src/main/java/io/github/eschizoid/telescope/internal/optics/Iso.java
+++ b/internal/src/main/java/io/github/eschizoid/telescope/internal/optics/Iso.java
@@ -198,26 +198,66 @@ public interface Iso<A, B> extends Lens<A, B>, Prism<A, B> {
   /** Swap directions — {@code to} and {@code from} trade places. */
   default Iso<B, A> reverse() {
     final var self = this;
-    return Iso.of(self::from, self::to);
+    return new Iso<>() {
+      @Override
+      public A to(final B source) {
+        return self.from(source);
+      }
+
+      @Override
+      public B from(final A value) {
+        return self.to(value);
+      }
+    };
   }
 
   /** {@code Iso . Iso = Iso} */
   default <C> Iso<A, C> then(final Iso<B, C> next) {
     final var self = this;
-    return Iso.of(a -> next.to(self.to(a)), c -> self.from(next.from(c)));
+    return new Iso<>() {
+      @Override
+      public C to(final A source) {
+        return next.to(self.to(source));
+      }
+
+      @Override
+      public A from(final C value) {
+        return self.from(next.from(value));
+      }
+    };
   }
 
   /** {@code Iso . Lens = Lens} — diamond resolution */
   @Override
   default <C> Lens<A, C> then(final Lens<B, C> next) {
     final var self = this;
-    return Lens.of(a -> next.get(self.to(a)), (a, c) -> self.from(next.set(self.to(a), c)));
+    return new Lens<>() {
+      @Override
+      public C get(final A source) {
+        return next.get(self.to(source));
+      }
+
+      @Override
+      public A set(final A source, final C value) {
+        return self.from(next.set(self.to(source), value));
+      }
+    };
   }
 
   /** {@code Iso . Prism = Prism} — diamond resolution */
   @Override
   default <C> Prism<A, C> then(final Prism<B, C> next) {
     final var self = this;
-    return Prism.of(a -> next.getOption(self.to(a)), c -> self.from(next.reverseGet(c)));
+    return new Prism<>() {
+      @Override
+      public Optional<C> getOption(final A source) {
+        return next.getOption(self.to(source));
+      }
+
+      @Override
+      public A reverseGet(final C value) {
+        return self.from(next.reverseGet(value));
+      }
+    };
   }
 }

--- a/internal/src/main/java/io/github/eschizoid/telescope/internal/optics/Lens.java
+++ b/internal/src/main/java/io/github/eschizoid/telescope/internal/optics/Lens.java
@@ -115,6 +115,20 @@ public interface Lens<S, A> extends Affine<S, A>, Getter<S, A> {
   /** {@code Lens . Prism = Affine} */
   default <B> Affine<S, B> then(final Prism<A, B> next) {
     final var self = this;
-    return Affine.of(source -> next.getOption(self.get(source)), (source, b) -> self.set(source, next.reverseGet(b)));
+    return new Affine<>() {
+      @Override
+      public Optional<B> getOption(final S source) {
+        return next.getOption(self.get(source));
+      }
+
+      @Override
+      public S modify(final S source, final Function<? super B, ? extends B> f) {
+        final var a = self.get(source);
+        return next
+          .getOption(a)
+          .map(b -> self.set(source, next.reverseGet(f.apply(b))))
+          .orElse(source);
+      }
+    };
   }
 }

--- a/internal/src/main/java/io/github/eschizoid/telescope/internal/optics/Prism.java
+++ b/internal/src/main/java/io/github/eschizoid/telescope/internal/optics/Prism.java
@@ -136,13 +136,19 @@ public interface Prism<S, A> extends Affine<S, A> {
   /** {@code Prism . Lens = Affine} */
   default <B> Affine<S, B> then(final Lens<A, B> next) {
     final var self = this;
-    return Affine.of(
-      source -> self.getOption(source).map(next::get),
-      (source, b) ->
-        self
+    return new Affine<>() {
+      @Override
+      public Optional<B> getOption(final S source) {
+        return self.getOption(source).map(next::get);
+      }
+
+      @Override
+      public S modify(final S source, final Function<? super B, ? extends B> f) {
+        return self
           .getOption(source)
-          .map(a -> self.reverseGet(next.set(a, b)))
-          .orElse(source)
-    );
+          .map(a -> self.reverseGet(next.set(a, f.apply(next.get(a)))))
+          .orElse(source);
+      }
+    };
   }
 }


### PR DESCRIPTION
Hotspot #9 from the dispatch analysis — the last big composition-time `Function::apply` source in the lattice.

## What changed

Six composition paths in the optic lattice still went through the lambda-based `*.of(...)` factories:

| Path                | Before                                                  |
| ------------------- | ------------------------------------------------------- |
| `Iso.reverse()`     | `Iso.of(self::from, self::to)`                          |
| `Iso.then(Iso)`     | `Iso.of(a -> ..., c -> ...)`                            |
| `Iso.then(Lens)`    | `Lens.of(a -> ..., (a, c) -> ...)`                      |
| `Iso.then(Prism)`   | `Prism.of(a -> ..., c -> ...)`                          |
| `Lens.then(Prism)`  | `Affine.of(source -> ..., (source, b) -> ...)`          |
| `Prism.then(Lens)`  | `Affine.of(source -> ..., (source, b) -> ...)`          |

Each of those factories wraps the supplied `Function` / `BiFunction` inside an anonymous subclass whose `get` / `set` / `to` / `from` / `getOption` body just delegates via `fn.apply(...)`. That adds one `Function::apply` hop per composition step — and because the bytecode for those wrapper bodies is shared across **all** `Iso.of` / `Lens.of` / ... instances ever created, the call site goes **megamorphic** as more optics get composed and the JIT stops inlining through it.

This PR replaces each path with a concrete anonymous class whose body inlines the inner optic call directly. No more `Function::apply` hop per composition level; the call site stays type-monomorphic per composition.

Example, `Iso.then(Iso)`:

```java
// Before
default <C> Iso<A, C> then(final Iso<B, C> next) {
  final var self = this;
  return Iso.of(a -> next.to(self.to(a)), c -> self.from(next.from(c)));
  //     ^^^^^^ anonymous class allocs forward/backward Function fields,
  //            then forward.apply(s) at call time
}

// After
default <C> Iso<A, C> then(final Iso<B, C> next) {
  final var self = this;
  return new Iso<>() {
    @Override public C to(final A source)   { return next.to(self.to(source)); }
    @Override public A from(final C value)  { return self.from(next.from(value)); }
  };
}
```

`Lens.then(Lens)`, `Lens.then(Iso)`, `Prism.then(Prism)`, `Prism.then(Iso)`, `Affine.then(Affine)`, and `Traversal.then(Traversal)` were already using concrete classes — this PR brings the remaining six in line.

## What's preserved

- **Public DSL surface: zero changes.** `Telescope.of`, `.field`, `.each`, `from/to/using`, `@Bridge` — all identical.
- **Lattice composition algebra: zero changes.** `Iso.then(Iso) = Iso`, `Iso.then(Lens) = Lens`, `Iso.then(Prism) = Prism`, etc. — `OpticLawsTest` still pins this and stays green.
- **Optic laws: zero changes.** All round-trip / get-set / set-get behavior is identical; only the dispatch path inside the composed optic changes.

## Test plan

- [x] `./gradlew check` (full multi-module incl. four Spring Boot examples) — **green**.
- [x] `OpticLawsTest` — green. Pins the composition algebra; if any of the six rewrites flipped semantics, the laws would fail.
- [x] `TelescopeTest` + `CompanyDemo` + `IndexedTraversalTest` — green. Exercise the composed optics end-to-end.
- [ ] JMH `MapStructComparisonBenchmark` rerun deferred to a quiet machine — same load-avg-60+ contention from earlier in the session. Tracked in #61.

## Expected impact

Per composition step, this saves one `Function::apply` virtual hop:

- **flat tier** (`@Bridge` Iso) — composes 0 layers (it's a single Iso, no `.then`). No impact.
- **nested tier** (`@Bridge` Iso with one nested sub-bridge) — composes 1 layer. ~3-5 ns saved per read/set.
- **deep tier** (`@Bridge` Iso with two nested sub-bridges + container lifts) — composes 3-5 layers. ~10-20 ns saved per read/set.

Stacking cumulatively with #61 (Telescope.read fast-path + Iso.liftList for-loop) and #62 (BridgeProcessor for-loop emission), the deep-tier dispatch should compress further toward MapStruct's 54-70 ns ceiling. **Real numbers when the machine is quiet enough to bench.**

## What this does NOT touch

- `Iso.of(forward, backward)` — still the user-facing factory used by `Telescope.from(...).to(...).using(...)` and `Telescope.iso(...)`. The `Function::apply` cost here is hotspot **#6**, addressed in a separate PR.
- `Lens.of(get, set)`, `Prism.of(getOption, reverseGet)`, `Affine.of(getOption, set)` — same. They stay for user-facing factories and the four call sites still using them. Removing them entirely would require restructuring the user-facing `Telescope.lens(...)` factory.
