### PR TITLE
chore(examples): JsonNode.asText() → asString() (Jackson 3.x deprecation)

### DIFF
--- a/examples/springboot/product-starter/src/test/java/io/github/eschizoid/telescope/demo/starter/ProductFlowTest.java
+++ b/examples/springboot/product-starter/src/test/java/io/github/eschizoid/telescope/demo/starter/ProductFlowTest.java
@@ -86,8 +86,8 @@ class ProductFlowTest {
     assertThat(raw.has("price_cents")).isTrue();
     assertThat(raw.has("id")).as("camelCase should not leak").isFalse();
     assertThat(raw.has("sku")).isFalse();
-    assertThat(raw.get("stock_keeping_unit").asText()).isEqualTo("SKU-001");
-    assertThat(raw.get("display_name").asText()).isEqualTo("Widget");
+    assertThat(raw.get("stock_keeping_unit").asString()).isEqualTo("SKU-001");
+    assertThat(raw.get("display_name").asString()).isEqualTo("Widget");
     assertThat(raw.get("price_cents").asLong()).isEqualTo(1999L);
     assertThat(raw.get("product_id").asLong()).isPositive();
   }


### PR DESCRIPTION
Spring Boot 4.1.0 (bumped in the recent release-pipeline fix) pulls in Jackson 3.x, which deprecates JsonNode.asText() in favor of asString(). Fixes the two warnings surfaced on PR #73's CI run.

Trivial cleanup, no behavior change.