### PR TITLE
feat(mapper): post-mapping hooks — afterForward / beforeBackward

### DIFF
--- a/core/src/main/java/io/github/eschizoid/telescope/conversion/Mapper.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/conversion/Mapper.java
@@ -155,7 +155,11 @@ public final class Mapper<A, B> {
    * }</pre>
    */
   public Telescope<A, B> asTelescope() {
-    return Telescope.iso(iso::to, iso::from);
+    // Route through this::forward / this::backward (NOT iso::to / iso::from) so the four hook
+    // fields (beforeForward / afterForward / beforeBackward / afterBackward) compose into the
+    // returned Telescope. Calling iso::to directly bypasses the hook chain — a configured mapper
+    // would silently drop its hooks when handed to longer .then(...) chains via this method.
+    return Telescope.iso(this::forward, this::backward);
   }
 
   /**
@@ -241,6 +245,9 @@ public final class Mapper<A, B> {
    * Telescope.mapper(Entity.class, Dto.class, ...)
    *     .beforeForward(e -> e.normalised());
    * }</pre>
+   *
+   * @see io.github.eschizoid.telescope.Telescope#before(Function) for the path-level (single-
+   *     direction, lattice-native) sibling that composes through {@code .then(...)} chains.
    */
   public Mapper<A, B> beforeForward(final Function<? super A, ? extends A> hook) {
     final Function<A, A> prev = this.preForward;
@@ -275,6 +282,9 @@ public final class Mapper<A, B> {
    * Telescope.mapper(Entity.class, Dto.class, ...)
    *     .afterForward(dto -> dto.withUpdatedAt(Instant.now().toString()));
    * }</pre>
+   *
+   * @see io.github.eschizoid.telescope.Telescope#after(Function) for the path-level (single-
+   *     direction, lattice-native) sibling that composes through {@code .then(...)} chains.
    */
   public Mapper<A, B> afterForward(final Function<? super B, ? extends B> hook) {
     return afterForward((a, b) -> hook.apply(b));

--- a/core/src/main/java/io/github/eschizoid/telescope/conversion/Mapper.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/conversion/Mapper.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 
 /**
@@ -43,6 +44,26 @@ public final class Mapper<A, B> {
   private final Reflective sourceRefl;
   private final Reflective targetRefl;
   private final Map<String, PatchEntry> patchByTargetField;
+  // Folded hook chains — null = no hook. Composed by repeated calls to before*/after*. Each side
+  // is a single Function/BiFunction reference at call time so HotSpot stays monomorphic regardless
+  // of chain depth (avoids the megamorphic Iso.of cliff that the per-hook-Iso composition shape
+  // produced at 3+ hooks).
+  //
+  // Lattice mandate carve-out — these are NOT routed through the optic lattice on purpose. The
+  // lattice's bidirectional substrate (`Iso<A, B>`) requires the round-trip law `from(to(a)) == a`.
+  // A user-supplied hook like `e -> e.normalised()` has no inverse — wrapping it as
+  // `Iso.of(hook, identity)` would construct a fake Iso that silently violates the laws
+  // `OpticLawsTest` pins. That's worse than admitting the hook isn't lattice-shaped. The Telescope-
+  // level equivalents (`Telescope.after/before`, PR #90) get away with the partial-Iso shape
+  // because Telescope is read-or-write through a Traversal — there's no single-value round-trip
+  // through both legs. `Mapper.forward(a)` and `Mapper.backward(b)` ARE both surfaces of a single
+  // contract, so the lattice-routed shape would break composition. The four hook fields below own
+  // that responsibility instead, and the engine `forward` / `backward` methods (just above)
+  // compose them around the underlying iso explicitly.
+  private final Function<A, A> preForward;
+  private final BiFunction<A, B, B> postForward;
+  private final Function<B, B> preBackward;
+  private final BiFunction<B, A, A> postBackward;
 
   /**
    * <b>Module-internal seam — NOT public API.</b> Construct a mapper directly from an {@link Iso},
@@ -59,6 +80,19 @@ public final class Mapper<A, B> {
     final Class<B> targetClass,
     final Map<String, PatchEntry> patchByTargetField
   ) {
+    this(iso, sourceClass, targetClass, patchByTargetField, null, null, null, null);
+  }
+
+  private Mapper(
+    final Iso<A, B> iso,
+    final Class<A> sourceClass,
+    final Class<B> targetClass,
+    final Map<String, PatchEntry> patchByTargetField,
+    final Function<A, A> preForward,
+    final BiFunction<A, B, B> postForward,
+    final Function<B, B> preBackward,
+    final BiFunction<B, A, A> postBackward
+  ) {
     this.iso = iso;
     this.sourceClass = sourceClass;
     this.targetClass = targetClass;
@@ -66,6 +100,10 @@ public final class Mapper<A, B> {
     this.targetRefl = Reflective.of(targetClass);
     // Defensive copy — patch behavior must not mutate after construction.
     this.patchByTargetField = Map.copyOf(patchByTargetField);
+    this.preForward = preForward;
+    this.postForward = postForward;
+    this.preBackward = preBackward;
+    this.postBackward = postBackward;
   }
 
   /**
@@ -101,7 +139,7 @@ public final class Mapper<A, B> {
    * use {@link #patch}.
    */
   public B read(final A a) {
-    return iso.to(a);
+    return forward(a);
   }
 
   /**
@@ -175,12 +213,145 @@ public final class Mapper<A, B> {
    * io.github.eschizoid.telescope.mapping.Mapping#via via(...)} row).
    */
   public B forward(final A a) {
-    return iso.to(a);
+    final A a1 = preForward == null ? a : preForward.apply(a);
+    final B b = iso.to(a1);
+    return postForward == null ? b : postForward.apply(a1, b);
   }
 
   /** Backward conversion {@code B → A}. See {@link #forward(Object)}. */
   public A backward(final B b) {
-    return iso.from(b);
+    final B b1 = preBackward == null ? b : preBackward.apply(b);
+    final A a = iso.from(b1);
+    return postBackward == null ? a : postBackward.apply(b1, a);
+  }
+
+  /**
+   * Compose a pre-forward hook: before the structural forward direction reads from {@code A}, run
+   * {@code hook} on the source and feed the result into the conversion. MapStruct's
+   * {@code @BeforeMapping void prep(Source src)} equivalent — the canonical place for input
+   * normalisation, validation, or canonicalisation.
+   *
+   * <p>The hook is a {@link Function}, not a {@link java.util.function.Consumer}, so it works for
+   * both immutable record sources (return a new {@code A} with the hook's changes) and mutable bean
+   * sources (mutate {@code a} in place and {@code return a} the same instance).
+   *
+   * <p>Returns a new {@code Mapper} — chains compose left-to-right.
+   *
+   * <pre>{@code
+   * Telescope.mapper(Entity.class, Dto.class, ...)
+   *     .beforeForward(e -> e.normalised());
+   * }</pre>
+   */
+  public Mapper<A, B> beforeForward(final Function<? super A, ? extends A> hook) {
+    final Function<A, A> prev = this.preForward;
+    final Function<A, A> next = prev == null ? a -> hook.apply(a) : a -> hook.apply(prev.apply(a));
+    return new Mapper<>(
+      iso,
+      sourceClass,
+      targetClass,
+      patchByTargetField,
+      next,
+      postForward,
+      preBackward,
+      postBackward
+    );
+  }
+
+  /**
+   * Compose a post-forward hook: after the structural forward direction produces a {@code B}, run
+   * {@code hook} on it and return whatever the hook returns. Closes MapStruct's
+   * {@code @AfterMapping} gap for the common "stamp a derived/computed value after the structural
+   * mapping completes" case ({@code entity.setUpdatedAt(Instant.now())} after the row data is in
+   * place).
+   *
+   * <p>The hook is a {@link Function}, not a {@link java.util.function.Consumer}, so it works for
+   * both immutable record targets (return a new {@code B} with the hook's changes) and mutable bean
+   * targets (mutate {@code b} in place and {@code return b} the same instance).
+   *
+   * <p>Returns a new {@code Mapper} — chains compose left-to-right (the first {@code afterForward}
+   * call's hook runs first, the second runs second, etc.). The backward direction is unchanged.
+   *
+   * <pre>{@code
+   * Telescope.mapper(Entity.class, Dto.class, ...)
+   *     .afterForward(dto -> dto.withUpdatedAt(Instant.now().toString()));
+   * }</pre>
+   */
+  public Mapper<A, B> afterForward(final Function<? super B, ? extends B> hook) {
+    return afterForward((a, b) -> hook.apply(b));
+  }
+
+  /**
+   * Source-aware post-forward hook: same as {@link #afterForward(Function)} but the hook receives
+   * BOTH the source {@code A} (as seen by the forward direction, after any {@link
+   * #beforeForward(Function)} normalisation) AND the structural result {@code B}. MapStruct's
+   * {@code @AfterMapping void enrich(Source src, @MappingTarget Dto dto)} equivalent — typed, not
+   * reflective.
+   *
+   * <pre>{@code
+   * Telescope.mapper(Entity.class, Dto.class, ...)
+   *     .afterForward((src, dto) -> dto.withDisplayName(src.firstName() + " " + src.lastName()));
+   * }</pre>
+   */
+  public Mapper<A, B> afterForward(final BiFunction<? super A, ? super B, ? extends B> hook) {
+    final BiFunction<A, B, B> prev = this.postForward;
+    final BiFunction<A, B, B> next =
+      prev == null ? (a, b) -> hook.apply(a, b) : (a, b) -> hook.apply(a, prev.apply(a, b));
+    return new Mapper<>(iso, sourceClass, targetClass, patchByTargetField, preForward, next, preBackward, postBackward);
+  }
+
+  /**
+   * Compose a pre-backward hook: before the structural backward direction consumes a {@code B}, run
+   * {@code hook} on it and feed the result into {@code backward}. The MapStruct
+   * {@code @BeforeMapping} equivalent for the backward direction.
+   *
+   * <p>Returns a new {@code Mapper} — chains compose left-to-right (the first {@code
+   * beforeBackward} call's hook runs first on a backward invocation). The forward direction is
+   * unchanged.
+   *
+   * <pre>{@code
+   * Telescope.mapper(Entity.class, Dto.class, ...)
+   *     .beforeBackward(dto -> dto.normalised());
+   * }</pre>
+   */
+  public Mapper<A, B> beforeBackward(final Function<? super B, ? extends B> hook) {
+    final Function<B, B> prev = this.preBackward;
+    final Function<B, B> next = prev == null ? b -> hook.apply(b) : b -> hook.apply(prev.apply(b));
+    return new Mapper<>(iso, sourceClass, targetClass, patchByTargetField, preForward, postForward, next, postBackward);
+  }
+
+  /**
+   * Compose a post-backward hook: after the structural backward direction produces a rebuilt {@code
+   * A}, run {@code hook} on it and return whatever the hook returns. The symmetric mirror of {@link
+   * #afterForward(Function)} for the backward direction.
+   *
+   * <p>The canonical place to stamp source-side derived fields after a target → source rebuild
+   * (e.g. {@code entity.setLastModifiedBy(currentUser())} during a backward write).
+   *
+   * <pre>{@code
+   * Telescope.mapper(Entity.class, Dto.class, ...)
+   *     .afterBackward(e -> e.withLastModifiedAt(Instant.now()));
+   * }</pre>
+   */
+  public Mapper<A, B> afterBackward(final Function<? super A, ? extends A> hook) {
+    return afterBackward((b, a) -> hook.apply(a));
+  }
+
+  /**
+   * Target-aware post-backward hook: same as {@link #afterBackward(Function)} but the hook receives
+   * BOTH the target {@code B} (as seen by the backward direction, after any {@link
+   * #beforeBackward(Function)} normalisation) AND the rebuilt source {@code A}. Use when the stamp
+   * depends on a target-side field that the source doesn't carry.
+   *
+   * <pre>{@code
+   * Telescope.mapper(Entity.class, Dto.class, ...)
+   *     .afterBackward((dto, entity) -> entity.withAuditTrail(dto.actor() + "@" + Instant.now()));
+   * }</pre>
+   */
+  public Mapper<A, B> afterBackward(final BiFunction<? super B, ? super A, ? extends A> hook) {
+    final BiFunction<B, A, A> prev = this.postBackward;
+    final BiFunction<B, A, A> next =
+      prev == null ? (b, a) -> hook.apply(b, a) : (b, a) -> hook.apply(b, prev.apply(b, a));
+    return new Mapper<>(iso, sourceClass, targetClass, patchByTargetField, preForward, postForward, preBackward, next);
   }
 
   /**

--- a/core/src/test/java/io/github/eschizoid/telescope/MapperPostHooksTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/MapperPostHooksTest.java
@@ -1,0 +1,208 @@
+package io.github.eschizoid.telescope;
+
+import static io.github.eschizoid.telescope.mapping.Mapping.drop;
+import static io.github.eschizoid.telescope.mapping.Mapping.to;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+
+import io.github.eschizoid.telescope.conversion.Mapper;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pins {@code Mapper}'s four symmetric pre/post hooks ({@code beforeForward}, {@code afterForward},
+ * {@code beforeBackward}, {@code afterBackward}) plus the source/target- aware {@link
+ * java.util.function.BiFunction} overloads on the after-hooks. Each hook returns a fresh {@link
+ * Mapper} with the hook folded into a per-direction {@link java.util.function.Function} / {@link
+ * java.util.function.BiFunction} field — no megamorphic {@link
+ * io.github.eschizoid.telescope.internal.optics.Iso} chain regardless of chain depth.
+ *
+ * <p>Hooks use {@code Function<X, X>} (or {@code BiFunction}) — not {@code Consumer<X>} — so they
+ * work for both immutable records and mutable beans.
+ */
+class MapperPostHooksTest {
+
+  record Entity(String id, String firstName, String lastName, Long updatedAtMillis) {}
+
+  record Dto(String id, String fullName, Long updatedAtMillis) {}
+
+  // DeepMap is strict on missing rows; drop firstName/lastName so the structural step doesn't
+  // reject the mismatch — the hooks supply fullName cross-cuttingly in these tests.
+  private static Mapper<Entity, Dto> baseMapper() {
+    return Telescope.mapper(
+      Entity.class,
+      Dto.class,
+      to(Entity::id, Dto::id),
+      drop(Entity::firstName),
+      drop(Entity::lastName),
+      to(Entity::updatedAtMillis, Dto::updatedAtMillis),
+      to(Entity::firstName, Dto::fullName)
+    );
+  }
+
+  @Nested
+  @DisplayName("beforeForward — runs before the structural forward direction reads the source")
+  class BeforeForward {
+
+    @Test
+    @DisplayName("hook rewrites the source seen by the forward conversion")
+    void hookRewritesSource() {
+      final Mapper<Entity, Dto> mapper = baseMapper().beforeForward(e ->
+        new Entity(e.id().trim(), e.firstName(), e.lastName(), e.updatedAtMillis())
+      );
+
+      final var out = mapper.forward(new Entity("  e-1  ", "Alice", null, null));
+      assertEquals("e-1", out.id(), "trimmed id from beforeForward hook lands on the dto");
+    }
+  }
+
+  @Nested
+  @DisplayName("afterForward — runs after the structural forward direction produces the target")
+  class AfterForward {
+
+    @Test
+    @DisplayName("Function<B, B> hook rewrites the forward output")
+    void hookRewritesForwardOutput() {
+      final Mapper<Entity, Dto> mapper = baseMapper().afterForward(d -> new Dto(d.id(), d.fullName(), 12345L));
+
+      assertEquals(12345L, mapper.forward(new Entity("e-1", "Alice", "X", null)).updatedAtMillis());
+    }
+
+    @Test
+    @DisplayName("BiFunction<A, B, B> hook sees both source and target — typed denormalization")
+    void biFunctionSeesSource() {
+      final Mapper<Entity, Dto> mapper = baseMapper().afterForward((src, dto) ->
+        new Dto(dto.id(), src.firstName() + " " + src.lastName(), dto.updatedAtMillis())
+      );
+
+      final var out = mapper.forward(new Entity("e-1", "Alice", "Wonderland", null));
+      assertEquals("Alice Wonderland", out.fullName());
+    }
+
+    @Test
+    @DisplayName("returns a new Mapper — the original is unchanged")
+    void returnsNewMapperInstance() {
+      final Mapper<Entity, Dto> base = baseMapper();
+      final Mapper<Entity, Dto> withHook = base.afterForward(d -> new Dto(d.id(), d.fullName(), 99L));
+
+      assertNotSame(base, withHook);
+      assertEquals(null, base.forward(new Entity("e-1", "A", null, null)).updatedAtMillis());
+      assertEquals(99L, withHook.forward(new Entity("e-1", "A", null, null)).updatedAtMillis());
+    }
+
+    @Test
+    @DisplayName("chained Function hooks compose left-to-right (first call runs first)")
+    void hooksComposeInOrder() {
+      final Mapper<Entity, Dto> mapper = baseMapper()
+        .afterForward(d -> new Dto(d.id(), d.fullName() + "-1", d.updatedAtMillis()))
+        .afterForward(d -> new Dto(d.id(), d.fullName() + "-2", d.updatedAtMillis()));
+
+      // fullName is null initially (no row maps it); 1st hook turns "null-1", 2nd → "null-1-2"
+      assertEquals("null-1-2", mapper.forward(new Entity("e-1", null, null, null)).fullName());
+    }
+
+    @Test
+    @DisplayName("chained BiFunction hooks also compose left-to-right with source access throughout")
+    void biFunctionHooksCompose() {
+      final Mapper<Entity, Dto> mapper = baseMapper()
+        .afterForward((src, dto) -> new Dto(dto.id(), src.firstName().toUpperCase(), dto.updatedAtMillis()))
+        .afterForward((src, dto) ->
+          new Dto(dto.id(), dto.fullName() + " (" + src.lastName() + ")", dto.updatedAtMillis())
+        );
+
+      assertEquals("ALICE (Wonderland)", mapper.forward(new Entity("e-1", "Alice", "Wonderland", null)).fullName());
+    }
+  }
+
+  @Nested
+  @DisplayName("beforeBackward — runs before the structural backward direction consumes the target")
+  class BeforeBackward {
+
+    @Test
+    @DisplayName("hook rewrites the input target value seen by backward")
+    void hookRewritesBackwardInput() {
+      final Mapper<Entity, Dto> mapper = baseMapper().beforeBackward(d ->
+        new Dto(d.id().trim(), d.fullName(), d.updatedAtMillis())
+      );
+
+      final var entity = mapper.backward(new Dto("  e-1  ", "Alice", 42L));
+      assertEquals("e-1", entity.id());
+    }
+  }
+
+  @Nested
+  @DisplayName("afterBackward — runs after the structural backward direction produces the source")
+  class AfterBackward {
+
+    @Test
+    @DisplayName("Function<A, A> hook rewrites the rebuilt source")
+    void hookRewritesBackwardOutput() {
+      final Mapper<Entity, Dto> mapper = baseMapper().afterBackward(e ->
+        new Entity(e.id(), e.firstName(), e.lastName(), 999L)
+      );
+
+      assertEquals(999L, mapper.backward(new Dto("e-1", "x", null)).updatedAtMillis());
+    }
+
+    @Test
+    @DisplayName("BiFunction<B, A, A> hook sees both target and source — audit-stamping pattern")
+    void biFunctionSeesTarget() {
+      final Mapper<Entity, Dto> mapper = baseMapper().afterBackward((dto, entity) ->
+        new Entity(entity.id(), entity.firstName(), entity.lastName(), dto.updatedAtMillis())
+      );
+
+      final var entity = mapper.backward(new Dto("e-1", "x", 555L));
+      assertEquals(
+        555L,
+        entity.updatedAtMillis(),
+        "BiFunction read the dto's audit field and stamped it on the entity"
+      );
+    }
+  }
+
+  @Nested
+  @DisplayName("hooks fire only on their direction — laziness contract")
+  class HookLaziness {
+
+    @Test
+    @DisplayName("each of the four hooks fires on exactly its direction; not the other")
+    void hooksFireOnlyOnTheirDirection() {
+      final var beforeFwd = new AtomicInteger();
+      final var afterFwd = new AtomicInteger();
+      final var beforeBwd = new AtomicInteger();
+      final var afterBwd = new AtomicInteger();
+
+      final Mapper<Entity, Dto> mapper = baseMapper()
+        .beforeForward(e -> {
+          beforeFwd.incrementAndGet();
+          return e;
+        })
+        .afterForward(d -> {
+          afterFwd.incrementAndGet();
+          return d;
+        })
+        .beforeBackward(d -> {
+          beforeBwd.incrementAndGet();
+          return d;
+        })
+        .afterBackward(e -> {
+          afterBwd.incrementAndGet();
+          return e;
+        });
+
+      mapper.forward(new Entity("e-1", "A", null, null));
+      assertEquals(1, beforeFwd.get(), "beforeForward fired on forward()");
+      assertEquals(1, afterFwd.get(), "afterForward fired on forward()");
+      assertEquals(0, beforeBwd.get(), "beforeBackward did NOT fire on forward()");
+      assertEquals(0, afterBwd.get(), "afterBackward did NOT fire on forward()");
+
+      mapper.backward(new Dto("e-1", "A", null));
+      assertEquals(1, beforeFwd.get(), "beforeForward did NOT fire on backward()");
+      assertEquals(1, afterFwd.get(), "afterForward did NOT fire on backward()");
+      assertEquals(1, beforeBwd.get(), "beforeBackward fired on backward()");
+      assertEquals(1, afterBwd.get(), "afterBackward fired on backward()");
+    }
+  }
+}

--- a/core/src/test/java/io/github/eschizoid/telescope/MapperPostHooksTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/MapperPostHooksTest.java
@@ -205,4 +205,65 @@ class MapperPostHooksTest {
       assertEquals(1, afterBwd.get(), "afterBackward fired on backward()");
     }
   }
+
+  @Nested
+  @DisplayName("asTelescope() — propagates hooks (regression: previously dropped them silently)")
+  class AsTelescopePropagatesHooks {
+
+    @Test
+    @DisplayName("asTelescope().read(a) runs beforeForward + afterForward (forward leg)")
+    void asTelescopeReadFiresForwardHooks() {
+      final var beforeFwd = new AtomicInteger();
+      final var afterFwd = new AtomicInteger();
+
+      final var telescope = baseMapper()
+        .beforeForward(e -> {
+          beforeFwd.incrementAndGet();
+          return e;
+        })
+        .afterForward(d -> {
+          afterFwd.incrementAndGet();
+          return d;
+        })
+        .asTelescope();
+
+      telescope.read(new Entity("e-1", "Alice", "Wonderland", 0L));
+      assertEquals(1, beforeFwd.get(), "beforeForward must fire on asTelescope().read()");
+      assertEquals(1, afterFwd.get(), "afterForward must fire on asTelescope().read()");
+    }
+
+    @Test
+    @DisplayName("asTelescope().set(a, b) runs beforeBackward + afterBackward (backward leg)")
+    void asTelescopeSetFiresBackwardHooks() {
+      final var beforeBwd = new AtomicInteger();
+      final var afterBwd = new AtomicInteger();
+
+      final var telescope = baseMapper()
+        .beforeBackward(d -> {
+          beforeBwd.incrementAndGet();
+          return d;
+        })
+        .afterBackward(e -> {
+          afterBwd.incrementAndGet();
+          return e;
+        })
+        .asTelescope();
+
+      telescope.set(new Entity("e-1", "X", "Y", 0L), new Dto("e-1", "X", null));
+      assertEquals(1, beforeBwd.get(), "beforeBackward must fire on asTelescope().set()");
+      assertEquals(1, afterBwd.get(), "afterBackward must fire on asTelescope().set()");
+    }
+
+    @Test
+    @DisplayName("asTelescope() preserves a hook's value-transforming behavior (not just side effects)")
+    void asTelescopePropagatesValueTransform() {
+      final var telescope = baseMapper()
+        .afterForward(d -> new Dto(d.id(), d.fullName() + "!", d.updatedAtMillis()))
+        .asTelescope();
+
+      final var dto = telescope.read(new Entity("e-1", "Alice", "X", 0L));
+      // afterForward suffixes "!" — if asTelescope() dropped the hook, this would just be "Alice"
+      assertEquals("Alice!", dto.fullName());
+    }
+  }
 }


### PR DESCRIPTION
## Summary

Closes MapStruct's `@AfterMapping` / `@BeforeMapping` gap. Four symmetric hooks on `Mapper` compose user-supplied transforms into either direction without breaking the bidirectional structural model.

```java
Telescope.mapper(Entity.class, Dto.class, ...)
    .beforeForward(e -> e.normalised())
    .afterForward((src, dto) -> dto.withDisplayName(src.firstName() + " " + src.lastName()))
    .beforeBackward(dto -> dto.canonicalised())
    .afterBackward((dto, entity) -> entity.withAuditTrail(dto.actor()));
```

- `beforeForward(Function<A, A>)` / `afterForward(Function<B, B>)` / `afterForward(BiFunction<A, B, B>)` — source-aware via the BiFunction overload.
- `beforeBackward(Function<B, B>)` / `afterBackward(Function<A, A>)` / `afterBackward(BiFunction<B, A, A>)` — symmetric.

## Source-aware BiFunction overloads

`afterForward(BiFunction<A, B, B>)` and `afterBackward(BiFunction<B, A, A>)` give the hook BOTH sides typed at compile time. MapStruct's `@AfterMapping void enrich(Source src, @MappingTarget Dto dto)` is the rough equivalent, but routed via reflection rather than typed signatures.

## Perf refactor — folded chain, not nested Iso

Hooks are stored as four nullable `Function`/`BiFunction` fields on `Mapper`, composed in-place at each `before*`/`after*` call. Avoids the megamorphic-Iso cliff that the per-hook-Iso composition shape produces at 3+ hooks.

**Lattice carve-out documented in code:** hooks have no inverse (a user transform like `e -> e.normalised()` is not a round-trippable Iso). Wrapping as `Iso.of(hook, identity)` would silently violate the round-trip law `from(to(a)) == a`. The four hook fields explicitly own this responsibility instead — the comment in `Mapper.java` explains why future-me can't "fix" this back into the lattice.

## Test plan

- [x] `MapperPostHooksTest` — 10 tests covering each of the four hooks, both arities of the after-hooks, new-Mapper-instance invariant, chain order, and laziness contract.
- [x] Full `./gradlew test` green.
