### PR TITLE
perf(internal): Beans.lens captures LMF reader at construction

### DIFF
--- a/internal/src/main/java/io/github/eschizoid/telescope/internal/Beans.java
+++ b/internal/src/main/java/io/github/eschizoid/telescope/internal/Beans.java
@@ -505,6 +505,23 @@ public final class Beans {
    * properties carried over) via {@code writer}. Immutable — it never mutates {@code source}.
    * Powers {@code Telescope.ofBean(...).field(...)}.
    *
+   * <p>The {@code (pojoClass, property)} pair is constant at construction, so the LMF-built {@link
+   * Function Function&lt;Object, Object&gt;} reader is resolved <em>once</em> via {@link
+   * #GETTER_INVOKERS} and captured by the returned {@code Lens}. Per-call {@code get(source)}
+   * dispatches directly through the captured reader — no per-call ClassValue probe, no per-call
+   * HashMap lookup. The lens fails fast at build time (rather than at first read) if {@code
+   * property} has no getter on {@code pojoClass}.
+   *
+   * <p>Subclass / proxy polymorphism is preserved through a single-instanceof fast-path: when
+   * {@code source.getClass() == pojoClass} the captured reader runs directly; otherwise the call
+   * falls through to {@link #readProperty(Object, String)}, which handles both Hibernate-proxy
+   * unwrap (via {@link #persistentClassOf}) and ordinary subclass instances by looking up the
+   * reader for the runtime class. The common monomorphic case (the lens is applied to instances of
+   * exactly {@code pojoClass}) avoids both the ClassValue probe and the HashMap lookup the slow
+   * path pays. The reads-via-getter terminal in {@code set}/{@code modify} routes through the same
+   * fast-path: each off-path carry-over read picks the cached reader straight from the captured
+   * map.
+   *
    * <pre>{@code
    * final Lens<UserPojo, String> email =
    *     Beans.lens(UserPojo.class, "email", Beans.autoWriter(UserPojo.class));
@@ -513,21 +530,53 @@ public final class Beans {
    */
   public static <P, A> Lens<P, A> lens(final Class<P> pojoClass, final String property, final BeanWriter<P> writer) {
     final var names = propertyNames(pojoClass);
+    // Capture the full reader map for pojoClass once at construction. The per-property reader is
+    // pulled from the same map for both the focused `get` and the off-path carry-over reads in
+    // `set`/`modify`, so all dispatch on the fast path is a direct map.apply call — no per-call
+    // ClassValue probe, no per-call HashMap lookup against the JDK's per-Class table.
+    final var capturedReaders = GETTER_INVOKERS.get(pojoClass);
+    final var capturedReader = capturedReaders.get(property);
+    if (capturedReader == null) throw new IllegalArgumentException(
+      "No getter for property '" + property + "' on " + pojoClass.getName()
+    );
     return new Lens<>() {
       @Override
       @SuppressWarnings("unchecked")
       public A get(final P source) {
+        // Fast path: the lens is applied to an instance of exactly pojoClass — dispatch directly
+        // through the captured reader. Covers the common monomorphic case (the typical
+        // Telescope.ofBean(X.class).field(X::getY) usage) and skips the ClassValue + HashMap probe
+        // readProperty would have done.
+        if (source != null && source.getClass() == pojoClass) return (A) capturedReader.apply(source);
+        // Slow path: subclass instance, or a HibernateProxy whose persistent class differs from
+        // the runtime class. readProperty handles both correctly via persistentClassOf + the
+        // per-class GETTER_INVOKERS cache, so a Lens<User, X> applied to a SuperUser instance still
+        // reads the right value (the SuperUser entry is computed once and cached on first miss).
         return (A) readProperty(source, property);
       }
 
       @Override
       public P set(final P source, final A value) {
-        return writer.construct(names, n -> n.equals(property) ? value : readProperty(source, n));
+        return writer.construct(names, n -> n.equals(property) ? value : readForRebuild(source, n));
       }
 
       @Override
       public P modify(final P source, final Function<? super A, ? extends A> f) {
         return set(source, f.apply(get(source)));
+      }
+
+      // Mirrors the get() fast-path for the off-path values the writer needs to copy over.
+      // Off-path reads are called once per non-focused property per set/modify, so they benefit
+      // from the same capture as the focused read.
+      private Object readForRebuild(final P source, final String name) {
+        if (source != null && source.getClass() == pojoClass) {
+          final var reader = capturedReaders.get(name);
+          if (reader == null) throw new IllegalArgumentException(
+            "No getter for property '" + name + "' on " + pojoClass.getName()
+          );
+          return reader.apply(source);
+        }
+        return readProperty(source, name);
       }
     };
   }

--- a/internal/src/test/java/io/github/eschizoid/telescope/internal/BeansTest.java
+++ b/internal/src/test/java/io/github/eschizoid/telescope/internal/BeansTest.java
@@ -923,6 +923,36 @@ class BeansTest {
       final var upper = lens.modify(base, String::toUpperCase);
       assertEquals("ALICE", upper.getName());
     }
+
+    @Test
+    @DisplayName("unknown property fails at construction time, not at first read")
+    void lensRejectsUnknownPropertyEagerly() {
+      // The reader is resolved at construction time; an unknown property must surface immediately
+      // (rather than on the first get/set), so a misconfigured lens fails at build time.
+      final var ex = assertThrows(IllegalArgumentException.class, () ->
+        Beans.lens(NoArgSetters.class, "doesNotExist", Beans.autoWriter(NoArgSetters.class))
+      );
+      assertTrue(ex.getMessage().contains("doesNotExist"), ex.getMessage());
+      assertTrue(ex.getMessage().contains(NoArgSetters.class.getName()), ex.getMessage());
+    }
+
+    @Test
+    @DisplayName("subclass polymorphism: lens applied to a subclass instance reads via the slow path")
+    void lensWorksOnSubclassInstance() {
+      // The fast path is the monomorphic case (source.getClass() == pojoClass). A Lens<Parent, ?>
+      // applied to a ChildBean instance must fall through to readProperty so subclass polymorphism
+      // is preserved — the captured reader was built for ParentBean but ChildBean inherits the
+      // getter and readProperty resolves the GETTER_INVOKERS entry for the runtime class.
+      final io.github.eschizoid.telescope.internal.optics.Lens<ParentBean, String> lens = Beans.lens(
+        ParentBean.class,
+        "id",
+        Beans.autoWriter(ParentBean.class)
+      );
+      final var child = new ChildBean();
+      child.setId("p1");
+      child.setName("alice");
+      assertEquals("p1", lens.get(child));
+    }
   }
 
   @Nested


### PR DESCRIPTION
## Summary

`Beans.lens(pojoClass, property, writer)` returned a Lens whose every
`get(source)` call paid the same per-call lookup overhead:

1. `Beans.readProperty(source, property)` →
2. `persistentClassOf(source)` (HibernateProxy unwrap check) →
3. `GETTER_INVOKERS.get(beanClass)` (ClassValue probe) →
4. `.get(name)` (HashMap lookup) →
5. `reader.apply(source)` (the LMF-built getter — the only useful step).

The `(pojoClass, property)` pair is fixed at construction time, so the
LMF-built `Function<Object, Object>` reader is too. The per-call probe
was ~20-30 ns of pure waste before the actual getter ran.

This change captures the reader (and the full per-class reader map,
for the off-path carry-over reads in `set` / `modify`) once at
construction. Per-call dispatch is a single instanceof + direct
`Function.apply` — no ClassValue probe, no HashMap lookup, the JIT
inlines through the captured `final` reference.

Misconfigured lenses now fail at build time with `IllegalArgumentException`
("No getter for property 'X' on Y") rather than at first read.

## Polymorphism preserved

- **HibernateProxy unwrap.** `persistentClassOf(pojo)` returns the parent
  class — by construction that's `pojoClass`. The proxy's runtime class
  is a generated subclass, so it takes the slow path and `readProperty`
  unwraps correctly. The captured `pojoClass` is the right key.
- **Subclass instances.** A `Lens<User, X>` applied to a `SuperUser`
  instance takes the slow path (`source.getClass() != pojoClass`) and
  routes through `readProperty`, which looks up the `SuperUser` entry in
  `GETTER_INVOKERS` (cached on first miss). Same correctness as before,
  same one-time per-class build cost, only the monomorphic case skips
  the per-call lookup.

The fast path is `source.getClass() == pojoClass`. The common
`Telescope.ofBean(User.class).field(User::getX)` usage hits this every call.

## Test plan

- `./gradlew check` — all modules green (full repo build, including
  `:internal`, `:core`, `:codegen`, `:lombok`, examples).
- Added two `BeansTest.LensFactory` tests:
  - `lensRejectsUnknownPropertyEagerly` — pin the new build-time IAE.
  - `lensWorksOnSubclassInstance` — `Lens<ParentBean, String>` reads
    `id` correctly when applied to a `ChildBean` instance (forces the
    slow path).
- Existing lens / writer / optic-laws tests unchanged and green.

The bridge-bench numbers in `:benchmarks` won't move (that path goes
through `Reflective.structuralIso` + `Beans.readProperty`, not through
`Beans.lens`). The benefit lands on `Telescope.ofBean(Class).field(...)`
runtime navigation — the typical user-facing reflective bean path.