### PR TITLE
feat(mapping): nested-path Mapping factories + codegen .of() entry rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -1101,7 +1101,7 @@ Telescope.of(Company.class)
   .update(company, String::toLowerCase);
 
 // Compile-time, reflection-free — same Telescope, generator-built
-CompanyPath.focus()
+CompanyPath.of()
   .departments().each().teams().each()
   .users().each().email()
   .update(company, String::toLowerCase);
@@ -1118,7 +1118,7 @@ import io.github.eschizoid.telescope.annotations.Focus;
 // Generated: <X>Path<R> per annotated type plus a step class per collection-shaped component.
 // Usage reads like the reflective DSL — but every hop is type-checked by javac and every read /
 // rebuild is a direct method-ref + constructor call (no reflection):
-final Telescope<Company, String> userNames = CompanyPath.focus()
+final Telescope<Company, String> userNames = CompanyPath.of()
   .teams().each()        // step over List<Team> → TeamPath<Company>
   .users().each()        // step over List<User> → UserPath<Company>
   .name();               // terminal Telescope<Company, String>
@@ -1126,7 +1126,7 @@ final Telescope<Company, String> userNames = CompanyPath.focus()
 final Company shouted = userNames.update(company, String::toUpperCase);
 
 // Single fields are just as direct:
-UserPath.focus().address().city().update(alice, String::toUpperCase);
+UserPath.of().address().city().update(alice, String::toUpperCase);
 ```
 
 Each scalar component yields a terminal `Telescope<R, T>`; each sub-record component (also `@Focus`-annotated) yields a
@@ -1140,7 +1140,7 @@ gives you.
 surface — `read` / `find` / `toList` / `count` / `exists` / `set` / `update` / `updateIndexed` / `toListIndexed` /
 `then` plus the four effect methods `updateAsync` (with or without `Executor`) / `updateOptional` / `updateEither` /
 `updateValidated`. You don't need to terminate with `.get()` first; the navigator stands in for the wrapped Telescope at
-any intermediate hop. So `CompanyPath.focus().teams().each().users().each().updateAsync(company, svc::lookup, pool)`
+any intermediate hop. So `CompanyPath.of().teams().each().users().each().updateAsync(company, svc::lookup, pool)`
 returns a `CompletableFuture<Company>` directly, with the effect threaded through the generated chain.
 
 **Bridge hops — conversion as a navigator step.** If a type carries both `@Focus`/`@BeanFocus` (so it has a `*Path`) and
@@ -1158,7 +1158,7 @@ record UserDto(String id, String email) {}
 
 // Navigate through the bridge into a target field, then update. The Iso round-trips, so the
 // result is a new UserEntity:
-final UserEntity lowered = UserEntityPath.focus()
+final UserEntity lowered = UserEntityPath.of()
   .asUserDto() // → UserDtoPath<UserEntity>
   .email() // → Telescope<UserEntity, String>
   .update(entity, String::toLowerCase);
@@ -1191,7 +1191,7 @@ import io.github.eschizoid.telescope.annotations.BeanFocus;
 @BeanFocus public class UserBean { /* getId/getEmail + setters, or a static builder() */ }
 
 // Generated alongside: UserBeanPath<R> with the same fluent surface as a record navigator.
-UserBeanPath.focus().email().update(user, String::toLowerCase);   // no reflection
+UserBeanPath.of().email().update(user, String::toLowerCase);   // no reflection
 ```
 
 ---

--- a/codegen/README.md
+++ b/codegen/README.md
@@ -12,7 +12,7 @@ Telescope.of(Company.class)             // runtime path (~262 ns/op for a 3-leve
     .field(User::email)
     .update(company, String::toLowerCase);
 
-CompanyPath.focus()                      // codegen path (~45 ns/op — 5.8× faster)
+CompanyPath.of()                      // codegen path (~45 ns/op — 5.8× faster)
     .departments().each()
     .teams().each()
     .users().each()
@@ -23,10 +23,10 @@ CompanyPath.focus()                      // codegen path (~45 ns/op — 5.8× fa
 
 - **Hot paths.** The codegen navigator emits direct method-reference + canonical-constructor bytecode at every hop. Zero
   `SerializedLambda` decode, zero `Records.fieldLens(String)` lookup, zero `Beans.lens(...)` reflection.
-- **Compile-time path validation.** A typo on `CompanyPath.focus().teams()` is a `javac` error. The reflective
+- **Compile-time path validation.** A typo on `CompanyPath.of().teams()` is a `javac` error. The reflective
   `.field(Company::teamz)` blows up at construction time.
 - **Cross-paradigm bridges.** `@Bridge(UserDto.class)` on a `UserEntity` POJO generates
-  `UserEntityPath.focus().asUserDto().email()` — one fluent chain hops from bean to record.
+  `UserEntityPath.of().asUserDto().email()` — one fluent chain hops from bean to record.
 
 Skip codegen for prototype / glue code that doesn't sit in a tight loop. The reflective path is sub-microsecond and
 still build-time-validated for method references.

--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/AbstractTelescopeProcessor.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/AbstractTelescopeProcessor.java
@@ -479,7 +479,9 @@ public abstract class AbstractTelescopeProcessor extends AbstractProcessor {
    * Emit the standard header members of a generated {@code <X>Telescope<R>} class: the private
    * {@code path} field, a public constructor (so navigators in <em>other</em> packages — bridge
    * hops, sub-navigators on records whose targets live in foreign packages — can still construct
-   * one), a {@code focus()} static factory, and a {@code get()} accessor. Used by every
+   * one), an {@code of()} static factory (symmetric with runtime {@link
+   * io.github.eschizoid.telescope.Telescope#of(Class)} — the navigator's name already names the
+   * type, so no class argument is needed), and a {@code get()} accessor. Used by every
    * navigator-emitting processor (records via {@link FocusProcessor} and beans via {@link
    * #emitBeanNavigator}) so the boilerplate lives in one place.
    */
@@ -493,7 +495,7 @@ public abstract class AbstractTelescopeProcessor extends AbstractProcessor {
         pathName +
         "<" +
         targetTypeName +
-        "> focus() { return new " +
+        "> of() { return new " +
         pathName +
         "<>(Telescope.of(" +
         targetTypeName +

--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/FocusProcessor.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/FocusProcessor.java
@@ -21,7 +21,7 @@ import javax.lang.model.element.TypeElement;
  * —
  *
  * <pre>{@code
- * CompanyPath.focus().departments().each().teams().each().users().each().email()
+ * CompanyPath.of().departments().each().teams().each().users().each().email()
  * }</pre>
  *
  * with end-to-end compile-time type checking, and the method bodies use {@link

--- a/codegen/src/test/java/io/github/eschizoid/telescope/codegen/BeanFocusProcessorTest.java
+++ b/codegen/src/test/java/io/github/eschizoid/telescope/codegen/BeanFocusProcessorTest.java
@@ -61,7 +61,7 @@ class BeanFocusProcessorTest {
       assertNotNull(generated, () -> "BuilderPojoPath not generated; saw " + compilation.generated().keySet());
 
       assertTrue(generated.contains("public final class BuilderPojoTelescope<R>"), generated);
-      assertTrue(generated.contains("public static BuilderPojoTelescope<BuilderPojo> focus()"), generated);
+      assertTrue(generated.contains("public static BuilderPojoTelescope<BuilderPojo> of()"), generated);
       assertTrue(generated.contains("public Telescope<R, String> id()"), generated);
       assertTrue(generated.contains("Telescope.lens(BuilderPojo::getId,"), generated);
       assertTrue(generated.contains("BuilderPojo.builder()"), generated);

--- a/codegen/src/test/java/io/github/eschizoid/telescope/codegen/FocusProcessorTest.java
+++ b/codegen/src/test/java/io/github/eschizoid/telescope/codegen/FocusProcessorTest.java
@@ -60,8 +60,8 @@ class FocusProcessorTest {
       assertTrue(generated.contains("public final class PersonTelescope<R>"), generated);
       assertTrue(generated.contains("import io.github.eschizoid.telescope.Telescope;"), generated);
 
-      // start() returns PersonTelescope<Person> rooted at Telescope.of(Person.class).
-      assertTrue(generated.contains("public static PersonTelescope<Person> focus()"), generated);
+      // of() returns PersonTelescope<Person> rooted at Telescope.of(Person.class).
+      assertTrue(generated.contains("public static PersonTelescope<Person> of()"), generated);
       assertTrue(generated.contains("Telescope.of(Person.class)"), generated);
 
       // get() exposes the current path as a Telescope.

--- a/core/src/main/java/io/github/eschizoid/telescope/DeepMap.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/DeepMap.java
@@ -5,11 +5,13 @@ import io.github.eschizoid.telescope.internal.Beans;
 import io.github.eschizoid.telescope.internal.Reflective;
 import io.github.eschizoid.telescope.internal.optics.Iso;
 import io.github.eschizoid.telescope.mapping.Drop;
+import io.github.eschizoid.telescope.mapping.FromTelescopeTo;
 import io.github.eschizoid.telescope.mapping.MapStep;
 import io.github.eschizoid.telescope.mapping.Mapping;
 import io.github.eschizoid.telescope.mapping.MappingInternals;
 import io.github.eschizoid.telescope.mapping.SameTypedTo;
 import io.github.eschizoid.telescope.mapping.TelescopeTo;
+import io.github.eschizoid.telescope.mapping.TelescopeToTelescope;
 import io.github.eschizoid.telescope.mapping.TypedTransformTo;
 import io.github.eschizoid.telescope.mapping.Via;
 import io.github.eschizoid.telescope.mapping.WriteHint;
@@ -231,14 +233,17 @@ public final class DeepMap {
     final var grouped = new HashMap<TypePair, List<Mapping<?, ?>>>();
     for (final var row : overrides) {
       final var internals = internalsOf(row);
-      // Drop rows have no target accessor. The single-arg drop(srcAcc) factory binds the row to
-      // the top-level (source, target) pair the user passed to Telescope.map(...); the two-arg
-      // drop(srcAcc, target) factory binds it to whatever nested (source, target) pair the user
-      // names explicitly. Internals.targetClass() returns null for the single-arg form and the
-      // explicit target Class for the two-arg form.
-      final Class<?> effectiveTarget =
-        row instanceof Drop<?, ?, ?> && internals.targetClass() == null ? topTarget : internals.targetClass();
-      final var key = new TypePair(internals.sourceClass(), effectiveTarget);
+      // Rows with null sourceClass / targetClass pin to the top-level pair the user passed to
+      // Telescope.mapper(...). Two reasons a class field comes back null:
+      //   - Drop(srcAcc) — single-arg form, no explicit target.
+      //   - TelescopeTo / FromTelescopeTo / TelescopeToTelescope / TelescopeZip — the side that's a
+      //     Telescope<X, ?> can't expose its root class via SerializedLambda (the lattice is built
+      //     from method-ref accessors but the root Class<S> isn't carried at runtime).
+      // In both cases the substitution lands the row on the outer (topSource, topTarget) bucket so
+      // populateIso picks it up at the outermost (source, target) recursion frame only.
+      final Class<?> effectiveSource = internals.sourceClass() == null ? topSource : internals.sourceClass();
+      final Class<?> effectiveTarget = internals.targetClass() == null ? topTarget : internals.targetClass();
+      final var key = new TypePair(effectiveSource, effectiveTarget);
       grouped.computeIfAbsent(key, _ -> new ArrayList<>()).add(row);
     }
     return grouped;
@@ -268,31 +273,54 @@ public final class DeepMap {
 
     final var byTargetName = new LinkedHashMap<String, FieldStep>();
     final var bySourceName = new LinkedHashMap<String, FieldStep>();
+    // Strict claims: at most one SameTypedTo / TypedTransformTo / Via / Drop row per (src, tgt)
+    // field.
+    // Duplicates among these would be genuinely ambiguous, so they fail fast.
     final var claimedTgt = new HashSet<String>();
     final var claimedSrc = new HashSet<String>();
-    final var telescopeFixups = new ArrayList<TelescopeTo<?, ?, ?>>();
+    // Soft claims: telescope-based rows are post-fixups, not exclusive overrides — they mark a
+    // field as "consumed by a telescope read/write" so the strict source/target must-be-claimed
+    // pass below accepts it, but don't conflict with strict rows or with each other on the same
+    // field. Multiple Mapping.to(srcAcc, tgtTelescope) rows reading the same source field, or
+    // Mapping.to(srcAcc, tgtTelescope) co-existing with a Mapping.to(srcAcc, tgtAcc), are both OK.
+    final var telescopeReadsSrc = new HashSet<String>();
+    final var telescopeWritesTgt = new HashSet<String>();
+    final var telescopeFixups = new ArrayList<Mapping<?, ?>>();
 
     for (final var row : overrides.getOrDefault(key, List.of())) {
       // Normalize raw method names per side — record::name stays "name", bean::getName becomes
       // "name".
       final var internals = internalsOf(row);
       final var srcField = srcRefl.normalize(internals.sourceField());
-      // TelescopeTo rows claim a source field and register a backward-side placeholder that the
-      // outer post-fixup (see wrapWithTelescopeFixups below) overwrites with the actual leaf value
-      // read from the target telescope. The forward direction is also handled by the outer wrap,
-      // which calls targetTelescope.set after the base assembleIso produces a base target.
+      // TelescopeTo: flat source accessor → nested target telescope.
+      // Soft claim on the source field (from srcAcc) AND the target telescope's first hop name.
+      // Multiple rows sharing the same source field or top-level target field all compose.
       if (row instanceof TelescopeTo<?, ?, ?> tRow) {
-        if (!claimedSrc.add(srcField)) throw new IllegalArgumentException(
-          "Deep map " +
-            source.getSimpleName() +
-            " → " +
-            target.getSimpleName() +
-            ": duplicate override row for source field '" +
-            srcField +
-            "'. Each (source, target) type pair may declare at most one row per source field."
-        );
-        bySourceName.put(srcField, new FieldStep(srcField, null, NULLING_ISO));
+        telescopeReadsSrc.add(srcField);
+        final var firstTgtHop = tRow.targetTelescope().firstHopName();
+        if (firstTgtHop != null) telescopeWritesTgt.add(tgtRefl.normalize(firstTgtHop));
         telescopeFixups.add(tRow);
+        continue;
+      }
+      // FromTelescopeTo: nested source telescope → flat target accessor — soft claim mirror.
+      // Soft claim on the target field (from tgtAcc) AND the source telescope's first hop name.
+      if (row instanceof FromTelescopeTo<?, ?, ?> fRow) {
+        telescopeWritesTgt.add(tgtRefl.normalize(internals.targetField()));
+        final var firstSrcHop = fRow.sourceTelescope().firstHopName();
+        if (firstSrcHop != null) telescopeReadsSrc.add(srcRefl.normalize(firstSrcHop));
+        telescopeFixups.add(fRow);
+        continue;
+      }
+      // TelescopeToTelescope (covers both Kind.BROADCAST from Mapping.to and Kind.ZIP from
+      // Mapping.zip): both sides are nested telescopes. Recover the top-level src/tgt field names
+      // from each telescope's first hop so auto-recursion can build the top-level structure; the
+      // post-fixup then overlays the deep leaf (broadcast or positional, depending on kind).
+      if (row instanceof TelescopeToTelescope<?, ?, ?> ttRow) {
+        final var firstSrcHop = ttRow.sourceTelescope().firstHopName();
+        final var firstTgtHop = ttRow.targetTelescope().firstHopName();
+        if (firstSrcHop != null) telescopeReadsSrc.add(srcRefl.normalize(firstSrcHop));
+        if (firstTgtHop != null) telescopeWritesTgt.add(tgtRefl.normalize(firstTgtHop));
+        telescopeFixups.add(ttRow);
         continue;
       }
       // Drop rows claim a source field with no target counterpart — they exist to satisfy the
@@ -346,21 +374,33 @@ public final class DeepMap {
     final var srcNameSet = new HashSet<>(List.of(srcNames));
     for (final var name : tgtRefl.names(target)) {
       if (claimedTgt.contains(name)) continue;
-      if (!srcNameSet.contains(name)) throw new IllegalStateException(
-        "Deep map " +
-          source.getSimpleName() +
-          " → " +
-          target.getSimpleName() +
-          ": target " +
-          slot(tgtRefl) +
-          " '" +
-          name +
-          "' has no same-name source " +
-          slot(srcRefl) +
-          ". Add a rename row to(sourceAccessor, targetAccessor) that maps to '" +
-          name +
-          "'."
-      );
+      // Telescope-row permissive mode: when ANY telescope row is registered for this pair, target
+      // fields with no same-name source get a NULLING_ISO placeholder. The post-fixup overlays it
+      // if a TelescopeToTelescope / FromTelescopeTo writes through that field; otherwise the field
+      // stays null. Telescope rows can't recover their top-level target field name from a
+      // Telescope<B, X> at runtime (generics erased), so we permit the gap instead of failing on
+      // every nested write. Without any telescope row, the strict same-name check still fires.
+      if (!srcNameSet.contains(name)) {
+        if (!telescopeFixups.isEmpty()) {
+          byTargetName.putIfAbsent(name, new FieldStep(null, name, NULLING_ISO));
+          continue;
+        }
+        throw new IllegalStateException(
+          "Deep map " +
+            source.getSimpleName() +
+            " → " +
+            target.getSimpleName() +
+            ": target " +
+            slot(tgtRefl) +
+            " '" +
+            name +
+            "' has no same-name source " +
+            slot(srcRefl) +
+            ". Add a rename row to(sourceAccessor, targetAccessor) that maps to '" +
+            name +
+            "'."
+        );
+      }
       final var step = new FieldStep(
         name,
         name,
@@ -372,7 +412,21 @@ public final class DeepMap {
     }
 
     for (final var name : srcNames) {
-      if (!claimedSrc.contains(name)) throw new IllegalStateException(
+      if (claimedSrc.contains(name)) continue;
+      // Telescope-read source without a same-name target consumer: register a NULLING_ISO
+      // backward-only placeholder so the source rebuilder produces null for this field; the
+      // backward post-fixup will fill the real value from the target telescope.
+      if (telescopeReadsSrc.contains(name)) {
+        bySourceName.putIfAbsent(name, new FieldStep(name, null, NULLING_ISO));
+        continue;
+      }
+      // Same permissive mode as the target side: when telescope rows are present, source fields
+      // with no consumer fall back to a NULLING placeholder rather than failing.
+      if (!telescopeFixups.isEmpty()) {
+        bySourceName.putIfAbsent(name, new FieldStep(name, null, NULLING_ISO));
+        continue;
+      }
+      throw new IllegalStateException(
         "Deep map " +
           source.getSimpleName() +
           " → " +
@@ -398,45 +452,161 @@ public final class DeepMap {
   }
 
   /**
-   * Compose the {@link TelescopeTo} post-fixups on top of the base {@link Iso} produced by {@link
-   * #assembleIso}. Forward: after the base produces a target {@code T}, each fixup's {@code
-   * targetTelescope.set(t, srcAccessor.apply(s))} overlays the leaf at the telescope's terminal
-   * focus. Backward: after the base produces a source {@code S}, each fixup reads the value at the
-   * target telescope and overwrites the source field via the source-side reflective rebuild.
+   * Compose post-fixups on top of the base {@link Iso} produced by {@link #assembleIso}. Four
+   * telescope-based row shapes route through this single wrapper; each contributes a forward
+   * overlay and a backward overlay built from the lattice's public {@code Telescope.set} / {@code
+   * Telescope.read} (and {@code toList} / {@code updateIndexed} for the {@link
+   * TelescopeToTelescope.Kind#ZIP} case).
    *
-   * <p>Uses {@code Telescope.set} and {@code Telescope.read} from the optics lattice's public
-   * surface for the actual leaf reads/writes — no new lattice machinery introduced.
+   * <ul>
+   *   <li>{@link TelescopeTo} (flat src → nested tgt): forward {@code tgtT.set(t,
+   *       srcAcc.apply(s))}; backward rebuilds {@code s} with {@code sourceField} = {@code
+   *       tgtT.read(t)}.
+   *   <li>{@link FromTelescopeTo} (nested src → flat tgt): forward rebuilds {@code t} with {@code
+   *       targetField} = {@code srcT.read(s)}; backward rebuilds {@code s} via {@code srcT.set(s,
+   *       tgtAcc.apply(t))}.
+   *   <li>{@link TelescopeToTelescope} with {@link TelescopeToTelescope.Kind#BROADCAST} (nested ↔
+   *       nested, broadcast): forward {@code tgtT.set(t, srcT.read(s))}; backward {@code
+   *       srcT.set(s, tgtT.read(t))}. When either side is many-focus the lattice's intrinsic
+   *       broadcast / first-focus semantics apply — no extra machinery here.
+   *   <li>{@link TelescopeToTelescope} with {@link TelescopeToTelescope.Kind#ZIP} (nested ↔ nested,
+   *       positional N:N): forward reads {@code srcT.toList(s)} and writes positionally via {@code
+   *       tgtT.updateIndexed(t, ...)} with cardinality enforcement; backward mirrors.
+   * </ul>
+   *
+   * <p>All reads / writes go through the lattice's public {@link io.github.eschizoid.telescope
+   * .Telescope} surface — no new optic primitives, no Iso composition beyond the base.
    */
   @SuppressWarnings({ "unchecked", "rawtypes" })
   private static <S, T> Iso<S, T> wrapWithTelescopeFixups(
     final Iso<S, T> base,
-    final List<TelescopeTo<?, ?, ?>> fixups,
+    final List<Mapping<?, ?>> fixups,
     final Reflective srcRefl,
     final Class<S> source
   ) {
     return Iso.of(
-      s -> {
-        T t = base.to(s);
-        for (final var fx : fixups) {
-          final var srcAcc = (io.github.eschizoid.telescope.Telescope.Accessor<S, Object>) fx.srcAccessor();
-          final var tgtT = (io.github.eschizoid.telescope.Telescope<T, Object>) fx.targetTelescope();
+      s -> applyForward(base.to(s), s, fixups),
+      t -> applyBackward(base.from(t), t, fixups, srcRefl, source)
+    );
+  }
+
+  @SuppressWarnings({ "unchecked", "rawtypes" })
+  private static <S, T> T applyForward(final T initial, final S s, final List<Mapping<?, ?>> fixups) {
+    T t = initial;
+    for (final var fx : fixups) {
+      switch (fx) {
+        case TelescopeTo<?, ?, ?> r -> {
+          final var srcAcc = (Telescope.Accessor<S, Object>) r.srcAccessor();
+          final var tgtT = (Telescope<T, Object>) r.targetTelescope();
           t = tgtT.set(t, srcAcc.apply(s));
         }
-        return t;
-      },
-      t -> {
-        final S baseS = base.from(t);
-        return (S) srcRefl.construct(source, name -> {
-          for (final var fx : fixups) {
-            if (srcRefl.normalize(fx.sourceField()).equals(name)) {
-              final var tgtT = (io.github.eschizoid.telescope.Telescope<T, Object>) fx.targetTelescope();
-              return tgtT.read(t);
-            }
+        case FromTelescopeTo<?, ?, ?> r -> {
+          final var srcT = (Telescope<S, Object>) r.sourceTelescope();
+          // The target side is a flat accessor; we need to rebuild t with the named target field
+          // overridden by srcT.read(s). Delegate to overrideTargetField, which uses the target
+          // Reflective.construct the same way the source-side path does in applyBackward.
+          t = overrideTargetField(t, r, srcT, s);
+        }
+        case TelescopeToTelescope<?, ?, ?> r -> {
+          final var srcT = (Telescope<S, Object>) r.sourceTelescope();
+          final var tgtT = (Telescope<T, Object>) r.targetTelescope();
+          if (r.kind() == TelescopeToTelescope.Kind.ZIP) {
+            final var values = srcT.toList(s);
+            final var targetCount = tgtT.count(t);
+            if (values.size() != targetCount) throw new IllegalStateException(
+              "Mapping.zip: source has " +
+                values.size() +
+                " focus(es), target has " +
+                targetCount +
+                " — cardinality must match for positional zip."
+            );
+            t = tgtT.updateIndexed(t, (i, _ignored) -> values.get(i));
+          } else {
+            t = tgtT.set(t, srcT.read(s));
           }
-          return srcRefl.read(baseS, name);
-        });
+        }
+        default -> {
+          /* non-telescope mappings are not routed through this wrapper */
+        }
       }
+    }
+    return t;
+  }
+
+  @SuppressWarnings({ "unchecked", "rawtypes" })
+  private static <S, T> S applyBackward(
+    final S baseS,
+    final T t,
+    final List<Mapping<?, ?>> fixups,
+    final Reflective srcRefl,
+    final Class<S> source
+  ) {
+    // Collect per-field override values keyed by normalized source field name; the rebuild reads
+    // through srcRefl.construct and substitutes our overrides per name. Telescope-source fixups
+    // (FromTelescopeTo, TelescopeToTelescope, TelescopeZip) don't have a top-level source field —
+    // they apply via srcT.set on the rebuilt baseS, after the name-keyed rebuild finishes.
+    final var fieldOverrides = new HashMap<String, Object>();
+    for (final var fx : fixups) {
+      if (fx instanceof TelescopeTo<?, ?, ?> r) {
+        final var tgtT = (Telescope<T, Object>) r.targetTelescope();
+        fieldOverrides.put(srcRefl.normalize(r.sourceField()), tgtT.read(t));
+      }
+    }
+    S s = (S) srcRefl.construct(source, name ->
+      fieldOverrides.containsKey(name) ? fieldOverrides.get(name) : srcRefl.read(baseS, name)
     );
+    // Telescope-source fixups overlay AFTER the name-keyed rebuild, via srcT.set on s.
+    for (final var fx : fixups) {
+      switch (fx) {
+        case FromTelescopeTo<?, ?, ?> r -> {
+          final var srcT = (Telescope<S, Object>) r.sourceTelescope();
+          final var tgtAcc = (Telescope.Accessor<T, Object>) r.tgtAccessor();
+          s = srcT.set(s, tgtAcc.apply(t));
+        }
+        case TelescopeToTelescope<?, ?, ?> r -> {
+          final var srcT = (Telescope<S, Object>) r.sourceTelescope();
+          final var tgtT = (Telescope<T, Object>) r.targetTelescope();
+          if (r.kind() == TelescopeToTelescope.Kind.ZIP) {
+            final var values = tgtT.toList(t);
+            final var sourceCount = srcT.count(s);
+            if (values.size() != sourceCount) throw new IllegalStateException(
+              "Mapping.zip: target has " +
+                values.size() +
+                " focus(es), source has " +
+                sourceCount +
+                " — cardinality must match for positional zip."
+            );
+            s = srcT.updateIndexed(s, (i, _ignored) -> values.get(i));
+          } else {
+            s = srcT.set(s, tgtT.read(t));
+          }
+        }
+        default -> {
+          /* TelescopeTo already handled above via fieldOverrides */
+        }
+      }
+    }
+    return s;
+  }
+
+  /**
+   * Forward overlay for {@link FromTelescopeTo} — rebuild the target with the named target field
+   * overridden by {@code srcTelescope.read(s)}. We can't construct a typed one-hop Telescope on the
+   * target side without knowing T's runtime class up-front (generics erased), so we use the target
+   * Reflective via the cached structural iso the same way the source-side path does.
+   */
+  @SuppressWarnings({ "unchecked", "rawtypes" })
+  private static <S, T> T overrideTargetField(
+    final T t,
+    final FromTelescopeTo<?, ?, ?> r,
+    final Telescope<S, Object> srcT,
+    final S s
+  ) {
+    final var tgtClass = (Class<T>) t.getClass();
+    final var tgtRefl = Reflective.of(tgtClass);
+    final var tgtField = tgtRefl.normalize(r.targetField());
+    final var newValue = srcT.read(s);
+    return (T) tgtRefl.construct(tgtClass, name -> name.equals(tgtField) ? newValue : tgtRefl.read(t, name));
   }
 
   // ---------- Per-component auto resolution ----------
@@ -545,10 +715,17 @@ public final class DeepMap {
       // calling fieldIsoOf. The case is here only to make the switch exhaustive for the sealed
       // hierarchy; reaching it indicates a routing bug above.
       case Drop<?, ?, ?> _ -> throw new IllegalStateException("Drop row should not reach fieldIsoOf");
-      // TelescopeTo rows never reach this method either — populateIso short-circuits on
-      // `instanceof TelescopeTo` before calling fieldIsoOf; the row applies as a post-fixup at the
-      // outer pair, not as a per-field leaf Iso.
+      // Telescope-based rows never reach this method — populateIso short-circuits on each of them
+      // before calling fieldIsoOf. They apply as post-fixups at the outer pair, not as per-field
+      // leaf Isos. The cases are here only to make the switch exhaustive for the sealed hierarchy;
+      // reaching any of them indicates a routing bug above.
       case TelescopeTo<?, ?, ?> _ -> throw new IllegalStateException("TelescopeTo row should not reach fieldIsoOf");
+      case FromTelescopeTo<?, ?, ?> _ -> throw new IllegalStateException(
+        "FromTelescopeTo row should not reach fieldIsoOf"
+      );
+      case TelescopeToTelescope<?, ?, ?> _ -> throw new IllegalStateException(
+        "TelescopeToTelescope row should not reach fieldIsoOf"
+      );
     };
   }
 

--- a/core/src/main/java/io/github/eschizoid/telescope/Telescope.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/Telescope.java
@@ -106,22 +106,50 @@ public sealed class Telescope<
   // accumulates both edits and runs them in order against {@code s}. Package-private for the same
   // reason as `fieldOptics`.
   final Function<S, S> chain;
+  // The method name of the FIRST hop accessor used to build this Telescope (e.g. "customer" for
+  // Telescope.of(A.class).field(A::getCustomer)…). Stays null for telescopes built without a path
+  // (e.g. Iso.identity() from Telescope.of). Used by DeepMap to route Mapping.to(Telescope, ...)
+  // rows back to the top-level source/target field — without it, deeply-nested telescope rows
+  // can't tell the engine which top-level field they traverse. Package-private; recovered via
+  // LambdaIntrospection.methodNameOf(accessor) on the first .field(…) / .each(…) / .eachValue(…)
+  // / .whenPresent(…) call that takes an Accessor.
+  final String firstHopName;
 
   // Package-private so that the conversion-builder classes (From, To, BeanTo, MapBuilder, Mapper,
   // …) — extracted to sibling files in this same package to keep Telescope.java navigable — can
   // construct Telescope instances without needing us to expose internals through the JPMS export.
   Telescope(final Traversal<S, A> optic) {
-    this(optic, RecordFieldOptics.INSTANCE, Function.identity());
+    this(optic, RecordFieldOptics.INSTANCE, Function.identity(), null);
   }
 
   private Telescope(final Traversal<S, A> optic, final FieldOptics fieldOptics) {
-    this(optic, fieldOptics, Function.identity());
+    this(optic, fieldOptics, Function.identity(), null);
   }
 
-  private Telescope(final Traversal<S, A> optic, final FieldOptics fieldOptics, final Function<S, S> chain) {
+  Telescope(final Traversal<S, A> optic, final FieldOptics fieldOptics, final Function<S, S> chain) {
+    this(optic, fieldOptics, chain, null);
+  }
+
+  Telescope(
+    final Traversal<S, A> optic,
+    final FieldOptics fieldOptics,
+    final Function<S, S> chain,
+    final String firstHopName
+  ) {
     this.optic = optic;
     this.fieldOptics = fieldOptics;
     this.chain = chain;
+    this.firstHopName = firstHopName;
+  }
+
+  /**
+   * Package-private — exposes the method name of the FIRST navigation hop used to build this
+   * Telescope, or {@code null} if the Telescope wasn't built via accessor-based navigation. {@link
+   * DeepMap} uses this to recover the top-level source/target field a {@code Mapping.to(Telescope,
+   * …)} row traverses so it can register a corresponding top-level mapping step.
+   */
+  String firstHopName() {
+    return firstHopName;
   }
 
   /**
@@ -349,6 +377,29 @@ public sealed class Telescope<
   }
 
   /**
+   * Same as {@link #lens(Function, BiFunction)} but with a Serializable {@link Accessor} for the
+   * getter — the method name is recovered via {@code SerializedLambda} and stored as the
+   * Telescope's first-hop name. Used by codegen-generated {@code <X>Telescope} navigators so the
+   * {@code Mapping.to(srcAcc, navigatorMethod())} factory routes through the engine the same way a
+   * runtime {@code Telescope.of(B.class).field(B::recipient)…} chain does.
+   *
+   * <p>Java's overload resolution prefers this overload over {@link #lens(Function, BiFunction)}
+   * when the getter is a method reference (method refs implicitly bind to {@link Accessor}'s
+   * Serializable contract), so codegen-emitted call sites pick it up automatically.
+   */
+  public static <S, A> Telescope<S, A> lens(
+    final Accessor<S, A> getter,
+    final BiFunction<? super S, ? super A, ? extends S> setter
+  ) {
+    return new Telescope<>(
+      Lens.of(getter, setter),
+      RecordFieldOptics.INSTANCE,
+      Function.identity(),
+      LambdaIntrospection.methodNameOf(getter)
+    );
+  }
+
+  /**
    * Begin a bidirectional type conversion. The fluent shape {@code from(A.class).to(B.class).using(
    * forward, backward)} produces a {@code Telescope<A, B>} backed by an {@link Iso} from the
    * internal lattice. The {@code Class} arguments exist purely for type inference; they're not
@@ -474,7 +525,15 @@ public sealed class Telescope<
    */
   public <B> Telescope<S, B> field(final Accessor<A, B> getter) {
     final Lens<A, B> lens = lensForAccessor(getter);
-    return new Telescope<>(optic.then(lens), fieldOptics, chain);
+    return new Telescope<>(optic.then(lens), fieldOptics, chain, hopName(getter));
+  }
+
+  /**
+   * First-hop name capture: only the first .field/.each/.eachValue/.whenPresent on a path is
+   * tracked.
+   */
+  private String hopName(final Accessor<?, ?> getter) {
+    return firstHopName != null ? firstHopName : LambdaIntrospection.methodNameOf(getter);
   }
 
   /**
@@ -495,7 +554,7 @@ public sealed class Telescope<
    */
   public <X> ListTelescope<S, X> list(final Accessor<A, List<X>> getter) {
     final Lens<A, List<X>> lens = lensForAccessor(getter);
-    return new ListTelescope<>(optic.then(lens), fieldOptics, chain);
+    return new ListTelescope<>(optic.then(lens), fieldOptics, chain, hopName(getter));
   }
 
   /**
@@ -508,7 +567,7 @@ public sealed class Telescope<
    */
   public <X> SetTelescope<S, X> setField(final Accessor<A, Set<X>> getter) {
     final Lens<A, Set<X>> lens = lensForAccessor(getter);
-    return new SetTelescope<>(optic.then(lens), fieldOptics, chain);
+    return new SetTelescope<>(optic.then(lens), fieldOptics, chain, hopName(getter));
   }
 
   /**
@@ -522,7 +581,7 @@ public sealed class Telescope<
    */
   public <K, V> MapTelescope<S, K, V> mapField(final Accessor<A, Map<K, V>> getter) {
     final Lens<A, Map<K, V>> lens = lensForAccessor(getter);
-    return new MapTelescope<>(optic.then(lens), fieldOptics, chain);
+    return new MapTelescope<>(optic.then(lens), fieldOptics, chain, hopName(getter));
   }
 
   /**
@@ -532,7 +591,7 @@ public sealed class Telescope<
    */
   public <X> OptionalTelescope<S, X> optional(final Accessor<A, Optional<X>> getter) {
     final Lens<A, Optional<X>> lens = lensForAccessor(getter);
-    return new OptionalTelescope<>(optic.then(lens), fieldOptics, chain);
+    return new OptionalTelescope<>(optic.then(lens), fieldOptics, chain, hopName(getter));
   }
 
   /**
@@ -597,7 +656,7 @@ public sealed class Telescope<
   public <E> Telescope<S, E> each(final Accessor<A, ? extends Iterable<E>> getter) {
     final Traversal<Iterable<E>, E> elements = Traversals.eachIterable();
     final Lens<A, Iterable<E>> lens = lensForAccessor(getter);
-    return new Telescope<>(optic.then(lens).then(elements), fieldOptics, chain);
+    return new Telescope<>(optic.then(lens).then(elements), fieldOptics, chain, hopName(getter));
   }
 
   /**
@@ -616,7 +675,7 @@ public sealed class Telescope<
   public <K, V> Telescope<S, V> eachValue(final Accessor<A, ? extends Map<K, V>> getter) {
     final Traversal<Map<K, V>, V> values = Traversals.eachMapValue();
     final Lens<A, Map<K, V>> lens = lensForAccessor(getter);
-    return new Telescope<>(optic.then(lens).then(values), fieldOptics, chain);
+    return new Telescope<>(optic.then(lens).then(values), fieldOptics, chain, hopName(getter));
   }
 
   /**
@@ -634,7 +693,7 @@ public sealed class Telescope<
   public <E> Telescope<S, E> whenPresent(final Accessor<A, ? extends Optional<E>> getter) {
     final Traversal<Optional<E>, E> present = Traversals.eachOptional();
     final Lens<A, Optional<E>> lens = lensForAccessor(getter);
-    return new Telescope<>(optic.then(lens).then(present), fieldOptics, chain);
+    return new Telescope<>(optic.then(lens).then(present), fieldOptics, chain, hopName(getter));
   }
 
   /**
@@ -686,7 +745,14 @@ public sealed class Telescope<
    * }</pre>
    */
   public <B> Telescope<S, B> then(final Telescope<A, B> next) {
-    return new Telescope<>(optic.then(next.optic), fieldOptics, chain);
+    // Prefer this side's firstHopName — only the FIRST hop on a chain is tracked. If this side has
+    // none (e.g. composing a root Telescope.of(...) with a sub-path), inherit from next.
+    return new Telescope<>(
+      optic.then(next.optic),
+      fieldOptics,
+      chain,
+      firstHopName != null ? firstHopName : next.firstHopName
+    );
   }
 
   /**
@@ -1279,9 +1345,18 @@ public sealed class Telescope<
       super(optic, fieldOptics, chain);
     }
 
+    ListTelescope(
+      final Traversal<S, List<X>> optic,
+      final FieldOptics fieldOptics,
+      final Function<S, S> chain,
+      final String firstHopName
+    ) {
+      super(optic, fieldOptics, chain, firstHopName);
+    }
+
     /** Step into list elements. Pure lattice composition; no reflection. */
     public Telescope<S, X> each() {
-      return new Telescope<>(this.optic.then(Traversals.eachList()), this.fieldOptics, this.chain);
+      return new Telescope<>(this.optic.then(Traversals.eachList()), this.fieldOptics, this.chain, this.firstHopName);
     }
   }
 
@@ -1296,9 +1371,18 @@ public sealed class Telescope<
       super(optic, fieldOptics, chain);
     }
 
+    SetTelescope(
+      final Traversal<S, Set<X>> optic,
+      final FieldOptics fieldOptics,
+      final Function<S, S> chain,
+      final String firstHopName
+    ) {
+      super(optic, fieldOptics, chain, firstHopName);
+    }
+
     /** Step into set elements. Output is iteration-order-preserving (LinkedHashSet). */
     public Telescope<S, X> each() {
-      return new Telescope<>(this.optic.then(Traversals.eachSet()), this.fieldOptics, this.chain);
+      return new Telescope<>(this.optic.then(Traversals.eachSet()), this.fieldOptics, this.chain, this.firstHopName);
     }
   }
 
@@ -1313,9 +1397,23 @@ public sealed class Telescope<
       super(optic, fieldOptics, chain);
     }
 
+    MapTelescope(
+      final Traversal<S, Map<K, V>> optic,
+      final FieldOptics fieldOptics,
+      final Function<S, S> chain,
+      final String firstHopName
+    ) {
+      super(optic, fieldOptics, chain, firstHopName);
+    }
+
     /** Step into map values; keys remain on the map. Pure lattice composition. */
     public Telescope<S, V> values() {
-      return new Telescope<>(this.optic.then(Traversals.eachMapValue()), this.fieldOptics, this.chain);
+      return new Telescope<>(
+        this.optic.then(Traversals.eachMapValue()),
+        this.fieldOptics,
+        this.chain,
+        this.firstHopName
+      );
     }
   }
 
@@ -1334,9 +1432,23 @@ public sealed class Telescope<
       super(optic, fieldOptics, chain);
     }
 
+    OptionalTelescope(
+      final Traversal<S, Optional<X>> optic,
+      final FieldOptics fieldOptics,
+      final Function<S, S> chain,
+      final String firstHopName
+    ) {
+      super(optic, fieldOptics, chain, firstHopName);
+    }
+
     /** Step into the Optional's payload. Empty Optional is a write no-op (Affine semantics). */
     public Telescope<S, X> present() {
-      return new Telescope<>(this.optic.then(Traversals.eachOptional()), this.fieldOptics, this.chain);
+      return new Telescope<>(
+        this.optic.then(Traversals.eachOptional()),
+        this.fieldOptics,
+        this.chain,
+        this.firstHopName
+      );
     }
   }
 }

--- a/core/src/main/java/io/github/eschizoid/telescope/mapping/FromTelescopeTo.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/mapping/FromTelescopeTo.java
@@ -1,0 +1,55 @@
+package io.github.eschizoid.telescope.mapping;
+
+import io.github.eschizoid.telescope.Telescope;
+import io.github.eschizoid.telescope.Telescope.Accessor;
+import io.github.eschizoid.telescope.internal.LambdaIntrospection;
+
+/**
+ * Nested-source correspondence row from {@link Mapping#to(Telescope, Accessor)}. Mirror of {@link
+ * TelescopeTo}: source is a multi-hop {@link Telescope} on the {@code A} side, target is a flat
+ * {@link Accessor} on the {@code B} side. Closes the gap with MapStruct's {@code @Mapping(source =
+ * "a.b.c", target = "flat")}.
+ *
+ * <p>The {@link DeepMap} engine applies this row at the outer {@code (sourceClass, targetClass)}
+ * pair only. Top-level target field claim: yes (recovered from the target accessor). Source field
+ * claim: none — the path's leaf lives nested inside the source. Forward: after the base produces
+ * {@code b}, rebuild it with the target field overridden by {@code sourceTelescope.read(a)}.
+ * Backward: rebuild {@code a} with the source telescope's leaf overridden by the target accessor
+ * read of {@code b}.
+ *
+ * <p>Internal — users construct via {@link Mapping#to(Telescope, Accessor)} and never see this type
+ * at the call site.
+ */
+public record FromTelescopeTo<A, B, X>(
+  Telescope<A, X> sourceTelescope,
+  Accessor<B, X> tgtAccessor
+) implements Mapping<A, B>, MappingInternals<A, B> {
+  /**
+   * Returns {@code null} — the source side is a {@link Telescope} whose root class isn't
+   * recoverable at runtime (Java generics erased). The engine pins the row to the outer mapper pair
+   * via {@code DeepMap.groupOverridesByPair}'s top-source substitution.
+   */
+  @Override
+  public Class<A> sourceClass() {
+    return null;
+  }
+
+  @Override
+  public Class<B> targetClass() {
+    return LambdaIntrospection.implClassOf(tgtAccessor);
+  }
+
+  /**
+   * Returns {@code null} — the source side's leaf isn't a top-level source field, so there's no
+   * top-level source field for this row to claim against.
+   */
+  @Override
+  public String sourceField() {
+    return null;
+  }
+
+  @Override
+  public String targetField() {
+    return LambdaIntrospection.methodNameOf(tgtAccessor);
+  }
+}

--- a/core/src/main/java/io/github/eschizoid/telescope/mapping/Mapping.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/mapping/Mapping.java
@@ -33,7 +33,10 @@ import java.util.function.Function;
  * package — {@link SameTypedTo}, {@link TypedTransformTo}, {@link Via}, {@link Drop}. Users
  * construct via the static factories below; the record types are not public API.
  */
-public sealed interface Mapping<A, B> extends MapStep permits SameTypedTo, TypedTransformTo, Via, Drop, TelescopeTo {
+public sealed interface Mapping<A, B>
+  extends MapStep
+  permits SameTypedTo, TypedTransformTo, Via, Drop, TelescopeTo, FromTelescopeTo, TelescopeToTelescope
+{
   /** Same-typed correspondence: {@code src↔tgt}, both with leaf type {@code X}. Identity. */
   static <A, B, X> Mapping<A, B> to(final Accessor<A, X> src, final Accessor<B, X> tgt) {
     return new SameTypedTo<>(src, tgt);
@@ -65,6 +68,7 @@ public sealed interface Mapping<A, B> extends MapStep permits SameTypedTo, Typed
    * each hop and {@code javac} catches a missing accessor everywhere.
    *
    * <pre>{@code
+   * // Runtime form — Telescope.of(...).field(...).field(...)
    * Telescope.mapper(Order.class, OrderDto.class,
    *     to(Order::getName,         OrderDto::getFullName),
    *     to(Order::getCustomerName,
@@ -72,6 +76,12 @@ public sealed interface Mapping<A, B> extends MapStep permits SameTypedTo, Typed
    *            .field(OrderDto::getShipping)
    *            .field(Shipping::getRecipient)
    *            .field(Recipient::getFullName)));
+   *
+   * // Codegen form — @Focus-generated navigator, same Telescope value, fully typed each hop.
+   * // Mapping.to accepts both interchangeably; pick whichever the call site is closest to.
+   * Telescope.mapper(Order.class, OrderDto.class,
+   *     to(Order::getCustomerName,
+   *        OrderDtoTelescope.of().shipping().recipient().fullName()));
    * }</pre>
    *
    * <p>The engine applies this row at the <em>outer</em> {@code (source, target)} pair only — after
@@ -81,6 +91,72 @@ public sealed interface Mapping<A, B> extends MapStep permits SameTypedTo, Typed
    */
   static <A, B, X> Mapping<A, B> to(final Accessor<A, X> src, final Telescope<B, X> targetTelescope) {
     return new TelescopeTo<>(src, targetTelescope);
+  }
+
+  /**
+   * Nested-source correspondence: source is a multi-hop {@link Telescope}, target is a flat
+   * accessor. Mirror of {@link #to(Accessor, Telescope)} — same fluent navigation on the source
+   * side, single accessor on the target. Closes MapStruct's {@code @Mapping(source = "a.b.c",
+   * target = "flat")} for that direction.
+   *
+   * <pre>{@code
+   * Telescope.mapper(Order.class, OrderDto.class,
+   *     to(Telescope.of(Order.class).field(Order::getCustomer).field(Customer::getEmail),
+   *        OrderDto::getRecipientEmail));
+   * }</pre>
+   *
+   * <p>Engine: applied at the outer {@code (source, target)} pair only. Forward: reads at {@code
+   * srcTelescope}, writes to {@code tgt} accessor on a rebuilt {@code b}. Backward: reads {@code
+   * tgt} on {@code b}, writes through {@code srcTelescope.set(a, value)} on a rebuilt {@code a}.
+   */
+  static <A, B, X> Mapping<A, B> to(final Telescope<A, X> srcTelescope, final Accessor<B, X> tgt) {
+    return new FromTelescopeTo<>(srcTelescope, tgt);
+  }
+
+  /**
+   * Both-nested correspondence: source and target sides are multi-hop {@link Telescope}s. Closes
+   * MapStruct's {@code @Mapping(source = "a.b.c", target = "x.y.z")} for the both-nested case.
+   *
+   * <pre>{@code
+   * Telescope.mapper(Order.class, OrderDto.class,
+   *     to(Telescope.of(Order.class).field(Order::getCustomer).field(Customer::getEmail),
+   *        Telescope.of(OrderDto.class).field(OrderDto::getShipping).field(Shipping::getEmail)));
+   * }</pre>
+   *
+   * <p>Engine: applied at the outer pair only. Forward overlay: {@code tgt.set(b, src.read(a))}.
+   * Backward overlay: {@code src.set(a, tgt.read(b))}.
+   *
+   * <p><b>Broadcast on many-focus telescopes.</b> When either side carries a many-focus telescope
+   * (built with {@code .each(...)} / {@code .eachValue(...)} / {@code .whenPresent(...)}), the
+   * lattice's intrinsic {@link Telescope#set} broadcasts the value to every focus on the target
+   * side, and {@link Telescope#read} returns the first focus on the source side. For positional N:N
+   * — Nth source value at Nth target focus — use {@link #zip(Telescope, Telescope)} instead.
+   */
+  static <A, B, X> Mapping<A, B> to(final Telescope<A, X> srcTelescope, final Telescope<B, X> targetTelescope) {
+    return new TelescopeToTelescope<>(srcTelescope, targetTelescope, TelescopeToTelescope.Kind.BROADCAST);
+  }
+
+  /**
+   * Positional N:N correspondence between two many-focus telescopes. The Nth source value lands at
+   * the Nth target focus; cardinality is enforced at apply time — a mismatch throws rather than
+   * silently truncating.
+   *
+   * <pre>{@code
+   * Telescope.mapper(Cart.class, CartDto.class,
+   *     zip(Telescope.of(Cart.class).each(Cart::items).field(Item::name),
+   *         Telescope.of(CartDto.class).each(CartDto::lines).field(Line::label)));
+   * }</pre>
+   *
+   * <p>Distinct from {@link #to(Telescope, Telescope)}, which broadcasts on the many side. {@code
+   * zip} is the explicit positional semantic — the call-site reader knows which write semantic
+   * they're getting from the method name.
+   *
+   * <p>Engine: applied at the outer pair only. Forward fixup uses {@link Telescope#toList} on the
+   * source and {@link Telescope#updateIndexed} on the target with a cardinality check; backward
+   * fixup is the mirror.
+   */
+  static <A, B, X> Mapping<A, B> zip(final Telescope<A, X> srcTelescope, final Telescope<B, X> targetTelescope) {
+    return new TelescopeToTelescope<>(srcTelescope, targetTelescope, TelescopeToTelescope.Kind.ZIP);
   }
 
   /**

--- a/core/src/main/java/io/github/eschizoid/telescope/mapping/MappingInternals.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/mapping/MappingInternals.java
@@ -11,27 +11,36 @@ package io.github.eschizoid.telescope.mapping;
  * DeepMap} casts a {@code Mapping<?, ?>} to {@code MappingInternals<?, ?>} when it needs the
  * recovery info.
  */
-public sealed interface MappingInternals<A, B> permits SameTypedTo, TypedTransformTo, Via, Drop, TelescopeTo {
+public sealed interface MappingInternals<
+  A,
+  B
+> permits SameTypedTo, TypedTransformTo, Via, Drop, TelescopeTo, FromTelescopeTo, TelescopeToTelescope {
   /**
    * Source class this row keys against (the declaring class of the source accessor, recovered via
-   * {@code SerializedLambda}). Used by {@link DeepMap} to decide which type pairs this override
-   * applies to.
+   * {@code SerializedLambda}). May be {@code null} for permits whose source side is a {@code
+   * Telescope<A, ?>} (root class isn't recoverable at runtime — generics erased); the engine pins
+   * the row to the outer mapper pair instead.
    */
   Class<A> sourceClass();
 
   /**
    * Target class this row keys against — declaring class of the target accessor. May be {@code
-   * null} for {@link ScalarPathTo}, where the target side is a {@code Telescope<B, X>} path whose
-   * root class isn't recoverable; the engine pins the row to the outer mapper pair instead.
+   * null} for permits whose target side is a {@code Telescope<B, ?>}; same outer-pair pinning as
+   * for {@link #sourceClass}.
    */
   Class<B> targetClass();
 
-  /** Source record component name this row claims (the source accessor's method name). */
+  /**
+   * Source record component name this row claims (the source accessor's method name). May be {@code
+   * null} for permits whose source side is a {@code Telescope<A, ?>} — the path's leaf isn't a
+   * top-level source field.
+   */
   String sourceField();
 
   /**
    * Target record component name this row claims (the target accessor's method name). May be {@code
-   * null} for {@link ScalarPathTo}, where the path's leaf isn't a top-level target field.
+   * null} for permits whose target side is a {@code Telescope<B, ?>} — the path's leaf isn't a
+   * top-level target field.
    */
   String targetField();
 }

--- a/core/src/main/java/io/github/eschizoid/telescope/mapping/TelescopeToTelescope.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/mapping/TelescopeToTelescope.java
@@ -1,0 +1,67 @@
+package io.github.eschizoid.telescope.mapping;
+
+import io.github.eschizoid.telescope.Telescope;
+
+/**
+ * Both-nested correspondence row from {@link Mapping#to(Telescope, Telescope)} (broadcast) and
+ * {@link Mapping#zip(Telescope, Telescope)} (positional). Source and target sides are multi-hop
+ * {@link Telescope}s with a shared leaf type {@code X}.
+ *
+ * <p>The {@link DeepMap} engine applies this row at the outer {@code (sourceClass, targetClass)}
+ * pair only — both class fields come back {@code null} since neither side carries its root class at
+ * runtime. Top-level field claim is recovered from each telescope's {@code firstHopName()}. The
+ * engine dispatches on {@link #kind()}:
+ *
+ * <ul>
+ *   <li>{@link Kind#BROADCAST} — forward overlay: {@code tgtTelescope.set(b,
+ *       srcTelescope.read(a))}. Backward overlay: {@code srcTelescope.set(a,
+ *       tgtTelescope.read(b))}. When either side is many-focus, the lattice's intrinsic broadcast /
+ *       first-focus semantics apply — no extra machinery.
+ *   <li>{@link Kind#ZIP} — forward fixup: read all values via {@link Telescope#toList} on the
+ *       source, then write positionally via {@link Telescope#updateIndexed} on the target with
+ *       cardinality enforcement (mismatch throws). Backward fixup mirrors.
+ * </ul>
+ *
+ * <p>Internal — users construct via {@link Mapping#to(Telescope, Telescope)} or {@link
+ * Mapping#zip(Telescope, Telescope)} and never see this type at the call site.
+ */
+public record TelescopeToTelescope<A, B, X>(
+  Telescope<A, X> sourceTelescope,
+  Telescope<B, X> targetTelescope,
+  Kind kind
+) implements Mapping<A, B>, MappingInternals<A, B> {
+  /** Discriminates broadcast vs positional-zip semantics. */
+  public enum Kind {
+    /** Single-value semantics: {@code Telescope.set} broadcasts on a many-focus target. */
+    BROADCAST,
+    /**
+     * Positional N:N: cardinality-enforced zip via {@code Telescope.toList} + {@code
+     * updateIndexed}.
+     */
+    ZIP,
+  }
+
+  /** Returns {@code null} — see class-level javadoc on outer-pair pinning. */
+  @Override
+  public Class<A> sourceClass() {
+    return null;
+  }
+
+  /** Returns {@code null} — see class-level javadoc on outer-pair pinning. */
+  @Override
+  public Class<B> targetClass() {
+    return null;
+  }
+
+  /** Returns {@code null} — no top-level source field to claim against. */
+  @Override
+  public String sourceField() {
+    return null;
+  }
+
+  /** Returns {@code null} — no top-level target field to claim against. */
+  @Override
+  public String targetField() {
+    return null;
+  }
+}

--- a/core/src/test/java/io/github/eschizoid/telescope/Address.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/Address.java
@@ -1,0 +1,7 @@
+package io.github.eschizoid.telescope;
+
+import io.github.eschizoid.telescope.annotations.Focus;
+
+/** Top-level @Focus fixture for {@code TelescopeMappingTest}'s codegen-1:1 verification. */
+@Focus
+public record Address(String city, String zip) {}

--- a/core/src/test/java/io/github/eschizoid/telescope/Person.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/Person.java
@@ -1,0 +1,7 @@
+package io.github.eschizoid.telescope;
+
+import io.github.eschizoid.telescope.annotations.Focus;
+
+/** Top-level @Focus fixture for {@code TelescopeMappingTest}'s codegen-1:1 verification. */
+@Focus
+public record Person(String name, int age, Address address) {}

--- a/core/src/test/java/io/github/eschizoid/telescope/TelescopeMappingTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/TelescopeMappingTest.java
@@ -1,0 +1,367 @@
+package io.github.eschizoid.telescope;
+
+import static io.github.eschizoid.telescope.mapping.Mapping.to;
+import static io.github.eschizoid.telescope.mapping.Mapping.zip;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import io.github.eschizoid.telescope.mapping.Mapping;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * End-to-end tests for the four telescope-aware {@code Mapping} factories — the public analogue of
+ * MapStruct's {@code @Mapping(source = "...", target = "...")} for nested-path correspondences.
+ *
+ * <ul>
+ *   <li>{@code to(Accessor, Telescope)} — flat source → nested target
+ *   <li>{@code to(Telescope, Accessor)} — nested source → flat target
+ *   <li>{@code to(Telescope, Telescope)} — both nested (broadcast when many-focus)
+ *   <li>{@code zip(Telescope, Telescope)} — positional N:N, cardinality-checked
+ * </ul>
+ *
+ * <p>All telescope rows are post-fixup overlays on top of the auto-recursion result; the fixtures
+ * here use same-named fields so auto-mapping handles the base shape and the telescope row stamps
+ * additional values at nested locations.
+ */
+class TelescopeMappingTest {
+
+  // ---------- Single-focus fixtures (same-named, auto-mappable) ----------
+  record Inner(String code) {}
+
+  record A(String label, Inner inner) {}
+
+  record B(String label, Inner inner) {}
+
+  @Nested
+  @DisplayName("Mapping.to(Accessor, Telescope) — flat source → nested target")
+  class FlatSrcToNestedTgt {
+
+    @Test
+    @DisplayName("forward overlays the source value at the target's nested leaf")
+    void forwardOverlaysLeaf() {
+      final var mapper = Telescope.mapper(
+        A.class,
+        B.class,
+        to(A::label, Telescope.of(B.class).field(B::inner).field(Inner::code))
+      );
+
+      final var out = mapper.forward(new A("LABEL-A", new Inner("ignored")));
+      assertEquals("LABEL-A", out.label()); // auto-mapped
+      assertEquals("LABEL-A", out.inner().code()); // telescope overlay
+    }
+
+    @Test
+    @DisplayName("backward reads the nested target leaf and rebuilds the source")
+    void backwardReadsNestedLeaf() {
+      final var mapper = Telescope.mapper(
+        A.class,
+        B.class,
+        to(A::label, Telescope.of(B.class).field(B::inner).field(Inner::code))
+      );
+
+      final var back = mapper.backward(new B("OUTER", new Inner("FROM-NESTED")));
+      assertEquals("FROM-NESTED", back.label()); // telescope read wins on backward
+    }
+
+    @Test
+    @DisplayName("multiple to() rows reading the same source field — additive forward writes")
+    void multipleRowsSharingSource() {
+      record Recipient(String fullName, String greetingName) {}
+      record Src(String label, Recipient recipient) {}
+      record Tgt(String label, Recipient recipient) {}
+
+      final var mapper = Telescope.mapper(
+        Src.class,
+        Tgt.class,
+        // Auto-recursion handles Src::label → Tgt::label and Src::recipient → Tgt::recipient.
+        // Both telescope rows read from Src::label and overlay it at different nested leaves
+        // —
+        // closest analogue to MapStruct's:
+        //   @Mapping(source = "label", target = "recipient.fullName")
+        //   @Mapping(source = "label", target = "recipient.greetingName")
+        to(Src::label, Telescope.of(Tgt.class).field(Tgt::recipient).field(Recipient::fullName)),
+        to(Src::label, Telescope.of(Tgt.class).field(Tgt::recipient).field(Recipient::greetingName))
+      );
+
+      final var out = mapper.forward(new Src("VAL", new Recipient("ignored1", "ignored2")));
+      assertEquals("VAL", out.label());
+      assertEquals("VAL", out.recipient().fullName());
+      assertEquals("VAL", out.recipient().greetingName());
+    }
+  }
+
+  @Nested
+  @DisplayName("Codegen 1:1 with runtime — Mapping.to works against @Focus-generated navigators")
+  class CodegenOnePointOne {
+
+    @Test
+    @DisplayName("a codegen-style hand-built Telescope.lens chain is interchangeable with .field(...)")
+    void handBuiltLensChainBehavesLikeFieldChain() {
+      // Hand-built like @Focus codegen would emit: Telescope.lens(getter, setter) composed via
+      // .then(...). This must behave identically to
+      // Telescope.of(B.class).field(B::inner).field(...)
+      // when fed into Mapping.to — same routing, same forward / backward result.
+      final var codegenStyleTgt = Telescope.<B, Inner>lens(B::inner, (s, v) -> new B(s.label(), v)).then(
+        Telescope.<Inner, String>lens(Inner::code, (s, v) -> new Inner(v))
+      );
+
+      final var mapper = Telescope.mapper(A.class, B.class, to(A::label, codegenStyleTgt));
+
+      final var out = mapper.forward(new A("LABEL", new Inner("ignored")));
+      assertEquals("LABEL", out.label()); // auto-mapped
+      assertEquals("LABEL", out.inner().code()); // codegen-style telescope overlay
+    }
+
+    @Test
+    @DisplayName("codegen-style nested-source telescope works with Mapping.to(Telescope, Accessor)")
+    void codegenStyleNestedSourceWorks() {
+      final var codegenStyleSrc = Telescope.<A, Inner>lens(A::inner, (s, v) -> new A(s.label(), v)).then(
+        Telescope.<Inner, String>lens(Inner::code, (s, v) -> new Inner(v))
+      );
+
+      final var mapper = Telescope.mapper(A.class, B.class, to(codegenStyleSrc, B::label));
+
+      final var out = mapper.forward(new A("ignored", new Inner("FROM-NESTED")));
+      assertEquals("FROM-NESTED", out.label());
+    }
+
+    @Test
+    @DisplayName("real @Focus-generated navigator works as the tgt telescope in Mapping.to(srcAcc, navigator.method())")
+    void realFocusNavigatorWorksAsTgtTelescope() {
+      // Use the actual @Focus-generated navigator chain end-to-end:
+      //   PersonTelescope.of().address().city() : Telescope<Person, String>
+      // The codegen-emitted .address() returns a typed step (AddressTelescope<Person>)
+      // and .city() returns the underlying Telescope<Person, String> directly — no escape
+      // hatch (.get() / .field(...)) needed. This is the codegen 1:1 promise at its strongest: the
+      // generated navigator value is a first-class Mapping.to(...) target argument.
+      //
+      // Auto-recursion fills the same-named "address" subtree from src → tgt; the telescope row
+      // then overlays the city leaf with the value read at a different source field
+      // (Src::displayCity).
+      record Src(String name, int age, Address address, String displayCity) {}
+
+      final var mapper = Telescope.mapper(
+        Src.class,
+        Person.class,
+        Mapping.drop(Src::displayCity),
+        to(Src::displayCity, PersonTelescope.of().address().city())
+      );
+
+      final var out = mapper.forward(new Src("Alice", 30, new Address("ignored", "11201"), "Brooklyn"));
+      assertEquals("Brooklyn", out.address().city()); // telescope overlay
+      assertEquals("11201", out.address().zip()); // auto-mapped from Src::address.zip
+      assertEquals("Alice", out.name());
+      assertEquals(30, out.age());
+    }
+
+    @Test
+    @DisplayName("real @Focus-generated navigators on BOTH sides of Mapping.to(Telescope, Telescope)")
+    void bothSidesCodegenNavigators() {
+      // Two same-shape @Focus fixtures (Person) — source and target both produce real
+      // codegen navigators. The telescope row reads city at the source nav and writes city at the
+      // target nav. Demonstrates Mapping.to(Telescope, Telescope) accepting codegen-emitted
+      // Telescope<R, X> on both sides without any runtime escape hatch.
+      final var srcCityPath = PersonTelescope.of().address().city();
+      final var tgtCityPath = PersonTelescope.of().address().city();
+
+      final var mapper = Telescope.mapper(Person.class, Person.class, to(srcCityPath, tgtCityPath));
+
+      final var out = mapper.forward(new Person("Alice", 30, new Address("Brooklyn", "11201")));
+      assertEquals("Brooklyn", out.address().city());
+      assertEquals("11201", out.address().zip());
+      assertEquals("Alice", out.name());
+    }
+  }
+
+  @Nested
+  @DisplayName("Mapping.to(Telescope, Accessor) — nested source → flat target")
+  class NestedSrcToFlatTgt {
+
+    @Test
+    @DisplayName("forward reads at the nested source path and writes to the flat target accessor")
+    void forwardReadsNestedSrc() {
+      final var mapper = Telescope.mapper(
+        A.class,
+        B.class,
+        to(Telescope.of(A.class).field(A::inner).field(Inner::code), B::label)
+      );
+
+      final var out = mapper.forward(new A("ignored", new Inner("FROM-NESTED")));
+      assertEquals("FROM-NESTED", out.label()); // telescope read wins
+      assertEquals("FROM-NESTED", out.inner().code()); // auto-mapped from A::inner.code
+    }
+  }
+
+  @Nested
+  @DisplayName("Mapping.to(Telescope, Telescope) — both nested, broadcast semantics on many-focus")
+  class NestedSrcToNestedTgt {
+
+    @Test
+    @DisplayName("single-focus on both sides: read at src telescope, write at tgt telescope")
+    void singleFocusBothSides() {
+      final var mapper = Telescope.mapper(
+        A.class,
+        B.class,
+        to(
+          Telescope.of(A.class).field(A::inner).field(Inner::code),
+          Telescope.of(B.class).field(B::inner).field(Inner::code)
+        )
+      );
+
+      final var out = mapper.forward(new A("L", new Inner("NESTED-VAL")));
+      assertEquals("NESTED-VAL", out.inner().code());
+    }
+
+    @Test
+    @DisplayName("multiple to() rows with deeply-nested telescopes on BOTH sides — different top-level names")
+    void multipleDeeplyNestedRowsCompose() {
+      record Leaf(String value) {}
+      record L2(Leaf leaf) {}
+      record L1(L2 l2) {}
+      record SrcDeep(L1 l1) {}
+      record TgtDeep(L1 l1) {}
+      record SrcTop(SrcDeep first, SrcDeep second) {}
+      record TgtTop(TgtDeep a, TgtDeep b) {}
+
+      // Top-level structure: SrcTop has `first`/`second`, TgtTop has `a`/`b` — different names AND
+      // different leaf types. Two SameTypedTo-via rows handle the top-level rename + structure
+      // initialization (SrcDeep → TgtDeep via the deep mapper). Two deeply-nested telescope rows
+      // then overlay leaves with cross-routed values.
+      //
+      // Closest analogue to MapStruct's:
+      //   @Mapping(source = "first",                       target = "a")
+      //   @Mapping(source = "second",                      target = "b")
+      //   @Mapping(source = "second.l1.l2.leaf.value",     target = "a.l1.l2.leaf.value")
+      //   @Mapping(source = "first.l1.l2.leaf.value",      target = "b.l1.l2.leaf.value")
+      final var deepMapper = Telescope.mapper(SrcDeep.class, TgtDeep.class);
+
+      final var mapper = Telescope.mapper(
+        SrcTop.class,
+        TgtTop.class,
+        Mapping.via(SrcTop::first, TgtTop::a, deepMapper),
+        Mapping.via(SrcTop::second, TgtTop::b, deepMapper),
+        to(
+          Telescope.of(SrcTop.class)
+            .field(SrcTop::second)
+            .field(SrcDeep::l1)
+            .field(L1::l2)
+            .field(L2::leaf)
+            .field(Leaf::value),
+          Telescope.of(TgtTop.class)
+            .field(TgtTop::a)
+            .field(TgtDeep::l1)
+            .field(L1::l2)
+            .field(L2::leaf)
+            .field(Leaf::value)
+        ),
+        to(
+          Telescope.of(SrcTop.class)
+            .field(SrcTop::first)
+            .field(SrcDeep::l1)
+            .field(L1::l2)
+            .field(L2::leaf)
+            .field(Leaf::value),
+          Telescope.of(TgtTop.class)
+            .field(TgtTop::b)
+            .field(TgtDeep::l1)
+            .field(L1::l2)
+            .field(L2::leaf)
+            .field(Leaf::value)
+        )
+      );
+
+      final var out = mapper.forward(
+        new SrcTop(
+          new SrcDeep(new L1(new L2(new Leaf("ORIG-FIRST")))),
+          new SrcDeep(new L1(new L2(new Leaf("ORIG-SECOND"))))
+        )
+      );
+      // Top-level rename via Mapping.via produced the base, then telescope rows cross-routed
+      // leaves.
+      assertEquals("ORIG-SECOND", out.a().l1().l2().leaf().value());
+      assertEquals("ORIG-FIRST", out.b().l1().l2().leaf().value());
+    }
+  }
+
+  // ---------- Many-focus / collection fixtures ----------
+  record Item(String name) {}
+
+  record Cart(String tenant, List<Item> items) {}
+
+  record CartDto(String tenant, List<Item> items) {}
+
+  @Nested
+  @DisplayName("Mapping.to(Accessor, Telescope) — broadcast on many-focus target")
+  class BroadcastOnTarget {
+
+    @Test
+    @DisplayName("forward writes the single source value to every focus of the target telescope")
+    void broadcasts() {
+      final var mapper = Telescope.mapper(
+        Cart.class,
+        CartDto.class,
+        to(Cart::tenant, Telescope.of(CartDto.class).each(CartDto::items).field(Item::name))
+      );
+
+      final var out = mapper.forward(new Cart("acme", List.of(new Item("a"), new Item("b"), new Item("c"))));
+      assertEquals(List.of("acme", "acme", "acme"), out.items().stream().map(Item::name).toList());
+    }
+  }
+
+  @Nested
+  @DisplayName("Mapping.zip(Telescope, Telescope) — positional N:N between two many-focus telescopes")
+  class ZipPositional {
+
+    @Test
+    @DisplayName("forward writes positionally when cardinality matches")
+    void zipsWhenCardinalityMatches() {
+      record SrcWrap(String tenant, List<Item> items) {}
+      record TgtWrap(String tenant, List<Item> items) {}
+
+      final var mapper = Telescope.mapper(
+        SrcWrap.class,
+        TgtWrap.class,
+        zip(
+          Telescope.of(SrcWrap.class).each(SrcWrap::items).field(Item::name),
+          Telescope.of(TgtWrap.class).each(TgtWrap::items).field(Item::name)
+        )
+      );
+
+      final var out = mapper.forward(new SrcWrap("t", List.of(new Item("x"), new Item("y"), new Item("z"))));
+      assertEquals(List.of("x", "y", "z"), out.items().stream().map(Item::name).toList());
+    }
+
+    @Test
+    @DisplayName("cardinality mismatch throws on apply")
+    void cardinalityMismatchThrows() {
+      // Force a mismatch: source and target list sizes diverge via a typed transform on the list.
+      // The transform shrinks 3 source items to 2 target items; zip then sees src.count=3 vs
+      // tgt.count=2 and throws.
+      record SrcWrap(String tenant, List<Item> items) {}
+      record TgtWrap(String tenant, List<Item> items) {}
+
+      final var mapper = Telescope.mapper(
+        SrcWrap.class,
+        TgtWrap.class,
+        Mapping.<SrcWrap, TgtWrap, List<Item>, List<Item>>to(
+          SrcWrap::items,
+          TgtWrap::items,
+          xs -> xs.stream().limit(2).toList(), // shrink to 2
+          ys -> ys
+        ),
+        zip(
+          Telescope.of(SrcWrap.class).each(SrcWrap::items).field(Item::name),
+          Telescope.of(TgtWrap.class).each(TgtWrap::items).field(Item::name)
+        )
+      );
+
+      final var ex = assertThrows(IllegalStateException.class, () ->
+        mapper.forward(new SrcWrap("t", List.of(new Item("x"), new Item("y"), new Item("z"))))
+      );
+      assertEquals(true, ex.getMessage().contains("cardinality must match"));
+    }
+  }
+}

--- a/core/src/test/java/io/github/eschizoid/telescope/focus/BeanFocusCodegenTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/focus/BeanFocusCodegenTest.java
@@ -19,7 +19,7 @@ class BeanFocusCodegenTest {
     bean.setId("u1");
     bean.setEmail("A@X");
 
-    final var email = FocusSetterBeanTelescope.focus().email();
+    final var email = FocusSetterBeanTelescope.of().email();
     final var updated = email.update(bean, String::toLowerCase);
     assertEquals("a@x", updated.getEmail());
     assertEquals("u1", updated.getId());
@@ -31,7 +31,7 @@ class BeanFocusCodegenTest {
   void builder() {
     final var bean = FocusBuilderBean.builder().id("u1").email("A@X").build();
 
-    final var updated = FocusBuilderBeanTelescope.focus().email().update(bean, String::toLowerCase);
+    final var updated = FocusBuilderBeanTelescope.of().email().update(bean, String::toLowerCase);
     assertEquals("a@x", updated.getEmail());
     assertEquals("u1", updated.getId());
   }

--- a/core/src/test/java/io/github/eschizoid/telescope/focus/FocusCodegenTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/focus/FocusCodegenTest.java
@@ -26,10 +26,10 @@ class FocusCodegenTest {
   class Generated {
 
     @Test
-    @DisplayName("FocusPersonTelescope.focus().name() reads and updates the name field")
+    @DisplayName("FocusPersonTelescope.of().name() reads and updates the name field")
     void nameNavigation() {
       final var alice = new FocusPerson("alice", 30, new FocusAddress("nyc", "10001"));
-      final var name = FocusPersonTelescope.focus().name();
+      final var name = FocusPersonTelescope.of().name();
 
       assertEquals("alice", name.read(alice));
 
@@ -40,10 +40,10 @@ class FocusCodegenTest {
     }
 
     @Test
-    @DisplayName("FocusPersonTelescope.focus().age() boxes int → Integer; round-trips correctly")
+    @DisplayName("FocusPersonTelescope.of().age() boxes int → Integer; round-trips correctly")
     void primitiveBoxing() {
       final var alice = new FocusPerson("alice", 30, new FocusAddress("nyc", "10001"));
-      final var age = FocusPersonTelescope.focus().age();
+      final var age = FocusPersonTelescope.of().age();
 
       assertEquals(30, age.read(alice));
 
@@ -58,7 +58,7 @@ class FocusCodegenTest {
 
       // address() returns FocusAddressTelescope<FocusPerson>; city() returns Telescope<FocusPerson,
       // String>
-      final var city = FocusPersonTelescope.focus().address().city();
+      final var city = FocusPersonTelescope.of().address().city();
 
       assertEquals("nyc", city.read(alice));
 
@@ -82,7 +82,7 @@ class FocusCodegenTest {
       // FocusPersonTelescope<FocusTeam>;
       // .name() returns Telescope<FocusTeam, String>. Whole path is compile-checked,
       // reflection-free.
-      final var memberNames = FocusTeamTelescope.focus().members().each().name();
+      final var memberNames = FocusTeamTelescope.of().members().each().name();
 
       assertEquals(List.of("alice", "bob"), memberNames.toList(team));
 
@@ -100,17 +100,17 @@ class FocusCodegenTest {
       final var bag = new FocusBag(Map.of("a", "x", "b", "y"), Optional.of("hi"), List.of("p", "q"));
 
       // Map<String, String> values: eachValue() returns terminal Telescope<FocusBag, String>.
-      final var labelValues = FocusBagTelescope.focus().labels().eachValue();
+      final var labelValues = FocusBagTelescope.of().labels().eachValue();
       final var upperValues = labelValues.update(bag, String::toUpperCase);
       assertEquals(Map.of("a", "X", "b", "Y"), upperValues.labels());
 
       // Optional<String>: whenPresent() returns terminal Telescope<FocusBag, String>.
-      final var noteValue = FocusBagTelescope.focus().note().whenPresent();
+      final var noteValue = FocusBagTelescope.of().note().whenPresent();
       final var upperNote = noteValue.update(bag, String::toUpperCase);
       assertEquals(Optional.of("HI"), upperNote.note());
 
       // List<String>: each() returns terminal Telescope<FocusBag, String>.
-      assertEquals(List.of("p", "q"), FocusBagTelescope.focus().tags().each().toList(bag));
+      assertEquals(List.of("p", "q"), FocusBagTelescope.of().tags().each().toList(bag));
     }
 
     @Test
@@ -119,7 +119,7 @@ class FocusCodegenTest {
       final var team = new FocusTeam("eng", List.of(new FocusPerson("alice", 30, new FocusAddress("nyc", "10001"))));
 
       // The members() step exposes the whole List as a Telescope<FocusTeam, List<FocusPerson>>.
-      final var membersList = FocusTeamTelescope.focus().members().get();
+      final var membersList = FocusTeamTelescope.of().members().get();
       assertEquals(1, membersList.read(team).size());
     }
 
@@ -129,13 +129,13 @@ class FocusCodegenTest {
       final var entity = new FocusEntity("u1", "Alice@Example.com");
 
       // Direct read across the bridge: FocusEntity -> FocusDto.
-      final FocusDto dto = FocusEntityTelescope.focus().asFocusDto().read(entity);
+      final FocusDto dto = FocusEntityTelescope.of().asFocusDto().read(entity);
       assertEquals("u1", dto.id());
       assertEquals("Alice@Example.com", dto.email());
 
       // Compose through the bridge into a target field and update — the Iso round-trips back to
       // FocusEntity, so we get an updated entity back.
-      final var lowered = FocusEntityTelescope.focus().asFocusDto().email().update(entity, String::toLowerCase);
+      final var lowered = FocusEntityTelescope.of().asFocusDto().email().update(entity, String::toLowerCase);
       assertEquals("alice@example.com", lowered.email());
       assertEquals("u1", lowered.id());
     }
@@ -146,15 +146,13 @@ class FocusCodegenTest {
       final var alice = new FocusPerson("alice", 30, new FocusAddress("nyc", "10001"));
 
       // Sync ops directly on the root Path — no .get() unwrap.
-      final var renamed = FocusPersonTelescope.focus().update(alice, p ->
-        new FocusPerson("ALICE", p.age(), p.address())
-      );
+      final var renamed = FocusPersonTelescope.of().update(alice, p -> new FocusPerson("ALICE", p.age(), p.address()));
       assertEquals("ALICE", renamed.name());
-      assertEquals("alice", FocusPersonTelescope.focus().read(alice).name());
+      assertEquals("alice", FocusPersonTelescope.of().read(alice).name());
 
       // Effect at an intermediate sub-record Path hop: updateAsync on
       // FocusAddressTelescope<FocusPerson>.
-      final var movedFuture = FocusPersonTelescope.focus()
+      final var movedFuture = FocusPersonTelescope.of()
         .address()
         .updateAsync(alice, addr ->
           CompletableFuture.completedFuture(new FocusAddress(addr.city().toUpperCase(), addr.zip()))
@@ -169,7 +167,7 @@ class FocusCodegenTest {
           new FocusPerson("bob", 25, new FocusAddress("sf", "94016"))
         )
       );
-      final Either<String, FocusTeam> ok = FocusTeamTelescope.focus()
+      final Either<String, FocusTeam> ok = FocusTeamTelescope.of()
         .members()
         .each()
         .updateEither(team, p -> Either.right(new FocusPerson(p.name().toUpperCase(), p.age(), p.address())));
@@ -184,7 +182,7 @@ class FocusCodegenTest {
       );
 
       // updateIndexed forwarded from a Step → Path chain.
-      final var bumped = FocusTeamTelescope.focus()
+      final var bumped = FocusTeamTelescope.of()
         .members()
         .each()
         .updateIndexed(team, (i, p) -> new FocusPerson(p.name() + ":" + i, p.age(), p.address()));

--- a/docs/adr/0006-codegen-runtime-1-1-lookup-via-metadata-holder.md
+++ b/docs/adr/0006-codegen-runtime-1-1-lookup-via-metadata-holder.md
@@ -21,7 +21,7 @@ and getter/setter resolution. Those probes:
   architecture diagram.
 
 [ADR-0004](0004-runtime-and-codegen-strategy-separate.md) deliberately kept runtime and codegen as **separate
-strategies**. Users who annotate switch their call sites to `UserPath.focus().name()` — different API entry. Users who
+strategies**. Users who annotate switch their call sites to `UserPath.of().name()` — different API entry. Users who
 don't, stay on `Telescope.of(User.class).field(User::name)` with the reflective metadata probe.
 
 The drawback of that split: a user who **wants** codegen ergonomics (no reflection) **and** the runtime entry point

--- a/examples/library/src/main/java/io/github/eschizoid/telescope/examples/CodegenDemo.java
+++ b/examples/library/src/main/java/io/github/eschizoid/telescope/examples/CodegenDemo.java
@@ -36,14 +36,14 @@ final class CodegenDemo {
 
   // @Focus emits a FocusUserTelescope<R> with one method per component and the full Telescope op
   // surface
-  // forwarded. .focus() returns FocusUserTelescope<FocusUser>.
+  // forwarded. .of() returns FocusUserTelescope<FocusUser>.
   private static void focusRecordNavigator() {
     final var alice = new FocusUser("alice", "ALICE@ACME.COM");
-    final var loweredEmail = FocusUserTelescope.focus().email().update(alice, String::toLowerCase);
+    final var loweredEmail = FocusUserTelescope.of().email().update(alice, String::toLowerCase);
     System.out.println("[@Focus] email update         : " + loweredEmail);
 
     // Forwarders: read / find / toList / set / etc. are all on the Path itself.
-    System.out.println("[@Focus] forwarder name()     : " + FocusUserTelescope.focus().name().read(alice));
+    System.out.println("[@Focus] forwarder name()     : " + FocusUserTelescope.of().name().read(alice));
   }
 
   // Two @Focus records compose via .then(...) — the runtime DSL still works on generated paths,
@@ -52,14 +52,14 @@ final class CodegenDemo {
     // The example is a degenerate one (we don't have nested @Focus structure here) — but it proves
     // a Path-typed value composes with another Telescope via .then(...) without unwrapping.
     final var addr = new FocusAddress("nyc", "10001");
-    final var loud = FocusAddressTelescope.focus().city().update(addr, String::toUpperCase);
+    final var loud = FocusAddressTelescope.of().city().update(addr, String::toUpperCase);
     System.out.println("[@Focus] composition fixture  : " + loud);
   }
 
   // @BeanFocus emits BeanFocusUserTelescope<R> with no-arg + setter rebuild.
   private static void beanFocusNavigator() {
     final var bean = new BeanFocusUser("u1", "FOO@BAR.COM");
-    final var lowered = BeanFocusUserTelescope.focus().email().update(bean, String::toLowerCase);
+    final var lowered = BeanFocusUserTelescope.of().email().update(bean, String::toLowerCase);
     System.out.println("[@BeanFocus] email update     : " + lowered);
   }
 
@@ -70,10 +70,7 @@ final class CodegenDemo {
     final var entity = new BridgeEntity("u1", "ALICE@ACME.COM");
 
     // Use the as<Target>() hop, then continue with the target Path's email() method, then update.
-    final BridgeEntity lowered = BridgeEntityTelescope.focus()
-      .asBridgeDto()
-      .email()
-      .update(entity, String::toLowerCase);
+    final BridgeEntity lowered = BridgeEntityTelescope.of().asBridgeDto().email().update(entity, String::toLowerCase);
     System.out.println("[@Bridge] entity via DTO hop  : " + lowered);
 
     // The bridge itself is also reachable as the BRIDGE constant for direct conversion.

--- a/examples/springboot/README.md
+++ b/examples/springboot/README.md
@@ -121,7 +121,7 @@ wiring. Useful when a particular conversion is in your tightest loop and you wan
 
 | Path                              | Generated machinery                                                                         |
 | --------------------------------- | ------------------------------------------------------------------------------------------- |
-| `POST /invoices/lines/forward`    | `InvoiceLineTelescope.focus().asInvoiceLineEntity().read(line)` — generated navigator hop   |
+| `POST /invoices/lines/forward`    | `InvoiceLineTelescope.of().asInvoiceLineEntity().read(line)` — generated navigator hop      |
 | `POST /invoices/lines/backward`   | `InvoiceLineBridge.backward(entity)` — generated static method                              |
 | `POST /invoices/headers/forward`  | `InvoiceHeaderBridge.forward(header)` — auto-recurses into `InvoiceLineBridge` for the list |
 | `POST /invoices/headers/backward` | `InvoiceHeaderBridge.backward(entity)` — same in reverse                                    |
@@ -158,9 +158,9 @@ wiring. Useful when a particular conversion is in your tightest loop and you wan
 
 The widest surface of any submodule. **Headline: "pick your trade-off per call site."** The same `Order` domain backs
 eight endpoints that each demonstrate a different telescope angle. Both the runtime DSL
-(`Telescope.of(Order.class).field(...)`) and the codegen path navigators (`OrderTelescope.focus().x()`) live side by
-side — the choice between them happens at the controller, not at the domain. Adding `@Focus` / `@BeanFocus` is purely
-opt-in: the runtime mapper transparently uses the codegen-emitted holder constants when present (holder-probe fast path,
+(`Telescope.of(Order.class).field(...)`) and the codegen path navigators (`OrderTelescope.of().x()`) live side by side —
+the choice between them happens at the controller, not at the domain. Adding `@Focus` / `@BeanFocus` is purely opt-in:
+the runtime mapper transparently uses the codegen-emitted holder constants when present (holder-probe fast path,
 post-ADR-0006), but doesn't require them.
 
 **Endpoints**
@@ -168,7 +168,7 @@ post-ADR-0006), but doesn't require them.
 | Path                              | Telescope angle                                                                                  |
 | --------------------------------- | ------------------------------------------------------------------------------------------------ |
 | `POST /orders`                    | Runtime DSL — basic CRUD with deep-update email normalisation pre-save                           |
-| `POST /orders/path`               | Codegen navigator — `OrderTelescope.focus().lineItems().each().unitPrice().update(...)`          |
+| `POST /orders/path`               | Codegen navigator — `OrderTelescope.of().lineItems().each().unitPrice().update(...)`             |
 | `POST /orders/validated`          | `updateValidated` accumulates per-line-item errors into one 400 payload (not first-failure-wins) |
 | `POST /orders/{id}/bulk-update`   | `Telescope.all(overIfPresent(...), mapIfPresent(...))` — sparse-PATCH composition, no if-ladder  |
 | `POST /orders/{id}/inspect`       | `read` / `find` / `count` / `exists` terminals — describe a path in the request body             |

--- a/examples/springboot/invoicing/src/main/java/io/github/eschizoid/telescope/demo/invoicing/api/InvoiceBridgeController.java
+++ b/examples/springboot/invoicing/src/main/java/io/github/eschizoid/telescope/demo/invoicing/api/InvoiceBridgeController.java
@@ -34,15 +34,15 @@ import org.springframework.web.bind.annotation.RestController;
 public class InvoiceBridgeController {
 
   /**
-   * Demonstrates the {@code InvoiceLineTelescope.focus().asInvoiceLineEntity()} navigator hop.
-   * {@code BridgeProcessor} generated the {@code asInvoiceLineEntity()} method on the source Path;
-   * because {@code InvoiceLineEntity} is {@code @BeanFocus}-navigable, the hop returns {@code
+   * Demonstrates the {@code InvoiceLineTelescope.of().asInvoiceLineEntity()} navigator hop. {@code
+   * BridgeProcessor} generated the {@code asInvoiceLineEntity()} method on the source Path; because
+   * {@code InvoiceLineEntity} is {@code @BeanFocus}-navigable, the hop returns {@code
    * InvoiceLineEntityPath<InvoiceLine>} and {@code .read(line)} runs the underlying Telescope
    * through the {@code BRIDGE} Iso to materialise the entity.
    */
   @PostMapping("/lines/forward")
   public ResponseEntity<InvoiceLineEntity> lineForward(@RequestBody final InvoiceLine line) {
-    final var entity = InvoiceLineTelescope.focus().asInvoiceLineEntity().read(line);
+    final var entity = InvoiceLineTelescope.of().asInvoiceLineEntity().read(line);
     return ResponseEntity.ok(entity);
   }
 

--- a/examples/springboot/invoicing/src/test/java/io/github/eschizoid/telescope/demo/invoicing/InvoiceBridgeTest.java
+++ b/examples/springboot/invoicing/src/test/java/io/github/eschizoid/telescope/demo/invoicing/InvoiceBridgeTest.java
@@ -38,13 +38,13 @@ class InvoiceBridgeTest {
   }
 
   @Test
-  @DisplayName("InvoiceLineTelescope.focus().asInvoiceLineEntity() reads through the BRIDGE Iso")
+  @DisplayName("InvoiceLineTelescope.of().asInvoiceLineEntity() reads through the BRIDGE Iso")
   void bridgeHopFromPathNavigator() {
     final var line = new InvoiceLine("SKU-B", 1, new BigDecimal("49.50"));
 
     // Compile-time-bound hop: BridgeProcessor wired the navigator's asInvoiceLineEntity() method
     // to return a typed continuation (InvoiceLineEntityPath because the target is @BeanFocus).
-    final InvoiceLineEntity entity = InvoiceLineTelescope.focus().asInvoiceLineEntity().read(line);
+    final InvoiceLineEntity entity = InvoiceLineTelescope.of().asInvoiceLineEntity().read(line);
 
     assertThat(entity.getSku()).isEqualTo("SKU-B");
     assertThat(entity.getQty()).isEqualTo(1);

--- a/examples/springboot/order-jpa/src/main/java/io/github/eschizoid/telescope/demo/spring/api/OrderTelescopeController.java
+++ b/examples/springboot/order-jpa/src/main/java/io/github/eschizoid/telescope/demo/spring/api/OrderTelescopeController.java
@@ -37,7 +37,7 @@ import org.springframework.web.bind.annotation.RestController;
  * <p>This controller's equivalent:
  *
  * <pre>{@code
- * OrderTelescope.focus()
+ * OrderTelescope.of()
  *     .customer()
  *     .email()
  *     .update(request, normalise);
@@ -89,7 +89,7 @@ public class OrderTelescopeController {
     // The processor generated `OrderPath#customer()` returning a CustomerTelescope<Order>, whose
     // `email()` method returns a Telescope<Order, String> — fully compile-checked, no runtime
     // decode, no SerializedLambda crackopen, no probe miss.
-    final var normalised = OrderTelescope.focus()
+    final var normalised = OrderTelescope.of()
       .customer()
       .email()
       .update(request, email -> email == null ? null : email.toLowerCase());
@@ -115,7 +115,7 @@ public class OrderTelescopeController {
     @RequestParam(defaultValue = "10") final int percent
   ) {
     // Demonstrates Mapper.asTelescope() composing across paradigms in one typed pipeline:
-    //   1. OrderTelescope.focus().lineItems().each().get() — typed record-side traversal down to a
+    //   1. OrderTelescope.of().lineItems().each().get() — typed record-side traversal down to a
     //      Telescope<Order, LineItem>. Codegen-emitted, compile-time-bound, multi-focus.
     //   2. .then(lineItemMapper.asTelescope()) — bridge into the entity side. The mapper
     //      exposes its bidirectional Iso<LineItem, LineItemEntity> as a Telescope so the lattice
@@ -134,9 +134,7 @@ public class OrderTelescopeController {
       .findById(id)
       .map(orderMapper::backward)
       .map(record ->
-        new LineItemEntityTelescope<>(
-          OrderTelescope.focus().lineItems().each().get().then(lineItemMapper.asTelescope())
-        )
+        new LineItemEntityTelescope<>(OrderTelescope.of().lineItems().each().get().then(lineItemMapper.asTelescope()))
           .unitPriceCents()
           .update(record, cents -> (cents * (100L - percent)) / 100L)
       )
@@ -153,7 +151,7 @@ public class OrderTelescopeController {
       .findById(id)
       .map(orderMapper::backward)
       .map(record ->
-        OrderTelescope.focus()
+        OrderTelescope.of()
           .customer()
           .email()
           .update(record, email -> email == null ? null : email.toLowerCase())

--- a/examples/springboot/order-jpa/src/test/java/io/github/eschizoid/telescope/demo/spring/PartnerLabelFlowTest.java
+++ b/examples/springboot/order-jpa/src/test/java/io/github/eschizoid/telescope/demo/spring/PartnerLabelFlowTest.java
@@ -127,7 +127,7 @@ class PartnerLabelFlowTest {
       .items(List.of())
       .build();
 
-    final var lowered = PartnerShippingLabelTelescope.focus().customer().email().update(original, String::toLowerCase);
+    final var lowered = PartnerShippingLabelTelescope.of().customer().email().update(original, String::toLowerCase);
 
     assertThat(lowered.getCustomer().getEmail()).isEqualTo("alice@example.com");
     // Everything else flows through unchanged — the lens setter rebuilds only the customer's email

--- a/lombok/README.md
+++ b/lombok/README.md
@@ -25,7 +25,7 @@ public class User {
 You want the same compile-checked navigator as `@Focus`/`@BeanFocus`:
 
 ```java
-UserPath.focus()
+UserPath.of()
     .address().city()
     .update(user, city -> city.toLowerCase());
 ```

--- a/lombok/src/test/java/io/github/eschizoid/telescope/codegen/lombok/LombokFocusProcessorTest.java
+++ b/lombok/src/test/java/io/github/eschizoid/telescope/codegen/lombok/LombokFocusProcessorTest.java
@@ -249,10 +249,10 @@ class LombokFocusProcessorTest {
   class Runtime {
 
     @Test
-    @DisplayName("DataUserTelescope.focus().email().update lower-cases the email via Lombok's setter rebuild")
+    @DisplayName("DataUserTelescope.of().email().update lower-cases the email via Lombok's setter rebuild")
     void dataUserPathRoundTrip() throws Exception {
       final var pathClass = Class.forName("io.github.eschizoid.telescope.codegen.lombok.fixtures.DataUserTelescope");
-      final var start = pathClass.getDeclaredMethod("focus").invoke(null);
+      final var start = pathClass.getDeclaredMethod("of").invoke(null);
       @SuppressWarnings("unchecked")
       final Telescope<DataUser, String> emailPath = (Telescope<DataUser, String>) pathClass
         .getDeclaredMethod("email")
@@ -265,10 +265,10 @@ class LombokFocusProcessorTest {
     }
 
     @Test
-    @DisplayName("BuilderUserTelescope.focus().email().update rebuilds via the synthesised builder()")
+    @DisplayName("BuilderUserTelescope.of().email().update rebuilds via the synthesised builder()")
     void builderUserPathRoundTrip() throws Exception {
       final var pathClass = Class.forName("io.github.eschizoid.telescope.codegen.lombok.fixtures.BuilderUserTelescope");
-      final var start = pathClass.getDeclaredMethod("focus").invoke(null);
+      final var start = pathClass.getDeclaredMethod("of").invoke(null);
       @SuppressWarnings("unchecked")
       final Telescope<BuilderUser, String> emailPath = (Telescope<BuilderUser, String>) pathClass
         .getDeclaredMethod("email")
@@ -282,7 +282,7 @@ class LombokFocusProcessorTest {
   }
 
   private static void assertHasFocusMethod(final Class<?> pathClass, final Class<?> rootType) throws Exception {
-    final var start = pathClass.getDeclaredMethod("focus");
+    final var start = pathClass.getDeclaredMethod("of");
     assertTrue(java.lang.reflect.Modifier.isStatic(start.getModifiers()), "start() must be static");
     assertEquals(pathClass, start.getReturnType(), () -> "start() should return " + pathClass.getSimpleName());
   }

--- a/lombok/src/test/java/io/github/eschizoid/telescope/codegen/lombok/fixtures/SameRoundConsumer.java
+++ b/lombok/src/test/java/io/github/eschizoid/telescope/codegen/lombok/fixtures/SameRoundConsumer.java
@@ -17,7 +17,7 @@ public final class SameRoundConsumer {
 
   /** Shouts the email through the typed DataUserTelescope navigator. */
   public static DataUser shoutEmail(final DataUser user) {
-    return DataUserTelescope.focus()
+    return DataUserTelescope.of()
       .email()
       .update(user, s -> s == null ? null : s.toUpperCase());
   }


### PR DESCRIPTION
## Summary

Closes the gap with MapStruct's `@Mapping(source = "a.b.c", target = "x.y.z")` by letting `Mapping` rows accept multi-hop `Telescope`s on either side. All four shapes route through the existing optic lattice via `Telescope.set` / `read` / `toList` / `updateIndexed` — no new internal primitives.

### New public `Mapping` factories

| Factory | Shape | Engine |
|---|---|---|
| `to(Accessor<A, X>, Telescope<B, X>)` | flat src → nested tgt | `tgtT.set(t, srcAcc.apply(a))` |
| `to(Telescope<A, X>, Accessor<B, X>)` | nested src → flat tgt | rebuild `t` with `targetField = srcT.read(a)` |
| `to(Telescope<A, X>, Telescope<B, X>)` | both nested (broadcast on many-focus) | `tgtT.set(t, srcT.read(a))` |
| `zip(Telescope<A, X>, Telescope<B, X>)` | positional N:N, cardinality-checked | `tgtT.updateIndexed(t, …)` against `srcT.toList(a)` |

### Engine

- `DeepMap` groups overrides by `(sourceClass, targetClass)`, now with a **soft/strict claim split** so multiple `Mapping.to` rows reading the same source field compose (MapStruct's multi-`@Mapping` shape).
- Telescope rows' top-level field claim is recovered via `firstHopName` — a new package-private string on `Telescope` captured by `Telescope.lens(Accessor, BiFunction)`, the overload Java picks for codegen-emitted method-refs. `.then(...)` propagates the first non-null `firstHopName`, so composition chains preserve it.
- `Mapping` is now sealed over `TelescopeTo`, `FromTelescopeTo`, and `TelescopeToTelescope` (with a `Kind` enum discriminating `BROADCAST` vs `ZIP`).

### Ergonomic rename: `<X>Telescope.focus()` → `<X>Telescope.of()`

Symmetric with runtime `Telescope.of(Class)`, and removes the "focus" doubling that made chains like `PersonTelescope.focus().address().city()` read awkwardly. ~50 call sites swept across `codegen`, `lombok`, examples, READMEs, and ADR-0006.

```java
// Before
PersonTelescope.focus().address().city()
// After — symmetric with runtime Telescope.of(Person.class)…
PersonTelescope.of().address().city()
```

### Codegen 1:1 verification

`TelescopeMappingTest.CodegenOnePointOne` exercises real `@Focus`-generated navigators (`Person` / `Address` top-level test fixtures) as both the source AND target side of `Mapping.to(...)`, proving the codegen navigator value is interchangeable with a runtime `Telescope.of(...).field(...)` chain at the `Telescope<S, A>` value level — not at the source-text level.

`Mapping.java` javadocs now document both runtime and codegen call shapes side-by-side so adopters see `PersonTelescope.of().address().city()` as a first-class argument to `Mapping.to`.

## Test plan

- [x] 13 telescope-mapping tests pass (`TelescopeMappingTest` covers all four factories, codegen 1:1, cardinality enforcement on zip, multiple rows sharing source field, deeply-nested telescopes on both sides)
- [x] `:core` / `:codegen` / `:lombok` / `:benchmarks` all green
- [x] `spotlessCheck` clean on every module
- [x] All four `examples/springboot/*` and `examples/library` compile after the `.focus()` → `.of()` sweep
- [x] Lombok integration tests pass — `<X>Telescope.of()` is reachable by reflection from `LombokFocusProcessorTest`