### PR TITLE
feat(mapping): Mapper.withPath family — closes the @Mapping(source/target nested) gap

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ Telescope.map(Order.class).to(OrderDto.class)
 | **Typo / type-mismatch caught at**   | Annotation-processor run                                | **`javac` compile time** — the wrong-type accessor doesn't compile         |
 | **Survives a rename (IDE refactor)** | String breaks; processor re-runs and surfaces the error | IDE refactor follows the accessor everywhere                               |
 | **Reverse direction**                | A second method with `@InheritInverseConfiguration`     | Same `Mapping.to(...)` row works both ways                                 |
-| **Nested path** (`source = "a.b.c"`) | Expression-string                                       | `Mapping.via(srcAcc, tgtAcc, nestedMapper)` — typed at every hop           |
+| **Nested path** (`source = "a.b.c"`) | Expression-string                                       | `mapper.withPath(srcPath, tgtPath)` — fully typed path on either side      |
 | **Custom expression**                | `@Mapping(expression = "java(...)")`                    | `Mapping.via(srcAcc, tgtAcc, customMapper)` — plain Java mapper, type-safe |
 | **`condition = "..."` predicate**    | Annotation attribute                                    | `Edit.overIfPresent(...)` for updates; `Mapping.drop(...)` for mappings    |
 
@@ -235,55 +235,51 @@ The intent is identical; the calculus is different. MapStruct trades the typed-r
 things like `source = "user.address.street"` as a single string. Telescope trades the string-path brevity for the
 guarantee that everything you wrote against the source/target types compiles iff it still makes sense.
 
-#### Per-field source/target mapping — side by side
+#### Nested-path mapping — `@Mapping(source="a.b.c", target="x.y.z")` in telescope
 
-The bread-and-butter MapStruct call — `@Mapping(source="x", target="y")` — has a direct telescope equivalent. The two
-look alike on purpose; the differences are where the safety lives.
+MapStruct's nested-path syntax has a typed equivalent in telescope via `Mapper.withPath(srcPath, tgtPath)`. The path on
+either side is a real `Telescope<S, A>` — composed with the same `.field(...)` / `.each(...)` navigation you already use
+for read / update — so the IDE refactor follows each hop and `javac` catches a missing accessor everywhere.
 
 ```java
 // MapStruct
 @Mapper
 public interface OrderMapper {
-  @Mapping(source = "customerName", target = "fullName")
-  @Mapping(source = "createdAt", target = "createdDate")
+  @Mapping(source = "customerName", target = "shipping.recipient.fullName")
+  @Mapping(source = "createdAt", target = "audit.createdDate")
   OrderDto toDto(Order order);
 }
 ```
 
 ```java
-// telescope — varargs factory
-final var mapper = Telescope.mapper(
-  Mapping.to(Order::getCustomerName, OrderDto::getFullName),
-  Mapping.to(Order::getCreatedAt, OrderDto::getCreatedDate),
-  Mapping.auto() // same-named fields backfill automatically
-);
+// telescope — chain `withPath` calls on the base Mapper
+final var mapper = Telescope.mapper(Order.class, OrderDto.class)
+  .withPath(
+    Order::getCustomerName,
+    Telescope.of(OrderDto.class)
+      .field(OrderDto::getShipping)
+      .field(Shipping::getRecipient)
+      .field(Recipient::getFullName)
+  )
+  .withPath(Order::getCreatedAt, Telescope.of(OrderDto.class).field(OrderDto::getAudit).field(Audit::getCreatedDate));
 
 final OrderDto dto = mapper.forward(order);
 
-final Order back = mapper.backward(dto);
+final Order back = mapper.backward(dto); // path-rules round-trip both ways
 ```
 
-```java
-// telescope — fluent chain (equivalent shape)
-Telescope.map(Order.class).to(OrderDto.class)
-  .field(Order::getCustomerName, OrderDto::getFullName)
-  .field(Order::getCreatedAt,    OrderDto::getCreatedDate)
-  .build();
-```
+For path **on the source side**, pass a `Telescope` instead of an accessor — both sides accept either shape.
 
-| Aspect                               | MapStruct                                               | telescope                                                                  |
-| ------------------------------------ | ------------------------------------------------------- | -------------------------------------------------------------------------- |
-| **Source / target syntax**           | Strings: `"customerName"`                               | Typed method references: `Order::getCustomerName`                          |
-| **Typo / type-mismatch caught at**   | Annotation-processor run                                | **`javac` compile time** — the wrong-type accessor doesn't compile         |
-| **Survives a rename (IDE refactor)** | String breaks; processor re-runs and surfaces the error | IDE refactor follows the accessor everywhere                               |
-| **Reverse direction**                | A second method with `@InheritInverseConfiguration`     | Same `Mapping.to(...)` row works both ways                                 |
-| **Nested path** (`source = "a.b.c"`) | Expression-string                                       | `Mapping.via(srcAcc, tgtAcc, nestedMapper)` — typed at every hop           |
-| **Custom expression**                | `@Mapping(expression = "java(...)")`                    | `Mapping.via(srcAcc, tgtAcc, customMapper)` — plain Java mapper, type-safe |
-| **`condition = "..."` predicate**    | Annotation attribute                                    | `Edit.overIfPresent(...)` for updates; `Mapping.drop(...)` for mappings    |
+**Collections** (Phase 2):
 
-The intent is identical; the calculus is different. MapStruct trades the typed-ref ergonomics for the ability to express
-things like `source = "user.address.street"` as a single string. Telescope trades the string-path brevity for the
-guarantee that everything you wrote against the source/target types compiles iff it still makes sense.
+- `mapper.withBroadcastPath(srcPath, tgtPath)` — single source value stamped into every focus of a many-focus target
+  (`Telescope.of(B.class).each(B::items).field(Item::tenantId)`). Forward is straightforward; backward assumes the foci
+  agree (round-trip law caveat).
+- `mapper.withZipPath(srcPath, tgtPath)` — positional N:N between two many-focus paths. Cardinality mismatch throws —
+  silent truncation would be a footgun.
+
+The single-focus `withPath`, broadcast `withBroadcastPath`, and zip `withZipPath` are three distinct method names so the
+call site signals the cardinality choice to a reader.
 
 #### When MapStruct is the right pick
 

--- a/core/src/main/java/io/github/eschizoid/telescope/conversion/Mapper.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/conversion/Mapper.java
@@ -184,6 +184,129 @@ public final class Mapper<A, B> {
   }
 
   /**
+   * Add a nested-path correspondence on top of this mapper. After {@link #forward}/{@link
+   * #backward} produces the base value, the path-pair is applied: forward reads the source value
+   * from {@code srcPath} and writes it through {@code tgtPath}; backward does the mirror. Closes
+   * the gap with MapStruct's {@code @Mapping(source = "a.b.c", target = "x.y.z")} for nested
+   * fields.
+   *
+   * <pre>{@code
+   * record A(String code, Inner inner) {}
+   * record Inner(String name) {}
+   * record B(String code, BInner inner) {}
+   * record BInner(String code) {}
+   *
+   * final var mapper = Telescope.mapper(A.class, B.class, Mapping.auto())
+   *     .withPath(
+   *         Telescope.of(A.class).field(A::code),                              // src path
+   *         Telescope.of(B.class).field(B::inner).field(BInner::code));        // tgt path
+   *
+   * mapper.forward(new A("X", new Inner("n"))).inner().code();  // "X"
+   * }</pre>
+   *
+   * <p><b>Phase 1 — single-focus paths.</b> Both paths must terminate at a single value (built from
+   * {@code .field(...)} navigation only; no {@code .each()} / {@code .eachValue()} / {@code
+   * .whenPresent()} in the chain). Many-focus paths fall through to broadcast/zip semantics with
+   * caveats documented at {@link #withBroadcastPath} (Phase 2).
+   *
+   * <p><b>Composition.</b> Returns a fresh mapper; the receiver is unchanged. Chain multiple {@code
+   * withPath} calls to layer N nested-path rules.
+   *
+   * <p><b>Patch table.</b> Carried through unchanged. Path-based rules don't participate in the
+   * sparse-overlay patch protocol — they fire on every forward/backward, not on {@link #patch}.
+   */
+  public <X> Mapper<A, B> withPath(final Telescope<A, X> srcPath, final Telescope<B, X> tgtPath) {
+    final Mapper<A, B> self = this;
+    return new Mapper<>(
+      Iso.of(a -> tgtPath.set(self.forward(a), srcPath.read(a)), b -> srcPath.set(self.backward(b), tgtPath.read(b))),
+      sourceClass,
+      targetClass,
+      patchByTargetField
+    );
+  }
+
+  /**
+   * Convenience: like {@link #withPath(Telescope, Telescope)} but with a flat source accessor —
+   * mirrors the common shape "pull a top-level field from {@code A} and stamp it into a nested
+   * location on {@code B}." Equivalent to {@code withPath(Telescope.of(A.class).field(srcAcc),
+   * tgtPath)} — the explicit form lets you compose multi-hop source paths when the source side is
+   * also nested.
+   */
+  public <X> Mapper<A, B> withPath(final Telescope.Accessor<A, X> srcAcc, final Telescope<B, X> tgtPath) {
+    return withPath(Telescope.of(sourceClass).field(srcAcc), tgtPath);
+  }
+
+  /** Mirror of {@link #withPath(Telescope.Accessor, Telescope)} — nested source, flat target. */
+  public <X> Mapper<A, B> withPath(final Telescope<A, X> srcPath, final Telescope.Accessor<B, X> tgtAcc) {
+    return withPath(srcPath, Telescope.of(targetClass).field(tgtAcc));
+  }
+
+  /**
+   * Phase-2 sibling of {@link #withPath(Telescope, Telescope)} — when the target path is many-focus
+   * (uses {@code .each()} / {@code .eachValue()} / {@code .whenPresent()}), forward broadcasts the
+   * single source value to every target focus, and backward reverse-maps the (assumed-uniform)
+   * value at the first focus back to the source. The "all foci hold the same value" precondition is
+   * the caveat to the iso laws — see the README for the round-trip semantics.
+   *
+   * <p>Implementation is identical to the scalar form because {@link Telescope#set} on a {@code
+   * Traversal} already broadcasts and {@link Telescope#read} returns the first focus. This method
+   * exists as a named documentation seam — call it when you intentionally want broadcast semantics
+   * so the call site signals the choice to a reader.
+   */
+  public <X> Mapper<A, B> withBroadcastPath(final Telescope<A, X> srcPath, final Telescope<B, X> tgtPath) {
+    return withPath(srcPath, tgtPath);
+  }
+
+  /**
+   * Phase-2 sibling of {@link #withPath(Telescope, Telescope)} for the symmetric many-focus case —
+   * both paths traverse collections of matching cardinality. Forward writes positionally: source's
+   * Nth value lands at target's Nth focus. A cardinality mismatch throws at apply time (silent
+   * truncation would be a footgun). Backward is the mirror.
+   *
+   * <p><b>Caveat.</b> {@link Telescope#set} on a {@code Traversal} broadcasts a single value to
+   * every focus — it does not natively support positional zip. This method enforces positional
+   * semantics by reading the source values as a list via {@link Telescope#toList} and using {@link
+   * Telescope#updateIndexed} on the target to write per position. See {@link #withPath} for the
+   * single-focus scalar case.
+   */
+  public <X> Mapper<A, B> withZipPath(final Telescope<A, X> srcPath, final Telescope<B, X> tgtPath) {
+    final Mapper<A, B> self = this;
+    return new Mapper<>(
+      Iso.of(
+        a -> {
+          final var baseB = self.forward(a);
+          final var srcValues = srcPath.toList(a);
+          final var targetCount = tgtPath.count(baseB);
+          if (srcValues.size() != targetCount) throw new IllegalStateException(
+            "withZipPath: source has " +
+              srcValues.size() +
+              " value(s), target has " +
+              targetCount +
+              " focus(es) — cardinality must match for positional zip."
+          );
+          return tgtPath.updateIndexed(baseB, (i, _ignored) -> srcValues.get(i));
+        },
+        b -> {
+          final var baseA = self.backward(b);
+          final var tgtValues = tgtPath.toList(b);
+          final var sourceCount = srcPath.count(baseA);
+          if (tgtValues.size() != sourceCount) throw new IllegalStateException(
+            "withZipPath: target has " +
+              tgtValues.size() +
+              " value(s), source has " +
+              sourceCount +
+              " focus(es) — cardinality must match for positional zip."
+          );
+          return srcPath.updateIndexed(baseA, (i, _ignored) -> tgtValues.get(i));
+        }
+      ),
+      sourceClass,
+      targetClass,
+      patchByTargetField
+    );
+  }
+
+  /**
    * Lift this element-level mapper to a {@code Mapper<List<A>, List<B>>}. Forward maps each element
    * through {@link #forward}; backward maps each element through {@link #backward}. {@code null}
    * lists round-trip to {@code null} (mirrors the null-pass-through convention of {@link

--- a/core/src/test/java/io/github/eschizoid/telescope/NestedPathMapperTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/NestedPathMapperTest.java
@@ -1,0 +1,213 @@
+package io.github.eschizoid.telescope;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import io.github.eschizoid.telescope.conversion.Mapper;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies the {@code Mapper.withPath} family — telescope's analogue of MapStruct's
+ * {@code @Mapping(source = "a.b.c", target = "x.y.z")} for nested-field correspondences. Phase 1
+ * covers scalar/single-focus paths on either side; Phase 2 covers many-focus broadcast and
+ * positional zip.
+ */
+class NestedPathMapperTest {
+
+  // ---------- Phase 1 fixtures ----------
+  record A(String code, Inner inner) {}
+
+  record Inner(String name) {}
+
+  record B(String code, BInner inner) {}
+
+  record BInner(String code) {}
+
+  @Nested
+  @DisplayName("Phase 1 — single-focus paths")
+  class Phase1 {
+
+    /** Hand-rolled base mapper so the tests isolate withPath from the auto-recursion logic. */
+    private Mapper<A, B> baseMapper() {
+      return Mapper.create(
+        (final A a) -> new B(a.code(), new BInner("")),
+        (final B b) -> new A(b.code(), new Inner("")),
+        A.class,
+        B.class,
+        Map.of()
+      );
+    }
+
+    @Test
+    @DisplayName("flat source accessor → nested target path stamps the value at the leaf")
+    void flatSourceToNestedTargetPath() {
+      final var mapper = baseMapper().withPath(A::code, Telescope.of(B.class).field(B::inner).field(BInner::code));
+
+      final var result = mapper.forward(new A("X", new Inner("n")));
+      assertEquals("X", result.inner().code());
+    }
+
+    @Test
+    @DisplayName("flat source accessor → nested target path round-trips through backward")
+    void flatSourceToNestedTargetPathBackward() {
+      final var mapper = baseMapper().withPath(A::code, Telescope.of(B.class).field(B::inner).field(BInner::code));
+
+      final var b = new B("X", new BInner("X"));
+      final var roundTripped = mapper.backward(b);
+      assertEquals("X", roundTripped.code());
+    }
+
+    @Test
+    @DisplayName("nested source path → nested target path round-trips")
+    void nestedSourcePathToNestedTargetPath() {
+      final var mapper = baseMapper().withPath(
+        Telescope.of(A.class).field(A::inner).field(Inner::name),
+        Telescope.of(B.class).field(B::inner).field(BInner::code)
+      );
+
+      final var result = mapper.forward(new A("X", new Inner("from-nested")));
+      assertEquals("from-nested", result.inner().code());
+    }
+
+    @Test
+    @DisplayName("multiple withPath calls layer N nested rules")
+    void multipleWithPathCalls() {
+      record A2(String a, String b) {}
+      record Inner2(String inner) {}
+      record Outer2(Inner2 first, Inner2 second) {}
+
+      final var base = Mapper.create(
+        (final A2 src) -> new Outer2(new Inner2(""), new Inner2("")),
+        (final Outer2 t) -> new A2("", ""),
+        A2.class,
+        Outer2.class,
+        Map.of()
+      );
+      final var mapper = base
+        .withPath(A2::a, Telescope.of(Outer2.class).field(Outer2::first).field(Inner2::inner))
+        .withPath(A2::b, Telescope.of(Outer2.class).field(Outer2::second).field(Inner2::inner));
+
+      final var out = mapper.forward(new A2("A-val", "B-val"));
+      assertEquals("A-val", out.first().inner());
+      assertEquals("B-val", out.second().inner());
+    }
+  }
+
+  // ---------- Phase 2 fixtures ----------
+  record C(String tenant, List<Item> items) {}
+
+  record Item(String name) {}
+
+  record D(String tenant, List<Product> products) {}
+
+  record Product(String name, String tenant) {}
+
+  @Nested
+  @DisplayName("Phase 2 — many-focus paths (broadcast and zip)")
+  class Phase2 {
+
+    @Test
+    @DisplayName("broadcast: single source value written to every focus of a many-focus target")
+    void broadcastSingleToMany() {
+      final var base = Mapper.create(
+        (final C c) ->
+          new D(
+            c.tenant(),
+            c
+              .items()
+              .stream()
+              .map(i -> new Product(i.name(), ""))
+              .toList()
+          ),
+        (final D d) ->
+          new C(
+            d.tenant(),
+            d
+              .products()
+              .stream()
+              .map(p -> new Item(p.name()))
+              .toList()
+          ),
+        C.class,
+        D.class,
+        Map.of()
+      );
+
+      final var mapper = base.withBroadcastPath(
+        Telescope.of(C.class).field(C::tenant),
+        Telescope.of(D.class).each(D::products).field(Product::tenant)
+      );
+
+      final var c = new C("acme", List.of(new Item("a"), new Item("b"), new Item("c")));
+      final var d = mapper.forward(c);
+      assertEquals(List.of("acme", "acme", "acme"), d.products().stream().map(Product::tenant).toList());
+    }
+
+    @Test
+    @DisplayName("zip: positional N-to-N when source path and target path have matching cardinality")
+    void zipPositional() {
+      record SrcWrapper(List<Item> items) {}
+      record TgtWrapper(List<Product> products) {}
+
+      final var base = Mapper.create(
+        (final SrcWrapper s) ->
+          new TgtWrapper(
+            s
+              .items()
+              .stream()
+              .map(i -> new Product("", ""))
+              .toList()
+          ),
+        (final TgtWrapper t) ->
+          new SrcWrapper(
+            t
+              .products()
+              .stream()
+              .map(p -> new Item(""))
+              .toList()
+          ),
+        SrcWrapper.class,
+        TgtWrapper.class,
+        Map.of()
+      );
+
+      final var mapper = base.withZipPath(
+        Telescope.of(SrcWrapper.class).each(SrcWrapper::items).field(Item::name),
+        Telescope.of(TgtWrapper.class).each(TgtWrapper::products).field(Product::name)
+      );
+
+      final var src = new SrcWrapper(List.of(new Item("x"), new Item("y"), new Item("z")));
+      final var tgt = mapper.forward(src);
+      assertEquals(List.of("x", "y", "z"), tgt.products().stream().map(Product::name).toList());
+    }
+
+    @Test
+    @DisplayName("zip: cardinality mismatch throws")
+    void zipCardinalityMismatch() {
+      record SrcWrapper(List<Item> items) {}
+      record TgtWrapper(List<Product> products) {}
+
+      // Base mapper deliberately produces a DIFFERENT cardinality on the target side.
+      final var base = Mapper.create(
+        (final SrcWrapper s) -> new TgtWrapper(List.of(new Product("", ""), new Product("", ""))), // always 2
+        (final TgtWrapper t) -> new SrcWrapper(List.of()),
+        SrcWrapper.class,
+        TgtWrapper.class,
+        Map.of()
+      );
+
+      final var mapper = base.withZipPath(
+        Telescope.of(SrcWrapper.class).each(SrcWrapper::items).field(Item::name),
+        Telescope.of(TgtWrapper.class).each(TgtWrapper::products).field(Product::name)
+      );
+
+      final var src = new SrcWrapper(List.of(new Item("x"), new Item("y"), new Item("z"))); // 3 items
+      final var ex = assertThrows(IllegalStateException.class, () -> mapper.forward(src));
+      assertEquals(true, ex.getMessage().contains("cardinality must match"));
+    }
+  }
+}


### PR DESCRIPTION
Closes the **`@Mapping(source="a.b.c", target="x.y.z")`** gap with MapStruct that surfaced as a feature ask earlier today.

Three new methods on `Mapper`, each with a documented cardinality semantic:

| Method | Cardinality | What it does |
|---|---|---|
| `withPath(srcPath, tgtPath)` | single → single | Phase 1. Both paths terminate at a single value. Forward stamps source value at the target leaf; backward reverses it. Round-trip preserved. |
| `withBroadcastPath(srcPath, tgtPath)` | single → many | Phase 2. Source is a single value; target traverses (e.g. `.each(...)`). Forward writes the value to every focus. Backward assumes foci agree — round-trip law caveat documented. |
| `withZipPath(srcPath, tgtPath)` | many → many | Phase 2. Both paths traverse collections. Forward writes positionally (source's Nth value → target's Nth focus). Cardinality mismatch throws — silent truncation would be a footgun. |

Plus convenience overloads accepting an `Accessor` on either side, lifted to a one-hop `Telescope` via the existing `sourceClass` / `targetClass` on `Mapper`.

## Why this shape

- **Path is a real `Telescope<S, A>`** — composed with the same `.field(...)` / `.each(...)` navigation users already use for read / update. IDE refactors follow each hop and `javac` catches missing accessors everywhere.
- **No DeepMap changes, no new sealed permits.** Pure composition layer over an existing `Mapper`. Users compose:
  ```java
  Telescope.mapper(A.class, B.class, /* flat rules */)
      .withPath(srcPath, tgtPath);
  ```
- **Three distinct method names** (vs. one overloaded method) so the call site signals cardinality intent to a reader. `withZipPath(...)` reads differently from `withBroadcastPath(...)` — that's the point.

## Side by side with MapStruct

```java
// MapStruct
@Mapper
public interface OrderMapper {
  @Mapping(source = "customerName", target = "shipping.recipient.fullName")
  @Mapping(source = "createdAt",    target = "audit.createdDate")
  OrderDto toDto(Order order);
}
```

```java
// telescope — chain withPath calls on the base Mapper
final var mapper = Telescope.mapper(Order.class, OrderDto.class)
    .withPath(
        Order::getCustomerName,
        Telescope.of(OrderDto.class).field(OrderDto::getShipping).field(Shipping::getRecipient).field(Recipient::getFullName))
    .withPath(
        Order::getCreatedAt,
        Telescope.of(OrderDto.class).field(OrderDto::getAudit).field(Audit::getCreatedDate));

final OrderDto dto  = mapper.forward(order);
final Order    back = mapper.backward(dto);  // path-rules round-trip both ways
```

## Test plan

- [x] `./gradlew check` (full multi-module incl. four Spring Boot examples) — **green**.
- [x] `NestedPathMapperTest` — 7 scenarios across both phases:
  - flat-source accessor → nested-target path (forward + backward round-trip)
  - nested-source path → nested-target path
  - layering multiple `withPath` calls
  - broadcast: single → many (every focus stamped)
  - zip: positional N:N with matching cardinality
  - zip: cardinality mismatch throws `IllegalStateException`
- [x] All 7 tests **PASSED**.

## Round-trip notes (Phase 2)

- **Broadcast:** backward reads the **first focus** of the target path and writes it back to the source. If the foci disagree on the actual value at backward time, the iso law breaks. Use this semantic only when you know all foci hold the same value. The README documents this caveat alongside the example.
- **Zip:** cardinality must match at apply time, both forward and backward. Throws `IllegalStateException` with the actual N vs M counts when violated.

## Cleanup also included

Removed a duplicate "Per-field source/target mapping" section that had landed twice in `main` (merge artifact from #62 → #64 sequencing). The remaining section's "Nested path" row in the comparison table is updated to point at `Mapper.withPath` (previously claimed `Mapping.via` covered this, which it doesn't perfectly).

## What this does NOT include

- **No new `Mapping.to(srcPath, tgtPath)` factory.** Full integration with the `Mapping` sealed interface + `DeepMap` engine would require additional design work (target field claiming, conflict resolution, post-fixup ordering). The Mapper-level composition gets the feature to users now; sugar can land in a follow-up.
- **No path arity detection.** `withPath` works on single-focus paths; the broadcast/zip methods exist as separate named entry points. A single overloaded `withPath` that auto-dispatches on the underlying optic shape is a possible future refinement.

## Stacked / merge order

Off `main` directly. Independent of the still-open PRs (#60 / #64 are README+bench; can land in any order with this).
