### PR TITLE
feat(mapping): nested Mapping.constant/compute + unify Constant/Compute + codegen-1:1 tests across all three features

### DIFF
--- a/core/src/main/java/io/github/eschizoid/telescope/DeepMap.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/DeepMap.java
@@ -325,39 +325,24 @@ public final class DeepMap {
         telescopeFixups.add(ttRow);
         continue;
       }
-      // Constant / Compute rows are the target-side mirror of Drop: they claim a target field
-      // with no source counterpart, stamping a fixed (Constant) or freshly-supplied (Compute)
-      // value into the rebuilt target at forward time. Backward direction silently drops the
-      // slot — the rebuilt source carries the type default at the dual position (same retraction
-      // semantics as Drop, in the inverse direction). Register only under byTargetName so the
-      // forward pass picks them up; absence from bySourceName means the source rebuilder ignores
-      // the slot entirely on backward.
+      // Constant / Compute rows are target-injection telescope fixups: claim the target
+      // telescope's first hop as written, register the row in telescopeFixups, and let the
+      // applyForward pass stamp value (Constant) or supplier.get() (Compute) at the location the
+      // telescope navigates to. The flat factories (constant(Accessor, X) / compute(Accessor,
+      // Supplier)) wrap the accessor in a single-hop telescope at construction time so this loop
+      // sees only one shape per kind — no separate flat handler. Backward direction is a no-op:
+      // these rows don't contribute to bySourceName, so the source rebuilder ignores the slot
+      // entirely on backward (same retraction semantics as Drop on the source side).
       if (row instanceof Constant<?, ?, ?> cRow) {
-        final var tgtFieldName = tgtRefl.normalize(internals.targetField());
-        if (!claimedTgt.add(tgtFieldName)) throw new IllegalArgumentException(
-          "Deep map " +
-            source.getSimpleName() +
-            " → " +
-            target.getSimpleName() +
-            ": duplicate override row for target field '" +
-            tgtFieldName +
-            "'. Each (source, target) type pair may declare at most one row per target field."
-        );
-        byTargetName.put(tgtFieldName, new FieldStep(null, tgtFieldName, constantIso(cRow.value())));
+        final var firstTgtHop = cRow.targetTelescope().firstHopName();
+        if (firstTgtHop != null) telescopeWritesTgt.add(tgtRefl.normalize(firstTgtHop));
+        telescopeFixups.add(cRow);
         continue;
       }
       if (row instanceof Compute<?, ?, ?> cpRow) {
-        final var tgtFieldName = tgtRefl.normalize(internals.targetField());
-        if (!claimedTgt.add(tgtFieldName)) throw new IllegalArgumentException(
-          "Deep map " +
-            source.getSimpleName() +
-            " → " +
-            target.getSimpleName() +
-            ": duplicate override row for target field '" +
-            tgtFieldName +
-            "'. Each (source, target) type pair may declare at most one row per target field."
-        );
-        byTargetName.put(tgtFieldName, new FieldStep(null, tgtFieldName, computeIso(cpRow.supplier())));
+        final var firstTgtHop = cpRow.targetTelescope().firstHopName();
+        if (firstTgtHop != null) telescopeWritesTgt.add(tgtRefl.normalize(firstTgtHop));
+        telescopeFixups.add(cpRow);
         continue;
       }
       // Drop rows claim a source field with no target counterpart — they exist to satisfy the
@@ -576,6 +561,14 @@ public final class DeepMap {
             t = tgtT.set(t, srcT.read(s));
           }
         }
+        case Constant<?, ?, ?> r -> {
+          final var tgtT = (Telescope<T, Object>) r.targetTelescope();
+          t = tgtT.set(t, r.value());
+        }
+        case Compute<?, ?, ?> r -> {
+          final var tgtT = (Telescope<T, Object>) r.targetTelescope();
+          t = tgtT.set(t, r.supplier().get());
+        }
         default -> {
           /* non-telescope mappings are not routed through this wrapper */
         }
@@ -777,9 +770,9 @@ public final class DeepMap {
       case TelescopeToTelescope<?, ?, ?> _ -> throw new IllegalStateException(
         "TelescopeToTelescope row should not reach fieldIsoOf"
       );
-      // Constant / Compute rows build their iso inline (constantIso / computeIso) at registration
-      // time in populateIso, since fieldIsoOf doesn't have the captured value / supplier in scope.
-      // These cases exist only to keep the sealed switch exhaustive.
+      // Constant / Compute rows apply as telescope post-fixups, same pattern as TelescopeTo and
+      // friends — they don't contribute a per-field leaf Iso. The cases exist only to keep the
+      // sealed switch exhaustive; reaching them indicates a routing bug above.
       case Constant<?, ?, ?> _ -> throw new IllegalStateException("Constant row should not reach fieldIsoOf");
       case Compute<?, ?, ?> _ -> throw new IllegalStateException("Compute row should not reach fieldIsoOf");
     };
@@ -1036,23 +1029,6 @@ public final class DeepMap {
    * fields that have no target counterpart; the forward direction skips the field entirely.
    */
   private static final Iso<Object, Object> NULLING_ISO = Iso.of(_ -> null, _ -> null);
-
-  /**
-   * Forward-only iso for {@link Constant} rows: {@code to(_)} ignores its argument and returns the
-   * captured literal; {@code from(_)} returns {@code null} (the backward direction discards the
-   * slot, mirroring {@link #NULLING_ISO} on the source side).
-   */
-  private static <X> Iso<Object, Object> constantIso(final X value) {
-    return Iso.of(_ -> value, _ -> null);
-  }
-
-  /**
-   * Forward-only iso for {@link Compute} rows: {@code to(_)} invokes the supplier on every call
-   * (fresh value each forward); {@code from(_)} returns {@code null}.
-   */
-  private static <X> Iso<Object, Object> computeIso(final java.util.function.Supplier<? extends X> supplier) {
-    return Iso.of(_ -> supplier.get(), _ -> null);
-  }
 
   /**
    * Forward-only iso that materialises a fresh default-tree instance of {@code recordType} on every

--- a/core/src/main/java/io/github/eschizoid/telescope/mapping/Compute.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/mapping/Compute.java
@@ -1,54 +1,50 @@
 package io.github.eschizoid.telescope.mapping;
 
-import io.github.eschizoid.telescope.DeepMap;
-import io.github.eschizoid.telescope.Telescope.Accessor;
-import io.github.eschizoid.telescope.internal.LambdaIntrospection;
+import io.github.eschizoid.telescope.Telescope;
 import java.util.function.Supplier;
 
 /**
- * Lazy-supplier correspondence row from {@link Mapping#compute(Accessor, Supplier)}. Calls the
- * supplier at every forward-apply, stamping the result onto a target field; the source side has no
- * slot, so {@link DeepMap}'s backward direction silently drops it (the rebuilt source carries the
- * type default at the dual slot — same retraction semantics as {@link Drop} but on the target
- * side).
+ * Forward-only lazy-supplier correspondence from {@link Mapping#compute(io.github.eschizoid
+ * .telescope.Telescope.Accessor, Supplier) Mapping.compute(Accessor, Supplier)} and {@link
+ * Mapping#compute(Telescope, Supplier) Mapping.compute(Telescope, Supplier)}. Invokes the supplier
+ * once per forward call and stamps the result at the target location.
  *
- * <p>Use for values that must be freshly evaluated each forward call: timestamps ({@code
- * Instant::now}), per-call generated IDs ({@code UUID::randomUUID}), and fresh mutable containers
- * ({@code HashMap::new} / {@code ArrayList::new}) where a literal would share one reference across
- * every call (a Java mutable-default-argument trap). For fixed values that ARE safe to share, use
- * {@link Constant}.
+ * <p>The target is always a {@link Telescope} — the flat factory {@code compute(Accessor,
+ * Supplier)} wraps the bare accessor in a single-hop telescope at construction time so the engine
+ * has one uniform handler. One shape, one fixup path, one set of laws.
  *
- * <p>Forward-only by design. Mirrors MapStruct's {@code @Mapping(expression = "java(...)")} but
- * stays in plain Java — the supplier is a typed {@link Supplier} that {@code javac} type-checks
- * against the target leaf, no string-templated body to parse. Declared once in the same {@code
- * Telescope.mapper(...)} call as the other rows.
+ * <p>Backward direction is a no-op. Same intermediate-allocation behavior as {@link Constant}:
+ * record-typed hops without a same-name source counterpart are allocated as a recursive
+ * default-tree so the supplier-stamped value can land at any depth.
  *
- * <p>Package-private — users construct via {@link Mapping#compute(Accessor, Supplier)} and never
- * see this type at the call site.
+ * <p>Package-private — users construct via {@link Mapping#compute Mapping.compute} and never see
+ * this type at the call site.
  */
 public record Compute<A, B, X>(
-  Accessor<B, X> tgtAccessor,
+  Telescope<B, X> targetTelescope,
   Supplier<? extends X> supplier
 ) implements Mapping<A, B>, MappingInternals<A, B> {
-  /** Returns {@code null} — no source-side accessor; the row is forward-only. */
+  /** Returns {@code null} — no source-side accessor; outer-pair pinning. */
   @Override
   public Class<A> sourceClass() {
     return null;
   }
 
+  /** Returns {@code null} — {@code Telescope<B, X>} doesn't carry its root class at runtime. */
   @Override
   public Class<B> targetClass() {
-    return LambdaIntrospection.implClassOf(tgtAccessor);
+    return null;
   }
 
-  /** Returns {@code null} — no source field to claim. */
+  /** Returns {@code null} — no source-side field. */
   @Override
   public String sourceField() {
     return null;
   }
 
+  /** Returns {@code null} — top-level target field is recovered via the telescope's first hop. */
   @Override
   public String targetField() {
-    return LambdaIntrospection.methodNameOf(tgtAccessor);
+    return null;
   }
 }

--- a/core/src/main/java/io/github/eschizoid/telescope/mapping/Constant.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/mapping/Constant.java
@@ -1,48 +1,54 @@
 package io.github.eschizoid.telescope.mapping;
 
 import io.github.eschizoid.telescope.DeepMap;
-import io.github.eschizoid.telescope.Telescope.Accessor;
-import io.github.eschizoid.telescope.internal.LambdaIntrospection;
+import io.github.eschizoid.telescope.Telescope;
 
 /**
- * Eager-literal correspondence row from {@link Mapping#constant(Accessor, Object)}. Stamps a fixed
- * value onto a target field at forward-apply time; the source-side has no slot for this value, so
- * {@link DeepMap}'s backward direction silently drops it (the rebuilt source carries the type
- * default at the dual slot — same retraction semantics as {@link Drop} but on the target side).
+ * Forward-only literal correspondence from {@link Mapping#constant(io.github.eschizoid.telescope
+ * .Telescope.Accessor, Object) Mapping.constant(Accessor, X)} and {@link
+ * Mapping#constant(Telescope, Object) Mapping.constant(Telescope, X)}. Stamps the captured value at
+ * the target location each forward call.
  *
- * <p>Use for tenant tags, schema versions, environment markers, and other values that should be the
- * same on every forward call. For values that need to be re-evaluated per call (timestamps, fresh
- * collections, IDs), use {@link Compute} instead — a literal {@code constant(Tgt::metadata, new
- * HashMap<>())} would share one map reference across every forward call.
+ * <p>The target is always a {@link Telescope} — the flat factory {@code constant(Accessor, X)}
+ * wraps the bare accessor in a single-hop telescope at construction time so the engine has one
+ * uniform handler. Users see two overloads in the public API; internally there's one shape, one
+ * fixup path, one set of laws.
  *
- * <p>Forward-only by design. Mirrors MapStruct's {@code @Mapping(constant = "...")}; the difference
- * is that the row lives next to the other field correspondences in the same {@code
- * Telescope.mapper(...)} call instead of being split across a second {@code @InheritInverse
- * Configuration} interface — declared once, semantically explicit.
+ * <p>Backward direction is a no-op (the rebuilt source carries the type default at the dual slot —
+ * same retraction semantics as {@link Drop} on the source side). Intermediate hops without a
+ * same-name source counterpart are allocated as a recursive default-tree (records only); see {@link
+ * Mapping#to(io.github.eschizoid.telescope.Telescope.Accessor, Telescope) Mapping.to(Accessor,
+ * Telescope)} for the same allocation behavior.
  *
- * <p>Package-private — users construct via {@link Mapping#constant(Accessor, Object)} and never see
- * this type at the call site.
+ * <p>Package-private — users construct via {@link Mapping#constant Mapping.constant} and never see
+ * this type at the call site. The engine in {@link DeepMap} routes this row through the
+ * telescope-fixup machinery.
  */
-public record Constant<A, B, X>(Accessor<B, X> tgtAccessor, X value) implements Mapping<A, B>, MappingInternals<A, B> {
-  /** Returns {@code null} — no source-side accessor; the row is forward-only. */
+public record Constant<A, B, X>(
+  Telescope<B, X> targetTelescope,
+  X value
+) implements Mapping<A, B>, MappingInternals<A, B> {
+  /** Returns {@code null} — no source-side accessor; outer-pair pinning. */
   @Override
   public Class<A> sourceClass() {
     return null;
   }
 
+  /** Returns {@code null} — {@code Telescope<B, X>} doesn't carry its root class at runtime. */
   @Override
   public Class<B> targetClass() {
-    return LambdaIntrospection.implClassOf(tgtAccessor);
+    return null;
   }
 
-  /** Returns {@code null} — no source field to claim. */
+  /** Returns {@code null} — no source-side field. */
   @Override
   public String sourceField() {
     return null;
   }
 
+  /** Returns {@code null} — top-level target field is recovered via the telescope's first hop. */
   @Override
   public String targetField() {
-    return LambdaIntrospection.methodNameOf(tgtAccessor);
+    return null;
   }
 }

--- a/core/src/main/java/io/github/eschizoid/telescope/mapping/Mapping.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/mapping/Mapping.java
@@ -4,6 +4,7 @@ import io.github.eschizoid.telescope.Edit;
 import io.github.eschizoid.telescope.Telescope;
 import io.github.eschizoid.telescope.Telescope.Accessor;
 import io.github.eschizoid.telescope.conversion.Mapper;
+import io.github.eschizoid.telescope.internal.LambdaIntrospection;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
@@ -274,7 +275,8 @@ public sealed interface Mapping<A, B>
    * is almost never what you want.
    */
   static <A, B, X> Mapping<A, B> constant(final Accessor<B, X> tgt, final X value) {
-    return new Constant<>(tgt, value);
+    final Class<B> tgtClass = LambdaIntrospection.implClassOf(tgt);
+    return new Constant<>(Telescope.of(tgtClass).field(tgt), value);
   }
 
   /**
@@ -301,6 +303,51 @@ public sealed interface Mapping<A, B>
    * {@link #constant(Accessor, Object)} when the value is genuinely a shared literal.
    */
   static <A, B, X> Mapping<A, B> compute(final Accessor<B, X> tgt, final Supplier<? extends X> supplier) {
-    return new Compute<>(tgt, supplier);
+    final Class<B> tgtClass = LambdaIntrospection.implClassOf(tgt);
+    return new Compute<>(Telescope.of(tgtClass).field(tgt), supplier);
+  }
+
+  /**
+   * Nested-target variant of {@link #constant(Accessor, Object)} — stamp a fixed value at a
+   * multi-hop target location via a {@link Telescope}. Closes MapStruct's {@code @Mapping(target =
+   * "a.b.c", constant = "...")} for nested targets.
+   *
+   * <pre>{@code
+   * // Runtime form
+   * Telescope.mapper(Order.class, OrderDto.class,
+   *     to(Order::id, OrderDto::id),
+   *     constant(
+   *         Telescope.of(OrderDto.class).field(OrderDto::shipping).field(Shipping::country),
+   *         "US"));
+   *
+   * // Codegen form — same value-level Telescope, fully typed each hop
+   * Telescope.mapper(Order.class, OrderDto.class,
+   *     to(Order::id, OrderDto::id),
+   *     constant(OrderDtoTelescope.of().shipping().country(), "US"));
+   * }</pre>
+   *
+   * <p>Forward-only. Intermediate hops without a same-name source counterpart are allocated as a
+   * recursive default-tree (records only); see {@link #to(Accessor, Telescope)} for the same
+   * allocation behavior on the {@code to(srcAcc, tgtTelescope)} family.
+   */
+  static <A, B, X> Mapping<A, B> constant(final Telescope<B, X> targetTelescope, final X value) {
+    return new Constant<>(targetTelescope, value);
+  }
+
+  /**
+   * Nested-target variant of {@link #compute(Accessor, Supplier)} — invoke the supplier per forward
+   * call and stamp the result at a multi-hop target location via a {@link Telescope}. Closes
+   * MapStruct's {@code @Mapping(target = "a.b.c", expression = "java(...)")} for nested targets.
+   *
+   * <pre>{@code
+   * Telescope.mapper(Order.class, OrderDto.class,
+   *     to(Order::id, OrderDto::id),
+   *     compute(OrderDtoTelescope.of().audit().createdAt(), Instant::now));
+   * }</pre>
+   *
+   * <p>Forward-only; same intermediate-allocation behavior as {@link #constant(Telescope, Object)}.
+   */
+  static <A, B, X> Mapping<A, B> compute(final Telescope<B, X> targetTelescope, final Supplier<? extends X> supplier) {
+    return new Compute<>(targetTelescope, supplier);
   }
 }

--- a/core/src/test/java/io/github/eschizoid/telescope/MappingCodegenOneToOneTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/MappingCodegenOneToOneTest.java
@@ -1,0 +1,229 @@
+package io.github.eschizoid.telescope;
+
+import static io.github.eschizoid.telescope.mapping.Mapping.compute;
+import static io.github.eschizoid.telescope.mapping.Mapping.constant;
+import static io.github.eschizoid.telescope.mapping.Mapping.drop;
+import static io.github.eschizoid.telescope.mapping.Mapping.to;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Codegen-1:1 verification across all three target-side mapping features: intermediate allocation,
+ * {@link io.github.eschizoid.telescope.mapping.Mapping#constant Mapping.constant}, and {@link
+ * io.github.eschizoid.telescope.mapping.Mapping#compute Mapping.compute}. Each feature is exercised
+ * in three shapes:
+ *
+ * <ol>
+ *   <li><b>Flat accessor</b> — bare {@code Tgt::field} method reference.
+ *   <li><b>Runtime telescope</b> — {@code Telescope.of(Tgt.class).field(...).field(...)} chain.
+ *   <li><b>Codegen navigator</b> — {@code TgtTelescope.of().field()...} chain emitted by the
+ *       {@code @Focus} processor.
+ * </ol>
+ *
+ * <p>The shapes must produce identical behavior at the {@code Telescope<S, A>} value level — the
+ * codegen-emitted navigator routes through the same {@code Telescope.lens(Accessor, BiFunction)}
+ * overload as the runtime path, so {@code firstHopName} recovery and the intermediate-allocation
+ * engine's behavior are guaranteed to match. These tests pin the guarantee end-to-end against the
+ * actual on-disk generated navigator classes ({@link PersonTelescope}, {@link AddressTelescope}).
+ *
+ * <p>The two top-level {@code @Focus} fixtures used here, {@link Person} and {@link Address}, are
+ * sibling files in this test package so the codegen processor emits real navigator classes at
+ * test-compile time.
+ */
+class MappingCodegenOneToOneTest {
+
+  // Genuinely-flat source — no `address` slot for the intermediate-allocation case.
+  record Slim(String value) {}
+
+  @Nested
+  @DisplayName("intermediate allocation — same Address synthesized for flat / runtime / codegen")
+  class IntermediateAllocation {
+
+    @Test
+    @DisplayName("runtime Telescope.of(...).field(...).field(...) — intermediate Address allocated")
+    void runtimeTelescope() {
+      final var mapper = Telescope.mapper(
+        Slim.class,
+        Person.class,
+        to(Slim::value, Telescope.of(Person.class).field(Person::address).field(Address::city))
+      );
+
+      final var out = mapper.forward(new Slim("Brooklyn"));
+      assertNotNull(out.address(), "intermediate Address allocated by the engine");
+      assertEquals("Brooklyn", out.address().city());
+    }
+
+    @Test
+    @DisplayName("codegen PersonTelescope.of().address().city() — same allocator path")
+    void codegenNavigator() {
+      final var mapper = Telescope.mapper(
+        Slim.class,
+        Person.class,
+        to(Slim::value, PersonTelescope.of().address().city())
+      );
+
+      final var out = mapper.forward(new Slim("Brooklyn"));
+      assertNotNull(out.address(), "intermediate Address allocated by the engine via codegen navigator");
+      assertEquals("Brooklyn", out.address().city());
+    }
+  }
+
+  @Nested
+  @DisplayName("Mapping.constant — same literal stamped via flat / runtime / codegen targets")
+  class ConstantInjection {
+
+    @Test
+    @DisplayName("flat Tgt::field — single-hop accessor, wrapped internally into a one-hop telescope")
+    void flatAccessor() {
+      // Top-level field on the Address record — flat factory wraps Address::zip into a single-hop
+      // telescope at construction time. Source is empty (Address has no Address sub-field), so we
+      // route the value through a wrapper Src for the engine to recurse over.
+      record SrcZ(String city) {}
+
+      final var mapper = Telescope.mapper(
+        SrcZ.class,
+        Address.class,
+        to(SrcZ::city, Address::city),
+        constant(Address::zip, "11201")
+      );
+
+      final var out = mapper.forward(new SrcZ("Brooklyn"));
+      assertEquals("Brooklyn", out.city());
+      assertEquals("11201", out.zip()); // constant stamped
+    }
+
+    @Test
+    @DisplayName("runtime Telescope.of(Person.class).field(...).field(...) — nested target via runtime chain")
+    void runtimeTelescope() {
+      record SrcZ(String name) {}
+
+      final var mapper = Telescope.mapper(
+        SrcZ.class,
+        Person.class,
+        to(SrcZ::name, Person::name),
+        constant(Telescope.of(Person.class).field(Person::address).field(Address::zip), "11201")
+      );
+
+      final var out = mapper.forward(new SrcZ("Alice"));
+      assertEquals("Alice", out.name());
+      assertNotNull(out.address(), "intermediate allocated because the constant claims address as a write hop");
+      assertEquals("11201", out.address().zip()); // constant stamped at nested target
+    }
+
+    @Test
+    @DisplayName("codegen PersonTelescope.of().address().zip() — same constant behavior end-to-end")
+    void codegenNavigator() {
+      record SrcZ(String name) {}
+
+      final var mapper = Telescope.mapper(
+        SrcZ.class,
+        Person.class,
+        to(SrcZ::name, Person::name),
+        constant(PersonTelescope.of().address().zip(), "11201")
+      );
+
+      final var out = mapper.forward(new SrcZ("Alice"));
+      assertEquals("Alice", out.name());
+      assertNotNull(out.address(), "intermediate allocated via codegen navigator firstHopName");
+      assertEquals("11201", out.address().zip());
+    }
+  }
+
+  @Nested
+  @DisplayName("Mapping.compute — fresh supplier value stamped via flat / runtime / codegen targets")
+  class ComputeInjection {
+
+    @Test
+    @DisplayName("flat Tgt::field — supplier wrapped internally, fresh value per call")
+    void flatAccessor() {
+      record SrcZ(String city) {}
+
+      final var counter = new int[] { 0 };
+      final var mapper = Telescope.mapper(
+        SrcZ.class,
+        Address.class,
+        to(SrcZ::city, Address::city),
+        compute(Address::zip, () -> String.format("%05d", ++counter[0]))
+      );
+
+      final var t1 = mapper.forward(new SrcZ("Brooklyn"));
+      final var t2 = mapper.forward(new SrcZ("Queens"));
+      assertEquals("00001", t1.zip());
+      assertEquals("00002", t2.zip()); // fresh per call
+    }
+
+    @Test
+    @DisplayName("runtime Telescope.of(Person.class).field(...).field(...) — supplier at nested location")
+    void runtimeTelescope() {
+      record SrcZ(String name) {}
+
+      final var counter = new int[] { 0 };
+      final var mapper = Telescope.mapper(
+        SrcZ.class,
+        Person.class,
+        to(SrcZ::name, Person::name),
+        compute(Telescope.of(Person.class).field(Person::address).field(Address::zip), () ->
+          String.format("%05d", ++counter[0])
+        )
+      );
+
+      final var t1 = mapper.forward(new SrcZ("Alice"));
+      final var t2 = mapper.forward(new SrcZ("Bob"));
+      assertEquals("00001", t1.address().zip());
+      assertEquals("00002", t2.address().zip());
+    }
+
+    @Test
+    @DisplayName("codegen PersonTelescope.of().address().zip() — supplier identical behavior")
+    void codegenNavigator() {
+      record SrcZ(String name) {}
+
+      final var counter = new int[] { 0 };
+      final var mapper = Telescope.mapper(
+        SrcZ.class,
+        Person.class,
+        to(SrcZ::name, Person::name),
+        compute(PersonTelescope.of().address().zip(), () -> String.format("%05d", ++counter[0]))
+      );
+
+      final var t1 = mapper.forward(new SrcZ("Alice"));
+      final var t2 = mapper.forward(new SrcZ("Bob"));
+      assertEquals("00001", t1.address().zip());
+      assertEquals("00002", t2.address().zip());
+    }
+  }
+
+  @Nested
+  @DisplayName("all three features composed in one mapper — flat src into deeply-nested codegen target")
+  class ComposedEndToEnd {
+
+    @Test
+    @DisplayName("a single mapper combines intermediate allocation + constant + compute via codegen navigators")
+    void allThreeFeaturesAtOnce() {
+      record FlatSrc(String displayName, String displayCity) {}
+
+      // age has no Src counterpart → drop. address is allocated by intermediate-allocation. city
+      // routes from displayCity via the codegen navigator. zip is a constant. name is computed.
+      final var mapper = Telescope.mapper(
+        FlatSrc.class,
+        Person.class,
+        drop(FlatSrc::displayName),
+        drop(FlatSrc::displayCity),
+        compute(PersonTelescope.of().name(), () -> "computed-name"),
+        to(FlatSrc::displayCity, PersonTelescope.of().address().city()),
+        constant(PersonTelescope.of().address().zip(), "11201")
+      );
+
+      final var out = mapper.forward(new FlatSrc("ignored", "Brooklyn"));
+      assertEquals("computed-name", out.name()); // compute via codegen navigator
+      assertEquals(0, out.age()); // primitive default, no source counterpart
+      assertNotNull(out.address(), "intermediate Address allocated");
+      assertEquals("Brooklyn", out.address().city()); // routed via codegen navigator
+      assertEquals("11201", out.address().zip()); // constant via codegen navigator
+    }
+  }
+}


### PR DESCRIPTION
Three threads in one PR — each cheap on its own, valuable as a unit.

## 1) Drop the Constant/ConstantTelescope split (and Compute/ComputeTelescope)

The post-PR-#72 surface had two internal record types per feature — one for the flat `constant(Accessor, X)` factory, one for the nested-target factory. Two engine handlers, two paths to keep in sync, for a feature users see as one concept ("stamp a value somewhere on the target").

**Unified**: one `Constant<A, B, X>` record carrying `Telescope<B, X>`. The flat factory wraps the bare accessor into a single-hop telescope at construction time via `Telescope.of(LambdaIntrospection.implClassOf(tgt)).field(tgt)`. Engine sees one shape, runs one handler. Compute follows the same pattern.

**Side effect**: the flat case now goes through the telescope-fixup pass instead of `byTargetName` / `FieldStep`. Per-call cost is one extra closure dispatch — negligible vs the rest of the engine. Half the surface, one path to reason about.

## 2) New nested-target overloads

```java
Mapping.constant(Telescope<B, X> targetTelescope, X value)
Mapping.compute(Telescope<B, X> targetTelescope, Supplier<? extends X> supplier)
```

Closes MapStruct's `@Mapping(target = "a.b.c", constant = "...")` and `@Mapping(target = "a.b.c", expression = "java(...)")` for nested targets:

```java
Telescope.mapper(Slim.class, Person.class,
  to(Slim::name, Person::name),
  constant(PersonTelescope.of().address().zip(),     "11201"),
  compute (PersonTelescope.of().audit().createdAt(), Instant::now));
```

Intermediate allocation (PR #72) kicks in automatically — a constant or compute at `PersonTelescope.of().address().zip()` allocates the `Address` intermediate before stamping. Records only; bean intermediates still need `Mapping.via`.

## 3) Codegen-1:1 verification across all three features

`MappingCodegenOneToOneTest` — 8 tests, each of the three target-side features exercised in three shapes:

| Feature | Flat accessor | Runtime telescope | Codegen navigator |
|---|---|---|---|
| **Intermediate allocation** (`Mapping.to(srcAcc, tgtTelescope)`) | n/a (single-hop) | ✓ | ✓ |
| **`Mapping.constant`** | ✓ | ✓ | ✓ |
| **`Mapping.compute`** | ✓ | ✓ | ✓ |

Plus a composed end-to-end test that combines all three features in one mapper through real `@Focus`-generated `PersonTelescope` navigators:

```java
Telescope.mapper(FlatSrc.class, Person.class,
  drop(FlatSrc::displayName),
  drop(FlatSrc::displayCity),
  compute (PersonTelescope.of().name(),                () -> "computed-name"),
  to      (FlatSrc::displayCity, PersonTelescope.of().address().city()),
  constant(PersonTelescope.of().address().zip(),       "11201"));
```

Pins the codegen-1:1 promise for the v1.0 MapStruct-parity slice end-to-end against the actual on-disk generated navigator classes.

## Engine changes

- `DeepMap.applyForward` gets two new switch cases (Constant, Compute) — each is a one-liner calling `tgtT.set(t, value)` / `tgtT.set(t, supplier.get())`.
- The PR-#72 `constantIso` / `computeIso` helpers are dropped (no longer used — flat-path-via-`byTargetName` is gone).
- Sealed permits collapse: `ConstantTelescope` / `ComputeTelescope` deleted; the unified `Constant` / `Compute` remain.

## Test plan

- [x] All 8 new tests in `MappingCodegenOneToOneTest` pass
- [x] Existing 5 `MappingConstantComputeTest` + 3 `MappingIntermediateAllocationTest` still pass after the Constant/Compute unification
- [x] Full `:core` test suite green (no regressions in `TelescopeMappingTest`, `DeepMappingTest`, `OpticLawsTest`, etc.)
- [x] `:codegen` / `:lombok` checks green
- [x] `spotlessCheck` clean on every module
