### PR TITLE
build: cross-compile to Java 17 (--release 17)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,11 @@ through lists, sets, maps, optionals, and sealed-type variants in one chain. Ski
 containers. Drop-in `telescope-spring-boot-starter` (Spring Boot 4) or `telescope-quarkus` (Quarkus 3) for autoconfig +
 a typed `Mapper<A,B>` bean registry — one dependency, zero wiring.
 
-[![JVM 25+](https://img.shields.io/badge/JVM-25%2B-brightgreen.svg?&logo=openjdk)](https://openjdk.org/projects/jdk/25/)
+[![JVM 17+](https://img.shields.io/badge/JVM-17%2B-brightgreen.svg?&logo=openjdk)](https://openjdk.org/projects/jdk/17/)
 [![Build](https://github.com/eschizoid/telescope/actions/workflows/ci.yaml/badge.svg)](https://github.com/eschizoid/telescope/actions/workflows/ci.yaml)
 [![Codecov](https://codecov.io/gh/eschizoid/telescope/graph/badge.svg?token=a235ea8b-e6dc-45c6-8fea-e5050940c5d4)](https://codecov.io/gh/eschizoid/telescope)
-[![Maven Central](https://img.shields.io/maven-central/v/io.github.eschizoid/telescope.svg?label=Maven%20Central)](https://central.sonatype.com/artifact/io.github.eschizoid/telescope)
-[![Javadoc](https://javadoc.io/badge2/io.github.eschizoid/telescope/javadoc.svg?color=purple)](https://javadoc.io/doc/io.github.eschizoid/telescope)
+[![Maven Central](https://img.shields.io/maven-central/v/io.github.eschizoid/telescope-core.svg?label=Maven%20Central)](https://central.sonatype.com/artifact/io.github.eschizoid/telescope-core)
+[![Javadoc](https://javadoc.io/badge2/io.github.eschizoid/telescope-core/javadoc.svg?color=purple)](https://javadoc.io/doc/io.github.eschizoid/telescope-core)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
 ---

--- a/benchmarks/build.gradle.kts
+++ b/benchmarks/build.gradle.kts
@@ -23,7 +23,7 @@ dependencies {
 }
 
 tasks.withType<JavaCompile>().configureEach {
-    options.release = 25
+    options.release = 17
     options.encoding = "UTF-8"
     modularity.inferModulePath = true
 }

--- a/codegen/build.gradle.kts
+++ b/codegen/build.gradle.kts
@@ -25,7 +25,7 @@ java {
 }
 
 tasks.withType<JavaCompile>().configureEach {
-    options.release = 25
+    options.release = 17
     options.encoding = "UTF-8"
     options.compilerArgs.addAll(listOf("-Xlint:all,-processing", "-parameters"))
 }

--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/AbstractTelescopeProcessor.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/AbstractTelescopeProcessor.java
@@ -872,7 +872,7 @@ public abstract class AbstractTelescopeProcessor extends AbstractProcessor {
     if (props.isEmpty()) {
       out.println("    return Map.of();");
     } else if (props.size() == 1) {
-      final var onlyName = props.getFirst().name();
+      final var onlyName = props.get(0).name();
       out.println("    return Map.of(\"" + onlyName + "\", " + onlyName + ");");
     } else {
       out.println("    return Map.ofEntries(");

--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BeanFocusProcessor.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BeanFocusProcessor.java
@@ -20,7 +20,7 @@ import javax.lang.model.element.TypeElement;
  * setters — see {@link AbstractTelescopeProcessor#emitBeanNavigator}.
  */
 @SupportedAnnotationTypes("io.github.eschizoid.telescope.annotations.BeanFocus")
-@SupportedSourceVersion(SourceVersion.RELEASE_25)
+@SupportedSourceVersion(SourceVersion.RELEASE_17)
 public final class BeanFocusProcessor extends AbstractTelescopeProcessor {
 
   /**

--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
@@ -49,7 +49,7 @@ import javax.lang.model.util.ElementFilter;
 @SupportedAnnotationTypes(
   { "io.github.eschizoid.telescope.annotations.Bridge", "io.github.eschizoid.telescope.annotations.Bridges" }
 )
-@SupportedSourceVersion(SourceVersion.RELEASE_25)
+@SupportedSourceVersion(SourceVersion.RELEASE_17)
 public final class BridgeProcessor extends AbstractTelescopeProcessor {
 
   /**
@@ -967,33 +967,39 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
       source,
       out -> {
         out.println("  public static " + targetFq + " forward(final " + sourceFq + " s) {");
-        out.println("    return switch (s) {");
         for (final var e : entries) {
           final var v = camelLower(e.sourceCase().getSimpleName().toString());
           out.println(
-            "      case " + e.sourceCase().getQualifiedName() + " " + v + " -> " + e.bridgeFq() + ".forward(" + v + ");"
+            "    if (s instanceof " +
+              e.sourceCase().getQualifiedName() +
+              " " +
+              v +
+              ") return " +
+              e.bridgeFq() +
+              ".forward(" +
+              v +
+              ");"
           );
         }
-        out.println("    };");
+        out.println("    throw new IllegalStateException(\"unreachable: sealed type\");");
         out.println("  }");
         out.println();
         out.println("  public static " + sourceFq + " backward(final " + targetFq + " t) {");
-        out.println("    return switch (t) {");
         for (final var e : entries) {
           final var v = camelLower(e.targetCase().getSimpleName().toString());
           out.println(
-            "      case " +
+            "    if (t instanceof " +
               e.targetCase().getQualifiedName() +
               " " +
               v +
-              " -> " +
+              ") return " +
               e.bridgeFq() +
               ".backward(" +
               v +
               ");"
           );
         }
-        out.println("    };");
+        out.println("    throw new IllegalStateException(\"unreachable: sealed type\");");
         out.println("  }");
         out.println();
         out.println("  /** One concrete BridgeFn type per @Bridge — monomorphic dispatch site. */");
@@ -1093,12 +1099,10 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
       if (!(el instanceof TypeElement te)) return null;
       final var args = dt.getTypeArguments();
       return switch (te.getQualifiedName().toString()) {
-        case "java.util.List" -> args.size() == 1
-          ? new ContainerShape(FieldPlan.Kind.LIST, args.getFirst(), null)
-          : null;
-        case "java.util.Set" -> args.size() == 1 ? new ContainerShape(FieldPlan.Kind.SET, args.getFirst(), null) : null;
+        case "java.util.List" -> args.size() == 1 ? new ContainerShape(FieldPlan.Kind.LIST, args.get(0), null) : null;
+        case "java.util.Set" -> args.size() == 1 ? new ContainerShape(FieldPlan.Kind.SET, args.get(0), null) : null;
         case "java.util.Optional" -> args.size() == 1
-          ? new ContainerShape(FieldPlan.Kind.OPTIONAL, args.getFirst(), null)
+          ? new ContainerShape(FieldPlan.Kind.OPTIONAL, args.get(0), null)
           : null;
         case "java.util.Map" -> args.size() == 2
           ? new ContainerShape(FieldPlan.Kind.MAP_VALUES, args.get(1), args.get(0))
@@ -1434,8 +1438,8 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
     final String subBridge,
     final String direction
   ) {
-    final var srcElement = ((DeclaredType) srcContainer).getTypeArguments().getFirst();
-    final var tgtElement = ((DeclaredType) tgtContainer).getTypeArguments().getFirst();
+    final var srcElement = ((DeclaredType) srcContainer).getTypeArguments().get(0);
+    final var tgtElement = ((DeclaredType) tgtContainer).getTypeArguments().get(0);
     out.println();
     out.println("  private static List<" + tgtElement + "> " + name + "(final List<" + srcElement + "> src) {");
     out.println("    if (src == null) return null;");
@@ -1453,8 +1457,8 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
     final String subBridge,
     final String direction
   ) {
-    final var srcElement = ((DeclaredType) srcContainer).getTypeArguments().getFirst();
-    final var tgtElement = ((DeclaredType) tgtContainer).getTypeArguments().getFirst();
+    final var srcElement = ((DeclaredType) srcContainer).getTypeArguments().get(0);
+    final var tgtElement = ((DeclaredType) tgtContainer).getTypeArguments().get(0);
     out.println();
     out.println("  private static Set<" + tgtElement + "> " + name + "(final Set<" + srcElement + "> src) {");
     out.println("    if (src == null) return null;");

--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/FocusProcessor.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/FocusProcessor.java
@@ -44,7 +44,7 @@ import javax.lang.model.element.TypeElement;
  * </ul>
  */
 @SupportedAnnotationTypes("io.github.eschizoid.telescope.annotations.Focus")
-@SupportedSourceVersion(SourceVersion.RELEASE_25)
+@SupportedSourceVersion(SourceVersion.RELEASE_17)
 public final class FocusProcessor extends AbstractTelescopeProcessor {
 
   /**
@@ -219,7 +219,7 @@ public final class FocusProcessor extends AbstractTelescopeProcessor {
     if (components.isEmpty()) {
       out.println("    return Map.of();");
     } else if (components.size() == 1) {
-      final var onlyName = components.getFirst().getSimpleName();
+      final var onlyName = components.get(0).getSimpleName();
       out.println("    return Map.of(\"" + onlyName + "\", " + onlyName + ");");
     } else {
       out.println("    return Map.ofEntries(");

--- a/codegen/src/test/java/io/github/eschizoid/telescope/codegen/BridgeProcessorTest.java
+++ b/codegen/src/test/java/io/github/eschizoid/telescope/codegen/BridgeProcessorTest.java
@@ -753,24 +753,28 @@ class BridgeProcessorTest {
 
       final var sealedBridge = compilation.generated().get("demo.payment.PaymentBridge");
       assertNotNull(sealedBridge, () -> "PaymentBridge not generated; saw " + compilation.generated().keySet());
-      // Forward switch fans out to per-case bridges.
-      assertTrue(
-        sealedBridge.contains("case demo.payment.CreditCard creditCard -> demo.payment.CreditCardBridge.forward("),
-        sealedBridge
-      );
-      assertTrue(
-        sealedBridge.contains("case demo.payment.PayPal payPal -> demo.payment.PayPalBridge.forward("),
-        sealedBridge
-      );
-      // Backward switch dispatches on the bean side's permits.
+      // Forward fans out to per-case bridges via instanceof chain (Java 17 source level).
       assertTrue(
         sealedBridge.contains(
-          "case demo.bean.CreditCardEntity creditCardEntity -> demo.payment.CreditCardBridge.backward("
+          "if (s instanceof demo.payment.CreditCard creditCard) return demo.payment.CreditCardBridge.forward("
         ),
         sealedBridge
       );
       assertTrue(
-        sealedBridge.contains("case demo.bean.PayPalEntity payPalEntity -> demo.payment.PayPalBridge.backward("),
+        sealedBridge.contains("if (s instanceof demo.payment.PayPal payPal) return demo.payment.PayPalBridge.forward("),
+        sealedBridge
+      );
+      // Backward dispatches on the bean side's permits.
+      assertTrue(
+        sealedBridge.contains(
+          "if (t instanceof demo.bean.CreditCardEntity creditCardEntity) return demo.payment.CreditCardBridge.backward("
+        ),
+        sealedBridge
+      );
+      assertTrue(
+        sealedBridge.contains(
+          "if (t instanceof demo.bean.PayPalEntity payPalEntity) return demo.payment.PayPalBridge.backward("
+        ),
         sealedBridge
       );
       // The umbrella BRIDGE constant exposes the composed Telescope at the sealed-root level.

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -24,7 +24,7 @@ java {
 }
 
 tasks.withType<JavaCompile>().configureEach {
-    options.release = 25
+    options.release = 17
     options.encoding = "UTF-8"
     options.compilerArgs.addAll(listOf("-Xlint:all,-processing", "-Werror", "-parameters"))
 }

--- a/core/src/main/java/io/github/eschizoid/telescope/DeepMap.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/DeepMap.java
@@ -159,11 +159,11 @@ public final class DeepMap {
   private static WriteHint.WriteStrategy extractDefaultStrategy(final List<WriteHint<?>> hints) {
     WriteHint.WriteStrategy defaultStrategy = null;
     for (final var hint : hints) {
-      if (!(hint instanceof WriteHint.DefaultWriteHint(WriteHint.WriteStrategy strat))) continue;
+      if (!(hint instanceof WriteHint.DefaultWriteHint defaultHint)) continue;
       if (defaultStrategy != null) throw new IllegalArgumentException(
         "Duplicate writeBeans(...) default — at most one default write strategy per Telescope.map(...) call."
       );
-      defaultStrategy = strat;
+      defaultStrategy = defaultHint.strategy();
     }
     return defaultStrategy;
   }
@@ -248,7 +248,7 @@ public final class DeepMap {
       final Class<?> effectiveSource = internals.sourceClass() == null ? topSource : internals.sourceClass();
       final Class<?> effectiveTarget = internals.targetClass() == null ? topTarget : internals.targetClass();
       final var key = new TypePair(effectiveSource, effectiveTarget);
-      grouped.computeIfAbsent(key, _ -> new ArrayList<>()).add(row);
+      grouped.computeIfAbsent(key, __ -> new ArrayList<>()).add(row);
     }
     return grouped;
   }
@@ -532,49 +532,41 @@ public final class DeepMap {
   private static <S, T> T applyForward(final T initial, final S s, final List<Mapping<?, ?>> fixups) {
     T t = initial;
     for (final var fx : fixups) {
-      switch (fx) {
-        case TelescopeTo<?, ?, ?> r -> {
-          final var srcAcc = (Telescope.Accessor<S, Object>) r.srcAccessor();
-          final var tgtT = (Telescope<T, Object>) r.targetTelescope();
-          t = tgtT.set(t, srcAcc.apply(s));
+      if (fx instanceof TelescopeTo<?, ?, ?> r) {
+        final var srcAcc = (Telescope.Accessor<S, Object>) r.srcAccessor();
+        final var tgtT = (Telescope<T, Object>) r.targetTelescope();
+        t = tgtT.set(t, srcAcc.apply(s));
+      } else if (fx instanceof FromTelescopeTo<?, ?, ?> r) {
+        final var srcT = (Telescope<S, Object>) r.sourceTelescope();
+        // The target side is a flat accessor; we need to rebuild t with the named target field
+        // overridden by srcT.read(s). Delegate to overrideTargetField, which uses the target
+        // Reflective.construct the same way the source-side path does in applyBackward.
+        t = overrideTargetField(t, r, srcT, s);
+      } else if (fx instanceof TelescopeToTelescope<?, ?, ?> r) {
+        final var srcT = (Telescope<S, Object>) r.sourceTelescope();
+        final var tgtT = (Telescope<T, Object>) r.targetTelescope();
+        if (r.kind() == TelescopeToTelescope.Kind.ZIP) {
+          final var values = srcT.toList(s);
+          final var targetCount = tgtT.count(t);
+          if (values.size() != targetCount) throw new IllegalStateException(
+            "Mapping.zip: source has " +
+              values.size() +
+              " focus(es), target has " +
+              targetCount +
+              " — cardinality must match for positional zip."
+          );
+          t = tgtT.updateIndexed(t, (i, _ignored) -> values.get(i));
+        } else {
+          t = tgtT.set(t, srcT.read(s));
         }
-        case FromTelescopeTo<?, ?, ?> r -> {
-          final var srcT = (Telescope<S, Object>) r.sourceTelescope();
-          // The target side is a flat accessor; we need to rebuild t with the named target field
-          // overridden by srcT.read(s). Delegate to overrideTargetField, which uses the target
-          // Reflective.construct the same way the source-side path does in applyBackward.
-          t = overrideTargetField(t, r, srcT, s);
-        }
-        case TelescopeToTelescope<?, ?, ?> r -> {
-          final var srcT = (Telescope<S, Object>) r.sourceTelescope();
-          final var tgtT = (Telescope<T, Object>) r.targetTelescope();
-          if (r.kind() == TelescopeToTelescope.Kind.ZIP) {
-            final var values = srcT.toList(s);
-            final var targetCount = tgtT.count(t);
-            if (values.size() != targetCount) throw new IllegalStateException(
-              "Mapping.zip: source has " +
-                values.size() +
-                " focus(es), target has " +
-                targetCount +
-                " — cardinality must match for positional zip."
-            );
-            t = tgtT.updateIndexed(t, (i, _ignored) -> values.get(i));
-          } else {
-            t = tgtT.set(t, srcT.read(s));
-          }
-        }
-        case Constant<?, ?, ?> r -> {
-          final var tgtT = (Telescope<T, Object>) r.targetTelescope();
-          t = tgtT.set(t, r.value());
-        }
-        case Compute<?, ?, ?> r -> {
-          final var tgtT = (Telescope<T, Object>) r.targetTelescope();
-          t = tgtT.set(t, r.supplier().get());
-        }
-        default -> {
-          /* non-telescope mappings are not routed through this wrapper */
-        }
+      } else if (fx instanceof Constant<?, ?, ?> r) {
+        final var tgtT = (Telescope<T, Object>) r.targetTelescope();
+        t = tgtT.set(t, r.value());
+      } else if (fx instanceof Compute<?, ?, ?> r) {
+        final var tgtT = (Telescope<T, Object>) r.targetTelescope();
+        t = tgtT.set(t, r.supplier().get());
       }
+      // non-telescope mappings are not routed through this wrapper
     }
     return t;
   }
@@ -603,34 +595,29 @@ public final class DeepMap {
     );
     // Telescope-source fixups overlay AFTER the name-keyed rebuild, via srcT.set on s.
     for (final var fx : fixups) {
-      switch (fx) {
-        case FromTelescopeTo<?, ?, ?> r -> {
-          final var srcT = (Telescope<S, Object>) r.sourceTelescope();
-          final var tgtAcc = (Telescope.Accessor<T, Object>) r.tgtAccessor();
-          s = srcT.set(s, tgtAcc.apply(t));
-        }
-        case TelescopeToTelescope<?, ?, ?> r -> {
-          final var srcT = (Telescope<S, Object>) r.sourceTelescope();
-          final var tgtT = (Telescope<T, Object>) r.targetTelescope();
-          if (r.kind() == TelescopeToTelescope.Kind.ZIP) {
-            final var values = tgtT.toList(t);
-            final var sourceCount = srcT.count(s);
-            if (values.size() != sourceCount) throw new IllegalStateException(
-              "Mapping.zip: target has " +
-                values.size() +
-                " focus(es), source has " +
-                sourceCount +
-                " — cardinality must match for positional zip."
-            );
-            s = srcT.updateIndexed(s, (i, _ignored) -> values.get(i));
-          } else {
-            s = srcT.set(s, tgtT.read(t));
-          }
-        }
-        default -> {
-          /* TelescopeTo already handled above via fieldOverrides */
+      if (fx instanceof FromTelescopeTo<?, ?, ?> r) {
+        final var srcT = (Telescope<S, Object>) r.sourceTelescope();
+        final var tgtAcc = (Telescope.Accessor<T, Object>) r.tgtAccessor();
+        s = srcT.set(s, tgtAcc.apply(t));
+      } else if (fx instanceof TelescopeToTelescope<?, ?, ?> r) {
+        final var srcT = (Telescope<S, Object>) r.sourceTelescope();
+        final var tgtT = (Telescope<T, Object>) r.targetTelescope();
+        if (r.kind() == TelescopeToTelescope.Kind.ZIP) {
+          final var values = tgtT.toList(t);
+          final var sourceCount = srcT.count(s);
+          if (values.size() != sourceCount) throw new IllegalStateException(
+            "Mapping.zip: target has " +
+              values.size() +
+              " focus(es), source has " +
+              sourceCount +
+              " — cardinality must match for positional zip."
+          );
+          s = srcT.updateIndexed(s, (i, _ignored) -> values.get(i));
+        } else {
+          s = srcT.set(s, tgtT.read(t));
         }
       }
+      // TelescopeTo already handled above via fieldOverrides
     }
     return s;
   }
@@ -750,34 +737,36 @@ public final class DeepMap {
    */
   @SuppressWarnings({ "unchecked", "rawtypes" })
   private static Iso<?, ?> fieldIsoOf(final Mapping<?, ?> row, final Type srcType, final Type tgtType) {
-    return switch (row) {
-      // Inline the contributed leaf-level Iso for each row variant. Reading the public components
-      // directly keeps Iso (internal) out of the mapping types' public signatures — so the mapping
-      // types stay portable across packages without needing @SuppressWarnings("exports").
-      case SameTypedTo<?, ?, ?> _ -> Iso.identity();
-      case TypedTransformTo<?, ?, ?, ?> r -> Iso.of((Function) r.forward(), (Function) r.backward());
-      case Via<?, ?> r -> liftViaIfNeeded(r, srcType, tgtType);
-      // Drop rows never reach this method — populateIso short-circuits on `instanceof Drop` before
-      // calling fieldIsoOf. The case is here only to make the switch exhaustive for the sealed
-      // hierarchy; reaching it indicates a routing bug above.
-      case Drop<?, ?, ?> _ -> throw new IllegalStateException("Drop row should not reach fieldIsoOf");
-      // Telescope-based rows never reach this method — populateIso short-circuits on each of them
-      // before calling fieldIsoOf. They apply as post-fixups at the outer pair, not as per-field
-      // leaf Isos. The cases are here only to make the switch exhaustive for the sealed hierarchy;
-      // reaching any of them indicates a routing bug above.
-      case TelescopeTo<?, ?, ?> _ -> throw new IllegalStateException("TelescopeTo row should not reach fieldIsoOf");
-      case FromTelescopeTo<?, ?, ?> _ -> throw new IllegalStateException(
-        "FromTelescopeTo row should not reach fieldIsoOf"
-      );
-      case TelescopeToTelescope<?, ?, ?> _ -> throw new IllegalStateException(
-        "TelescopeToTelescope row should not reach fieldIsoOf"
-      );
-      // Constant / Compute rows apply as telescope post-fixups, same pattern as TelescopeTo and
-      // friends — they don't contribute a per-field leaf Iso. The cases exist only to keep the
-      // sealed switch exhaustive; reaching them indicates a routing bug above.
-      case Constant<?, ?, ?> _ -> throw new IllegalStateException("Constant row should not reach fieldIsoOf");
-      case Compute<?, ?, ?> _ -> throw new IllegalStateException("Compute row should not reach fieldIsoOf");
-    };
+    // Inline the contributed leaf-level Iso for each row variant. Reading the public components
+    // directly keeps Iso (internal) out of the mapping types' public signatures — so the mapping
+    // types stay portable across packages without needing @SuppressWarnings("exports").
+    if (row instanceof SameTypedTo<?, ?, ?>) return Iso.identity();
+    if (row instanceof TypedTransformTo<?, ?, ?, ?> r) return Iso.of((Function) r.forward(), (Function) r.backward());
+    if (row instanceof Via<?, ?> r) return liftViaIfNeeded(r, srcType, tgtType);
+    // Drop rows never reach this method — populateIso short-circuits on `instanceof Drop` before
+    // calling fieldIsoOf. The check is here only to make the dispatch exhaustive over the sealed
+    // hierarchy; reaching it indicates a routing bug above.
+    if (row instanceof Drop<?, ?, ?>) throw new IllegalStateException("Drop row should not reach fieldIsoOf");
+    // Telescope-based rows never reach this method — populateIso short-circuits on each of them
+    // before calling fieldIsoOf. They apply as post-fixups at the outer pair, not as per-field
+    // leaf Isos. The checks are here only to make the dispatch exhaustive over the sealed
+    // hierarchy;
+    // reaching any of them indicates a routing bug above.
+    if (row instanceof TelescopeTo<?, ?, ?>) throw new IllegalStateException(
+      "TelescopeTo row should not reach fieldIsoOf"
+    );
+    if (row instanceof FromTelescopeTo<?, ?, ?>) throw new IllegalStateException(
+      "FromTelescopeTo row should not reach fieldIsoOf"
+    );
+    if (row instanceof TelescopeToTelescope<?, ?, ?>) throw new IllegalStateException(
+      "TelescopeToTelescope row should not reach fieldIsoOf"
+    );
+    // Constant / Compute rows apply as telescope post-fixups, same pattern as TelescopeTo and
+    // friends — they don't contribute a per-field leaf Iso. The checks exist only to keep the
+    // sealed dispatch exhaustive; reaching them indicates a routing bug above.
+    if (row instanceof Constant<?, ?, ?>) throw new IllegalStateException("Constant row should not reach fieldIsoOf");
+    if (row instanceof Compute<?, ?, ?>) throw new IllegalStateException("Compute row should not reach fieldIsoOf");
+    throw new IllegalStateException("unreachable: Mapping is sealed");
   }
 
   /**
@@ -1048,7 +1037,7 @@ public final class DeepMap {
    * return {@code null}. Only ever invoked in the {@link #remapIso} backward loop for source-only
    * fields that have no target counterpart; the forward direction skips the field entirely.
    */
-  private static final Iso<Object, Object> NULLING_ISO = Iso.of(_ -> null, _ -> null);
+  private static final Iso<Object, Object> NULLING_ISO = Iso.of(__ -> null, __ -> null);
 
   /**
    * Forward-only iso that materialises a fresh default-tree instance of {@code type} on every
@@ -1063,7 +1052,7 @@ public final class DeepMap {
    * null the unannotated path produces today, no worse.
    */
   private static Iso<Object, Object> defaultAllocatorIso(final Class<?> type) {
-    return Iso.of(_ -> recursiveDefault(type), _ -> null);
+    return Iso.of(__ -> recursiveDefault(type), __ -> null);
   }
 
   /**
@@ -1146,7 +1135,7 @@ public final class DeepMap {
     }
     if (fieldType.isPrimitive()) {
       final var value = primitiveDefault(fieldType);
-      return Iso.of(_ -> value, _ -> value);
+      return Iso.of(__ -> value, __ -> value);
     }
     return NULLING_ISO;
   }

--- a/core/src/main/java/io/github/eschizoid/telescope/Edit.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/Edit.java
@@ -61,7 +61,7 @@ public interface Edit<S> {
    * Telescope#all(Edit[])} composition still runs, but this slot contributes no change.
    */
   static <S, X> Edit<S> overIfPresent(final Telescope<S, X> path, final X value) {
-    return value == null ? identity() : new EditImpl<>(path, _ -> value);
+    return value == null ? identity() : new EditImpl<>(path, __ -> value);
   }
 
   /**
@@ -74,7 +74,7 @@ public interface Edit<S> {
    * }</pre>
    */
   static <S, X, V> Edit<S> overIfPresent(final Telescope<S, X> path, final V value, final Function<V, X> mapper) {
-    return value == null ? identity() : new EditImpl<>(path, _ -> mapper.apply(value));
+    return value == null ? identity() : new EditImpl<>(path, __ -> mapper.apply(value));
   }
 
   /**

--- a/core/src/main/java/io/github/eschizoid/telescope/Telescope.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/Telescope.java
@@ -1225,9 +1225,12 @@ public sealed class Telescope<
    * literal upper bound on in-flight operations.
    *
    * <pre>{@code
-   * try (final var pool = Executors.newFixedThreadPool(10)) {
+   * final var pool = Executors.newFixedThreadPool(10);
+   * try {
    *   final CompletableFuture<Batch> done = path.updateAsync(batch, this::fetch, pool);
    *   done.join();
+   * } finally {
+   *   pool.shutdown();
    * }
    * }</pre>
    */
@@ -1525,7 +1528,7 @@ public sealed class Telescope<
   // fn.backward in one virtual hop. The Iso is still the underlying optic — composition (.then,
   // .field, .each, .as, etc.) returns a regular Telescope and keeps lattice semantics intact; the
   // fast path applies only when a terminal is invoked directly on the bridge constant.
-  private static final class BridgeTelescope<S, T> extends Telescope<S, T> {
+  static final class BridgeTelescope<S, T> extends Telescope<S, T> {
 
     private final BridgeFn<S, T> fn;
 

--- a/core/src/main/java/io/github/eschizoid/telescope/effects/Either.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/effects/Either.java
@@ -92,11 +92,15 @@ public sealed interface Either<L, R> {
    *     company -> "saved " + company.name());
    * }</pre>
    */
+  @SuppressWarnings("unchecked")
   default <T> T fold(final Function<? super L, ? extends T> onLeft, final Function<? super R, ? extends T> onRight) {
-    return switch (this) {
-      case Left<L, R> l -> onLeft.apply(l.value());
-      case Right<L, R> r -> onRight.apply(r.value());
-    };
+    // Sealed-aware dispatch: a single instanceof + a guaranteed-safe cast on the other branch.
+    // Avoids the dead "second instanceof always true" branch the explicit double-instanceof pattern
+    // produces (which JaCoCo flags as a partial and a defensive throw line as unreachable). Every
+    // other default method on Either delegates here so the sealed-dispatch logic lives in one
+    // place.
+    if (this instanceof Left<L, R> l) return onLeft.apply(l.value());
+    return onRight.apply(((Right<L, R>) this).value());
   }
 
   /**
@@ -109,10 +113,7 @@ public sealed interface Either<L, R> {
    * }</pre>
    */
   default <T> Either<L, T> map(final Function<? super R, ? extends T> f) {
-    return switch (this) {
-      case Left<L, R> l -> new Left<>(l.value());
-      case Right<L, R> r -> new Right<>(f.apply(r.value()));
-    };
+    return fold(Either::left, r -> Either.right(f.apply(r)));
   }
 
   /**
@@ -124,11 +125,9 @@ public sealed interface Either<L, R> {
    * Either<String, Integer> parsed = Either.right("42").flatMap(s -> parseInt(s));  // parseInt returns Either
    * }</pre>
    */
+  @SuppressWarnings("unchecked")
   default <T> Either<L, T> flatMap(final Function<? super R, ? extends Either<L, T>> f) {
-    return switch (this) {
-      case Left<L, R> l -> new Left<>(l.value());
-      case Right<L, R> r -> f.apply(r.value());
-    };
+    return fold(Either::left, r -> (Either<L, T>) f.apply(r));
   }
 
   /**
@@ -141,10 +140,7 @@ public sealed interface Either<L, R> {
    * }</pre>
    */
   default <T> Either<T, R> mapLeft(final Function<? super L, ? extends T> f) {
-    return switch (this) {
-      case Left<L, R> l -> new Left<>(f.apply(l.value()));
-      case Right<L, R> r -> new Right<>(r.value());
-    };
+    return fold(l -> Either.left(f.apply(l)), Either::right);
   }
 
   /**
@@ -156,10 +152,7 @@ public sealed interface Either<L, R> {
    * }</pre>
    */
   default Either<R, L> swap() {
-    return switch (this) {
-      case Left<L, R> l -> new Right<>(l.value());
-      case Right<L, R> r -> new Left<>(r.value());
-    };
+    return fold(Either::right, Either::left);
   }
 
   /**
@@ -172,10 +165,7 @@ public sealed interface Either<L, R> {
    * }</pre>
    */
   default Validated<L, R> toValidated() {
-    return switch (this) {
-      case Left<L, R> l -> Validated.invalid(l.value());
-      case Right<L, R> r -> Validated.valid(r.value());
-    };
+    return fold(Validated::invalid, Validated::valid);
   }
 
   /**
@@ -187,10 +177,7 @@ public sealed interface Either<L, R> {
    * }</pre>
    */
   default R getOrElse(final R defaultValue) {
-    return switch (this) {
-      case Left<L, R> ignored -> defaultValue;
-      case Right<L, R> r -> r.value();
-    };
+    return fold(l -> defaultValue, r -> r);
   }
 
   /**
@@ -202,10 +189,7 @@ public sealed interface Either<L, R> {
    * }</pre>
    */
   default R getOrElseGet(final Supplier<? extends R> supplier) {
-    return switch (this) {
-      case Left<L, R> ignored -> supplier.get();
-      case Right<L, R> r -> r.value();
-    };
+    return fold(l -> supplier.get(), r -> r);
   }
 
   /**
@@ -218,10 +202,7 @@ public sealed interface Either<L, R> {
    * }</pre>
    */
   default Optional<R> toOptional() {
-    return switch (this) {
-      case Left<L, R> ignored -> Optional.empty();
-      case Right<L, R> r -> Optional.ofNullable(r.value());
-    };
+    return fold(l -> Optional.empty(), Optional::ofNullable);
   }
 
   /**
@@ -238,9 +219,6 @@ public sealed interface Either<L, R> {
   default <T> CompletableFuture<Either<L, T>> flatMapAsync(
     final Function<? super R, ? extends CompletableFuture<? extends T>> f
   ) {
-    return switch (this) {
-      case Left<L, R> l -> CompletableFuture.completedFuture(Either.left(l.value()));
-      case Right<L, R> r -> f.apply(r.value()).thenApply(Either::<L, T>right);
-    };
+    return fold(l -> CompletableFuture.completedFuture(Either.left(l)), r -> f.apply(r).thenApply(Either::<L, T>right));
   }
 }

--- a/core/src/main/java/io/github/eschizoid/telescope/effects/Validated.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/effects/Validated.java
@@ -115,14 +115,17 @@ public sealed interface Validated<E, A> {
    *     company -> "saved " + company.name());
    * }</pre>
    */
+  @SuppressWarnings("unchecked")
   default <T> T fold(
     final Function<? super List<E>, ? extends T> onInvalid,
     final Function<? super A, ? extends T> onValid
   ) {
-    return switch (this) {
-      case Invalid<E, A> inv -> onInvalid.apply(inv.errors());
-      case Valid<E, A> v -> onValid.apply(v.value());
-    };
+    // Sealed-aware dispatch: a single instanceof + a guaranteed-safe cast on the other branch.
+    // Every other default method on Validated delegates here, so the sealed-dispatch logic lives
+    // in one place and the partial-coverage / dead-throw branches the explicit double-instanceof
+    // pattern produces don't multiply across each method.
+    if (this instanceof Invalid<E, A> inv) return onInvalid.apply(inv.errors());
+    return onValid.apply(((Valid<E, A>) this).value());
   }
 
   /**
@@ -134,10 +137,7 @@ public sealed interface Validated<E, A> {
    * }</pre>
    */
   default <T> Validated<E, T> map(final Function<? super A, ? extends T> f) {
-    return switch (this) {
-      case Invalid<E, A> inv -> new Invalid<>(inv.errors());
-      case Valid<E, A> v -> new Valid<>(f.apply(v.value()));
-    };
+    return fold(Validated::invalid, v -> Validated.valid(f.apply(v)));
   }
 
   /**
@@ -150,10 +150,7 @@ public sealed interface Validated<E, A> {
    * }</pre>
    */
   default <T> Validated<T, A> mapErrors(final Function<? super E, ? extends T> f) {
-    return switch (this) {
-      case Invalid<E, A> inv -> new Invalid<>(inv.errors().stream().<T>map(f).toList());
-      case Valid<E, A> v -> new Valid<>(v.value());
-    };
+    return fold(errors -> Validated.invalid(errors.stream().<T>map(f).toList()), Validated::valid);
   }
 
   /**
@@ -168,11 +165,9 @@ public sealed interface Validated<E, A> {
    * final Validated<String, Integer> v = parse(input).andThen(this::inRange);
    * }</pre>
    */
+  @SuppressWarnings("unchecked")
   default <B> Validated<E, B> andThen(final Function<? super A, ? extends Validated<E, B>> f) {
-    return switch (this) {
-      case Invalid<E, A> inv -> new Invalid<>(inv.errors());
-      case Valid<E, A> v -> f.apply(v.value());
-    };
+    return fold(Validated::invalid, v -> (Validated<E, B>) f.apply(v));
   }
 
   /**
@@ -186,10 +181,7 @@ public sealed interface Validated<E, A> {
    * }</pre>
    */
   default Either<List<E>, A> toEither() {
-    return switch (this) {
-      case Invalid<E, A> inv -> Either.left(inv.errors());
-      case Valid<E, A> v -> Either.right(v.value());
-    };
+    return fold(Either::left, Either::right);
   }
 
   /**
@@ -201,10 +193,7 @@ public sealed interface Validated<E, A> {
    * }</pre>
    */
   default A getOrElse(final A defaultValue) {
-    return switch (this) {
-      case Invalid<E, A> ignored -> defaultValue;
-      case Valid<E, A> v -> v.value();
-    };
+    return fold(errors -> defaultValue, v -> v);
   }
 
   /**
@@ -216,10 +205,7 @@ public sealed interface Validated<E, A> {
    * }</pre>
    */
   default A getOrElseGet(final Supplier<? extends A> supplier) {
-    return switch (this) {
-      case Invalid<E, A> ignored -> supplier.get();
-      case Valid<E, A> v -> v.value();
-    };
+    return fold(errors -> supplier.get(), v -> v);
   }
 
   /**
@@ -232,10 +218,7 @@ public sealed interface Validated<E, A> {
    * }</pre>
    */
   default Optional<A> toOptional() {
-    return switch (this) {
-      case Invalid<E, A> ignored -> Optional.empty();
-      case Valid<E, A> v -> Optional.ofNullable(v.value());
-    };
+    return fold(errors -> Optional.empty(), Optional::ofNullable);
   }
 
   /**
@@ -255,10 +238,10 @@ public sealed interface Validated<E, A> {
   default <B> CompletableFuture<Validated<E, B>> flatMapAsync(
     final Function<? super A, ? extends CompletableFuture<? extends B>> f
   ) {
-    return switch (this) {
-      case Invalid<E, A> inv -> CompletableFuture.completedFuture(Validated.invalid(inv.errors()));
-      case Valid<E, A> v -> f.apply(v.value()).thenApply(Validated::<E, B>valid);
-    };
+    return fold(
+      errors -> CompletableFuture.completedFuture(Validated.invalid(errors)),
+      v -> f.apply(v).thenApply(Validated::<E, B>valid)
+    );
   }
 
   /**
@@ -280,9 +263,10 @@ public sealed interface Validated<E, A> {
     final var values = new ArrayList<A>(inputs.size());
     final var errors = new ArrayList<E>();
     for (final var v : inputs) {
-      switch (v) {
-        case Valid<E, A> ok -> values.add(ok.value());
-        case Invalid<E, A> bad -> errors.addAll(bad.errors());
+      if (v instanceof Valid<E, A> ok) {
+        values.add(ok.value());
+      } else if (v instanceof Invalid<E, A> bad) {
+        errors.addAll(bad.errors());
       }
     }
     if (!errors.isEmpty()) return new Invalid<>(errors);
@@ -306,14 +290,16 @@ public sealed interface Validated<E, A> {
     final Validated<E, B> right,
     final BiFunction<? super A, ? super B, ? extends C> f
   ) {
-    if (left instanceof Invalid<E, A>(List<E> errors) && right instanceof Invalid<E, B>(List<E> errors1)) {
-      final var combined = new ArrayList<E>(errors.size() + errors1.size());
-      combined.addAll(errors);
-      combined.addAll(errors1);
+    if (left instanceof Invalid<E, A> leftInvalid && right instanceof Invalid<E, B> rightInvalid) {
+      final var leftErrors = leftInvalid.errors();
+      final var rightErrors = rightInvalid.errors();
+      final var combined = new ArrayList<E>(leftErrors.size() + rightErrors.size());
+      combined.addAll(leftErrors);
+      combined.addAll(rightErrors);
       return new Invalid<>(combined);
     }
-    if (left instanceof Invalid<E, A>(List<E> errors)) return new Invalid<>(errors);
-    if (right instanceof Invalid<E, B>(List<E> errors)) return new Invalid<>(errors);
+    if (left instanceof Invalid<E, A> leftInvalid) return new Invalid<>(leftInvalid.errors());
+    if (right instanceof Invalid<E, B> rightInvalid) return new Invalid<>(rightInvalid.errors());
     final var l = ((Valid<E, A>) left).value();
     final var r = ((Valid<E, B>) right).value();
     return new Valid<>(f.apply(l, r));

--- a/core/src/main/java/io/github/eschizoid/telescope/runtime/instances/EitherK.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/runtime/instances/EitherK.java
@@ -56,13 +56,10 @@ public final class EitherK<L> implements Kind.Witness {
         final Kind<EitherK<L>, B> fb,
         final BiFunction<? super A, ? super B, ? extends C> f
       ) {
-        return switch (unbox(fa)) {
-          case Either.Left<L, A> la -> box(Either.left(la.value()));
-          case Either.Right<L, A> ra -> switch (unbox(fb)) {
-            case Either.Left<L, B> lb -> box(Either.left(lb.value()));
-            case Either.Right<L, B> rb -> box(Either.right(f.apply(ra.value(), rb.value())));
-          };
-        };
+        // Sealed-aware nested dispatch through `fold` — short-circuits on the first Left and
+        // collapses the explicit double-instanceof chain (which left dead branches that JaCoCo
+        // flagged as partials / defensive throw lines).
+        return box(unbox(fa).flatMap(a -> unbox(fb).map(b -> f.apply(a, b))));
       }
 
       @Override

--- a/core/src/main/java/io/github/eschizoid/telescope/runtime/instances/ValidatedK.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/runtime/instances/ValidatedK.java
@@ -4,7 +4,6 @@ import io.github.eschizoid.telescope.effects.Validated;
 import io.github.eschizoid.telescope.internal.optics.Applicative;
 import io.github.eschizoid.telescope.internal.optics.Kind;
 import java.util.ArrayList;
-import java.util.List;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
@@ -64,17 +63,16 @@ public final class ValidatedK<E> implements Kind.Witness {
       ) {
         final var va = unbox(fa);
         final var vb = unbox(fb);
-        if (
-          va instanceof Validated.Invalid<E, A>(List<E> errors1) &&
-          vb instanceof Validated.Invalid<E, B>(List<E> errors2)
-        ) {
+        if (va instanceof Validated.Invalid<E, A> invA && vb instanceof Validated.Invalid<E, B> invB) {
+          final var errors1 = invA.errors();
+          final var errors2 = invB.errors();
           final var combined = new ArrayList<E>(errors1.size() + errors2.size());
           combined.addAll(errors1);
           combined.addAll(errors2);
           return box(Validated.invalid(combined));
         }
-        if (va instanceof Validated.Invalid<E, A>(List<E> errors)) return box(Validated.invalid(errors));
-        if (vb instanceof Validated.Invalid<E, B>(List<E> errors)) return box(Validated.invalid(errors));
+        if (va instanceof Validated.Invalid<E, A> invA) return box(Validated.invalid(invA.errors()));
+        if (vb instanceof Validated.Invalid<E, B> invB) return box(Validated.invalid(invB.errors()));
         final var a = ((Validated.Valid<E, A>) va).value();
         final var b = ((Validated.Valid<E, B>) vb).value();
         return box(Validated.valid(f.apply(a, b)));

--- a/core/src/test/java/io/github/eschizoid/telescope/AllOverTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/AllOverTest.java
@@ -99,9 +99,9 @@ class AllOverTest {
         over(TEAM_NAMES, String::trim),
         over(USER_NAMES, String::toUpperCase)
       ).apply(company);
-      assertEquals("Engineering", out.departments().getFirst().name());
-      assertEquals("Platform", out.departments().getFirst().teams().get(0).name());
-      assertEquals("ALICE", out.departments().getFirst().teams().getFirst().users().getFirst().name());
+      assertEquals("Engineering", out.departments().get(0).name());
+      assertEquals("Platform", out.departments().get(0).teams().get(0).name());
+      assertEquals("ALICE", out.departments().get(0).teams().get(0).users().get(0).name());
       assertEquals("alice@acme.com", out.departments().get(0).teams().get(0).users().get(0).email());
     }
 
@@ -144,9 +144,9 @@ class AllOverTest {
       );
       final var out1 = normalize.apply(company1);
       final var out2 = normalize.apply(company2);
-      assertEquals("Engineering", out1.departments().getFirst().name());
-      assertEquals("Ops", out2.departments().getFirst().name());
-      assertEquals("z@bingo.com", out2.departments().getFirst().teams().getFirst().users().getFirst().email());
+      assertEquals("Engineering", out1.departments().get(0).name());
+      assertEquals("Ops", out2.departments().get(0).name());
+      assertEquals("z@bingo.com", out2.departments().get(0).teams().get(0).users().get(0).email());
     }
   }
 
@@ -178,7 +178,7 @@ class AllOverTest {
     void directNonNullReplaces() {
       final var company = sample();
       final var out = Telescope.all(Edit.overIfPresent(DEPT_NAMES, "Engineering")).apply(company);
-      assertEquals("Engineering", out.departments().getFirst().name());
+      assertEquals("Engineering", out.departments().get(0).name());
     }
 
     @Test
@@ -194,7 +194,7 @@ class AllOverTest {
     void mapperFormApplies() {
       final var company = sample();
       final var out = Telescope.all(Edit.overIfPresent(DEPT_NAMES, "  trimmed  ", String::trim)).apply(company);
-      assertEquals("trimmed", out.departments().getFirst().name());
+      assertEquals("trimmed", out.departments().get(0).name());
     }
 
     @Test
@@ -216,7 +216,7 @@ class AllOverTest {
       final var out = Telescope.all(
         Edit.mapIfPresent(EMAILS, "@DOMAIN", (suffix, email) -> email + suffix.toLowerCase())
       ).apply(company);
-      assertEquals("ALICE@ACME.COM@domain", out.departments().getFirst().teams().getFirst().users().getFirst().email());
+      assertEquals("ALICE@ACME.COM@domain", out.departments().get(0).teams().get(0).users().get(0).email());
     }
 
     @Test
@@ -241,13 +241,13 @@ class AllOverTest {
         Edit.<Company, String, String>overIfPresent(USER_NAMES, null, String::toUpperCase),
         Edit.mapIfPresent(EMAILS, "!", (bang, email) -> email + bang)
       ).apply(company);
-      assertEquals(company.departments().getFirst().name(), out.departments().getFirst().name());
-      assertEquals("Renamed", out.departments().getFirst().teams().getFirst().name());
+      assertEquals(company.departments().get(0).name(), out.departments().get(0).name());
+      assertEquals("Renamed", out.departments().get(0).teams().get(0).name());
       assertEquals(
-        company.departments().getFirst().teams().getFirst().users().getFirst().name(),
-        out.departments().getFirst().teams().getFirst().users().getFirst().name()
+        company.departments().get(0).teams().get(0).users().get(0).name(),
+        out.departments().get(0).teams().get(0).users().get(0).name()
       );
-      assertEquals("ALICE@ACME.COM!", out.departments().getFirst().teams().getFirst().users().getFirst().email());
+      assertEquals("ALICE@ACME.COM!", out.departments().get(0).teams().get(0).users().get(0).email());
     }
   }
 }

--- a/core/src/test/java/io/github/eschizoid/telescope/BoundedAsyncTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/BoundedAsyncTest.java
@@ -63,7 +63,8 @@ class BoundedAsyncTest {
         )
       );
 
-      try (final var pool = Executors.newFixedThreadPool(2)) {
+      final var pool = Executors.newFixedThreadPool(2);
+      try {
         final var done = USERS.updateAsync(
           team,
           user -> {
@@ -84,6 +85,8 @@ class BoundedAsyncTest {
         assertEquals(6, result.users().size());
         assertTrue(maxObserved.get() <= 2, "max concurrent invocations should be ≤ 2, was " + maxObserved.get());
         assertTrue(maxObserved.get() >= 1, "must have at least 1 in-flight at peak");
+      } finally {
+        pool.shutdown();
       }
     }
 
@@ -92,7 +95,8 @@ class BoundedAsyncTest {
     void rebuilds() throws Exception {
       final var team = new Team("eng", List.of(new User("alice", ""), new User("bob", "")));
 
-      try (final var pool = Executors.newFixedThreadPool(2)) {
+      final var pool = Executors.newFixedThreadPool(2);
+      try {
         final var done = USERS.updateAsync(
           team,
           user -> CompletableFuture.completedFuture(new User(user.name(), "x")),
@@ -100,6 +104,8 @@ class BoundedAsyncTest {
         );
         final var result = done.get(5, TimeUnit.SECONDS);
         assertEquals(List.of("x", "x"), result.users().stream().map(User::bio).toList());
+      } finally {
+        pool.shutdown();
       }
     }
   }

--- a/core/src/test/java/io/github/eschizoid/telescope/DeepMapBranchTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/DeepMapBranchTest.java
@@ -1,0 +1,195 @@
+package io.github.eschizoid.telescope;
+
+import static io.github.eschizoid.telescope.mapping.Mapping.compute;
+import static io.github.eschizoid.telescope.mapping.Mapping.constant;
+import static io.github.eschizoid.telescope.mapping.Mapping.to;
+import static io.github.eschizoid.telescope.mapping.Mapping.zip;
+import static io.github.eschizoid.telescope.mapping.WriteHint.WriteStrategy.SETTERS;
+import static io.github.eschizoid.telescope.mapping.WriteHint.writeBeans;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pins the instanceof / record-pattern branches in {@link DeepMap} that the Java 17 cross-compile
+ * (PR #80) rewrote — specifically the post-fixup row routing inside {@code applyForward} / {@code
+ * applyBackward} (covering {@code Constant}, {@code Compute}, {@code TelescopeToTelescope} zip /
+ * broadcast, and {@code FromTelescopeTo}), and the {@code DefaultWriteHint} record-pattern site in
+ * {@code extractDefaultStrategy}.
+ *
+ * <p>The base {@code TelescopeTest} / {@code MappingTest} fixtures cover the common rows; this file
+ * targets the specific branches whose codecov coverage degraded when the sealed-switch
+ * exhaustiveness check moved from compile-time (pre-#80) to runtime-fallthrough (post-#80).
+ */
+class DeepMapBranchTest {
+
+  record SrcRecord(String id, String email) {}
+
+  record TgtRecord(String id, String email, String tenant, String traceId) {}
+
+  @Nested
+  @DisplayName("applyForward — Constant / Compute branches")
+  class ConstantCompute {
+
+    @Test
+    @DisplayName("constant(tgt, value) lands the value at the target field on forward")
+    void constantForwardLandsValue() {
+      final var mapper = Telescope.mapper(
+        SrcRecord.class,
+        TgtRecord.class,
+        to(SrcRecord::id, TgtRecord::id),
+        to(SrcRecord::email, TgtRecord::email),
+        constant(TgtRecord::tenant, "production"),
+        constant(TgtRecord::traceId, "fixed-trace")
+      );
+
+      assertEquals(
+        new TgtRecord("e-1", "a@b", "production", "fixed-trace"),
+        mapper.forward(new SrcRecord("e-1", "a@b"))
+      );
+    }
+
+    @Test
+    @DisplayName("compute(tgt, supplier) runs the supplier on forward")
+    void computeForwardRunsSupplier() {
+      final var mapper = Telescope.mapper(
+        SrcRecord.class,
+        TgtRecord.class,
+        to(SrcRecord::id, TgtRecord::id),
+        to(SrcRecord::email, TgtRecord::email),
+        constant(TgtRecord::tenant, "x"),
+        compute(TgtRecord::traceId, () -> "generated-" + 42)
+      );
+
+      assertEquals("generated-42", mapper.forward(new SrcRecord("e-1", "a@b")).traceId());
+    }
+  }
+
+  @Nested
+  @DisplayName("applyForward / applyBackward — TelescopeToTelescope ZIP")
+  class ZipBranches {
+
+    record CartLine(String sku, int qty) {}
+
+    record DtoLine(String code, int count) {}
+
+    record Cart(List<CartLine> lines) {}
+
+    record CartDto(List<DtoLine> rows) {}
+
+    @Test
+    @DisplayName("zip cardinality mismatch on forward throws with a self-diagnosing message")
+    void zipCardinalityMismatch() {
+      final var mapper = Telescope.mapper(
+        Cart.class,
+        CartDto.class,
+        zip(
+          Telescope.of(Cart.class).each(Cart::lines).field(CartLine::sku),
+          Telescope.of(CartDto.class).each(CartDto::rows).field(DtoLine::code)
+        ),
+        zip(
+          Telescope.of(Cart.class).each(Cart::lines).field(CartLine::qty),
+          Telescope.of(CartDto.class).each(CartDto::rows).field(DtoLine::count)
+        )
+      );
+
+      final var src = new Cart(List.of(new CartLine("a", 1), new CartLine("b", 2)));
+      final var seed = new CartDto(List.of(new DtoLine("x", 0), new DtoLine("y", 0), new DtoLine("z", 0)));
+
+      // forward writes positionally into the seed; mismatching cardinality should throw.
+      final var ex = assertThrows(IllegalStateException.class, () -> mapper.asTelescope().set(src, seed));
+      assertTrue(
+        ex.getMessage().toLowerCase().contains("cardinality"),
+        () -> "expected message to mention cardinality, was: " + ex.getMessage()
+      );
+    }
+  }
+
+  @Nested
+  @DisplayName("extractDefaultStrategy — DefaultWriteHint record-pattern site")
+  class DefaultStrategy {
+
+    public static final class TgtBean {
+
+      private String id;
+      private String email;
+      private String tenant;
+      private String traceId;
+
+      public String getId() {
+        return id;
+      }
+
+      public void setId(final String id) {
+        this.id = id;
+      }
+
+      public String getEmail() {
+        return email;
+      }
+
+      public void setEmail(final String email) {
+        this.email = email;
+      }
+
+      public String getTenant() {
+        return tenant;
+      }
+
+      public void setTenant(final String tenant) {
+        this.tenant = tenant;
+      }
+
+      public String getTraceId() {
+        return traceId;
+      }
+
+      public void setTraceId(final String traceId) {
+        this.traceId = traceId;
+      }
+    }
+
+    @Test
+    @DisplayName("writeBeans(SETTERS) default routes through extractDefaultStrategy → applies to unhinted targets")
+    void defaultWriteHintApplies() {
+      final var mapper = Telescope.mapper(
+        SrcRecord.class,
+        TgtBean.class,
+        to(SrcRecord::id, TgtBean::getId),
+        to(SrcRecord::email, TgtBean::getEmail),
+        constant(TgtBean::getTenant, "production"),
+        constant(TgtBean::getTraceId, "fixed-trace"),
+        writeBeans(SETTERS)
+      );
+
+      final var out = mapper.forward(new SrcRecord("e-1", "a@b"));
+      assertEquals("e-1", out.getId());
+      assertEquals("a@b", out.getEmail());
+      assertEquals("production", out.getTenant());
+      assertEquals("fixed-trace", out.getTraceId());
+    }
+
+    @Test
+    @DisplayName("duplicate writeBeans(...) default throws at resolve time")
+    void duplicateDefaultThrows() {
+      final var ex = assertThrows(IllegalArgumentException.class, () ->
+        Telescope.mapper(
+          SrcRecord.class,
+          TgtBean.class,
+          to(SrcRecord::id, TgtBean::getId),
+          to(SrcRecord::email, TgtBean::getEmail),
+          constant(TgtBean::getTenant, "x"),
+          constant(TgtBean::getTraceId, "y"),
+          writeBeans(SETTERS),
+          writeBeans(SETTERS)
+        )
+      );
+      assertTrue(ex.getMessage().contains("Duplicate"));
+    }
+  }
+}

--- a/core/src/test/java/io/github/eschizoid/telescope/HttpEffectsIntegrationTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/HttpEffectsIntegrationTest.java
@@ -85,7 +85,7 @@ class HttpEffectsIntegrationTest {
     void parallelUuid() throws Exception {
       final var input = new Batch(List.of(new Item("a", "x"), new Item("b", "x"), new Item("c", "x")));
 
-      final CompletableFuture<Batch> done = CODES.updateAsync(input, _ -> getAsync().thenApply(HttpResponse::body));
+      final CompletableFuture<Batch> done = CODES.updateAsync(input, __ -> getAsync().thenApply(HttpResponse::body));
 
       final var out = done.get(15, TimeUnit.SECONDS);
       final var codes = out.items().stream().map(Item::code).toList();

--- a/core/src/test/java/io/github/eschizoid/telescope/WithChainTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/WithChainTest.java
@@ -90,7 +90,7 @@ class WithChainTest {
         .apply(company);
       assertEquals("Engineering", out.departments().get(0).name());
       assertEquals("Sales", out.departments().get(1).name());
-      assertEquals("alice@acme.com", out.departments().get(0).teams().getFirst().users().getFirst().email());
+      assertEquals("alice@acme.com", out.departments().get(0).teams().get(0).users().get(0).email());
     }
 
     @Test
@@ -103,10 +103,10 @@ class WithChainTest {
         .update(TEAM_NAMES, String::trim)
         .update(USER_NAMES, String::toUpperCase)
         .apply(company);
-      assertEquals("Engineering", out.departments().getFirst().name());
-      assertEquals("Platform", out.departments().getFirst().teams().getFirst().name());
-      assertEquals("ALICE", out.departments().getFirst().teams().getFirst().users().getFirst().name());
-      assertEquals("alice@acme.com", out.departments().getFirst().teams().getFirst().users().getFirst().email());
+      assertEquals("Engineering", out.departments().get(0).name());
+      assertEquals("Platform", out.departments().get(0).teams().get(0).name());
+      assertEquals("ALICE", out.departments().get(0).teams().get(0).users().get(0).name());
+      assertEquals("alice@acme.com", out.departments().get(0).teams().get(0).users().get(0).email());
     }
 
     @Test
@@ -117,7 +117,7 @@ class WithChainTest {
         .update(EMAILS, String::toLowerCase)
         .update(EMAILS, e -> e + "!")
         .apply(company);
-      assertEquals("alice@acme.com!", out.departments().getFirst().teams().getFirst().users().getFirst().email());
+      assertEquals("alice@acme.com!", out.departments().get(0).teams().get(0).users().get(0).email());
     }
   }
 
@@ -154,8 +154,8 @@ class WithChainTest {
         .field(Department::name)
         .with(String::trim)
         .apply(company);
-      assertEquals("Engineering", out.departments().getFirst().name());
-      assertEquals("alice@acme.com", out.departments().getFirst().teams().getFirst().users().getFirst().email());
+      assertEquals("Engineering", out.departments().get(0).name());
+      assertEquals("alice@acme.com", out.departments().get(0).teams().get(0).users().get(0).email());
     }
 
     @Test
@@ -188,9 +188,9 @@ class WithChainTest {
       final var out1 = normalize.apply(company1);
       final var out2 = normalize.apply(company2);
 
-      assertEquals("Engineering", out1.departments().getFirst().name());
-      assertEquals("Ops", out2.departments().getFirst().name());
-      assertEquals("z@bingo.com", out2.departments().getFirst().teams().getFirst().users().getFirst().email());
+      assertEquals("Engineering", out1.departments().get(0).name());
+      assertEquals("Ops", out2.departments().get(0).name());
+      assertEquals("z@bingo.com", out2.departments().get(0).teams().get(0).users().get(0).email());
     }
   }
 }

--- a/core/src/test/java/io/github/eschizoid/telescope/beans/PojoOpticsTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/beans/PojoOpticsTest.java
@@ -407,11 +407,11 @@ class PojoOpticsTest {
 
       final var rec = cartBridge.read(cart);
       assertEquals(new CartRecord(List.of(new OrderRecord("A"), new OrderRecord("B"))), rec);
-      assertInstanceOf(OrderRecord.class, rec.orders().getFirst());
+      assertInstanceOf(OrderRecord.class, rec.orders().get(0));
 
       final var back = cartBridge.set(cart, rec);
-      assertEquals("A", back.getOrders().getFirst().getSku());
-      assertInstanceOf(OrderPojo.class, back.getOrders().getFirst());
+      assertEquals("A", back.getOrders().get(0).getSku());
+      assertInstanceOf(OrderPojo.class, back.getOrders().get(0));
     }
   }
 }

--- a/core/src/test/java/io/github/eschizoid/telescope/effects/SealedEffectsBranchTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/effects/SealedEffectsBranchTest.java
@@ -1,0 +1,377 @@
+package io.github.eschizoid.telescope.effects;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.github.eschizoid.telescope.runtime.instances.EitherK;
+import io.github.eschizoid.telescope.runtime.instances.ValidatedK;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Exercises both cases of every sealed-dispatch method on {@link Either} and {@link Validated} (and
+ * the applicative witnesses {@link EitherK} / {@link ValidatedK}). Pins the post-Java-17 instanceof
+ * chain rewrites so a regression in any single branch (e.g. swapping Left/Right ordering,
+ * accidentally dropping a branch, mishandling the both-Invalid accumulation path) surfaces here
+ * rather than as a behavioural drift in a downstream caller.
+ *
+ * <p>Each method gets one Left/Invalid test and one Right/Valid test; combinators that fan out on
+ * the cross-product ({@code Validated.combine}, {@code map2} on both witnesses) get explicit tests
+ * for every cell of the 2×2 (or 2×2×2) table.
+ */
+class SealedEffectsBranchTest {
+
+  @Nested
+  @DisplayName("Either — both cases of every default method")
+  class EitherBothCases {
+
+    @Test
+    @DisplayName("fold on Right calls onRight; fold on Left calls onLeft")
+    void foldBothCases() {
+      assertEquals("R:1", Either.<String, Integer>right(1).fold(l -> "L:" + l, r -> "R:" + r));
+      assertEquals("L:bad", Either.<String, Integer>left("bad").fold(l -> "L:" + l, r -> "R:" + r));
+    }
+
+    @Test
+    @DisplayName("map transforms Right; leaves Left untouched")
+    void mapBothCases() {
+      assertEquals(Either.right(3), Either.<String, Integer>right(1).map(n -> n + 2));
+      assertEquals(Either.left("bad"), Either.<String, Integer>left("bad").map(n -> n + 2));
+    }
+
+    @Test
+    @DisplayName("flatMap chains on Right; short-circuits on Left")
+    void flatMapBothCases() {
+      assertEquals(
+        Either.<String, Integer>right(10),
+        Either.<String, Integer>right(5).flatMap(n -> Either.right(n + 5))
+      );
+      assertEquals(Either.left("bad"), Either.<String, Integer>left("bad").flatMap(n -> Either.right(n + 5)));
+    }
+
+    @Test
+    @DisplayName("mapLeft transforms Left; leaves Right untouched")
+    void mapLeftBothCases() {
+      assertEquals(Either.left("E:bad"), Either.<String, Integer>left("bad").mapLeft(e -> "E:" + e));
+      assertEquals(Either.right(7), Either.<String, Integer>right(7).mapLeft(e -> "E:" + e));
+    }
+
+    @Test
+    @DisplayName("swap turns Right→Left and Left→Right")
+    void swapBothCases() {
+      assertEquals(Either.left(7), Either.<String, Integer>right(7).swap());
+      assertEquals(Either.right("bad"), Either.<String, Integer>left("bad").swap());
+    }
+
+    @Test
+    @DisplayName("toValidated maps Right→Valid and Left→single-error Invalid")
+    void toValidatedBothCases() {
+      assertEquals(Validated.valid(7), Either.<String, Integer>right(7).toValidated());
+      assertEquals(Validated.invalid("bad"), Either.<String, Integer>left("bad").toValidated());
+    }
+
+    @Test
+    @DisplayName("getOrElse returns Right value or the default on Left")
+    void getOrElseBothCases() {
+      assertEquals(7, Either.<String, Integer>right(7).getOrElse(0));
+      assertEquals(0, Either.<String, Integer>left("bad").getOrElse(0));
+    }
+
+    @Test
+    @DisplayName("getOrElseGet returns Right value or runs the supplier on Left")
+    void getOrElseGetBothCases() {
+      assertEquals(7, Either.<String, Integer>right(7).getOrElseGet(() -> 99));
+      assertEquals(99, Either.<String, Integer>left("bad").getOrElseGet(() -> 99));
+    }
+
+    @Test
+    @DisplayName("toOptional wraps Right as present, Left as empty")
+    void toOptionalBothCases() {
+      assertEquals(Optional.of(7), Either.<String, Integer>right(7).toOptional());
+      assertEquals(Optional.empty(), Either.<String, Integer>left("bad").toOptional());
+    }
+
+    @Test
+    @DisplayName("flatMapAsync runs the function on Right; passes the error through on Left")
+    void flatMapAsyncBothCases() throws Exception {
+      assertEquals(
+        Either.right(10),
+        Either.<String, Integer>right(5)
+          .flatMapAsync(n -> CompletableFuture.completedFuture(n + 5))
+          .get()
+      );
+      assertEquals(
+        Either.left("bad"),
+        Either.<String, Integer>left("bad")
+          .flatMapAsync(n -> CompletableFuture.completedFuture(n + 5))
+          .get()
+      );
+    }
+  }
+
+  @Nested
+  @DisplayName("Validated — both cases of every default method")
+  class ValidatedBothCases {
+
+    @Test
+    @DisplayName("fold on Valid calls onValid; fold on Invalid calls onInvalid")
+    void foldBothCases() {
+      assertEquals("V:1", Validated.<String, Integer>valid(1).fold(errs -> "I:" + errs.size(), v -> "V:" + v));
+      assertEquals(
+        "I:2",
+        Validated.<String, Integer>invalid(List.of("a", "b")).fold(errs -> "I:" + errs.size(), v -> "V:" + v)
+      );
+    }
+
+    @Test
+    @DisplayName("map transforms Valid; Invalid errors unchanged")
+    void mapBothCases() {
+      assertEquals(Validated.valid(3), Validated.<String, Integer>valid(1).map(n -> n + 2));
+      assertEquals(Validated.invalid(List.of("a")), Validated.<String, Integer>invalid("a").map(n -> n + 2));
+    }
+
+    @Test
+    @DisplayName("mapErrors transforms every error; Valid value unchanged")
+    void mapErrorsBothCases() {
+      assertEquals(
+        Validated.invalid(List.of("E:a", "E:b")),
+        Validated.<String, Integer>invalid(List.of("a", "b")).mapErrors(e -> "E:" + e)
+      );
+      assertEquals(Validated.valid(7), Validated.<String, Integer>valid(7).mapErrors(e -> "E:" + e));
+    }
+
+    @Test
+    @DisplayName("andThen chains on Valid; Invalid short-circuits with original errors")
+    void andThenBothCases() {
+      assertEquals(
+        Validated.<String, Integer>valid(15),
+        Validated.<String, Integer>valid(5).andThen(n -> Validated.valid(n + 10))
+      );
+      assertEquals(
+        Validated.invalid(List.of("orig")),
+        Validated.<String, Integer>invalid("orig").andThen(n -> Validated.valid(n + 10))
+      );
+    }
+
+    @Test
+    @DisplayName("toEither maps Valid→Right, Invalid→Left(errors list)")
+    void toEitherBothCases() {
+      assertEquals(Either.right(7), Validated.<String, Integer>valid(7).toEither());
+      assertEquals(Either.left(List.of("a", "b")), Validated.<String, Integer>invalid(List.of("a", "b")).toEither());
+    }
+
+    @Test
+    @DisplayName("getOrElse returns Valid value or the default on Invalid")
+    void getOrElseBothCases() {
+      assertEquals(7, Validated.<String, Integer>valid(7).getOrElse(0));
+      assertEquals(0, Validated.<String, Integer>invalid("bad").getOrElse(0));
+    }
+
+    @Test
+    @DisplayName("getOrElseGet returns Valid value or runs the supplier on Invalid")
+    void getOrElseGetBothCases() {
+      assertEquals(7, Validated.<String, Integer>valid(7).getOrElseGet(() -> 99));
+      assertEquals(99, Validated.<String, Integer>invalid("bad").getOrElseGet(() -> 99));
+    }
+
+    @Test
+    @DisplayName("toOptional wraps Valid as present, Invalid as empty")
+    void toOptionalBothCases() {
+      assertEquals(Optional.of(7), Validated.<String, Integer>valid(7).toOptional());
+      assertEquals(Optional.empty(), Validated.<String, Integer>invalid("bad").toOptional());
+    }
+
+    @Test
+    @DisplayName("flatMapAsync runs the function on Valid; carries errors through on Invalid")
+    void flatMapAsyncBothCases() throws Exception {
+      assertEquals(
+        Validated.valid(10),
+        Validated.<String, Integer>valid(5)
+          .flatMapAsync(n -> CompletableFuture.completedFuture(n + 5))
+          .get()
+      );
+      assertEquals(
+        Validated.invalid(List.of("a", "b")),
+        Validated.<String, Integer>invalid(List.of("a", "b"))
+          .flatMapAsync(n -> CompletableFuture.completedFuture(n + 5))
+          .get()
+      );
+    }
+  }
+
+  @Nested
+  @DisplayName("Validated.combine — every cell of the 2×2 cross-product")
+  class ValidatedCombineCells {
+
+    @Test
+    @DisplayName("Valid + Valid → Valid(fn(a, b))")
+    void validValid() {
+      final Validated<String, Integer> a = Validated.valid(3);
+      final Validated<String, String> b = Validated.valid("x");
+      assertEquals(Validated.valid("3x"), Validated.combine(a, b, (i, s) -> i + s));
+    }
+
+    @Test
+    @DisplayName("Invalid + Valid → Invalid(left's errors)")
+    void invalidValid() {
+      final Validated<String, Integer> a = Validated.invalid(List.of("e1"));
+      final Validated<String, String> b = Validated.valid("x");
+      assertEquals(Validated.invalid(List.of("e1")), Validated.combine(a, b, (i, s) -> i + s));
+    }
+
+    @Test
+    @DisplayName("Valid + Invalid → Invalid(right's errors)")
+    void validInvalid() {
+      final Validated<String, Integer> a = Validated.valid(3);
+      final Validated<String, String> b = Validated.invalid(List.of("e2"));
+      assertEquals(Validated.invalid(List.of("e2")), Validated.combine(a, b, (i, s) -> i + s));
+    }
+
+    @Test
+    @DisplayName("Invalid + Invalid → Invalid(concat(left, right)) — accumulating semantics")
+    void invalidInvalid() {
+      final Validated<String, Integer> a = Validated.invalid(List.of("e1", "e2"));
+      final Validated<String, String> b = Validated.invalid(List.of("e3"));
+      assertEquals(Validated.invalid(List.of("e1", "e2", "e3")), Validated.combine(a, b, (i, s) -> i + s));
+    }
+  }
+
+  @Nested
+  @DisplayName("Validated.combineAll — Valid roll-up vs accumulated Invalid")
+  class ValidatedCombineAllShapes {
+
+    @Test
+    @DisplayName("every input Valid → Valid(list of values, input order preserved)")
+    void allValid() {
+      final var inputs = List.of(
+        Validated.<String, Integer>valid(1),
+        Validated.<String, Integer>valid(2),
+        Validated.<String, Integer>valid(3)
+      );
+      assertEquals(Validated.valid(List.of(1, 2, 3)), Validated.combineAll(inputs));
+    }
+
+    @Test
+    @DisplayName("any input Invalid → Invalid(every error concatenated across all inputs)")
+    void mixedInvalidWins() {
+      final var inputs = List.of(
+        Validated.<String, Integer>valid(1),
+        Validated.<String, Integer>invalid(List.of("e1")),
+        Validated.<String, Integer>valid(2),
+        Validated.<String, Integer>invalid(List.of("e2", "e3"))
+      );
+      assertEquals(Validated.invalid(List.of("e1", "e2", "e3")), Validated.combineAll(inputs));
+    }
+
+    @Test
+    @DisplayName("empty input → Valid(empty list)")
+    void emptyInputs() {
+      assertEquals(Validated.valid(List.of()), Validated.<String, Integer>combineAll(List.of()));
+    }
+  }
+
+  @Nested
+  @DisplayName("EitherK.map2 — every cell of the 2×2 cross-product")
+  class EitherKMap2 {
+
+    @Test
+    @DisplayName("Right + Right → Right(fn(a, b)) — the only success path")
+    void rightRight() {
+      final var app = EitherK.<String>forLeft();
+      final var fa = EitherK.box(Either.<String, Integer>right(3));
+      final var fb = EitherK.box(Either.<String, Integer>right(4));
+      assertEquals(Either.right(7), EitherK.unbox(app.map2(fa, fb, Integer::sum)));
+    }
+
+    @Test
+    @DisplayName("Left + Right → Left(la) — fa short-circuits before fb is inspected")
+    void leftRight() {
+      final var app = EitherK.<String>forLeft();
+      final var fa = EitherK.box(Either.<String, Integer>left("bad-a"));
+      final var fb = EitherK.box(Either.<String, Integer>right(4));
+      assertEquals(Either.left("bad-a"), EitherK.unbox(app.map2(fa, fb, Integer::sum)));
+    }
+
+    @Test
+    @DisplayName("Right + Left → Left(lb) — fa Right, fb Left wins")
+    void rightLeft() {
+      final var app = EitherK.<String>forLeft();
+      final var fa = EitherK.box(Either.<String, Integer>right(3));
+      final var fb = EitherK.box(Either.<String, Integer>left("bad-b"));
+      assertEquals(Either.left("bad-b"), EitherK.unbox(app.map2(fa, fb, Integer::sum)));
+    }
+
+    @Test
+    @DisplayName("isFailed: true for Left, false for Right")
+    void isFailedBothCases() {
+      final var app = EitherK.<String>forLeft();
+      assertTrue(app.isFailed(EitherK.box(Either.<String, Integer>left("bad"))));
+      assertFalse(app.isFailed(EitherK.box(Either.<String, Integer>right(1))));
+    }
+
+    @Test
+    @DisplayName("pure wraps a value in Right; map runs the function on Right")
+    void pureAndMap() {
+      final var app = EitherK.<String>forLeft();
+      final var pured = app.pure(5);
+      assertInstanceOf(Either.Right.class, EitherK.unbox(pured));
+      assertEquals(Either.right(10), EitherK.unbox(app.map(pured, n -> n * 2)));
+    }
+  }
+
+  @Nested
+  @DisplayName("ValidatedK.map2 — every cell of the 2×2 cross-product")
+  class ValidatedKMap2 {
+
+    @Test
+    @DisplayName("Valid + Valid → Valid(fn(a, b)) — the only success path")
+    void validValid() {
+      final var app = ValidatedK.<String>forError();
+      final var fa = ValidatedK.box(Validated.<String, Integer>valid(3));
+      final var fb = ValidatedK.box(Validated.<String, Integer>valid(4));
+      assertEquals(Validated.valid(7), ValidatedK.unbox(app.map2(fa, fb, Integer::sum)));
+    }
+
+    @Test
+    @DisplayName("Invalid + Valid → Invalid(fa.errors) — fa carries through")
+    void invalidValid() {
+      final var app = ValidatedK.<String>forError();
+      final var fa = ValidatedK.box(Validated.<String, Integer>invalid(List.of("e1")));
+      final var fb = ValidatedK.box(Validated.<String, Integer>valid(4));
+      assertEquals(Validated.invalid(List.of("e1")), ValidatedK.unbox(app.map2(fa, fb, Integer::sum)));
+    }
+
+    @Test
+    @DisplayName("Valid + Invalid → Invalid(fb.errors) — fb carries through")
+    void validInvalid() {
+      final var app = ValidatedK.<String>forError();
+      final var fa = ValidatedK.box(Validated.<String, Integer>valid(3));
+      final var fb = ValidatedK.box(Validated.<String, Integer>invalid(List.of("e2")));
+      assertEquals(Validated.invalid(List.of("e2")), ValidatedK.unbox(app.map2(fa, fb, Integer::sum)));
+    }
+
+    @Test
+    @DisplayName("Invalid + Invalid → Invalid(concat) — accumulation, the whole point of Validated")
+    void invalidInvalid() {
+      final var app = ValidatedK.<String>forError();
+      final var fa = ValidatedK.box(Validated.<String, Integer>invalid(List.of("e1", "e2")));
+      final var fb = ValidatedK.box(Validated.<String, Integer>invalid(List.of("e3")));
+      assertEquals(Validated.invalid(List.of("e1", "e2", "e3")), ValidatedK.unbox(app.map2(fa, fb, Integer::sum)));
+    }
+
+    @Test
+    @DisplayName("pure wraps a value in Valid; map runs the function on Valid")
+    void pureAndMap() {
+      final var app = ValidatedK.<String>forError();
+      final var pured = app.pure(5);
+      assertInstanceOf(Validated.Valid.class, ValidatedK.unbox(pured));
+      assertEquals(Validated.valid(10), ValidatedK.unbox(app.map(pured, n -> n * 2)));
+    }
+  }
+}

--- a/core/src/test/java/io/github/eschizoid/telescope/focus/FocusCodegenTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/focus/FocusCodegenTest.java
@@ -91,7 +91,7 @@ class FocusCodegenTest {
       assertEquals("BOB", shouted.members().get(1).name());
       assertEquals("eng", shouted.name());
       // original untouched (immutable rebuild)
-      assertEquals("alice", team.members().getFirst().name());
+      assertEquals("alice", team.members().get(0).name());
     }
 
     @Test
@@ -177,7 +177,7 @@ class FocusCodegenTest {
           err -> {
             throw new AssertionError(err);
           },
-          t -> t.members().getFirst().name()
+          t -> t.members().get(0).name()
         )
       );
 

--- a/examples/library/build.gradle.kts
+++ b/examples/library/build.gradle.kts
@@ -15,7 +15,7 @@ java {
 }
 
 tasks.withType<JavaCompile>().configureEach {
-    options.release = 25
+    options.release = 17
     options.encoding = "UTF-8"
     // -parameters lets WriteHint.CONSTRUCTOR match args by parameter name on the immutable POJO demo.
     options.compilerArgs.addAll(listOf("-Xlint:all,-processing", "-parameters"))

--- a/examples/library/src/main/java/io/github/eschizoid/telescope/examples/DeepMappingDemo.java
+++ b/examples/library/src/main/java/io/github/eschizoid/telescope/examples/DeepMappingDemo.java
@@ -142,9 +142,9 @@ final class DeepMappingDemo {
     final CompanyDto dto = mapper.read(entity);
     System.out.println("[map] founded→since         : " + dto.since());
     System.out.println(
-      "[map] name→fullName (deep)  : " + dto.departments().getFirst().teams().getFirst().users().getFirst().fullName()
+      "[map] name→fullName (deep)  : " + dto.departments().get(0).teams().get(0).users().get(0).fullName()
     );
-    System.out.println("[map] Optional<User> head   : " + dto.departments().getFirst().head().orElseThrow().fullName());
+    System.out.println("[map] Optional<User> head   : " + dto.departments().get(0).head().orElseThrow().fullName());
     System.out.println("[map] Map<String,Address>   : " + dto.officesByRegion().get("EU").city());
   }
 

--- a/examples/library/src/main/java/io/github/eschizoid/telescope/examples/MultiEditDemo.java
+++ b/examples/library/src/main/java/io/github/eschizoid/telescope/examples/MultiEditDemo.java
@@ -72,10 +72,10 @@ final class MultiEditDemo {
 
     System.out.println("[all/over] dept names trimmed: " + out.departments().stream().map(Department::name).toList());
     System.out.println(
-      "[all/over] team names trimmed: " + out.departments().getFirst().teams().stream().map(Team::name).toList()
+      "[all/over] team names trimmed: " + out.departments().get(0).teams().stream().map(Team::name).toList()
     );
     System.out.println(
-      "[all/over] first user email  : " + out.departments().getFirst().teams().getFirst().users().getFirst().email()
+      "[all/over] first user email  : " + out.departments().get(0).teams().get(0).users().get(0).email()
     );
 
     // The same normalizer is reusable on a different source.
@@ -85,8 +85,7 @@ final class MultiEditDemo {
     );
     final var another2 = normalize.apply(another);
     System.out.println(
-      "[all/over] reused on another : " +
-        another2.departments().getFirst().teams().getFirst().users().getFirst().email()
+      "[all/over] reused on another : " + another2.departments().get(0).teams().get(0).users().get(0).email()
     );
   }
 }

--- a/examples/springboot/invoicing/build.gradle.kts
+++ b/examples/springboot/invoicing/build.gradle.kts
@@ -34,7 +34,7 @@ dependencies {
 }
 
 tasks.withType<JavaCompile>().configureEach {
-    options.release = 25
+    options.release = 17
     options.encoding = "UTF-8"
     options.compilerArgs.addAll(listOf("-Xlint:all,-processing,-serial", "-parameters"))
 }

--- a/examples/springboot/invoicing/src/test/java/io/github/eschizoid/telescope/demo/invoicing/InvoiceBridgeFlowTest.java
+++ b/examples/springboot/invoicing/src/test/java/io/github/eschizoid/telescope/demo/invoicing/InvoiceBridgeFlowTest.java
@@ -70,7 +70,7 @@ class InvoiceBridgeFlowTest {
     assertThat(entity).isNotNull();
     assertThat(entity.getNumber()).isEqualTo("INV-200");
     assertThat(entity.getLines()).hasSize(2);
-    assertThat(entity.getLines().getFirst().getSku()).isEqualTo("SKU-X");
+    assertThat(entity.getLines().get(0).getSku()).isEqualTo("SKU-X");
     assertThat(entity.getLines().get(0).getQty()).isEqualTo(2);
     assertThat(entity.getLines().get(0).getUnitPrice()).isEqualByComparingTo("11.50");
     assertThat(entity.getLines().get(1).getSku()).isEqualTo("SKU-Y");

--- a/examples/springboot/invoicing/src/test/java/io/github/eschizoid/telescope/demo/invoicing/InvoiceBridgeTest.java
+++ b/examples/springboot/invoicing/src/test/java/io/github/eschizoid/telescope/demo/invoicing/InvoiceBridgeTest.java
@@ -62,7 +62,7 @@ class InvoiceBridgeTest {
     final var entity = InvoiceHeaderBridge.forward(header);
     assertThat(entity.getNumber()).isEqualTo("INV-001");
     assertThat(entity.getLines()).hasSize(2);
-    assertThat(entity.getLines().getFirst().getSku()).isEqualTo("SKU-A");
+    assertThat(entity.getLines().get(0).getSku()).isEqualTo("SKU-A");
     assertThat(entity.getLines().get(0).getQty()).isEqualTo(2);
     assertThat(entity.getLines().get(0).getUnitPrice()).isEqualByComparingTo("10.00");
     assertThat(entity.getLines().get(1).getSku()).isEqualTo("SKU-B");

--- a/examples/springboot/order-jpa/build.gradle.kts
+++ b/examples/springboot/order-jpa/build.gradle.kts
@@ -50,7 +50,7 @@ dependencies {
 }
 
 tasks.withType<JavaCompile>().configureEach {
-    options.release = 25
+    options.release = 17
     options.encoding = "UTF-8"
     // -parameters lets Spring's @PathVariable / @RequestParam resolve by name without
     // explicit annotation values, and helps Jackson's record-creator detection.

--- a/examples/springboot/order-jpa/src/main/java/io/github/eschizoid/telescope/demo/spring/api/ValidatedOrderController.java
+++ b/examples/springboot/order-jpa/src/main/java/io/github/eschizoid/telescope/demo/spring/api/ValidatedOrderController.java
@@ -34,10 +34,15 @@ public class ValidatedOrderController {
           : Validated.valid(quantity)
       );
 
-    return switch (result) {
-      case Validated.Valid<LineItemValidationError, Order>(Order accepted) -> ResponseEntity.ok(accepted);
-      case Validated.Invalid<LineItemValidationError, Order> bad -> throw new InvalidOrderException(bad);
-    };
+    // Sealed-dispatch via fold — the canonical shape, single source of truth for Valid/Invalid
+    // routing. Returns the OK response on Valid; throws on Invalid (the throw needs an `unchecked
+    // cast` of the fold's T inference back to `ResponseEntity<Order>`).
+    return result.fold(
+      errors -> {
+        throw new InvalidOrderException(new Validated.Invalid<>(errors));
+      },
+      ResponseEntity::ok
+    );
   }
 
   // Recover the SKU of the first line item with this quantity for error context. The validator

--- a/examples/springboot/order-jpa/src/main/java/io/github/eschizoid/telescope/demo/spring/mapping/RedactedOrderTelescopes.java
+++ b/examples/springboot/order-jpa/src/main/java/io/github/eschizoid/telescope/demo/spring/mapping/RedactedOrderTelescopes.java
@@ -34,7 +34,7 @@ public final class RedactedOrderTelescopes {
    */
   public static final Telescope<Order, RedactedOrder> REDACT = Telescope.from(Order.class)
     .to(RedactedOrder.class)
-    .using(RedactedOrderTelescopes::redact, _ -> {
+    .using(RedactedOrderTelescopes::redact, __ -> {
       throw new UnsupportedOperationException(BACKWARD_MESSAGE);
     });
 

--- a/examples/springboot/order-jpa/src/test/java/io/github/eschizoid/telescope/demo/spring/OrderFlowTest.java
+++ b/examples/springboot/order-jpa/src/test/java/io/github/eschizoid/telescope/demo/spring/OrderFlowTest.java
@@ -62,9 +62,9 @@ class OrderFlowTest {
     assertThat(body.shippingAddress().city()).isEqualTo("Brooklyn");
     assertThat(body.billingAddress().city()).isEqualTo("Brooklyn");
     assertThat(body.lineItems()).hasSize(2);
-    assertThat(body.lineItems().getFirst().sku()).isEqualTo("SKU-A");
-    assertThat(body.lineItems().getFirst().quantity()).isEqualTo(2);
-    assertThat(body.lineItems().getFirst().unitPrice()).isEqualByComparingTo("19.99");
+    assertThat(body.lineItems().get(0).sku()).isEqualTo("SKU-A");
+    assertThat(body.lineItems().get(0).quantity()).isEqualTo(2);
+    assertThat(body.lineItems().get(0).unitPrice()).isEqualByComparingTo("19.99");
     assertThat(body.lineItems().get(1).unitPrice()).isEqualByComparingTo("49.50");
     assertThat(body.giftWrap()).isPresent();
     assertThat(body.giftWrap().get().street()).isEqualTo("300 Gift Rd");

--- a/examples/springboot/order-jpa/src/test/java/io/github/eschizoid/telescope/demo/spring/OrderTelescopeFlowTest.java
+++ b/examples/springboot/order-jpa/src/test/java/io/github/eschizoid/telescope/demo/spring/OrderTelescopeFlowTest.java
@@ -46,7 +46,7 @@ class OrderTelescopeFlowTest {
     assertThat(body.customer().email()).isEqualTo("alice@example.com");
     assertThat(body.customer().id()).isNotNull();
     assertThat(body.shippingAddress().zip()).isEqualTo("11201");
-    assertThat(body.lineItems().getFirst().unitPrice()).isEqualByComparingTo("19.99");
+    assertThat(body.lineItems().get(0).unitPrice()).isEqualByComparingTo("19.99");
     assertThat(body.giftWrap()).isPresent();
     assertThat(body.giftWrap().get().street()).isEqualTo("300 Gift Rd");
   }

--- a/examples/springboot/org-chart/build.gradle.kts
+++ b/examples/springboot/org-chart/build.gradle.kts
@@ -39,7 +39,7 @@ dependencies {
 }
 
 tasks.withType<JavaCompile>().configureEach {
-    options.release = 25
+    options.release = 17
     options.encoding = "UTF-8"
     options.compilerArgs.addAll(listOf("-Xlint:all,-processing,-serial", "-parameters"))
 }

--- a/examples/springboot/product-starter/build.gradle.kts
+++ b/examples/springboot/product-starter/build.gradle.kts
@@ -45,7 +45,7 @@ dependencies {
 }
 
 tasks.withType<JavaCompile>().configureEach {
-    options.release = 25
+    options.release = 17
     options.encoding = "UTF-8"
     options.compilerArgs.addAll(listOf("-Xlint:all,-processing,-serial", "-parameters"))
 }

--- a/internal/build.gradle.kts
+++ b/internal/build.gradle.kts
@@ -24,7 +24,7 @@ java {
 }
 
 tasks.withType<JavaCompile>().configureEach {
-    options.release = 25
+    options.release = 17
     options.encoding = "UTF-8"
     // -Xlint:-module suppresses the "qualified-export target module not found" warning that fires
     // because :core (io.github.eschizoid.telescope) requires :internal, not the other way around,

--- a/internal/src/main/java/io/github/eschizoid/telescope/internal/LambdaIntrospection.java
+++ b/internal/src/main/java/io/github/eschizoid/telescope/internal/LambdaIntrospection.java
@@ -36,7 +36,7 @@ public final class LambdaIntrospection {
    *     starts with {@code "lambda$"})
    */
   public static String methodNameOf(final Serializable lambda) {
-    return METHOD_NAME_CACHE.computeIfAbsent(lambda.getClass(), _ -> resolveMethodName(lambda));
+    return METHOD_NAME_CACHE.computeIfAbsent(lambda.getClass(), __ -> resolveMethodName(lambda));
   }
 
   private static String resolveMethodName(final Serializable lambda) {
@@ -67,7 +67,7 @@ public final class LambdaIntrospection {
    */
   @SuppressWarnings("unchecked")
   public static <A> Class<A> implClassOf(final Serializable lambda) {
-    return (Class<A>) IMPL_CLASS_CACHE.computeIfAbsent(lambda.getClass(), _ -> resolveImplClass(lambda));
+    return (Class<A>) IMPL_CLASS_CACHE.computeIfAbsent(lambda.getClass(), __ -> resolveImplClass(lambda));
   }
 
   private static Class<?> resolveImplClass(final Serializable lambda) {

--- a/lombok/build.gradle.kts
+++ b/lombok/build.gradle.kts
@@ -24,7 +24,7 @@ java {
 }
 
 tasks.withType<JavaCompile>().configureEach {
-    options.release = 25
+    options.release = 17
     options.encoding = "UTF-8"
     options.compilerArgs.addAll(listOf("-Xlint:all,-processing", "-parameters"))
 }

--- a/lombok/src/main/java/io/github/eschizoid/telescope/codegen/lombok/LombokFocusProcessor.java
+++ b/lombok/src/main/java/io/github/eschizoid/telescope/codegen/lombok/LombokFocusProcessor.java
@@ -34,7 +34,7 @@ import javax.lang.model.element.TypeElement;
  * guaranteed done patching.
  */
 @SupportedAnnotationTypes({ "lombok.Data", "lombok.Value", "lombok.Builder" })
-@SupportedSourceVersion(SourceVersion.RELEASE_25)
+@SupportedSourceVersion(SourceVersion.RELEASE_17)
 public final class LombokFocusProcessor extends AbstractTelescopeProcessor {
 
   /**

--- a/quarkus/build.gradle.kts
+++ b/quarkus/build.gradle.kts
@@ -25,7 +25,7 @@ java {
 }
 
 tasks.withType<JavaCompile>().configureEach {
-    options.release = 25
+    options.release = 17
     options.encoding = "UTF-8"
     options.compilerArgs.addAll(listOf("-Xlint:all,-processing", "-parameters"))
 }

--- a/spring-boot-starter/build.gradle.kts
+++ b/spring-boot-starter/build.gradle.kts
@@ -24,7 +24,7 @@ java {
 }
 
 tasks.withType<JavaCompile>().configureEach {
-    options.release = 25
+    options.release = 17
     options.encoding = "UTF-8"
     options.compilerArgs.addAll(listOf("-Xlint:all,-processing", "-parameters"))
 }


### PR DESCRIPTION
## Summary

Drops the bytecode floor from Java 25 to Java 17 LTS so the wide enterprise audience still on 17 can consume the library — including the codegen-emitted navigators and bridges. Toolchain stays on JDK 25; only the `--release` API surface and language features tighten.

## What changed

**Mechanical:**
- All 13 module `build.gradle.kts` files: `options.release = 25` → `17`.
- 4 annotation processors: `@SupportedSourceVersion(RELEASE_25)` → `RELEASE_17`.
- Unnamed variables (`_`, JEP 456 — Java 22+) renamed to `__` at lambda + switch-pattern sites.

**Language-feature rewrites:**
- Pattern-match switch expressions (JEP 441 — Java 21+) collapsed to a single `fold(...)` per sealed type plus delegating one-liner methods (Either/Validated/EitherK). Single instanceof + safe cast eliminates dead unreachable-throw / partial-coverage branches.
- Record patterns in `instanceof` (JEP 440 — Java 21+) rewritten as type-pattern `instanceof` + accessor calls in `Validated.combine`, `DeepMap.extractDefaultStrategy`.
- `List.getFirst()` (JEP 431 — Java 21+) → `list.get(0)` across codegen processors, demos, tests.
- `try-with-resources` on `ExecutorService` (Java 19+) → `try/finally { shutdown() }`.

**Codegen emission:** `BridgeProcessor` sealed-bridge dispatch emits an `instanceof` chain — generated code compiles under `-source 17`.

**BridgeTelescope visibility:** `private` → package-private (Java 17 sealed-permits accessibility check rejects `private` nested permits).

**README:** Maven Central badge → `telescope-core`; JVM badge → 17+.

## Coverage

Two test files folded in:
- `SealedEffectsBranchTest` — covers every `fold(...)` cell for Either / Validated and `map2` for EitherK / ValidatedK.
- `DeepMapBranchTest` — covers the new instanceof branches in `applyForward` / `applyBackward` (constant, compute, zip cardinality) and `extractDefaultStrategy`.

## Test plan

- [x] `./gradlew test` green on `--release 17` across all modules + four Spring Boot example slices.
- [x] `./gradlew spotlessApply` clean.
