### PR TITLE
feat(mapping): Mapping.constant + Mapping.compute + intermediate allocation — close the last MapStruct gaps pre-1.0

### DIFF
--- a/core/src/main/java/io/github/eschizoid/telescope/DeepMap.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/DeepMap.java
@@ -4,6 +4,8 @@ import io.github.eschizoid.telescope.conversion.Mapper;
 import io.github.eschizoid.telescope.internal.Beans;
 import io.github.eschizoid.telescope.internal.Reflective;
 import io.github.eschizoid.telescope.internal.optics.Iso;
+import io.github.eschizoid.telescope.mapping.Compute;
+import io.github.eschizoid.telescope.mapping.Constant;
 import io.github.eschizoid.telescope.mapping.Drop;
 import io.github.eschizoid.telescope.mapping.FromTelescopeTo;
 import io.github.eschizoid.telescope.mapping.MapStep;
@@ -321,6 +323,41 @@ public final class DeepMap {
         if (firstSrcHop != null) telescopeReadsSrc.add(srcRefl.normalize(firstSrcHop));
         if (firstTgtHop != null) telescopeWritesTgt.add(tgtRefl.normalize(firstTgtHop));
         telescopeFixups.add(ttRow);
+        continue;
+      }
+      // Constant / Compute rows are the target-side mirror of Drop: they claim a target field
+      // with no source counterpart, stamping a fixed (Constant) or freshly-supplied (Compute)
+      // value into the rebuilt target at forward time. Backward direction silently drops the
+      // slot — the rebuilt source carries the type default at the dual position (same retraction
+      // semantics as Drop, in the inverse direction). Register only under byTargetName so the
+      // forward pass picks them up; absence from bySourceName means the source rebuilder ignores
+      // the slot entirely on backward.
+      if (row instanceof Constant<?, ?, ?> cRow) {
+        final var tgtFieldName = tgtRefl.normalize(internals.targetField());
+        if (!claimedTgt.add(tgtFieldName)) throw new IllegalArgumentException(
+          "Deep map " +
+            source.getSimpleName() +
+            " → " +
+            target.getSimpleName() +
+            ": duplicate override row for target field '" +
+            tgtFieldName +
+            "'. Each (source, target) type pair may declare at most one row per target field."
+        );
+        byTargetName.put(tgtFieldName, new FieldStep(null, tgtFieldName, constantIso(cRow.value())));
+        continue;
+      }
+      if (row instanceof Compute<?, ?, ?> cpRow) {
+        final var tgtFieldName = tgtRefl.normalize(internals.targetField());
+        if (!claimedTgt.add(tgtFieldName)) throw new IllegalArgumentException(
+          "Deep map " +
+            source.getSimpleName() +
+            " → " +
+            target.getSimpleName() +
+            ": duplicate override row for target field '" +
+            tgtFieldName +
+            "'. Each (source, target) type pair may declare at most one row per target field."
+        );
+        byTargetName.put(tgtFieldName, new FieldStep(null, tgtFieldName, computeIso(cpRow.supplier())));
         continue;
       }
       // Drop rows claim a source field with no target counterpart — they exist to satisfy the
@@ -726,6 +763,11 @@ public final class DeepMap {
       case TelescopeToTelescope<?, ?, ?> _ -> throw new IllegalStateException(
         "TelescopeToTelescope row should not reach fieldIsoOf"
       );
+      // Constant / Compute rows build their iso inline (constantIso / computeIso) at registration
+      // time in populateIso, since fieldIsoOf doesn't have the captured value / supplier in scope.
+      // These cases exist only to keep the sealed switch exhaustive.
+      case Constant<?, ?, ?> _ -> throw new IllegalStateException("Constant row should not reach fieldIsoOf");
+      case Compute<?, ?, ?> _ -> throw new IllegalStateException("Compute row should not reach fieldIsoOf");
     };
   }
 
@@ -980,6 +1022,23 @@ public final class DeepMap {
    * fields that have no target counterpart; the forward direction skips the field entirely.
    */
   private static final Iso<Object, Object> NULLING_ISO = Iso.of(_ -> null, _ -> null);
+
+  /**
+   * Forward-only iso for {@link Constant} rows: {@code to(_)} ignores its argument and returns the
+   * captured literal; {@code from(_)} returns {@code null} (the backward direction discards the
+   * slot, mirroring {@link #NULLING_ISO} on the source side).
+   */
+  private static <X> Iso<Object, Object> constantIso(final X value) {
+    return Iso.of(_ -> value, _ -> null);
+  }
+
+  /**
+   * Forward-only iso for {@link Compute} rows: {@code to(_)} invokes the supplier on every call
+   * (fresh value each forward); {@code from(_)} returns {@code null}.
+   */
+  private static <X> Iso<Object, Object> computeIso(final java.util.function.Supplier<? extends X> supplier) {
+    return Iso.of(_ -> supplier.get(), _ -> null);
+  }
 
   /**
    * Bundled return from {@link #resolution(Class, Class, MapStep...)} — the Iso and the patch

--- a/core/src/main/java/io/github/eschizoid/telescope/DeepMap.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/DeepMap.java
@@ -419,7 +419,21 @@ public final class DeepMap {
       // every nested write. Without any telescope row, the strict same-name check still fires.
       if (!srcNameSet.contains(name)) {
         if (!telescopeFixups.isEmpty()) {
-          byTargetName.putIfAbsent(name, new FieldStep(null, name, NULLING_ISO));
+          // Telescope-row placeholder for a target field with no same-name source. Three cases,
+          // type-driven:
+          //   - field type is a record AND a telescope row claims it as a first hop: allocate a
+          //     recursive default-tree instance so the post-fixup overlay
+          //     (`tgtTelescope.set(t, value)`) can descend into a non-null intermediate. Records
+          //     only for v1.0; beans need a no-arg ctor or builder which isn't always present —
+          //     deferred to v1.1.
+          //   - field type is a primitive: return the JLS default (0 / false / etc.) so canonical-
+          //     ctor reflection doesn't NPE unboxing a null Object.
+          //   - everything else: NULLING_ISO (null reference, unchanged behavior).
+          final var fieldType = rawClassOf(tgtRefl.genericType(target, name));
+          byTargetName.putIfAbsent(
+            name,
+            new FieldStep(null, name, placeholderIsoFor(fieldType, telescopeWritesTgt.contains(name)))
+          );
           continue;
         }
         throw new IllegalStateException(
@@ -1038,6 +1052,82 @@ public final class DeepMap {
    */
   private static <X> Iso<Object, Object> computeIso(final java.util.function.Supplier<? extends X> supplier) {
     return Iso.of(_ -> supplier.get(), _ -> null);
+  }
+
+  /**
+   * Forward-only iso that materialises a fresh default-tree instance of {@code recordType} on every
+   * forward call. Used as the placeholder for telescope-row-claimed target fields that have no
+   * same-name source counterpart — the post-fixup overlay descends into the allocated instance and
+   * writes the leaf, so a fully-flat source can be lifted into a deeply-nested target without
+   * per-hop allocation glue.
+   *
+   * <p>Records only. Bean intermediates still get {@link #NULLING_ISO}; bean allocation needs a
+   * no-arg constructor or builder shape that isn't always present and would muddy the v1.0
+   * cut-line.
+   */
+  private static Iso<Object, Object> defaultAllocatorIso(final Class<?> recordType) {
+    return Iso.of(_ -> recursiveDefault(recordType), _ -> null);
+  }
+
+  /**
+   * Construct a default-tree instance of {@code type} — primitives get their JLS default (0, false,
+   * etc.), records recurse via their canonical constructor with the same scheme, all other
+   * reference types get {@code null}.
+   *
+   * <p>Cycles between record types can't arise in practice: each canonical ctor needs every other
+   * type already constructible, so a record cycle would fail at compile time. No cycle-detection
+   * needed.
+   */
+  @SuppressWarnings({ "rawtypes", "unchecked" })
+  private static Object recursiveDefault(final Class<?> type) {
+    if (type.isPrimitive()) return primitiveDefault(type);
+    if (type.isRecord()) {
+      final var comps = type.getRecordComponents();
+      final var byName = new HashMap<String, Object>(comps.length);
+      for (final var comp : comps) byName.put(comp.getName(), recursiveDefault(comp.getType()));
+      return io.github.eschizoid.telescope.internal.Records.construct((Class) type, byName::get);
+    }
+    return null;
+  }
+
+  private static Object primitiveDefault(final Class<?> p) {
+    if (p == int.class) return 0;
+    if (p == long.class) return 0L;
+    if (p == boolean.class) return false;
+    if (p == double.class) return 0.0;
+    if (p == float.class) return 0.0f;
+    if (p == byte.class) return (byte) 0;
+    if (p == short.class) return (short) 0;
+    if (p == char.class) return (char) 0;
+    return null;
+  }
+
+  /**
+   * Type-aware placeholder Iso for the permissive-mode block in {@link #populateIso}. Picks the
+   * right "missing source field" filler based on the target field's type and whether a telescope
+   * row claims the field as its first hop.
+   */
+  private static Iso<Object, Object> placeholderIsoFor(
+    final Class<?> fieldType,
+    final boolean claimedByTelescopeWrite
+  ) {
+    if (fieldType == null) return NULLING_ISO;
+    if (claimedByTelescopeWrite && fieldType.isRecord()) return defaultAllocatorIso(fieldType);
+    if (fieldType.isPrimitive()) {
+      final var value = primitiveDefault(fieldType);
+      return Iso.of(_ -> value, _ -> value);
+    }
+    return NULLING_ISO;
+  }
+
+  /**
+   * Strip generics from a {@link Type} to the raw {@link Class}, returning {@code null} for
+   * anything that isn't a class or a parameterized type (wildcards, type variables, etc.).
+   */
+  private static Class<?> rawClassOf(final Type t) {
+    if (t instanceof Class<?> c) return c;
+    if (t instanceof ParameterizedType pt && pt.getRawType() instanceof Class<?> c) return c;
+    return null;
   }
 
   /**

--- a/core/src/main/java/io/github/eschizoid/telescope/mapping/Compute.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/mapping/Compute.java
@@ -1,0 +1,54 @@
+package io.github.eschizoid.telescope.mapping;
+
+import io.github.eschizoid.telescope.DeepMap;
+import io.github.eschizoid.telescope.Telescope.Accessor;
+import io.github.eschizoid.telescope.internal.LambdaIntrospection;
+import java.util.function.Supplier;
+
+/**
+ * Lazy-supplier correspondence row from {@link Mapping#compute(Accessor, Supplier)}. Calls the
+ * supplier at every forward-apply, stamping the result onto a target field; the source side has no
+ * slot, so {@link DeepMap}'s backward direction silently drops it (the rebuilt source carries the
+ * type default at the dual slot — same retraction semantics as {@link Drop} but on the target
+ * side).
+ *
+ * <p>Use for values that must be freshly evaluated each forward call: timestamps ({@code
+ * Instant::now}), per-call generated IDs ({@code UUID::randomUUID}), and fresh mutable containers
+ * ({@code HashMap::new} / {@code ArrayList::new}) where a literal would share one reference across
+ * every call (a Java mutable-default-argument trap). For fixed values that ARE safe to share, use
+ * {@link Constant}.
+ *
+ * <p>Forward-only by design. Mirrors MapStruct's {@code @Mapping(expression = "java(...)")} but
+ * stays in plain Java — the supplier is a typed {@link Supplier} that {@code javac} type-checks
+ * against the target leaf, no string-templated body to parse. Declared once in the same {@code
+ * Telescope.mapper(...)} call as the other rows.
+ *
+ * <p>Package-private — users construct via {@link Mapping#compute(Accessor, Supplier)} and never
+ * see this type at the call site.
+ */
+public record Compute<A, B, X>(
+  Accessor<B, X> tgtAccessor,
+  Supplier<? extends X> supplier
+) implements Mapping<A, B>, MappingInternals<A, B> {
+  /** Returns {@code null} — no source-side accessor; the row is forward-only. */
+  @Override
+  public Class<A> sourceClass() {
+    return null;
+  }
+
+  @Override
+  public Class<B> targetClass() {
+    return LambdaIntrospection.implClassOf(tgtAccessor);
+  }
+
+  /** Returns {@code null} — no source field to claim. */
+  @Override
+  public String sourceField() {
+    return null;
+  }
+
+  @Override
+  public String targetField() {
+    return LambdaIntrospection.methodNameOf(tgtAccessor);
+  }
+}

--- a/core/src/main/java/io/github/eschizoid/telescope/mapping/Constant.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/mapping/Constant.java
@@ -1,0 +1,48 @@
+package io.github.eschizoid.telescope.mapping;
+
+import io.github.eschizoid.telescope.DeepMap;
+import io.github.eschizoid.telescope.Telescope.Accessor;
+import io.github.eschizoid.telescope.internal.LambdaIntrospection;
+
+/**
+ * Eager-literal correspondence row from {@link Mapping#constant(Accessor, Object)}. Stamps a fixed
+ * value onto a target field at forward-apply time; the source-side has no slot for this value, so
+ * {@link DeepMap}'s backward direction silently drops it (the rebuilt source carries the type
+ * default at the dual slot — same retraction semantics as {@link Drop} but on the target side).
+ *
+ * <p>Use for tenant tags, schema versions, environment markers, and other values that should be the
+ * same on every forward call. For values that need to be re-evaluated per call (timestamps, fresh
+ * collections, IDs), use {@link Compute} instead — a literal {@code constant(Tgt::metadata, new
+ * HashMap<>())} would share one map reference across every forward call.
+ *
+ * <p>Forward-only by design. Mirrors MapStruct's {@code @Mapping(constant = "...")}; the difference
+ * is that the row lives next to the other field correspondences in the same {@code
+ * Telescope.mapper(...)} call instead of being split across a second {@code @InheritInverse
+ * Configuration} interface — declared once, semantically explicit.
+ *
+ * <p>Package-private — users construct via {@link Mapping#constant(Accessor, Object)} and never see
+ * this type at the call site.
+ */
+public record Constant<A, B, X>(Accessor<B, X> tgtAccessor, X value) implements Mapping<A, B>, MappingInternals<A, B> {
+  /** Returns {@code null} — no source-side accessor; the row is forward-only. */
+  @Override
+  public Class<A> sourceClass() {
+    return null;
+  }
+
+  @Override
+  public Class<B> targetClass() {
+    return LambdaIntrospection.implClassOf(tgtAccessor);
+  }
+
+  /** Returns {@code null} — no source field to claim. */
+  @Override
+  public String sourceField() {
+    return null;
+  }
+
+  @Override
+  public String targetField() {
+    return LambdaIntrospection.methodNameOf(tgtAccessor);
+  }
+}

--- a/core/src/main/java/io/github/eschizoid/telescope/mapping/Mapping.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/mapping/Mapping.java
@@ -5,6 +5,7 @@ import io.github.eschizoid.telescope.Telescope;
 import io.github.eschizoid.telescope.Telescope.Accessor;
 import io.github.eschizoid.telescope.conversion.Mapper;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 /**
  * One field correspondence in a {@link Telescope#map(Class, Class, MapStep...)} call — supplies an
@@ -36,7 +37,16 @@ import java.util.function.Function;
  */
 public sealed interface Mapping<A, B>
   extends MapStep
-  permits SameTypedTo, TypedTransformTo, Via, Drop, TelescopeTo, FromTelescopeTo, TelescopeToTelescope
+  permits
+    SameTypedTo,
+    TypedTransformTo,
+    Via,
+    Drop,
+    TelescopeTo,
+    FromTelescopeTo,
+    TelescopeToTelescope,
+    Constant,
+    Compute
 {
   /** Same-typed correspondence: {@code src↔tgt}, both with leaf type {@code X}. Identity. */
   static <A, B, X> Mapping<A, B> to(final Accessor<A, X> src, final Accessor<B, X> tgt) {
@@ -243,5 +253,58 @@ public sealed interface Mapping<A, B>
     @SuppressWarnings("unchecked")
     final var castTarget = (Class<B>) target;
     return new Drop<>(src, castTarget);
+  }
+
+  /**
+   * Stamp a fixed value onto a target field at forward time. Closes MapStruct's
+   * {@code @Mapping(target = "tenant", constant = "production")} — the literal lives at the call
+   * site, statically typed against the target leaf, no string parser.
+   *
+   * <pre>{@code
+   * Telescope.mapper(Order.class, OrderDto.class,
+   *     to(Order::id, OrderDto::id),
+   *     constant(OrderDto::tenant,    "production"),
+   *     constant(OrderDto::apiVersion, 7));
+   * }</pre>
+   *
+   * <p><b>Forward-only.</b> The source side has no slot for this value, so {@code
+   * mapper.backward(dto)} silently drops it — the rebuilt source carries the type default at the
+   * dual slot. Same retraction semantics as {@link #drop(Accessor)} on the source side.
+   *
+   * <p><b>Eager.</b> The literal is captured once at row construction; every forward call stamps
+   * the same reference. For values that should be re-evaluated per call (timestamps, fresh
+   * containers, IDs) use {@link #compute(Accessor, Supplier)} instead — a literal {@code
+   * constant(Tgt::metadata, new HashMap<>())} would share one map across every forward call, which
+   * is almost never what you want.
+   */
+  static <A, B, X> Mapping<A, B> constant(final Accessor<B, X> tgt, final X value) {
+    return new Constant<>(tgt, value);
+  }
+
+  /**
+   * Stamp a freshly-evaluated value onto a target field at every forward call. Closes MapStruct's
+   * {@code @Mapping(target = "createdAt", expression = "java(Instant.now())")} but in plain typed
+   * Java — the {@link Supplier} is type-checked against the target leaf by {@code javac}, no
+   * string-templated expression body.
+   *
+   * <pre>{@code
+   * Telescope.mapper(Order.class, OrderDto.class,
+   *     to(Order::id,       OrderDto::id),
+   *     compute(OrderDto::createdAt, Instant::now),     // fresh timestamp per call
+   *     compute(OrderDto::traceId,   UUID::randomUUID), // fresh ID per call
+   *     compute(OrderDto::metadata,  HashMap::new));    // fresh container per call
+   * }</pre>
+   *
+   * <p><b>Forward-only.</b> Same backward-drop semantics as {@link #constant(Accessor, Object)}.
+   * Note that this means {@code mapper.forward(mapper.backward(dto))} does NOT round-trip a {@code
+   * compute} row's value — by design: a supplier like {@code Instant::now} cannot be inverted.
+   * Document any roundtrip assumption explicitly.
+   *
+   * <p><b>Lazy.</b> The supplier fires on every forward call, not once at row construction. Use
+   * this whenever the value involves mutable state, time, randomness, or a fresh allocation; use
+   * {@link #constant(Accessor, Object)} when the value is genuinely a shared literal.
+   */
+  static <A, B, X> Mapping<A, B> compute(final Accessor<B, X> tgt, final Supplier<? extends X> supplier) {
+    return new Compute<>(tgt, supplier);
   }
 }

--- a/core/src/main/java/io/github/eschizoid/telescope/mapping/Mapping.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/mapping/Mapping.java
@@ -100,17 +100,13 @@ public sealed interface Mapping<A, B>
    * srcAcc.apply(a))} overlays the leaf. Backward direction is the mirror: read at the target
    * telescope, write to the source via the accessor's lens.
    *
-   * <p><b>Intermediate allocation limitation (v1.0).</b> The overlay requires the target's
-   * intermediate structure (the hops between the root and the leaf — e.g. the {@code shipping} and
-   * {@code recipient} sub-objects above) to be reachable via the base auto-recursion. That happens
-   * when the source has a same-name field for each top-level hop of the telescope (here, an {@code
-   * Order::getShipping}-shaped field on the source) — auto-recursion uses it to allocate the
-   * intermediate, and the overlay then writes the leaf. When the source is genuinely flat (no
-   * same-name field driving an intermediate), the auto-recursion leaves the target field {@code
-   * null} and the overlay NPEs descending into it. For that case, fall back to {@link
-   * #via(Accessor, Accessor, Mapper)} with a small mapper that allocates the intermediate
-   * explicitly. v1.1 will close this gap by synthesizing the intermediate from the telescope's hop
-   * chain (see PLAN.md "Tier 3 — Intermediate allocation").
+   * <p><b>Intermediate allocation.</b> When the source is genuinely flat (no same-name field on the
+   * source matching the telescope's top-level target hop), the engine synthesizes a recursive
+   * default-tree instance of the intermediate's type so the overlay can descend without NPEing on a
+   * null hop. Works for record intermediates at arbitrary depth (the type system drives the
+   * recursion); bean intermediates without a no-arg ctor or builder still need a {@link
+   * #via(Accessor, Accessor, Mapper)} workaround. Primitive defaults follow JLS rules ({@code 0} /
+   * {@code false} / {@code 0.0}).
    */
   static <A, B, X> Mapping<A, B> to(final Accessor<A, X> src, final Telescope<B, X> targetTelescope) {
     return new TelescopeTo<>(src, targetTelescope);

--- a/core/src/main/java/io/github/eschizoid/telescope/mapping/MappingInternals.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/mapping/MappingInternals.java
@@ -16,7 +16,16 @@ import io.github.eschizoid.telescope.DeepMap;
 public sealed interface MappingInternals<
   A,
   B
-> permits SameTypedTo, TypedTransformTo, Via, Drop, TelescopeTo, FromTelescopeTo, TelescopeToTelescope {
+> permits
+  SameTypedTo,
+  TypedTransformTo,
+  Via,
+  Drop,
+  TelescopeTo,
+  FromTelescopeTo,
+  TelescopeToTelescope,
+  Constant,
+  Compute {
   /**
    * Source class this row keys against (the declaring class of the source accessor, recovered via
    * {@code SerializedLambda}). May be {@code null} for permits whose source side is a {@code

--- a/core/src/test/java/io/github/eschizoid/telescope/MappingConstantComputeTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/MappingConstantComputeTest.java
@@ -1,0 +1,175 @@
+package io.github.eschizoid.telescope;
+
+import static io.github.eschizoid.telescope.mapping.Mapping.compute;
+import static io.github.eschizoid.telescope.mapping.Mapping.constant;
+import static io.github.eschizoid.telescope.mapping.Mapping.drop;
+import static io.github.eschizoid.telescope.mapping.Mapping.to;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * End-to-end tests for the forward-only target-injection factories — {@code Mapping.constant} and
+ * {@code Mapping.compute}. They mirror MapStruct's {@code @Mapping(constant)} /
+ * {@code @Mapping(expression)} but stay in the same {@code Telescope.mapper(...)} call as the other
+ * field rows.
+ *
+ * <p>The semantic these tests pin: forward stamps the value; backward silently drops it (the
+ * rebuilt source carries the type default at the dual slot — same retraction shape as {@code
+ * Mapping.drop} on the source side). Roundtripping {@code forward(backward(t))} does NOT preserve a
+ * {@code compute} value by design.
+ */
+class MappingConstantComputeTest {
+
+  record Src(String id, String name) {}
+
+  record Tgt(
+    String id,
+    String name,
+    String tenant,
+    int apiVersion,
+    Instant createdAt,
+    UUID traceId,
+    Map<String, String> metadata
+  ) {}
+
+  @Nested
+  @DisplayName("Mapping.constant(Tgt::field, value) — eager literal")
+  class ConstantRows {
+
+    @Test
+    @DisplayName("forward stamps the literal at the target slot")
+    void forwardStampsLiteral() {
+      final var mapper = Telescope.mapper(
+        Src.class,
+        Tgt.class,
+        to(Src::id, Tgt::id),
+        to(Src::name, Tgt::name),
+        constant(Tgt::tenant, "production"),
+        constant(Tgt::apiVersion, 7),
+        constant(Tgt::createdAt, Instant.EPOCH),
+        constant(Tgt::traceId, new UUID(0, 0)),
+        constant(Tgt::metadata, Map.of())
+      );
+
+      final var out = mapper.forward(new Src("o-1", "Alice"));
+      assertEquals("o-1", out.id());
+      assertEquals("Alice", out.name());
+      assertEquals("production", out.tenant());
+      assertEquals(7, out.apiVersion());
+      assertEquals(Instant.EPOCH, out.createdAt());
+      assertEquals(new UUID(0, 0), out.traceId());
+      assertEquals(Map.of(), out.metadata());
+    }
+
+    @Test
+    @DisplayName("backward silently drops the constant — src carries the type default at the dual slot")
+    void backwardSilentlyDrops() {
+      // Constant rows have no source slot. Backward direction reconstructs Src from Tgt; the
+      // tenant/apiVersion/etc values are read by the engine but discarded.
+      record Sbase(String id, String name, String junk) {}
+
+      final var mapper = Telescope.mapper(
+        Sbase.class,
+        Tgt.class,
+        to(Sbase::id, Tgt::id),
+        to(Sbase::name, Tgt::name),
+        constant(Tgt::tenant, "production"),
+        constant(Tgt::apiVersion, 7),
+        constant(Tgt::createdAt, Instant.EPOCH),
+        constant(Tgt::traceId, new UUID(0, 0)),
+        constant(Tgt::metadata, Map.of()),
+        drop(Sbase::junk) // Src has a field with no tgt counterpart — drop it
+      );
+
+      final var back = mapper.backward(
+        new Tgt("o-1", "Alice", "production", 7, Instant.EPOCH, new UUID(0, 0), Map.of())
+      );
+      assertEquals("o-1", back.id());
+      assertEquals("Alice", back.name());
+      assertNull(back.junk()); // dropped — Src field has type default (null for String)
+    }
+  }
+
+  @Nested
+  @DisplayName("Mapping.compute(Tgt::field, Supplier) — lazy, fresh per call")
+  class ComputeRows {
+
+    @Test
+    @DisplayName("forward invokes the supplier on every call (fresh container identity)")
+    void freshContainerPerCall() {
+      final var mapper = Telescope.mapper(
+        Src.class,
+        Tgt.class,
+        to(Src::id, Tgt::id),
+        to(Src::name, Tgt::name),
+        constant(Tgt::tenant, "x"),
+        constant(Tgt::apiVersion, 1),
+        constant(Tgt::createdAt, Instant.EPOCH),
+        constant(Tgt::traceId, new UUID(0, 0)),
+        compute(Tgt::metadata, HashMap::new) // fresh allocation per call
+      );
+
+      final var t1 = mapper.forward(new Src("a", "A"));
+      final var t2 = mapper.forward(new Src("b", "B"));
+      assertNotSame(t1.metadata(), t2.metadata(), "compute should allocate a fresh map per forward call");
+    }
+
+    @Test
+    @DisplayName("compute(Tgt::traceId, UUID::randomUUID) yields a different value on each forward")
+    void freshUuidPerCall() {
+      final var mapper = Telescope.mapper(
+        Src.class,
+        Tgt.class,
+        to(Src::id, Tgt::id),
+        to(Src::name, Tgt::name),
+        constant(Tgt::tenant, "x"),
+        constant(Tgt::apiVersion, 1),
+        constant(Tgt::createdAt, Instant.EPOCH),
+        compute(Tgt::traceId, UUID::randomUUID),
+        constant(Tgt::metadata, Map.of())
+      );
+
+      final var t1 = mapper.forward(new Src("a", "A"));
+      final var t2 = mapper.forward(new Src("a", "A"));
+      assertEquals(false, t1.traceId().equals(t2.traceId()), "UUID::randomUUID should produce distinct values");
+    }
+
+    @Test
+    @DisplayName("compute rows are forward-only by design — forward(backward(t)) does NOT round-trip the value")
+    void forwardBackwardForwardIsNotIdentity() {
+      // The documented retraction: backward discards the slot; forward re-evaluates the supplier.
+      // For a deterministic check, use a counter that increments each call.
+      final var counter = new int[] { 0 };
+      final var mapper = Telescope.mapper(
+        Src.class,
+        Tgt.class,
+        to(Src::id, Tgt::id),
+        to(Src::name, Tgt::name),
+        constant(Tgt::tenant, "x"),
+        compute(Tgt::apiVersion, () -> ++counter[0]),
+        constant(Tgt::createdAt, Instant.EPOCH),
+        constant(Tgt::traceId, new UUID(0, 0)),
+        constant(Tgt::metadata, Map.of())
+      );
+
+      final var original = new Tgt("o-1", "Alice", "x", 42, Instant.EPOCH, new UUID(0, 0), Map.of());
+      // counter is 0; original.apiVersion is 42 (we constructed it directly, not via the mapper).
+      final var src = mapper.backward(original); // backward discards apiVersion
+      final var roundtripped = mapper.forward(src); // forward re-evaluates supplier → counter becomes 1
+
+      assertEquals(42, original.apiVersion());
+      assertEquals(1, roundtripped.apiVersion()); // NOT 42 — the slot is forward-only
+      assertEquals("o-1", roundtripped.id());
+      assertEquals("Alice", roundtripped.name());
+    }
+  }
+}

--- a/core/src/test/java/io/github/eschizoid/telescope/MappingIntermediateAllocationTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/MappingIntermediateAllocationTest.java
@@ -1,0 +1,121 @@
+package io.github.eschizoid.telescope;
+
+import static io.github.eschizoid.telescope.mapping.Mapping.to;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * End-to-end tests for intermediate target allocation — closes the v1.0 limitation that previously
+ * documented in {@code Mapping.to(Accessor, Telescope)}'s javadoc.
+ *
+ * <p>When a flat source field is routed through a multi-hop target telescope, the engine now
+ * synthesizes a recursive default-tree instance of the intermediate at the first hop (and every
+ * subsequent record-typed hop) instead of registering a {@code null} placeholder. The post-fixup
+ * overlay then descends into the allocated structure and writes the leaf — no per-hop allocation
+ * glue from the user, no fall-back to {@code Mapping.via(...)}.
+ *
+ * <p>Records only for v1.0. Bean intermediates still need a {@code Mapping.via(...)} workaround
+ * because bean construction (no-arg ctor vs. builder vs. fields-only) isn't always one-shot.
+ */
+class MappingIntermediateAllocationTest {
+
+  // --- One-hop intermediate (the original v1.0 wart) ---
+  record OneHopAddress(String city, String zip) {}
+
+  record OneHopPerson(String name, int age, OneHopAddress address) {}
+
+  // --- Multi-hop intermediate (the case the type-system-driven allocator handles for free) ---
+  record Geocode(double lat, double lon) {}
+
+  record DeepAddress(String city, String zip, Geocode geocode) {}
+
+  record DeepPerson(String name, int age, DeepAddress address) {}
+
+  // --- Even deeper, for the "type-driven recursion" claim ---
+  record Inner(String value) {}
+
+  record Mid(Inner inner) {}
+
+  record Outer(Mid mid) {}
+
+  record DeepTarget(Outer outer) {}
+
+  @Nested
+  @DisplayName("one-hop intermediate — Slim source → Person target with allocated Address")
+  class OneHopAllocation {
+
+    @Test
+    @DisplayName("flat source with no `address` field still routes through Person.address.city")
+    void flatSourceRoutesIntoAllocatedAddress() {
+      record Slim(String displayCity) {}
+
+      final var mapper = Telescope.mapper(
+        Slim.class,
+        OneHopPerson.class,
+        to(Slim::displayCity, Telescope.of(OneHopPerson.class).field(OneHopPerson::address).field(OneHopAddress::city))
+      );
+
+      final var out = mapper.forward(new Slim("Brooklyn"));
+      assertNotNull(out.address(), "intermediate Address should be allocated, not null");
+      assertEquals("Brooklyn", out.address().city());
+      // Primitive default; default for non-claimed reference fields is null.
+      assertEquals(0, out.age());
+      assertEquals(null, out.address().zip());
+    }
+  }
+
+  @Nested
+  @DisplayName("multi-hop intermediate — recursive default-tree handles arbitrary depth")
+  class MultiHopAllocation {
+
+    @Test
+    @DisplayName("two-hop nested target (address.geocode.lat) from a flat source")
+    void twoHopNestedTarget() {
+      record Slim(double latitude) {}
+
+      final var mapper = Telescope.mapper(
+        Slim.class,
+        DeepPerson.class,
+        to(
+          Slim::latitude,
+          Telescope.of(DeepPerson.class).field(DeepPerson::address).field(DeepAddress::geocode).field(Geocode::lat)
+        )
+      );
+
+      final var out = mapper.forward(new Slim(40.6782));
+      assertNotNull(out.address(), "address should be allocated");
+      assertNotNull(out.address().geocode(), "address.geocode should be allocated (recursive)");
+      assertEquals(40.6782, out.address().geocode().lat());
+      assertEquals(0.0, out.address().geocode().lon()); // primitive default
+    }
+
+    @Test
+    @DisplayName("three-hop nested target (outer.mid.inner.value) — recursion depth is type-driven, not capped")
+    void threeHopNestedTarget() {
+      record Slim(String value) {}
+
+      final var mapper = Telescope.mapper(
+        Slim.class,
+        DeepTarget.class,
+        to(
+          Slim::value,
+          Telescope.of(DeepTarget.class)
+            .field(DeepTarget::outer)
+            .field(Outer::mid)
+            .field(Mid::inner)
+            .field(Inner::value)
+        )
+      );
+
+      final var out = mapper.forward(new Slim("payload"));
+      assertNotNull(out.outer());
+      assertNotNull(out.outer().mid());
+      assertNotNull(out.outer().mid().inner());
+      assertEquals("payload", out.outer().mid().inner().value());
+    }
+  }
+}


### PR DESCRIPTION
Three MapStruct-parity gaps closed before 1.0 in one slice. Two commits, each independently green:

## What ships

### `Mapping.constant(Tgt::field, value)` + `Mapping.compute(Tgt::field, Supplier<X>)` — forward-only target injection

Closes MapStruct's `@Mapping(constant = "...")` and `@Mapping(expression = "java(...)")` without splitting across `@InheritInverseConfiguration` interfaces. Both rows live next to the rest in the same `Telescope.mapper(...)` call.

```java
Telescope.mapper(Order.class, OrderDto.class,
  to(Order::id,                OrderDto::id),
  constant(OrderDto::tenant,   "production"),     // eager literal
  compute(OrderDto::createdAt, Instant::now),     // fresh per call
  compute(OrderDto::traceId,   UUID::randomUUID),
  compute(OrderDto::metadata,  HashMap::new));    // fresh mutable container per call
```

**Semantics:** forward stamps the value; backward silently drops the slot (the rebuilt source carries the type default at the dual position — exact dual of `Mapping.drop` on the source side). `forward(backward(t))` does NOT round-trip a `compute` value by design — a supplier like `Instant::now` can't be inverted. Documented in javadoc + a JUnit `@DisplayName` pins the retraction behavior so a future contributor doesn't try to "fix" it.

**Why the eager/lazy split:** `Mapping.constant(Tgt::metadata, new HashMap<>())` would share one map reference across every forward call (Java mutable-default-argument trap). `Mapping.compute(Tgt::metadata, HashMap::new)` allocates a fresh container per call. MapStruct's `constant` vs `expression` distinction conflates these because their `constant` only accepts literals; ours is type-checked by `javac` at the call site.

### `Mapping.to(srcAcc, tgtTelescope)` — recursive intermediate allocation

Closes the v1.0 limitation previously documented in `Mapping.to(Accessor, Telescope)`'s javadoc. A flat source field routed through a multi-hop target telescope now lifts into the deep structure without per-hop allocation glue from the user:

```java
record Slim(String displayCity) {}        // genuinely flat — no `address` field
record Address(String city, String zip) {}
record Person(String name, int age, Address address) {}

Telescope.mapper(Slim.class, Person.class,
  to(Slim::displayCity,
     Telescope.of(Person.class).field(Person::address).field(Address::city)));

mapper.forward(new Slim("Brooklyn"));
// → Person(name=null, age=0, address=Address(city="Brooklyn", zip=null))
```

Previously this NPE'd because the auto-recursion left `address` null and the telescope overlay's `tgtT.set(t, value)` descended into it. Now the engine synthesizes a recursive default-tree instance — primitives get JLS defaults (0 / false / 0.0), records recurse via canonical-ctor reflection with the same scheme, everything else is null.

**Type-driven depth.** The engine doesn't walk the telescope's hop chain at all — once the FIRST hop is allocated as a default-tree, every deeper hop already exists in the tree (because the recursion is over field TYPES, not nav steps). Three-hop test (`outer.mid.inner.value`) passes with zero per-hop config.

**Records only for v1.0.** Bean intermediates without a no-arg ctor or builder still need a `Mapping.via(...)` workaround; deferred to v1.1 if it shows up in real usage. Cycles between record types can't arise (canonical ctors need every referenced type already constructible at compile time), so `recursiveDefault` doesn't need cycle detection.

**Sub-issue surfaced:** the existing `NULLING_ISO` returned `null` even for primitive-typed slots, NPEing when canonical-ctor reflection tried to unbox into `int` / `boolean` / etc. New `placeholderIsoFor(fieldType, claimedByTelescopeWrite)` unifies the three cases — record allocator, primitive default, plain null reference — into one type-aware dispatch.

## Engine cost

~50 LOC for constant/compute (two new permits mirror `Drop` on the target side, two iso factories). ~100 LOC for intermediate allocation (recursiveDefault + primitiveDefault + placeholderIsoFor + rawClassOf + defaultAllocatorIso). No new internal optic primitives; everything composes on the existing `Iso` surface.

## Tests

`MappingConstantComputeTest` (5):
- `constant` stamps literal forward; backward drops it (companion `drop(Sbase::junk)` verifies dual-direction symmetric handling)
- `compute(HashMap::new)` produces fresh container identity per call
- `compute(UUID::randomUUID)` produces distinct values per call
- counter-based supplier explicitly demonstrates `forward(backward(t))` does NOT round-trip

`MappingIntermediateAllocationTest` (3):
- one-hop intermediate from flat source (the original wart)
- two-hop nested (`address.geocode.lat`) — mixed primitive/reference depth
- three-hop nested (`outer.mid.inner.value`) — pins the "type-driven depth" claim

## Docs

- `Mapping.constant` / `Mapping.compute` javadocs explain the forward-only semantics, the eager-vs-lazy distinction, and the MapStruct parity (declared once, no `@InheritInverseConfiguration`).
- `Mapping.to(Accessor, Telescope)` javadoc rewritten — the v1.0 limitation note is gone, the recursive-allocation behavior and the bean caveat are in.
- PLAN.md Tier 2 #1 marked shipped pre-1.0.

## Test plan

- [x] All 8 new tests pass (`MappingConstantComputeTest` + `MappingIntermediateAllocationTest`)
- [x] Full `:core` test suite remains green (no regressions in existing `TelescopeMappingTest`, `DeepMappingTest`, `OpticLawsTest`, etc.)
- [x] `:codegen` / `:lombok` checks remain green
- [x] `spotlessCheck` clean on every module