### PR TITLE
feat(mapping): forward-only Mapping.into(src, tgt, fwd)

### DIFF
--- a/core/src/main/java/io/github/eschizoid/telescope/mapping/Mapping.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/mapping/Mapping.java
@@ -82,26 +82,31 @@ public sealed interface Mapping<A, B>
    * io.github.eschizoid.telescope.conversion.Mapper#backward} on the resulting mapper.
    *
    * <pre>{@code
-   * into(UserEntity::createdAt, UserDto::createdAtIso, Instant::toString)
+   * forward(UserEntity::createdAt, UserDto::createdAtIso, Instant::toString)
    * }</pre>
+   *
+   * <p>Naming chain: {@code Mapping.forward(...)} rows feed the {@link
+   * io.github.eschizoid.telescope.Telescope#mapperForward(Class, Class, MapStep...)} factory,
+   * producing a {@link io.github.eschizoid.telescope.conversion.ForwardMapper}. The three names
+   * rhyme so the forward-only family is self-discoverable at the call site.
    *
    * <p>For the bidirectional variant, supply the inverse explicitly via {@link #to(Accessor,
    * Accessor, Function, Function)}.
    */
-  static <A, B, X, Y> Mapping<A, B> into(
+  static <A, B, X, Y> Mapping<A, B> forward(
     final Accessor<A, X> src,
     final Accessor<B, Y> tgt,
-    final Function<? super X, ? extends Y> forward
+    final Function<? super X, ? extends Y> fn
   ) {
     final String fieldName = LambdaIntrospection.methodNameOf(src);
     final Function<? super Y, ? extends X> throwingBackward = y -> {
       throw new UnsupportedOperationException(
-        "Mapping.into is forward-only — backward direction is undefined for field '" +
+        "Mapping.forward is forward-only — backward direction is undefined for field '" +
           fieldName +
           "'. Use Mapping.to(src, tgt, forward, backward) if a bidirectional row is required."
       );
     };
-    return new TypedTransformTo<>(src, tgt, forward, throwingBackward);
+    return new TypedTransformTo<>(src, tgt, fn, throwingBackward);
   }
 
   /**

--- a/core/src/main/java/io/github/eschizoid/telescope/mapping/Mapping.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/mapping/Mapping.java
@@ -5,7 +5,9 @@ import io.github.eschizoid.telescope.Telescope;
 import io.github.eschizoid.telescope.Telescope.Accessor;
 import io.github.eschizoid.telescope.conversion.Mapper;
 import io.github.eschizoid.telescope.internal.LambdaIntrospection;
+import java.util.Objects;
 import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
 
 /**
@@ -107,6 +109,99 @@ public sealed interface Mapping<A, B>
       );
     };
     return new TypedTransformTo<>(src, tgt, fn, throwingBackward);
+  }
+
+  /**
+   * Null-coalescing same-typed correspondence: when the source accessor returns {@code null}, the
+   * target receives {@code defaultValue} instead. Source and target share the same leaf type {@code
+   * X}; non-null source values pass through unchanged. Closes MapStruct's {@code defaultValue} gap
+   * without the inline {@code n == null ? FALLBACK : n} lambda.
+   *
+   * <pre>{@code
+   * toOrElse(UserEntity::displayName, UserDto::displayName, "(unnamed)")
+   * }</pre>
+   *
+   * <p>Backward direction is identity — the default value, if it lands on the target, round-trips
+   * back to the source slot as that same value rather than the original null. Accept the asymmetry
+   * when the default is a domain-meaningful sentinel rather than a placeholder; reach for an
+   * explicit 4-arg {@link #to(Accessor, Accessor, Function, Function)} when both directions need
+   * bespoke logic.
+   */
+  static <A, B, X> Mapping<A, B> toOrElse(final Accessor<A, X> src, final Accessor<B, X> tgt, final X defaultValue) {
+    return new TypedTransformTo<>(src, tgt, x -> x == null ? defaultValue : x, y -> y);
+  }
+
+  /**
+   * Predicate-gated null-coalescing same-typed correspondence: the target receives {@code
+   * defaultValue} when {@code missing.test(srcValue)} returns true. Generalises {@link
+   * #toOrElse(Accessor, Accessor, Object)} (which is strict-null) to cover empty-string,
+   * empty-collection, zero-numeric, or any custom predicate-equivalent of "missing". MapStruct has
+   * no equivalent — {@code defaultValue} is strictly null-checked at the bytecode level.
+   *
+   * <pre>{@code
+   * toOrElse(Src::displayName, Dst::displayName, "(unnamed)", String::isBlank)
+   * toOrElse(Src::items,       Dst::items,       List.of(),  List::isEmpty)
+   * }</pre>
+   *
+   * <p>Backward direction is identity; the asymmetry of {@link #toOrElse(Accessor, Accessor,
+   * Object)} applies here too. Reach for the explicit 4-arg {@link #to(Accessor, Accessor,
+   * Function, Function)} when both directions need bespoke logic.
+   */
+  static <A, B, X> Mapping<A, B> toOrElse(
+    final Accessor<A, X> src,
+    final Accessor<B, X> tgt,
+    final X defaultValue,
+    final Predicate<? super X> missing
+  ) {
+    Objects.requireNonNull(missing, "Mapping.toOrElse: missing predicate is null");
+    // Null-short-circuit BEFORE the predicate fires so predicates like String::isBlank /
+    // List::isEmpty don't NPE on a null source value. Matches the 3-arg toOrElse's strict-null
+    // semantics for the leading-null case.
+    return new TypedTransformTo<>(src, tgt, x -> x == null || missing.test(x) ? defaultValue : x, y -> y);
+  }
+
+  /**
+   * Lazy null-coalescing same-typed correspondence: like {@link #toOrElse(Accessor, Accessor,
+   * Object)} but the fallback comes from a {@link Supplier} so an expensive-to-construct default is
+   * only materialized when the source actually is {@code null}. Closes MapStruct's {@code
+   * defaultExpression = "java(…)"} gap.
+   *
+   * <pre>{@code
+   * toOrElseGet(UserEntity::createdAt, UserDto::createdAt, Instant::now)
+   * }</pre>
+   *
+   * <p>Same backward-is-identity trade-off as {@link #toOrElse(Accessor, Accessor, Object)} — the
+   * supplied value, once it lands on the target, round-trips back to the source slot as itself
+   * rather than the original null.
+   */
+  static <A, B, X> Mapping<A, B> toOrElseGet(
+    final Accessor<A, X> src,
+    final Accessor<B, X> tgt,
+    final Supplier<? extends X> supplier
+  ) {
+    return new TypedTransformTo<>(src, tgt, x -> x == null ? supplier.get() : x, y -> y);
+  }
+
+  /**
+   * Predicate-gated lazy null-coalescing same-typed correspondence: {@code supplier.get()} runs
+   * when {@code missing.test(srcValue)} returns true. Generalises {@link #toOrElseGet(Accessor,
+   * Accessor, Supplier)} the same way the 4-arg {@link #toOrElse(Accessor, Accessor, Object,
+   * Predicate)} generalises {@link #toOrElse(Accessor, Accessor, Object)}.
+   *
+   * <pre>{@code
+   * toOrElseGet(Src::traceId, Dst::traceId, UUID::randomUUID, String::isBlank)
+   * }</pre>
+   */
+  static <A, B, X> Mapping<A, B> toOrElseGet(
+    final Accessor<A, X> src,
+    final Accessor<B, X> tgt,
+    final Supplier<? extends X> supplier,
+    final Predicate<? super X> missing
+  ) {
+    Objects.requireNonNull(missing, "Mapping.toOrElseGet: missing predicate is null");
+    // Null-short-circuit BEFORE the predicate fires — see the parallel toOrElse overload for the
+    // rationale (String::isBlank / List::isEmpty would NPE on null).
+    return new TypedTransformTo<>(src, tgt, x -> x == null || missing.test(x) ? supplier.get() : x, y -> y);
   }
 
   /**

--- a/core/src/main/java/io/github/eschizoid/telescope/mapping/Mapping.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/mapping/Mapping.java
@@ -73,6 +73,38 @@ public sealed interface Mapping<A, B>
   }
 
   /**
+   * Forward-only typed-transform correspondence: same shape as {@link #to(Accessor, Accessor,
+   * Function, Function)} but the backward function is supplied automatically and throws {@link
+   * UnsupportedOperationException} at the row level if invoked. Use this for one-shot entity →
+   * DB-schema mappings whose backward direction is never called — saves the boilerplate of passing
+   * an unused inverse function, and the throw message names the field so the failure is
+   * self-diagnosing if a downstream user does call {@link
+   * io.github.eschizoid.telescope.conversion.Mapper#backward} on the resulting mapper.
+   *
+   * <pre>{@code
+   * into(UserEntity::createdAt, UserDto::createdAtIso, Instant::toString)
+   * }</pre>
+   *
+   * <p>For the bidirectional variant, supply the inverse explicitly via {@link #to(Accessor,
+   * Accessor, Function, Function)}.
+   */
+  static <A, B, X, Y> Mapping<A, B> into(
+    final Accessor<A, X> src,
+    final Accessor<B, Y> tgt,
+    final Function<? super X, ? extends Y> forward
+  ) {
+    final String fieldName = LambdaIntrospection.methodNameOf(src);
+    final Function<? super Y, ? extends X> throwingBackward = y -> {
+      throw new UnsupportedOperationException(
+        "Mapping.into is forward-only — backward direction is undefined for field '" +
+          fieldName +
+          "'. Use Mapping.to(src, tgt, forward, backward) if a bidirectional row is required."
+      );
+    };
+    return new TypedTransformTo<>(src, tgt, forward, throwingBackward);
+  }
+
+  /**
    * Nested-target correspondence: stamp a flat source field through a multi-hop {@link Telescope}
    * on the target side. Closes the gap with MapStruct's {@code @Mapping(source = "flat", target =
    * "a.b.c")} by letting the second argument be a real {@code Telescope<B, X>} built with the same

--- a/core/src/test/java/io/github/eschizoid/telescope/MappingForwardTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/MappingForwardTest.java
@@ -1,6 +1,6 @@
 package io.github.eschizoid.telescope;
 
-import static io.github.eschizoid.telescope.mapping.Mapping.into;
+import static io.github.eschizoid.telescope.mapping.Mapping.forward;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -11,13 +11,13 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 /**
- * Pins {@code Mapping.into(src, tgt, fwd)} — the forward-only sibling of {@code Mapping.to(src,
+ * Pins {@code Mapping.forward(src, tgt, fn)} — the forward-only sibling of {@code Mapping.to(src,
  * tgt, fwd, bwd)} for one-shot entity → DB schema mappings whose backward is never called. The user
  * supplies just the forward function; the row's backward, if invoked, throws {@link
  * UnsupportedOperationException} with a self-diagnosing message that names the row and the target
  * field.
  */
-class MappingIntoTest {
+class MappingForwardTest {
 
   record Entity(Instant createdAt, String label) {}
 
@@ -25,15 +25,15 @@ class MappingIntoTest {
 
   @Nested
   @DisplayName("forward direction — runs the user's transform")
-  class Forward {
+  class ForwardRuns {
 
     @Test
-    @DisplayName("into transforms the source value into the target leaf")
+    @DisplayName("forward transforms the source value into the target leaf")
     void forwardRuns() {
       final var mapper = Telescope.mapper(
         Entity.class,
         Dto.class,
-        into(Entity::createdAt, Dto::createdAtIso, Instant::toString)
+        forward(Entity::createdAt, Dto::createdAtIso, Instant::toString)
       );
 
       final var entity = new Entity(Instant.parse("2026-01-01T00:00:00Z"), "x");
@@ -51,15 +51,15 @@ class MappingIntoTest {
       final var mapper = Telescope.mapper(
         Entity.class,
         Dto.class,
-        into(Entity::createdAt, Dto::createdAtIso, Instant::toString)
+        forward(Entity::createdAt, Dto::createdAtIso, Instant::toString)
       );
 
       final var dto = new Dto("2026-01-01T00:00:00Z", "x");
       final var ex = assertThrows(UnsupportedOperationException.class, () -> mapper.backward(dto));
       // Message should name the factory + the field so the failure is self-diagnosing.
       assertTrue(
-        ex.getMessage().toLowerCase().contains("into"),
-        () -> "expected message to mention into, was: " + ex.getMessage()
+        ex.getMessage().toLowerCase().contains("forward"),
+        () -> "expected message to mention forward, was: " + ex.getMessage()
       );
       assertTrue(
         ex.getMessage().contains("createdAt"),

--- a/core/src/test/java/io/github/eschizoid/telescope/MappingIntoTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/MappingIntoTest.java
@@ -1,0 +1,70 @@
+package io.github.eschizoid.telescope;
+
+import static io.github.eschizoid.telescope.mapping.Mapping.into;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Instant;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pins {@code Mapping.into(src, tgt, fwd)} — the forward-only sibling of {@code Mapping.to(src,
+ * tgt, fwd, bwd)} for one-shot entity → DB schema mappings whose backward is never called. The user
+ * supplies just the forward function; the row's backward, if invoked, throws {@link
+ * UnsupportedOperationException} with a self-diagnosing message that names the row and the target
+ * field.
+ */
+class MappingIntoTest {
+
+  record Entity(Instant createdAt, String label) {}
+
+  record Dto(String createdAtIso, String label) {}
+
+  @Nested
+  @DisplayName("forward direction — runs the user's transform")
+  class Forward {
+
+    @Test
+    @DisplayName("into transforms the source value into the target leaf")
+    void forwardRuns() {
+      final var mapper = Telescope.mapper(
+        Entity.class,
+        Dto.class,
+        into(Entity::createdAt, Dto::createdAtIso, Instant::toString)
+      );
+
+      final var entity = new Entity(Instant.parse("2026-01-01T00:00:00Z"), "x");
+      assertEquals(new Dto("2026-01-01T00:00:00Z", "x"), mapper.forward(entity));
+    }
+  }
+
+  @Nested
+  @DisplayName("backward direction — unsupported")
+  class Backward {
+
+    @Test
+    @DisplayName("backward throws UnsupportedOperationException with a self-diagnosing message")
+    void backwardThrows() {
+      final var mapper = Telescope.mapper(
+        Entity.class,
+        Dto.class,
+        into(Entity::createdAt, Dto::createdAtIso, Instant::toString)
+      );
+
+      final var dto = new Dto("2026-01-01T00:00:00Z", "x");
+      final var ex = assertThrows(UnsupportedOperationException.class, () -> mapper.backward(dto));
+      // Message should name the factory + the field so the failure is self-diagnosing.
+      assertTrue(
+        ex.getMessage().toLowerCase().contains("into"),
+        () -> "expected message to mention into, was: " + ex.getMessage()
+      );
+      assertTrue(
+        ex.getMessage().contains("createdAt"),
+        () -> "expected message to mention the row's field, was: " + ex.getMessage()
+      );
+    }
+  }
+}

--- a/core/src/test/java/io/github/eschizoid/telescope/MappingOrElseTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/MappingOrElseTest.java
@@ -1,0 +1,171 @@
+package io.github.eschizoid.telescope;
+
+import static io.github.eschizoid.telescope.mapping.Mapping.toOrElse;
+import static io.github.eschizoid.telescope.mapping.Mapping.toOrElseGet;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pins {@code Mapping.toOrElse(src, tgt, default)} and {@code Mapping.toOrElseGet(src, tgt,
+ * supplier)} — the null-coalescing defaults that close the gap with MapStruct's {@code
+ * defaultValue} / {@code defaultExpression}. When the source accessor returns {@code null}, the
+ * target receives the configured default (or the supplier's value) instead of the lambda dance
+ * users would otherwise write inline.
+ */
+class MappingOrElseTest {
+
+  record Src(String region, Integer count) {}
+
+  record Dst(String region, Integer count) {}
+
+  @Nested
+  @DisplayName("Mapping.toOrElse — constant default")
+  class ConstantDefault {
+
+    @Test
+    @DisplayName("null source → default lands on target")
+    void nullSourceUsesDefault() {
+      final var mapper = Telescope.mapper(
+        Src.class,
+        Dst.class,
+        toOrElse(Src::region, Dst::region, "DEFAULT-REGION"),
+        toOrElse(Src::count, Dst::count, 0)
+      );
+
+      assertEquals(new Dst("DEFAULT-REGION", 0), mapper.forward(new Src(null, null)));
+    }
+
+    @Test
+    @DisplayName("non-null source → source value passes through unchanged")
+    void nonNullSourcePassesThrough() {
+      final var mapper = Telescope.mapper(
+        Src.class,
+        Dst.class,
+        toOrElse(Src::region, Dst::region, "DEFAULT-REGION"),
+        toOrElse(Src::count, Dst::count, 0)
+      );
+
+      assertEquals(new Dst("US-WEST", 42), mapper.forward(new Src("US-WEST", 42)));
+    }
+  }
+
+  @Nested
+  @DisplayName("Mapping.toOrElseGet — supplier default (lazy)")
+  class SupplierDefault {
+
+    @Test
+    @DisplayName("null source → supplier is invoked; non-null source → supplier is NOT invoked")
+    void supplierLazyEvaluation() {
+      final var calls = new AtomicInteger();
+      final var mapper = Telescope.mapper(
+        Src.class,
+        Dst.class,
+        toOrElseGet(Src::region, Dst::region, () -> {
+          calls.incrementAndGet();
+          return "LAZY-DEFAULT";
+        })
+      );
+
+      // null source → supplier runs once.
+      assertEquals("LAZY-DEFAULT", mapper.forward(new Src(null, 1)).region());
+      assertEquals(1, calls.get(), "supplier invoked on null source");
+
+      // non-null source → supplier NOT invoked, source value lands.
+      assertEquals("EU-WEST", mapper.forward(new Src("EU-WEST", 1)).region());
+      assertEquals(1, calls.get(), "supplier NOT invoked when source is non-null");
+    }
+  }
+
+  @Nested
+  @DisplayName("Mapping.toOrElse — predicate-gated (4-arg overload)")
+  class PredicateGatedDefault {
+
+    record Wide(String region, List<Integer> items) {}
+
+    @Test
+    @DisplayName("predicate fires the default on empty string, not just null")
+    void blankStringFires() {
+      final var mapper = Telescope.mapper(
+        Wide.class,
+        Wide.class,
+        toOrElse(Wide::region, Wide::region, "DEFAULT", String::isBlank)
+      );
+
+      assertEquals("DEFAULT", mapper.forward(new Wide("", List.of(1))).region(), "empty string → default");
+      assertEquals("DEFAULT", mapper.forward(new Wide("   ", List.of(1))).region(), "whitespace → default");
+      assertEquals("US", mapper.forward(new Wide("US", List.of(1))).region(), "non-blank → passes through");
+    }
+
+    @Test
+    @DisplayName("predicate fires the default on empty collection")
+    void emptyCollectionFires() {
+      final var mapper = Telescope.mapper(
+        Wide.class,
+        Wide.class,
+        toOrElse(Wide::items, Wide::items, List.<Integer>of(99), List::isEmpty)
+      );
+
+      assertEquals(List.of(99), mapper.forward(new Wide("US", List.of())).items());
+      assertEquals(List.of(1, 2), mapper.forward(new Wide("US", List.of(1, 2))).items());
+    }
+  }
+
+  @Nested
+  @DisplayName("Mapping.toOrElseGet — predicate-gated (4-arg overload)")
+  class PredicateGatedSupplierDefault {
+
+    @Test
+    @DisplayName("supplier fires only when predicate matches")
+    void supplierLazyOnPredicate() {
+      final var calls = new AtomicInteger();
+      final var mapper = Telescope.mapper(
+        Src.class,
+        Dst.class,
+        toOrElseGet(
+          Src::region,
+          Dst::region,
+          () -> {
+            calls.incrementAndGet();
+            return "GENERATED";
+          },
+          String::isBlank
+        )
+      );
+
+      // empty → supplier fires
+      assertEquals("GENERATED", mapper.forward(new Src("", 1)).region());
+      assertEquals(1, calls.get());
+
+      // non-blank, non-null → predicate is false, supplier is NOT invoked
+      assertEquals("US", mapper.forward(new Src("US", 1)).region());
+      assertEquals(1, calls.get(), "supplier NOT invoked when predicate is false");
+
+      // null → null-short-circuit BEFORE the predicate, so `String::isBlank` doesn't NPE on null.
+      // Supplier fires; result is the supplier's value.
+      assertEquals("GENERATED", mapper.forward(new Src(null, 1)).region());
+      assertEquals(2, calls.get(), "supplier invoked on null source via null-short-circuit");
+    }
+
+    @Test
+    @DisplayName("predicate-gated toOrElse(value, predicate) null-short-circuits before the predicate")
+    void valueDefaultNullSafe() {
+      final var mapper = Telescope.mapper(
+        Src.class,
+        Dst.class,
+        toOrElse(Src::region, Dst::region, "FALLBACK", String::isBlank)
+      );
+
+      // null → null-short-circuit, predicate not called, default lands on target
+      assertEquals("FALLBACK", mapper.forward(new Src(null, 1)).region());
+      // blank → predicate true, default lands
+      assertEquals("FALLBACK", mapper.forward(new Src("   ", 1)).region());
+      // non-blank → predicate false, source passes through
+      assertEquals("UK", mapper.forward(new Src("UK", 1)).region());
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds `Mapping.into(src, tgt, fwd)` — a forward-only sibling of `Mapping.to(src, tgt, fwd, bwd)`. The user supplies just the forward function.

```java
// Before
Mapping.to(UserEntity::createdAt, UserDto::createdAtIso,
           Instant::toString,
           Instant::parse);  // backward never called

// After
Mapping.into(UserEntity::createdAt, UserDto::createdAtIso, Instant::toString);
```

The name `into` reads as "one-way deposit" — distinguishes the call site from the bidirectional `to*` family.

Thin wrapper delegating to the existing `TypedTransformTo` record — no new sealed permits, no engine changes (in this PR; PR for the sealed permit follows separately).

## Test plan

- [x] `MappingIntoTest` — forward runs the user's transform; backward throws `UnsupportedOperationException` naming both the factory (`into`) and the source field.
- [x] Full `./gradlew test` green.
