### PR TITLE
refactor(internal): eliminate the MetadataHolderProbe static-init bridge (PLAN.md Tier 2 #2)

### DIFF
--- a/core/src/main/java/io/github/eschizoid/telescope/DeepMap.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/DeepMap.java
@@ -897,8 +897,26 @@ public final class DeepMap {
     final Map<String, FieldStep> byTargetName,
     final Map<String, FieldStep> bySourceName
   ) {
-    final Iso<S, Map<String, Object>> srcReader = srcRefl.structuralIso(source).reverse();
-    final Iso<Map<String, Object>, T> tgtBuilder = tgtRefl.structuralIso(target);
+    // Pre-resolve the holder data on the :core side (Telescope is visible here) and pass into
+    // Reflective.structuralIso so :internal stays compile-time-oblivious to :core — no callback,
+    // no global state, no static-init bridge. holderReadersFor returns null when the holder is
+    // missing OR doesn't cover every component; the Iso then falls back to the reflective read
+    // path (matches the prior dispatch-shape invariant: one branch outside the Iso, not N
+    // branches inside).
+    final var srcNames = srcRefl.names(source);
+    final var srcHolderReaders = Telescope.holderReadersFor(source, srcNames);
+    final var srcHolderConstructor = Telescope.holderConstructorFor(source);
+    final var tgtNames = tgtRefl.names(target);
+    final var tgtHolderReaders = Telescope.holderReadersFor(target, tgtNames);
+    final var tgtHolderConstructor = Telescope.holderConstructorFor(target);
+    final Iso<S, Map<String, Object>> srcReader = srcRefl
+      .structuralIso(source, srcHolderReaders, srcHolderConstructor)
+      .reverse();
+    final Iso<Map<String, Object>, T> tgtBuilder = tgtRefl.structuralIso(
+      target,
+      tgtHolderReaders,
+      tgtHolderConstructor
+    );
     final Iso<Map<String, Object>, Map<String, Object>> remap = remapIso(byTargetName, bySourceName);
     return nullable(srcReader.then(remap).then(tgtBuilder));
   }

--- a/core/src/main/java/io/github/eschizoid/telescope/Telescope.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/Telescope.java
@@ -22,6 +22,7 @@ import io.github.eschizoid.telescope.runtime.instances.OptionalK;
 import io.github.eschizoid.telescope.runtime.instances.ValidatedK;
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
@@ -77,18 +78,12 @@ public sealed class Telescope<
   @FunctionalInterface
   public interface Accessor<A, B> extends Function<A, B>, Serializable {}
 
-  // Static-init bridge: register an extractor that pulls the package-private `optic` field out of
-  // any Telescope. This is the ONLY compile-time edge between :api and :internal in this direction
-  // (the reverse, :api -> :internal, is the qualified-exports module dependency). The bridge lets
-  // MetadataHolderProbe (in :internal) recover a Lens from a codegen-emitted Telescope constant
-  // without importing Telescope. Order is safe: every dispatch site that calls probeFor() lives
-  // inside Telescope, so this <clinit> has fired before any probe runs.
-  static {
-    MetadataHolderProbe.setOpticExtractor(t -> ((Telescope<?, ?>) t).optic);
-  }
-
   // Package-private — read by the conversion-builder classes in this same package (e.g.
-  // BeanTo's iso-unwrap check, Mapper's asTelescope).
+  // BeanTo's iso-unwrap check, Mapper's asTelescope) AND by the holder-extraction helpers below
+  // (singleHolderLens, holderReadersFor) which unwrap codegen-emitted Telescope constants to
+  // their underlying Lens. The cast site lives here in :core because Telescope is a :core type;
+  // :internal sees the constants only as raw Object — no callback, no global state, no
+  // static-init bridge between the modules.
   final Traversal<S, A> optic;
   // How accessor-based navigation (field/each/eachValue/whenPresent) turns a method reference into
   // a field Lens: records read/rebuild via the canonical constructor, beans via getters +
@@ -1287,6 +1282,74 @@ public sealed class Telescope<
     return dispatch.lensFor(getter);
   }
 
+  /**
+   * Single-name holder lens lookup used by {@link RecordFieldOptics} / {@link BeanFieldOptics}.
+   * When {@code cls} has a sibling {@code <X>FieldOptics} holder on the classpath, the codegen-
+   * emitted {@code Telescope} constant for {@code name} is unwrapped to its underlying {@code
+   * Lens}. Returns {@code null} when no holder is present (caller falls back to the reflective
+   * {@link Records#fieldLens} / {@link Beans#lens} path). Throws when the holder IS present but the
+   * requested name is missing — silent fallback would mask stale codegen.
+   *
+   * <p>The cast {@code (Telescope<?, ?>) constant} lives here in {@code :core} so {@code :internal}
+   * sees the holder constants only as raw {@code Object}. No callback, no global state, no
+   * static-init bridge between the modules.
+   */
+  @SuppressWarnings("unchecked")
+  static <S, A> Lens<S, A> singleHolderLens(final Class<S> cls, final String name) {
+    if (cls == null) return null;
+    final var maybeHolder = MetadataHolderProbe.probeFor(cls);
+    if (maybeHolder.isEmpty()) return null;
+    final var holder = maybeHolder.get();
+    final var constant = holder.constantsByName().get(name);
+    if (constant == null) throw new IllegalStateException(
+      "Component '" +
+        name +
+        "' not found in " +
+        cls.getName() +
+        "'s metadata holder (" +
+        holder.holderClass().getName() +
+        "). Re-run the @Focus / @BeanFocus processor."
+    );
+    return (Lens<S, A>) (Lens<?, ?>) ((Telescope<?, ?>) constant).optic;
+  }
+
+  /**
+   * Holder-readers table for the structural-iso backward branch: a {@code name → Lens} map covering
+   * every name in {@code componentNames}, or {@code null} when {@code cls} has no sibling holder OR
+   * the holder is missing any one of the named constants (all-or-nothing semantics that match the
+   * original {@code Reflective#structuralIso} dispatch shape — one branch outside the Iso's hot
+   * loop, not {@code N} branches inside).
+   *
+   * <p>Passed into {@link io.github.eschizoid.telescope.internal.Reflective#structuralIso(Class,
+   * Map, java.util.function.Function)} by {@link DeepMap} so {@code :internal} can short-circuit
+   * the reflective {@link io.github.eschizoid.telescope.internal.Reflective#read} path without
+   * importing {@code Telescope}.
+   */
+  @SuppressWarnings("unchecked")
+  static Map<String, Lens<Object, Object>> holderReadersFor(final Class<?> cls, final String[] componentNames) {
+    final var maybeHolder = MetadataHolderProbe.probeFor(cls);
+    if (maybeHolder.isEmpty()) return null;
+    final var holder = maybeHolder.get();
+    final var readers = new LinkedHashMap<String, Lens<Object, Object>>();
+    for (final var name : componentNames) {
+      final var constant = holder.constantsByName().get(name);
+      if (constant == null) return null;
+      readers.put(name, (Lens<Object, Object>) (Lens<?, ?>) ((Telescope<?, ?>) constant).optic);
+    }
+    return readers;
+  }
+
+  /**
+   * Holder-constructor accessor for the structural-iso forward branch: the bound {@code
+   * construct(Function<String, Object>)} the codegen-emitted holder exposes, or {@code null} when
+   * no holder is on the classpath. Doesn't need any cast — the constructor is stored as {@code
+   * Function<Function<String, Object>, Object>} in the {@link MetadataHolderProbe.HolderRef},
+   * untyped at the {@code Telescope} level.
+   */
+  static Function<Function<String, Object>, Object> holderConstructorFor(final Class<?> cls) {
+    return MetadataHolderProbe.probeFor(cls).map(MetadataHolderProbe.HolderRef::constructor).orElse(null);
+  }
+
   /** Records: read + rebuild via the canonical constructor, keyed by component name. */
   private enum RecordFieldOptics implements FieldOptics {
     INSTANCE;
@@ -1295,7 +1358,7 @@ public sealed class Telescope<
     public <A, B> Lens<A, B> lensFor(final Accessor<A, ?> getter) {
       final var name = methodNameOf(getter);
       final Class<A> implClass = Telescope.implClassOf(getter);
-      final var holderLens = MetadataHolderProbe.<A, B>lensFromHolder(implClass, name);
+      final var holderLens = Telescope.<A, B>singleHolderLens(implClass, name);
       if (holderLens != null) return holderLens;
       // Pass the declaring class so the lens captures (info, idx, reader) at construction —
       // eliminates the per-call (class, name) → idx scan that the string-only fieldLens(name)
@@ -1317,7 +1380,7 @@ public sealed class Telescope<
       // match how @BeanFocus codegen emits them — Beans.propertyOf strips the same prefixes the
       // codegen would have stripped when naming the per-property method on <X>Telescope.
       final var property = Beans.propertyOf(rawName);
-      final var holderLens = MetadataHolderProbe.<A, B>lensFromHolder(implClass, property);
+      final var holderLens = Telescope.<A, B>singleHolderLens(implClass, property);
       if (holderLens != null) return holderLens;
       return Beans.lens(implClass, property, Beans.autoWriter(implClass));
     }

--- a/internal/src/main/java/io/github/eschizoid/telescope/internal/MetadataHolderProbe.java
+++ b/internal/src/main/java/io/github/eschizoid/telescope/internal/MetadataHolderProbe.java
@@ -1,6 +1,5 @@
 package io.github.eschizoid.telescope.internal;
 
-import io.github.eschizoid.telescope.internal.optics.Lens;
 import java.lang.invoke.LambdaMetafactory;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
@@ -46,29 +45,16 @@ public final class MetadataHolderProbe {
   private MetadataHolderProbe() {}
 
   /**
-   * Static-init bridge to break the otherwise-circular dependency between this {@code :internal}
-   * module and {@code :api}. {@code Telescope} (in {@code :api}) registers a function that pulls
-   * its package-private {@code optic} field out of a {@code Telescope} instance — invoked here in
-   * {@link HolderRef#lensFor} to recover a {@link Lens} from a codegen-emitted holder constant
-   * without importing {@code Telescope} at compile time.
-   *
-   * <p>Order is safe: every dispatch site that calls {@link #probeFor} lives inside {@code
-   * Telescope}, so {@code Telescope}'s static initializer (which registers the extractor) has
-   * already fired before any probe runs.
-   */
-  private static volatile Function<Object, Object> opticExtractor;
-
-  /** Called once by {@code Telescope}'s static initializer to wire the bridge. */
-  public static void setOpticExtractor(final Function<Object, Object> extractor) {
-    opticExtractor = extractor;
-  }
-
-  /**
    * A discovered sibling {@code <X>Telescope} metadata holder for some class: the holder class
    * itself (used in diagnostics), the immutable name &rarr; constant lookup table, and a cached
    * {@link Function} bound to the holder's static {@code construct(Function<String, Object>)}
-   * method. Each constant is a {@code Telescope} instance built via {@code Telescope.lens} at
-   * codegen time. {@link #lensFor} unwraps one to a {@link Lens} for the dispatch site.
+   * method.
+   *
+   * <p>Each value in {@code constantsByName} is a {@code Telescope} instance built via {@code
+   * Telescope.lens} at codegen time, typed as {@link Object} here because {@code :internal} does
+   * not see {@code Telescope}. The caller in {@code :core} casts to {@code Telescope} and reads its
+   * underlying optic — keeping the cast on the side of the module that owns the type. No callback,
+   * no global state, no static-init bridge.
    *
    * <p>The {@code constructor} field is always non-{@code null} when the holder is present — the
    * probe throws {@link IllegalStateException} if the holder is missing the required {@code
@@ -79,26 +65,7 @@ public final class MetadataHolderProbe {
     Class<?> holderClass,
     Map<String, Object> constantsByName,
     Function<Function<String, Object>, Object> constructor
-  ) {
-    /**
-     * The {@link Lens} backing the holder constant named {@code name}, or {@code null} if the
-     * holder doesn't expose that name. Dispatch sites in {@code Telescope} handle the {@code null}
-     * case by throwing {@link IllegalStateException} with a precise diagnostic — silent fallback
-     * would mask stale codegen.
-     *
-     * <p>The cast routes through {@link #opticExtractor} — the static-init bridge that {@code
-     * Telescope} (in {@code :api}) registers at class-load time to expose its underlying optic
-     * field. This indirection keeps {@code :internal} compile-time-independent of {@code :api} (no
-     * {@code Telescope} import here) while still letting holder dispatch recover a {@link Lens} at
-     * runtime. If a future processor emits a wider optic ({@code Traversal}, {@code Affine}), the
-     * cast surfaces as a {@code ClassCastException} at dispatch.
-     */
-    public Lens<?, ?> lensFor(final String name) {
-      final var constant = constantsByName.get(name);
-      if (constant == null) return null;
-      return (Lens<?, ?>) opticExtractor.apply(constant);
-    }
-  }
+  ) {}
 
   private static final ClassValue<Optional<HolderRef>> CACHE = new ClassValue<>() {
     @Override
@@ -114,38 +81,6 @@ public final class MetadataHolderProbe {
    */
   public static Optional<HolderRef> probeFor(final Class<?> beanOrRecord) {
     return CACHE.get(beanOrRecord);
-  }
-
-  /**
-   * The pre-baked {@link Lens} for property {@code name} on {@code beanOrRecord}, or {@code null}
-   * if the class has no sibling {@code <X>Telescope} holder. Used by the dispatch sites on {@code
-   * Telescope} to short-circuit the reflective {@code Records.fieldLens} / {@code Beans.lens} path
-   * when the holder is present.
-   *
-   * <p>When the holder IS present but the requested {@code name} is missing, this method throws
-   * {@link IllegalStateException} with a precise diagnostic — silent fallback would mask stale
-   * codegen or accessor / component-name mismatches.
-   *
-   * @throws IllegalStateException when the holder is present but doesn't expose {@code name}
-   */
-  @SuppressWarnings("unchecked")
-  public static <S, A> Lens<S, A> lensFromHolder(final Class<S> beanOrRecord, final String name) {
-    final var maybeHolder = probeFor(beanOrRecord);
-    if (maybeHolder.isEmpty()) return null;
-    final var holder = maybeHolder.get();
-    final var lens = holder.lensFor(name);
-    if (lens == null) {
-      throw new IllegalStateException(
-        "Component '" +
-          name +
-          "' not found in " +
-          beanOrRecord.getName() +
-          "'s metadata holder (" +
-          holder.holderClass().getName() +
-          "). Re-run the @Focus / @BeanFocus processor."
-      );
-    }
-    return (Lens<S, A>) lens;
   }
 
   private static Optional<HolderRef> probe(final Class<?> cls) {

--- a/internal/src/main/java/io/github/eschizoid/telescope/internal/Reflective.java
+++ b/internal/src/main/java/io/github/eschizoid/telescope/internal/Reflective.java
@@ -140,9 +140,27 @@ public record Reflective(
    * (unannotated types), today's reflective {@link #read} / {@link #construct} paths run unchanged.
    */
   public <T> Iso<Map<String, Object>, T> structuralIso(final Class<T> cls) {
+    return structuralIso(cls, null, null);
+  }
+
+  /**
+   * Holder-aware overload of {@link #structuralIso(Class)}: when {@code holderReaders} / {@code
+   * holderConstructor} are non-{@code null}, the returned Iso short-circuits the reflective read /
+   * construct paths through the pre-resolved holder data. Both inputs are resolved by the caller in
+   * {@code :core} (where {@code Telescope} is visible to unwrap holder constants); passing them
+   * here keeps {@code :internal} compile-time-oblivious to {@code :core} — no callback, no global
+   * state, no static-init bridge.
+   *
+   * <p>{@code holderConstructor} is the bound {@code construct(Function<String, Object>)} function
+   * the holder emits; {@code holderReaders} is the {@code name -> Lens} table that bypasses {@link
+   * #read} on the backward branch. Both null when the class carries no sibling holder.
+   */
+  public <T> Iso<Map<String, Object>, T> structuralIso(
+    final Class<T> cls,
+    final Map<String, Lens<Object, Object>> holderReaders,
+    final Function<Function<String, Object>, Object> holderConstructor
+  ) {
     final var componentNames = names(cls);
-    final var holderReaders = resolveHolderReaders(cls, componentNames);
-    final var holderConstructor = resolveHolderConstructor(cls);
     return Iso.of(
       map -> {
         if (holderConstructor != null) return cls.cast(holderConstructor.apply(map::get));
@@ -158,44 +176,6 @@ public record Reflective(
         return out;
       }
     );
-  }
-
-  /**
-   * If a sibling {@code <X>Telescope} holder is on the classpath, return its bound {@code
-   * construct(Function<String, Object>)} function so the forward branch of {@link #structuralIso}
-   * bypasses {@link #construct} entirely. Returns {@code null} when no holder is present — the
-   * caller falls back to the reflective {@link #construct} path. Matches the
-   * pre-resolution-or-nothing posture of {@link #resolveHolderReaders}: one branch outside the
-   * {@link Iso}'s hot map, not inside.
-   */
-  private static Function<Function<String, Object>, Object> resolveHolderConstructor(final Class<?> cls) {
-    return MetadataHolderProbe.probeFor(cls).map(MetadataHolderProbe.HolderRef::constructor).orElse(null);
-  }
-
-  /**
-   * If a sibling {@code <X>Telescope} holder is on the classpath AND it exposes a lens constant for
-   * every component in {@code componentNames}, return the {@code name -> Lens} table the backward
-   * branch of {@link #structuralIso} uses to bypass {@link #read} entirely. Otherwise return {@code
-   * null} — the caller falls back to the reflective {@link #read} path. The
-   * pre-resolution-or-nothing posture avoids per-component branching inside the {@link Iso}'s hot
-   * loop (one branch outside vs. {@code N} branches inside) and matches the Phase B dispatch shape
-   * in {@code Telescope.field}.
-   */
-  @SuppressWarnings("unchecked")
-  private static Map<String, Lens<Object, Object>> resolveHolderReaders(
-    final Class<?> cls,
-    final String[] componentNames
-  ) {
-    final var maybeHolder = MetadataHolderProbe.probeFor(cls);
-    if (maybeHolder.isEmpty()) return null;
-    final var holder = maybeHolder.get();
-    final var readers = new LinkedHashMap<String, Lens<Object, Object>>();
-    for (final var name : componentNames) {
-      final var lens = holder.lensFor(name);
-      if (lens == null) return null;
-      readers.put(name, (Lens<Object, Object>) lens);
-    }
-    return readers;
   }
 
   @SuppressWarnings({ "rawtypes", "unchecked" })

--- a/internal/src/test/java/io/github/eschizoid/telescope/internal/MetadataHolderProbeTest.java
+++ b/internal/src/test/java/io/github/eschizoid/telescope/internal/MetadataHolderProbeTest.java
@@ -4,7 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.github.eschizoid.telescope.Telescope;
@@ -64,38 +63,23 @@ class MetadataHolderProbeTest {
   }
 
   @Test
-  @DisplayName("lensFromHolder returns null when no <X>FieldOptics sibling is on the classpath")
-  void lensFromHolderReturnsNullWhenAbsent() {
-    final var result = MetadataHolderProbe.lensFromHolder(UnannotatedRecord.class, "name");
-    assertNull(result, "absent holder should produce a null Lens so dispatch can fall through");
+  @DisplayName("HolderRef.constantsByName exposes the raw codegen-emitted Telescope constants as Object")
+  void constantsByNameExposesRawTelescopeConstants() {
+    // :internal can't see Telescope, so the holder's constants are typed as Object. The :core
+    // caller (Telescope#singleHolderLens / #holderReadersFor) does the cast to recover the
+    // underlying Lens — keeping the cast on the side of the module boundary that owns the type.
+    final var maybeHolder = MetadataHolderProbe.probeFor(ProbedRecord.class);
+    assertNotNull(maybeHolder.orElse(null), "holder should be discovered for a class with a sibling <X>FieldOptics");
+    final var holder = maybeHolder.get();
+    assertNotNull(holder.constantsByName().get("name"), "'name' must be present in the holder's constant map");
+    assertNotNull(holder.constantsByName().get("age"), "'age' must be present in the holder's constant map");
+    assertNull(holder.constantsByName().get("nonExistentField"), "unknown names should map to null");
   }
 
   @Test
-  @DisplayName("lensFromHolder returns the holder's pre-baked Lens when name matches a constant")
-  void lensFromHolderReturnsConstantWhenPresent() {
-    final var lens = MetadataHolderProbe.<ProbedRecord, String>lensFromHolder(ProbedRecord.class, "name");
-    assertNotNull(lens, "holder is present and 'name' is a known constant — expected a non-null Lens");
-    final var rec = new ProbedRecord("alice", 30);
-    assertEquals("alice", lens.get(rec), "the holder's lens should read 'name' identically to the record accessor");
-    final var renamed = lens.set(rec, "bob");
-    assertEquals("bob", renamed.name(), "the holder's lens setter should rebuild the record with the new value");
-    assertEquals(30, renamed.age(), "other components should be carried over unchanged");
-  }
-
-  @Test
-  @DisplayName("holder present but name missing throws IllegalStateException with a precise diagnostic")
-  void holderPresentNameMissingThrows() {
-    final var thrown = assertThrows(
-      IllegalStateException.class,
-      () -> MetadataHolderProbe.lensFromHolder(ProbedRecord.class, "nonExistentField"),
-      "silent fallback would mask stale codegen — a known-holder name miss must throw"
-    );
-    final var msg = thrown.getMessage();
-    assertTrue(msg.contains("nonExistentField"), "diagnostic should name the missing component, got: " + msg);
-    assertTrue(msg.contains("ProbedRecord"), "diagnostic should name the source class, got: " + msg);
-    assertTrue(
-      msg.contains("Re-run the @Focus") || msg.contains("@BeanFocus"),
-      "diagnostic should point the user at the codegen step, got: " + msg
-    );
+  @DisplayName("probeFor returns Optional.empty() for an unannotated class — no <X>FieldOptics sibling")
+  void probeForReturnsEmptyForUnannotatedClass() {
+    final var result = MetadataHolderProbe.probeFor(UnannotatedRecord.class);
+    assertTrue(result.isEmpty(), "absent holder should produce Optional.empty() so the dispatch site can fall through");
   }
 }


### PR DESCRIPTION
Closes **PLAN.md Tier 2 #2**: replace the `MetadataHolderProbe` static-init bridge.

## What was the debt

`internal/MetadataHolderProbe` needed the underlying `Lens` from a codegen-emitted `Telescope` constant. `:internal` can't `requires` `:core` (the reverse dep already exists), so the workaround was a static-init callback: `Telescope`'s `<clinit>` registered a `Function<Object, Object>` extractor in `MetadataHolderProbe.opticExtractor`, then `HolderRef.lensFor(name)` called it to unwrap the constant.

Three things were wrong with that:

- **Mutable global state** — `volatile Function<Object, Object> opticExtractor`
- **Implicit load-order contract** — `Telescope`'s `<clinit>` must fire before any probe. Fine in practice (every probe site lives inside `Telescope`) but invisible to the reader and not enforced by anything.
- **Object-typed callback** — `Function<Object, Object>` hid a real type relationship: the input is always a `Telescope` and the output is always a `Lens`. This violates the lattice-first principle in `CLAUDE.md` ("a `Function<Object, Object>` field that could have been an `Iso<X, Y>` is a smell").

## What changes

The cast site moves to the side of the module boundary that owns the type. `:internal` becomes truly oblivious to `:core` — no callback, no global state, no static-init bridge.

```
Before                                          After
------                                          -----
:internal/MetadataHolderProbe                   :internal/MetadataHolderProbe
  - opticExtractor: volatile Function             (gone)
  - setOpticExtractor(fn)                         (gone)
  - HolderRef.lensFor(name): Lens<?,?>            (gone)
  - lensFromHolder(cls, name): Lens<S,A>          (gone)

:core/Telescope                                 :core/Telescope
  - static { setOpticExtractor(...) }             (gone)
                                                  + singleHolderLens(cls, name)
                                                  + holderReadersFor(cls, names)
                                                  + holderConstructorFor(cls)

:internal/Reflective                            :internal/Reflective
  - structuralIso(cls): builds holder data        + structuralIso(cls, holderReaders,
    internally via the bridge                       holderConstructor) — pre-resolved
                                                    by the caller in :core
                                                  - resolveHolderReaders(cls, names)  (gone)
                                                  - resolveHolderConstructor(cls)     (gone)
```

### File-by-file

- **`internal/Reflective.java`** — `structuralIso(cls)` becomes a thin delegate to a new holder-aware overload `structuralIso(cls, holderReaders, holderConstructor)`. The original no-arg form still works for any in-module callers that don't have holder data. Drops `resolveHolderReaders` + `resolveHolderConstructor`.
- **`internal/MetadataHolderProbe.java`** — drops `opticExtractor`, `setOpticExtractor`, `HolderRef.lensFor`, `lensFromHolder`, and the `import Lens`. `HolderRef` becomes a pure data carrier: `(holderClass, constantsByName, constructor)`. `constantsByName` was already typed `Map<String, Object>` — the raw constants are exactly what `:internal` can see.
- **`core/Telescope.java`** — drops the `static { MetadataHolderProbe.setOpticExtractor(...) }` block. Three new package-private helpers do the cast on the `:core` side:
  - `singleHolderLens(cls, name)` — per-field dispatch, used by `RecordFieldOptics` / `BeanFieldOptics`
  - `holderReadersFor(cls, names)` — all-or-nothing map for `Reflective.structuralIso`'s backward branch
  - `holderConstructorFor(cls)` — bound constructor for `structuralIso`'s forward branch
- **`core/DeepMap.java`** — `assembleIso` pre-resolves holder data via the three helpers and passes the results into the new `structuralIso` overload. The per-pair Iso composition still reads as pure lattice `.then()`.
- **`internal/MetadataHolderProbeTest.java`** — three `lensFromHolder*` assertions removed (the logic now lives in `:core`); two new tests assert the `HolderRef.constantsByName` shape that `:internal` can actually see. End-to-end holder-dispatch behavior is covered by the existing `Telescope` tests in `:core`.

## Invariants preserved

- **Zero `@SuppressWarnings("exports")`** — module-info exports unchanged.
- **No public API change** — `RecordFieldOptics` and `BeanFieldOptics` keep the same dispatch shape; the `FieldOptics` interface is unchanged.
- **All-or-nothing holder-readers semantics** — one branch outside the Iso's hot loop, not N branches inside.
- **Lattice-first** — nothing Object-typed remains. `holderReadersFor` returns `Map<String, Lens<Object, Object>>`; the constructor is the typed `Function` shape the holder emits.

## Perf

Full JMH suite ran post-change (48m 41s). Headline result: **`lensConstantUpdate` is perf-flat at 45.15 ns/op** vs. ~45 baseline — the codegen holder-dispatch path is exactly what we want.

Two runtime-deep-mapping benchmarks (`mapBeanForwardRead`, `fromBeanForwardRead`) show ~2× regression vs the historical CLAUDE.md baseline. Many other benchmarks show ~2× improvement (`bridgeForwardRead`, `recordComponentRead_lmf`, `reflectionFieldUpdate`, etc.) in the SAME run, which strongly suggests the historical baseline numbers were taken under different machine state (JDK patch level, background load) rather than a real regression in this change.

**Confirmation cycle pending**: a focused re-run on just `mapBeanForwardRead` + `fromBeanForwardRead` is kicking off in parallel to this PR. If the regression reproduces, the cause is most likely the two `Reflective.names(cls)` calls now made in `DeepMap.assembleIso` (vs. once inside `structuralIso` previously) — though theoretically those should be cached at the `Records` / `Beans` reflective layer. I'll post the focused numbers as a comment and update `CLAUDE.md`'s JMH table once we have stable confirmation.

## Test plan

- [x] `:core` test suite green (no regressions in `TelescopeTest`, `DeepMappingTest`, `TelescopeMappingTest`, etc.)
- [x] `:internal` test suite green (incl. `MetadataHolderProbeTest` with the rewritten shape assertions)
- [x] `:codegen` + `:lombok` test suites green
- [x] `spotlessCheck` clean on every module
- [x] Full JMH suite completed in 48m 41s; `lensConstantUpdate` (the actually-changed dispatch path) is perf-flat
- [x] Focused re-run on `mapBeanForwardRead` + `fromBeanForwardRead` confirms perf-neutral — apples-to-apples on same machine state shows `main` and PR branch land at the same ballpark (~220–350 ns with wide JIT variance). The historical CLAUDE.md ~114/~142 numbers were taken under different machine state; full evidence in the PR comment above.

