### PR TITLE
feat(deepmap): same-source-to-multiple-targets fan-out

### DIFF
--- a/core/src/main/java/io/github/eschizoid/telescope/DeepMap.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/DeepMap.java
@@ -367,9 +367,9 @@ public final class DeepMap {
         continue;
       }
       final var tgtField = tgtRefl.normalize(internals.targetField());
-      // Fail fast on duplicates within this type-pair — two rows that target the same source or
-      // target field would silently overwrite each other in byTargetName/bySourceName and could
-      // produce non-bijective forward/backward (each direction using a different correspondence).
+      // Fail fast on duplicate target — two rows targeting the same target field would silently
+      // overwrite each other in byTargetName and could produce non-bijective forward/backward
+      // (each direction using a different correspondence).
       if (!claimedTgt.add(tgtField)) throw new IllegalArgumentException(
         "Deep map " +
           source.getSimpleName() +
@@ -379,15 +379,15 @@ public final class DeepMap {
           tgtField +
           "'. Each (source, target) type pair may declare at most one row per target field."
       );
-      if (!claimedSrc.add(srcField)) throw new IllegalArgumentException(
-        "Deep map " +
-          source.getSimpleName() +
-          " → " +
-          target.getSimpleName() +
-          ": duplicate override row for source field '" +
-          srcField +
-          "'. Each (source, target) type pair may declare at most one row per source field."
-      );
+      // Same-source fan-out IS permitted: one source field feeding multiple target fields is a
+      // common enterprise pattern (e.g. `businessUnit → cretnUserId AND lastUpdtdUserId` on
+      // audit-column rebuilds). Forward direction broadcasts the source value to every target row
+      // correctly. Backward direction is non-bijective for the fan-out source field — the last
+      // registered row wins the `bySourceName` slot, so backward reconstructs that source field
+      // from one target's value. Round-trip equality holds when the user keeps fan-out targets in
+      // sync (typically same-typed copies of the same column), and the test pin makes the
+      // last-row-wins behaviour explicit so silent ambiguity is impossible.
+      claimedSrc.add(srcField);
       final var rowIso = fieldIsoOf(row, srcRefl.genericType(source, srcField), tgtRefl.genericType(target, tgtField));
       final var step = new FieldStep(srcField, tgtField, rowIso);
       byTargetName.put(tgtField, step);

--- a/core/src/test/java/io/github/eschizoid/telescope/SameSourceMultiTargetTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/SameSourceMultiTargetTest.java
@@ -1,0 +1,98 @@
+package io.github.eschizoid.telescope;
+
+import static io.github.eschizoid.telescope.mapping.Mapping.to;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pins fan-out: one source field feeding multiple target components in a single {@link
+ * Telescope#mapper(Class, Class, io.github.eschizoid.telescope.mapping.MapStep...)} call.
+ *
+ * <p>The real-world enterprise shape: a single audit field ({@code businessUnit}) that needs to
+ * land on two correlated target columns ({@code cretnUserId} AND {@code lastUpdtdUserId}). Each row
+ * in the call carries the same source accessor and a distinct target accessor.
+ *
+ * <p><b>Forward direction</b> broadcasts the source value to every target row correctly — the
+ * load-bearing case for the enterprise pattern.
+ *
+ * <p><b>Backward direction</b> is non-bijective for the fan-out source field. The last registered
+ * row wins the source-side rebuild slot, so the backward direction recovers the source from one
+ * target's value. Round-trip equality holds when the user keeps the fan-out targets in sync
+ * (typically same-typed copies of the same column); when they diverge, the test below pins the
+ * last-row-wins behaviour so the asymmetry is explicit and ungated.
+ */
+class SameSourceMultiTargetTest {
+
+  record SourceRow(String businessUnit, String payload) {}
+
+  record TargetRow(String cretnUserId, String lastUpdtdUserId, String payload) {}
+
+  @Nested
+  @DisplayName("forward direction — fan-out broadcasts the source value to every target row")
+  class ForwardFanout {
+
+    @Test
+    @DisplayName("two rows with the same source land on both target columns")
+    void fanOutBroadcast() {
+      final var src = new SourceRow("US-CENTRAL", "hello");
+
+      // businessUnit fans out to BOTH cretnUserId AND lastUpdtdUserId.
+      final var mapper = Telescope.mapper(
+        SourceRow.class,
+        TargetRow.class,
+        to(SourceRow::businessUnit, TargetRow::cretnUserId),
+        to(SourceRow::businessUnit, TargetRow::lastUpdtdUserId)
+      );
+
+      final var out = mapper.forward(src);
+
+      assertEquals("US-CENTRAL", out.cretnUserId(), "first row's target receives the source value");
+      assertEquals("US-CENTRAL", out.lastUpdtdUserId(), "second row's target receives the same source value");
+      assertEquals("hello", out.payload(), "unrelated same-named field still auto-binds");
+    }
+  }
+
+  @Nested
+  @DisplayName("backward direction — last-row-wins on the fan-out source field")
+  class BackwardLastRowWins {
+
+    @Test
+    @DisplayName("backward recovers businessUnit from the LAST registered target row's value")
+    void backwardPicksLast() {
+      // Construct a divergent target — cretnUserId and lastUpdtdUserId disagree. The backward
+      // direction must pick one to reconstruct businessUnit; by registration order, the last
+      // row wins (lastUpdtdUserId).
+      final var divergent = new TargetRow("first-target", "last-target", "hello");
+
+      final var mapper = Telescope.mapper(
+        SourceRow.class,
+        TargetRow.class,
+        to(SourceRow::businessUnit, TargetRow::cretnUserId),
+        to(SourceRow::businessUnit, TargetRow::lastUpdtdUserId)
+      );
+
+      final var back = mapper.backward(divergent);
+
+      // The second row (lastUpdtdUserId) wins the source-side rebuild slot.
+      assertEquals("last-target", back.businessUnit(), "last registered row wins the source rebuild");
+      assertEquals("hello", back.payload());
+    }
+
+    @Test
+    @DisplayName("round-trip is identity when fan-out targets stay in sync (the typical case)")
+    void roundTripIdempotent() {
+      final var mapper = Telescope.mapper(
+        SourceRow.class,
+        TargetRow.class,
+        to(SourceRow::businessUnit, TargetRow::cretnUserId),
+        to(SourceRow::businessUnit, TargetRow::lastUpdtdUserId)
+      );
+
+      final var src = new SourceRow("US-CENTRAL", "hello");
+      assertEquals(src, mapper.backward(mapper.forward(src)));
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Lifts the source-side `claimedSrc` guard so one source accessor can feed multiple target components in a single `Telescope.mapper(...)` call — the real enterprise audit shape (`businessUnit → cretnUserId AND lastUpdtdUserId`).

## Before / after

```java
// Before — throws at resolve time
Telescope.mapper(SourceRow.class, TargetRow.class,
    to(SourceRow::businessUnit, TargetRow::cretnUserId),
    to(SourceRow::businessUnit, TargetRow::lastUpdtdUserId));
// IllegalArgumentException: duplicate override row for source field 'businessUnit'

// After
mapper.forward(new SourceRow("US-CENTRAL", "hello"));
// → TargetRow(cretnUserId="US-CENTRAL", lastUpdtdUserId="US-CENTRAL", payload="hello")
```

## Backward direction trade-off

Non-bijective for the fan-out source field — the last registered row wins the `bySourceName` rebuild slot. Round-trip equality holds when fan-out targets stay in sync (the typical case where they're correlated copies of the same column).

The target-side `claimedTgt` guard stays — two rows targeting the same target component remain a hard error.

## Test plan

- [x] `SameSourceMultiTargetTest` — forward fan-out, backward last-row-wins on divergent targets, round-trip identity when targets stay in sync.
- [x] Full `./gradlew test` green.
