### PR TITLE
perf(records): cache reader at Lens construction in Records.fieldLens

### DIFF
--- a/core/src/main/java/io/github/eschizoid/telescope/Telescope.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/Telescope.java
@@ -1164,7 +1164,11 @@ public sealed class Telescope<
       final Class<A> implClass = Telescope.implClassOf(getter);
       final var holderLens = MetadataHolderProbe.<A, B>lensFromHolder(implClass, name);
       if (holderLens != null) return holderLens;
-      return Records.fieldLens(name);
+      // Pass the declaring class so the lens captures (info, idx, reader) at construction —
+      // eliminates the per-call (class, name) → idx scan that the string-only fieldLens(name)
+      // overload pays. The string-only overload remains the fallback for fieldByName(String),
+      // where the source class isn't known until call time.
+      return implClass != null ? Records.fieldLens(implClass, name) : Records.fieldLens(name);
     }
   }
 

--- a/internal/src/main/java/io/github/eschizoid/telescope/internal/Records.java
+++ b/internal/src/main/java/io/github/eschizoid/telescope/internal/Records.java
@@ -50,7 +50,12 @@ public final class Records {
    * A {@link Lens} over a record component, identified by name. The {@code get} reads the
    * component; {@code set}/{@code modify} return a copy of the record with that one component
    * replaced. Backs {@link io.github.eschizoid.telescope.Telescope}'s {@code .fieldByName(String)}
-   * overload.
+   * overload — the late-bound case where the runtime class isn't known until the source flows in.
+   *
+   * <p>This overload pays a per-call {@code (class, name) → idx} lookup. When the declaring class
+   * is known at construction time (every method-reference-based {@code .field(...)} call site),
+   * prefer {@link #fieldLens(Class, String)} which resolves the reader once and bakes the index
+   * into the returned lens.
    *
    * <pre>{@code
    * record User(String name, int age) {}
@@ -75,6 +80,49 @@ public final class Records {
       @SuppressWarnings("unchecked")
       public S modify(final S source, final Function<? super A, ? extends A> f) {
         return updateField(source, fieldName, current -> ((Function<Object, Object>) f).apply(current));
+      }
+    };
+  }
+
+  /**
+   * Class-aware variant of {@link #fieldLens(String)}. Resolves the per-class {@link RecordInfo},
+   * the component index, and the LMF-built reader once at construction; the returned lens's {@code
+   * get} / {@code set} / {@code modify} dispatch directly through the captured handles with no
+   * per-call name lookup.
+   *
+   * <p>Used by the method-reference {@code .field(...)} path on {@link
+   * io.github.eschizoid.telescope.Telescope}, which already knows the declaring class via the
+   * captured method reference. The runtime escape hatch {@code fieldByName(String)} still uses
+   * {@link #fieldLens(String)} because the source class isn't known until call time.
+   *
+   * <pre>{@code
+   * record User(String name, int age) {}
+   * final Lens<User, String> name = Records.fieldLens(User.class, "name");
+   * final var renamed = name.set(new User("ann", 30), "bob"); // User[name=bob, age=30]
+   * }</pre>
+   */
+  public static <S, A> Lens<S, A> fieldLens(final Class<S> cls, final String fieldName) {
+    final var info = info(cls);
+    final var idx = info.indexOf(fieldName);
+    if (idx < 0) throw noField(fieldName, cls);
+    final var reader = info.readers()[idx];
+    return new Lens<>() {
+      @SuppressWarnings("unchecked")
+      @Override
+      public A get(final S source) {
+        if (source == null) return null;
+        return (A) reader.apply(source);
+      }
+
+      @Override
+      public S set(final S source, final A value) {
+        return rebuildWith(info, idx, source, ignored -> value);
+      }
+
+      @Override
+      @SuppressWarnings("unchecked")
+      public S modify(final S source, final Function<? super A, ? extends A> f) {
+        return rebuildWith(info, idx, source, current -> ((Function<Object, Object>) f).apply(current));
       }
     };
   }
@@ -171,6 +219,24 @@ public final class Records {
     final var info = info(cls);
     final var idx = info.indexOf(fieldName);
     if (idx < 0) throw noField(fieldName, cls);
+    return rebuildWith(info, idx, source, fn);
+  }
+
+  /**
+   * Rebuild {@code source} with the component at {@code idx} replaced by {@code fn} applied to its
+   * current value. Captures-friendly: the caller supplies the pre-resolved {@link RecordInfo} and
+   * {@code idx}, so there's no per-call {@code (class, name) → idx} lookup. The class-aware {@link
+   * #fieldLens(Class, String)} overload uses this directly; the late-bound {@link
+   * #updateField(Object, String, Function)} resolves info+idx then delegates here.
+   */
+  @SuppressWarnings("unchecked")
+  private static <S> S rebuildWith(
+    final RecordInfo info,
+    final int idx,
+    final S source,
+    final Function<Object, Object> fn
+  ) {
+    if (source == null) return null;
     final var readers = info.readers();
     final var args = new Object[readers.length];
     for (var i = 0; i < args.length; i++) {
@@ -184,7 +250,7 @@ public final class Records {
     try {
       return (S) info.ctorFn().apply(args);
     } catch (final RuntimeException re) {
-      throw new RuntimeException("Failed to rebuild " + cls.getSimpleName(), re);
+      throw new RuntimeException("Failed to rebuild " + source.getClass().getSimpleName(), re);
     }
   }
 


### PR DESCRIPTION
## Summary

The runtime `Records.fieldLens(String)` overload re-resolved `(class, name) -> idx` on every `lens.get(source)` call — a linear scan over the cached `RecordComponent[]` to translate the field name into the array index used to pick the LMF reader. For the method-reference path (`Telescope.of(User.class).field(User::name)`), that scan was pure overhead: the declaring class is captured at `.field(...)` construction time via `Telescope.implClassOf(getter)`, so the index can be baked in once.

This PR:

- Adds `Records.fieldLens(Class<S> cls, String fieldName)` — resolves the per-class `RecordInfo`, the component index, and the LMF-built `Function<Object, Object>` reader once at construction. The returned Lens's `get` / `set` / `modify` dispatch through the captured handles directly.
- Refactors the rebuild path so the class-aware lens reuses the existing canonical-constructor invoker via a new private `rebuildWith(info, idx, source, fn)` helper. `updateField(...)` (the string-only path) delegates to the same helper after its own resolution step, so there's a single rebuild implementation.
- Wires `RecordFieldOptics.lensFor(...)` in `Telescope.java` to call the new class-aware overload via the already-captured `implClass`. Falls back to the string-only overload only when `implClassOf(...)` returns `null` (a pathological lambda case the runtime already handles defensively).
- Keeps `Records.fieldLens(String)` working unchanged. It remains the fallback for `fieldByName(String)`, where the source class genuinely isn't known until call time.

The LMF dispatch primitive itself (`reader.apply`) is unchanged. This PR only eliminates the per-call `indexOf(fieldName)` linear scan and the per-call `info(source.getClass())` `ClassValue` lookup that the `set` / `modify` paths used to repeat.

Hotspot #7 of the bughunt-fold-architecture batch. Sibling agent ships Hotspot #8 (`Beans.java`).

## Test plan

- [x] `./gradlew check` green across all modules (`:internal`, `:core`, `:codegen`, `:lombok`, `:benchmarks`, `:spring-boot-starter`, `:quarkus`, `:examples`)
- [x] `OpticLawsTest` get-set / set-get / set-set Lens laws pass
- [x] `TelescopeTest`, `FocusCodegenTest`, `BeanFocusCodegenTest`, `PojoOpticsTest` pass
- [x] `HybridDispatchIntegrationTest` (verifies the unannotated-record fallthrough into `Records.fieldLens`) passes
- [x] `spotlessApply` clean

## Caveats

- The bridge-bench numbers won't move — different path (codegen-generated `Iso<A, B>`). This PR helps `Telescope.of(Class).field(...)` runtime navigation (the `ofBeanFieldUpdate` / `reflectionFieldUpdate` tier rows in the benchmark table).
- No new JMH benchmark added; the existing `HolderDispatchBenchmark.fallbackPath` exercises this path and should see a tighter number, but per the agent brief the JMH suite wasn't run here to avoid contaminating numbers under shared load.
- Pre-1.0 — no `@Deprecated` shim on the string-only overload per the project's no-deprecated-aliases convention. The string-only `fieldLens(String)` remains a first-class API for the `fieldByName(...)` escape hatch.