### PR TITLE
docs(readme): rewrite "Performance honesty" with measured numbers + refresh "What it is not"

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,16 +144,22 @@ capability lists, vs-MapStruct callouts, and benchmark cross-links.
 
 ## What it is _not_
 
-- Not a MapStruct replacement. MapStruct is a purpose-built bean-mapping framework with deep ecosystem integration
-  (Spring, Quarkus, MicroProfile) and ten years of edge-case fixes. Telescope is an optics DSL that includes
-  bidirectional mapping as one capability — see [How it compares to MapStruct](#how-it-compares-to-mapstruct) below for
-  the actual side-by-side.
-- Not a fuzzy auto-mapper. `Telescope.map(...)` matches fields by exact name and type, nothing more — no fuzzy name
+- **Not a MapStruct replacement — and not trying to be.** MapStruct emits one hand-tuned method body per type pair and
+  wins on dispatch speed (measured — 2-4× on flat conversion; see [Performance honesty](#performance-honesty)).
+  Telescope's case is the capabilities MapStruct doesn't compose to: deep navigation, effectful update (`updateAsync` /
+  `updateValidated` / `updateEither` / `updateOptional`), sealed-narrow paradigm hop, JPA cycle handling, Hibernate
+  `LAZY` proxy unwrap, bidirectional from one declaration. Spring / Quarkus integration: `telescope-quarkus` ships as an
+  Arc extension (Jandex-discovered, native-image safe); Spring wiring is bring-your-own, demonstrated end-to-end across
+  four Boot apps in [`examples/springboot/`](examples/springboot). If your problem is one of those, see
+  [When telescope is the right pick](#when-telescope-is-the-right-pick). If it isn't, MapStruct is the right pick — pick
+  it.
+- **Not a fuzzy auto-mapper.** `Telescope.map(...)` matches fields by exact name and type, nothing more — no fuzzy name
   heuristics, no flattening, no inferred relationships (that's ModelMapper / Dozer territory, and they lost to MapStruct
   for good reasons). Anything that isn't an exact name match you declare yourself with a `Mapping.to(srcAcc, tgtAcc)` or
   `Mapping.via(srcAcc, tgtAcc, nestedMapper)` row.
-- Not category theory. Internally, it's the same idea as a Monocle "Traversal" (get-many + modify-many), but you never
-  have to type those words.
+- **Not category theory.** Internally it's a Monocle-style Traversal, but `Iso`, `Lens`, `Prism`, `Affine`, and
+  `Traversal` are all package-private behind a JPMS boundary. You read, write, update, traverse, convert, and lift
+  through one `Telescope<S, A>` type — you never have to type the academic words.
 
 ---
 
@@ -165,19 +171,69 @@ integration. Telescope is an **optics DSL** where mapping is one capability amon
 update, and sealed-type narrowing. They overlap on the deep record↔record / bean↔record / bean↔bean band; the rest of
 each tool's surface doesn't.
 
-| Capability                                           | telescope                                                                                           | MapStruct                                                  |
-| ---------------------------------------------------- | --------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
-| **Bidirectional out of the box**                     | Every `Mapping.to(srcAcc, tgtAcc)` row works both ways via `Mapper.forward(...)` / `.backward(...)` | One direction per `@Mapper` interface; reverse is separate |
-| **Deep nested navigation + update**                  | `Telescope.of(C).each(C::depts).field(D::address).update(c, fn)`                                    | Not in scope                                               |
-| **Effectful update**                                 | `updateAsync` / `updateOptional` / `updateEither` / `updateValidated`                               | Not in scope                                               |
-| **Compile-time codegen**                             | `@Focus` / `@BeanFocus` / `@Bridge` annotation processors                                           | `@Mapper` interfaces                                       |
-| **Runtime path (no codegen required)**               | `Telescope.of(Class)` with reflective metadata probe; users can opt into `@Focus` later             | Compile-time only                                          |
-| **Sealed types / pattern matching**                  | `.as(Subtype.class)` narrows; the path stays type-safe                                              | Not in scope                                               |
-| **Conditional / expression-based mappings**          | `Mapping.via(srcAcc, tgtAcc, customMapper)` only — no embedded expression language                  | `@Mapping(expression = "...")`, `condition = "..."`        |
-| **`@BeforeMapping` / `@AfterMapping` hooks**         | Not supported                                                                                       | Yes                                                        |
-| **Spring / Quarkus / CDI integration**               | None today — bring-your-own wiring                                                                  | Native via `componentModel = "spring"` / `"jsr330"` / etc. |
-| **Maturity**                                         | 1.0 line; 6 ADRs documenting load-bearing decisions; JMH-backed perf claims                         | Ten years; thousands of production deployments             |
-| **Per-field dispatch perf (codegen path, ADR-0006)** | ~25 ns/op (`field_holder`, 3.23× faster than the reflective fallback)                               | Direct bytecode, no dispatch overhead                      |
+| Capability                                   | telescope                                                                                           | MapStruct                                                  |
+| -------------------------------------------- | --------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
+| **Bidirectional out of the box**             | Every `Mapping.to(srcAcc, tgtAcc)` row works both ways via `Mapper.forward(...)` / `.backward(...)` | One direction per `@Mapper` interface; reverse is separate |
+| **Deep nested navigation + update**          | `Telescope.of(C).each(C::depts).field(D::address).update(c, fn)`                                    | Not in scope                                               |
+| **Effectful update**                         | `updateAsync` / `updateOptional` / `updateEither` / `updateValidated`                               | Not in scope                                               |
+| **Compile-time codegen**                     | `@Focus` / `@BeanFocus` / `@Bridge` annotation processors                                           | `@Mapper` interfaces                                       |
+| **Runtime path (no codegen required)**       | `Telescope.of(Class)` with reflective metadata probe; users can opt into `@Focus` later             | Compile-time only                                          |
+| **Sealed types / pattern matching**          | `.as(Subtype.class)` narrows; the path stays type-safe                                              | Not in scope                                               |
+| **Conditional / expression-based mappings**  | `Mapping.via(srcAcc, tgtAcc, customMapper)` only — no embedded expression language                  | `@Mapping(expression = "...")`, `condition = "..."`        |
+| **`@BeforeMapping` / `@AfterMapping` hooks** | Not supported                                                                                       | Yes                                                        |
+| **Spring / Quarkus / CDI integration**       | None today — bring-your-own wiring                                                                  | Native via `componentModel = "spring"` / `"jsr330"` / etc. |
+| **Maturity**                                 | 1.0 line; 6 ADRs documenting load-bearing decisions; JMH-backed perf claims                         | Ten years; thousands of production deployments             |
+| **Dispatch perf — codegen vs codegen**       | Slower by 2–4× on flat/nested/deep tiers — see Performance honesty below for the measured numbers   | Direct bytecode, monomorphic call site                     |
+
+#### Per-field source/target mapping — side by side
+
+The bread-and-butter MapStruct call — `@Mapping(source="x", target="y")` — has a direct telescope equivalent. The two
+look alike on purpose; the differences are where the safety lives.
+
+```java
+// MapStruct
+@Mapper
+public interface OrderMapper {
+  @Mapping(source = "customerName", target = "fullName")
+  @Mapping(source = "createdAt", target = "createdDate")
+  OrderDto toDto(Order order);
+}
+```
+
+```java
+// telescope — varargs factory
+final var mapper = Telescope.mapper(
+  Mapping.to(Order::getCustomerName, OrderDto::getFullName),
+  Mapping.to(Order::getCreatedAt, OrderDto::getCreatedDate),
+  Mapping.auto() // same-named fields backfill automatically
+);
+
+final OrderDto dto = mapper.forward(order);
+
+final Order back = mapper.backward(dto);
+```
+
+```java
+// telescope — fluent chain (equivalent shape)
+Telescope.map(Order.class).to(OrderDto.class)
+  .field(Order::getCustomerName, OrderDto::getFullName)
+  .field(Order::getCreatedAt,    OrderDto::getCreatedDate)
+  .build();
+```
+
+| Aspect                               | MapStruct                                               | telescope                                                                  |
+| ------------------------------------ | ------------------------------------------------------- | -------------------------------------------------------------------------- |
+| **Source / target syntax**           | Strings: `"customerName"`                               | Typed method references: `Order::getCustomerName`                          |
+| **Typo / type-mismatch caught at**   | Annotation-processor run                                | **`javac` compile time** — the wrong-type accessor doesn't compile         |
+| **Survives a rename (IDE refactor)** | String breaks; processor re-runs and surfaces the error | IDE refactor follows the accessor everywhere                               |
+| **Reverse direction**                | A second method with `@InheritInverseConfiguration`     | Same `Mapping.to(...)` row works both ways                                 |
+| **Nested path** (`source = "a.b.c"`) | Expression-string                                       | `Mapping.via(srcAcc, tgtAcc, nestedMapper)` — typed at every hop           |
+| **Custom expression**                | `@Mapping(expression = "java(...)")`                    | `Mapping.via(srcAcc, tgtAcc, customMapper)` — plain Java mapper, type-safe |
+| **`condition = "..."` predicate**    | Annotation attribute                                    | `Edit.overIfPresent(...)` for updates; `Mapping.drop(...)` for mappings    |
+
+The intent is identical; the calculus is different. MapStruct trades the typed-ref ergonomics for the ability to express
+things like `source = "user.address.street"` as a single string. Telescope trades the string-path brevity for the
+guarantee that everything you wrote against the source/target types compiles iff it still makes sense.
 
 #### When MapStruct is the right pick
 
@@ -202,14 +258,36 @@ each tool's surface doesn't.
 
 #### Performance honesty
 
-The 3.23× ratio in the table compares telescope's `@Focus` codegen path against its own reflective fallback — not
-against MapStruct. We haven't run an apples-to-apples vs MapStruct benchmark; MapStruct's generated bytecode and
-telescope's codegen-emitted `<X>Telescope` constants both compile down to roughly direct method calls, and the per-call
-delta on a trivial accessor would be dominated by JIT inlining and cache behaviour rather than by either library's
-dispatch shape. Use the
-[HolderDispatchBenchmark](benchmarks/README.md#holderdispatchbenchmark--sibling-metadata-holder-routing-adr-0006-phases-b--c--d)
-to reproduce telescope's internal numbers. For "is it fast enough?", both tools clear sub-microsecond on deep-record
-conversions — the choice should be on feature fit, not on perf within an order of magnitude.
+We now have the apples-to-apples numbers
+([`MapStructComparisonBenchmark`](benchmarks/README.md#mapstruct-comparison-apples-to-apples), JDK 25, Apple Silicon, 3
+warmup + 5 measurement × 1 fork) on identical fixture shapes across three depth tiers and both directions:
+
+| Tier   | Direction     | MapStruct (ns/op) | Telescope codegen (ns/op) | Telescope runtime (ns/op) |
+| ------ | ------------- | ----------------: | ------------------------: | ------------------------: |
+| flat   | bean → record |       3.66 ± 0.19 |              15.37 ± 3.27 |            371.85 ± 39.06 |
+| flat   | record → bean |       3.56 ± 0.12 |               6.85 ± 3.12 |            507.21 ± 23.47 |
+| nested | bean → record |       5.41 ± 0.56 |              17.86 ± 1.45 |            564.47 ± 59.91 |
+| nested | record → bean |       5.71 ± 0.80 |              11.53 ± 2.36 |            762.93 ± 37.40 |
+| deep   | bean → record |      53.88 ± 5.62 |             189.43 ± 4.62 |          2304.62 ± 119.68 |
+| deep   | record → bean |     70.81 ± 68.75 |            191.64 ± 14.09 |          2678.48 ± 592.70 |
+
+**MapStruct wins on every row.** No spin. On the closest comparison (codegen vs codegen) telescope sits **2–4× behind**
+across the three tiers. The reflective runtime path is **30–100× slower** than MapStruct's generated bytecode.
+
+**Why MapStruct wins on dispatch.** It emits one hand-templated method body per pair — every getter / setter / nested
+call is fully monomorphic and the JIT inlines the whole conversion into a single basic block. Telescope's `@Bridge`
+emits an `Iso` chain composed via the lattice's `.then(...)` rules. The composition is what makes the lattice reusable
+(Iso round-trips, threads through `Telescope` paths, lifts through containers via `Iso.liftList`), but at the dispatch
+level each `.then` is a virtual call. On a tight bench loop the JIT inlines them; the residual overhead vs MapStruct's
+flat bytecode is the 2–4× delta.
+
+**What this means.** If your use case is pure speed of `Entity → DTO` conversion and back, MapStruct is the right tool.
+Telescope's case isn't perf — it's the capabilities MapStruct doesn't compose to (sealed-narrow paradigm hop, effectful
+update, JPA cycles, Hibernate LAZY unwrap, deep navigation as a primitive, all backed by ADR-0001's invariant that the
+optic lattice stays hidden). All of those are demoed end-to-end in the `examples/springboot/` modules. Both tools clear
+sub-microsecond on the flat/nested tiers and stay in single-microsecond territory on the deep tier — for typical
+request-handling code, the 2–4× codegen delta translates to ~10–140 ns absolute. It matters when conversion is the hot
+loop in a batch pipeline; it doesn't when it's one of N steps in a REST → JPA flow.
 
 ---
 


### PR DESCRIPTION
Extracted from PR #60 (https://github.com/eschizoid/telescope/pull/60) so the narrative ships independently of the bench code.

## What changes

Two README-only edits in the same neighborhood of the file:

### 1. "Performance honesty" — replaces the hedge with measured numbers

Old paragraph said: *"we haven't run an apples-to-apples vs MapStruct benchmark"*. PR #60 fixed that by adding the benchmark; this PR updates the narrative around it.

The new section drops the full results table (3 tiers × 2 directions × 3 engines = 18 rows from `MapStructComparisonBenchmark`) plus an honest read:

- **MapStruct wins every row.** No spin.
- **Codegen vs codegen:** telescope sits **2-4× behind** across tiers.
- **Reflective runtime path:** **30-100× slower** than MapStruct's generated bytecode.

And reframes telescope's case explicitly as the capabilities MapStruct doesn't compose to — sealed-narrow paradigm hop, effectful update, JPA cycles, Hibernate LAZY unwrap, deep navigation as a primitive — not raw dispatch speed.

The comparison table row that previously read *"Per-field dispatch perf (codegen path, ADR-0006)"* is now *"Dispatch perf — codegen vs codegen"* with a direct pointer to the new section.

### 2. "What it is not" — refreshed bullets

Option-A "sharp pivot" rewrite:

- **"Not a MapStruct replacement"** — credits what shipped since the original bullet was written (`telescope-quarkus` Arc extension, four Spring Boot examples), states the asymmetry up front (MapStruct wins on dispatch, telescope wins on composable capabilities), and links the measured table.
- **"Not a fuzzy auto-mapper"** — unchanged (still accurate).
- **"Not category theory"** — explicitly names the package-private lattice types (`Iso`, `Lens`, `Prism`, `Affine`, `Traversal`) and the JPMS boundary that keeps them off the public surface.

## What this depends on

This PR references `MapStructComparisonBenchmark` and `benchmarks/README.md#mapstruct-comparison-apples-to-apples`. Those land on main with **PR #60** (the bench code itself). Merge order: **#60 first, then this PR.** The README anchor links will be dead until #60 lands, but the file itself is independent of the bench.

## Test plan

- [x] No code changes; nothing to test.
- [x] Markdown renders correctly (tables, anchors, code blocks).
- [ ] Cross-link check after #60 merges (the `#mapstruct-comparison-apples-to-apples` anchor lives in `benchmarks/README.md` from #60).