### PR TITLE
feat(conversion): ForwardMapper<A, B> + Telescope.mapperForward(...)

### DIFF
--- a/core/src/main/java/io/github/eschizoid/telescope/Telescope.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/Telescope.java
@@ -1,6 +1,7 @@
 package io.github.eschizoid.telescope;
 
 import io.github.eschizoid.telescope.conversion.BridgeFn;
+import io.github.eschizoid.telescope.conversion.ForwardMapper;
 import io.github.eschizoid.telescope.conversion.From;
 import io.github.eschizoid.telescope.conversion.Mapper;
 import io.github.eschizoid.telescope.effects.Either;
@@ -506,6 +507,38 @@ public sealed class Telescope<
    */
   public static <A, B> Mapper<A, B> mapper(final Class<A> source, final Class<B> target, final MapStep... steps) {
     return DeepMap.resolveMapper(source, target, steps);
+  }
+
+  /**
+   * Forward-only sibling of {@link #mapper(Class, Class, MapStep...)} — returns a {@link
+   * ForwardMapper} whose backward direction is not present at the type level. Use when the
+   * conversion is genuinely one-way (entity → DTO write-only, audit-log projection, normalisation
+   * pipeline) and rows include {@link io.github.eschizoid.telescope.mapping.Mapping#into into(...)}
+   * / {@link io.github.eschizoid.telescope.mapping.Mapping#constant constant(...)} / {@link
+   * io.github.eschizoid.telescope.mapping.Mapping#compute compute(...)} that make the backward
+   * direction meaningless.
+   *
+   * <p>The compiler enforces the one-way contract — there is no {@code backward(...)} method on
+   * {@link ForwardMapper} to call. MapStruct cannot express "this mapper is one-way" in its type
+   * system; this is the differentiator the type system buys.
+   *
+   * <pre>{@code
+   * ForwardMapper<UserEntity, UserDto> projector = Telescope.mapperForward(
+   *     UserEntity.class, UserDto.class,
+   *     to(UserEntity::id, UserDto::id),
+   *     into(UserEntity::createdAt, UserDto::createdAtIso, Instant::toString),
+   *     constant(UserDto::tenant, "production"));
+   *
+   * UserDto dto = projector.forward(entity);
+   * }</pre>
+   */
+  public static <A, B> ForwardMapper<A, B> mapperForward(
+    final Class<A> source,
+    final Class<B> target,
+    final MapStep... steps
+  ) {
+    final var bidi = DeepMap.resolveMapper(source, target, steps);
+    return ForwardMapper.create(bidi::forward, source, target);
   }
 
   /**

--- a/core/src/main/java/io/github/eschizoid/telescope/conversion/ForwardMapper.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/conversion/ForwardMapper.java
@@ -73,7 +73,9 @@ public final class ForwardMapper<A, B> {
    * }</pre>
    */
   public <C> ForwardMapper<A, C> then(final ForwardMapper<B, C> next) {
-    final Getter<A, C> composed = a -> next.forward.get(forward.get(a));
+    // Genuine lattice routing: Getter.then(Getter) composes two read-only optics into one. The
+    // composition is one method call on the substrate, not an inline lambda closure.
+    final Getter<A, C> composed = forward.then(next.forward);
     return new ForwardMapper<>(composed, sourceClass, next.targetClass);
   }
 

--- a/core/src/main/java/io/github/eschizoid/telescope/conversion/ForwardMapper.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/conversion/ForwardMapper.java
@@ -1,0 +1,89 @@
+package io.github.eschizoid.telescope.conversion;
+
+import io.github.eschizoid.telescope.Telescope;
+import io.github.eschizoid.telescope.internal.optics.Getter;
+
+/**
+ * A forward-only {@code A → B} mapper produced by {@link Telescope#mapperForward(Class, Class,
+ * io.github.eschizoid.telescope.mapping.MapStep...)}. The backward direction is not present at the
+ * type level — there is no {@code backward(...)} method to call — so the "this mapper is one-way"
+ * contract is enforced by the compiler rather than by a runtime throw.
+ *
+ * <p>Use this when the conversion is genuinely directional — entity → DTO write-only, audit-log
+ * projection, normalisation pipeline — and the round-trip ergonomics of {@link Mapper} are not just
+ * unused but actively misleading. MapStruct cannot express "this mapper is one-way" in its type
+ * system; the typed escape valve here is exactly the differentiator the type system buys.
+ *
+ * <p>For bidirectional conversions, use {@link Telescope#mapper(Class, Class,
+ * io.github.eschizoid.telescope.mapping.MapStep...)} and the regular {@link Mapper}.
+ */
+public final class ForwardMapper<A, B> {
+
+  // Lattice-routed: the read substrate is the internal `Getter<A, B>` (the lattice's read-only
+  // optic primitive — the same shape Mapper's bidirectional `Iso<A, B>` weakens to). Stored as
+  // the optic, not a raw `Function`, so the lattice carries the field semantics — composition
+  // via .then(...) below routes through Getter.then(Getter) rather than ad-hoc Function chains.
+  private final Getter<A, B> forward;
+  private final Class<A> sourceClass;
+  private final Class<B> targetClass;
+
+  ForwardMapper(final Getter<A, B> forward, final Class<A> sourceClass, final Class<B> targetClass) {
+    this.forward = forward;
+    this.sourceClass = sourceClass;
+    this.targetClass = targetClass;
+  }
+
+  /**
+   * <b>Module-internal seam — NOT public API.</b> Cross-package factory used by {@link
+   * Telescope#mapperForward(Class, Class, io.github.eschizoid.telescope.mapping.MapStep...)}. The
+   * supplied {@link java.util.function.Function} is adapted to the lattice's {@link Getter}
+   * substrate immediately — the lattice still owns the read shape, this factory is just the
+   * cross-package adapter that the {@code Telescope} factory pipes through. External code must not
+   * call this directly; use {@link Telescope#mapperForward(Class, Class,
+   * io.github.eschizoid.telescope.mapping.MapStep...)}.
+   */
+  public static <A, B> ForwardMapper<A, B> create(
+    final java.util.function.Function<? super A, ? extends B> forward,
+    final Class<A> sourceClass,
+    final Class<B> targetClass
+  ) {
+    final Getter<A, B> getter = forward::apply;
+    return new ForwardMapper<>(getter, sourceClass, targetClass);
+  }
+
+  /** Forward conversion {@code A → B}. */
+  public B forward(final A a) {
+    return forward.get(a);
+  }
+
+  /** Alias of {@link #forward(Object)}. */
+  public B read(final A a) {
+    return forward.get(a);
+  }
+
+  /**
+   * Compose with another forward-only projection: {@code this.then(next).forward(a) ==
+   * next.forward(this.forward(a))}. Routes through the lattice's {@code Getter.then(Getter)}
+   * composition — no ad-hoc function chains.
+   *
+   * <pre>{@code
+   * ForwardMapper<Entity, Dto> entityToDto = Telescope.mapperForward(Entity.class, Dto.class, ...);
+   * ForwardMapper<Dto, AuditEvent> dtoToAudit = Telescope.mapperForward(Dto.class, AuditEvent.class, ...);
+   * ForwardMapper<Entity, AuditEvent> pipeline = entityToDto.then(dtoToAudit);
+   * }</pre>
+   */
+  public <C> ForwardMapper<A, C> then(final ForwardMapper<B, C> next) {
+    final Getter<A, C> composed = a -> next.forward.get(forward.get(a));
+    return new ForwardMapper<>(composed, sourceClass, next.targetClass);
+  }
+
+  /** The mapper's source class. */
+  public Class<A> sourceClass() {
+    return sourceClass;
+  }
+
+  /** The mapper's target class. */
+  public Class<B> targetClass() {
+    return targetClass;
+  }
+}

--- a/core/src/test/java/io/github/eschizoid/telescope/ForwardMapperTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/ForwardMapperTest.java
@@ -1,0 +1,108 @@
+package io.github.eschizoid.telescope;
+
+import static io.github.eschizoid.telescope.mapping.Mapping.constant;
+import static io.github.eschizoid.telescope.mapping.Mapping.into;
+import static io.github.eschizoid.telescope.mapping.Mapping.to;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.github.eschizoid.telescope.conversion.ForwardMapper;
+import java.time.Instant;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pins {@link Telescope#mapperForward(Class, Class,
+ * io.github.eschizoid.telescope.mapping.MapStep...)} — the forward-only factory that returns a
+ * {@link ForwardMapper} whose backward direction is not present at the type level. MapStruct cannot
+ * express "this mapper is one-way" in its type system at all; this is the differentiator the type
+ * system buys.
+ *
+ * <p>The compile-time enforcement is invisible in JUnit (you can't write a test that asserts a
+ * method does NOT exist), so the negative case is implicit in the rest of the call site: there is
+ * no {@code mapper.backward(...)} to call anywhere in this file. The positive surface (forward,
+ * read alias, sourceClass / targetClass) is pinned below.
+ */
+class ForwardMapperTest {
+
+  record Entity(String id, Instant createdAt, String firstName, String lastName) {}
+
+  record Dto(String id, String createdAtIso, String fullName, String tenant) {}
+
+  @Test
+  @DisplayName("ForwardMapper assembles a typed forward-only result with into / constant rows")
+  void forwardOnlyProjector() {
+    final ForwardMapper<Entity, Dto> projector = Telescope.mapperForward(
+      Entity.class,
+      Dto.class,
+      to(Entity::id, Dto::id),
+      into(Entity::createdAt, Dto::createdAtIso, Instant::toString),
+      to(Entity::firstName, Dto::fullName),
+      constant(Dto::tenant, "production")
+    );
+
+    final var dto = projector.forward(new Entity("e-1", Instant.parse("2026-01-01T00:00:00Z"), "Alice", "Wonderland"));
+
+    assertEquals("e-1", dto.id());
+    assertEquals("2026-01-01T00:00:00Z", dto.createdAtIso());
+    assertEquals("Alice", dto.fullName());
+    assertEquals("production", dto.tenant());
+  }
+
+  @Test
+  @DisplayName("read(...) is an alias of forward(...)")
+  void readIsAlias() {
+    final ForwardMapper<Entity, Dto> projector = Telescope.mapperForward(
+      Entity.class,
+      Dto.class,
+      to(Entity::id, Dto::id),
+      into(Entity::createdAt, Dto::createdAtIso, Instant::toString),
+      to(Entity::firstName, Dto::fullName),
+      constant(Dto::tenant, "x")
+    );
+
+    final var input = new Entity("e-2", Instant.parse("2026-02-02T00:00:00Z"), "B", "C");
+    assertEquals(projector.forward(input), projector.read(input));
+  }
+
+  @Test
+  @DisplayName(".then composes two forward-only projections via the Getter lattice substrate")
+  void thenComposes() {
+    record Audit(String summary) {}
+
+    final ForwardMapper<Entity, Dto> entityToDto = Telescope.mapperForward(
+      Entity.class,
+      Dto.class,
+      to(Entity::id, Dto::id),
+      into(Entity::createdAt, Dto::createdAtIso, Instant::toString),
+      to(Entity::firstName, Dto::fullName),
+      constant(Dto::tenant, "p")
+    );
+    final ForwardMapper<Dto, Audit> dtoToAudit = ForwardMapper.create(
+      d -> new Audit(d.id() + ":" + d.fullName() + "@" + d.tenant()),
+      Dto.class,
+      Audit.class
+    );
+
+    final ForwardMapper<Entity, Audit> pipeline = entityToDto.then(dtoToAudit);
+    final var out = pipeline.forward(new Entity("e-1", Instant.parse("2026-01-01T00:00:00Z"), "Alice", "X"));
+    assertEquals(new Audit("e-1:Alice@p"), out);
+    assertEquals(Entity.class, pipeline.sourceClass());
+    assertEquals(Audit.class, pipeline.targetClass());
+  }
+
+  @Test
+  @DisplayName("sourceClass / targetClass expose the typed pair")
+  void exposesClasses() {
+    final ForwardMapper<Entity, Dto> projector = Telescope.mapperForward(
+      Entity.class,
+      Dto.class,
+      to(Entity::id, Dto::id),
+      into(Entity::createdAt, Dto::createdAtIso, Instant::toString),
+      to(Entity::firstName, Dto::fullName),
+      constant(Dto::tenant, "x")
+    );
+
+    assertEquals(Entity.class, projector.sourceClass());
+    assertEquals(Dto.class, projector.targetClass());
+  }
+}

--- a/core/src/test/java/io/github/eschizoid/telescope/ForwardMapperTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/ForwardMapperTest.java
@@ -1,7 +1,7 @@
 package io.github.eschizoid.telescope;
 
 import static io.github.eschizoid.telescope.mapping.Mapping.constant;
-import static io.github.eschizoid.telescope.mapping.Mapping.into;
+import static io.github.eschizoid.telescope.mapping.Mapping.forward;
 import static io.github.eschizoid.telescope.mapping.Mapping.to;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -29,13 +29,13 @@ class ForwardMapperTest {
   record Dto(String id, String createdAtIso, String fullName, String tenant) {}
 
   @Test
-  @DisplayName("ForwardMapper assembles a typed forward-only result with into / constant rows")
+  @DisplayName("ForwardMapper assembles a typed forward-only result with forward / constant rows")
   void forwardOnlyProjector() {
     final ForwardMapper<Entity, Dto> projector = Telescope.mapperForward(
       Entity.class,
       Dto.class,
       to(Entity::id, Dto::id),
-      into(Entity::createdAt, Dto::createdAtIso, Instant::toString),
+      forward(Entity::createdAt, Dto::createdAtIso, Instant::toString),
       to(Entity::firstName, Dto::fullName),
       constant(Dto::tenant, "production")
     );
@@ -55,7 +55,7 @@ class ForwardMapperTest {
       Entity.class,
       Dto.class,
       to(Entity::id, Dto::id),
-      into(Entity::createdAt, Dto::createdAtIso, Instant::toString),
+      forward(Entity::createdAt, Dto::createdAtIso, Instant::toString),
       to(Entity::firstName, Dto::fullName),
       constant(Dto::tenant, "x")
     );
@@ -73,7 +73,7 @@ class ForwardMapperTest {
       Entity.class,
       Dto.class,
       to(Entity::id, Dto::id),
-      into(Entity::createdAt, Dto::createdAtIso, Instant::toString),
+      forward(Entity::createdAt, Dto::createdAtIso, Instant::toString),
       to(Entity::firstName, Dto::fullName),
       constant(Dto::tenant, "p")
     );
@@ -97,7 +97,7 @@ class ForwardMapperTest {
       Entity.class,
       Dto.class,
       to(Entity::id, Dto::id),
-      into(Entity::createdAt, Dto::createdAtIso, Instant::toString),
+      forward(Entity::createdAt, Dto::createdAtIso, Instant::toString),
       to(Entity::firstName, Dto::fullName),
       constant(Dto::tenant, "x")
     );

--- a/internal/src/main/java/io/github/eschizoid/telescope/internal/optics/Getter.java
+++ b/internal/src/main/java/io/github/eschizoid/telescope/internal/optics/Getter.java
@@ -14,8 +14,9 @@ import java.util.stream.Stream;
  * }</pre>
  *
  * <p>Falls out of the lattice as the read-only specialization that {@link Lens} extends. Rarely
- * built directly — most field navigation produces a full {@link Lens}. There is no {@code
- * then(...)} here; composition happens on the read+write optics.
+ * built directly — most field navigation produces a full {@link Lens}. Two Getters compose into a
+ * Getter via {@link #then(Getter)}; the write-side composition lives on {@link Lens} and the other
+ * read+write optics.
  */
 @FunctionalInterface
 public interface Getter<S, A> extends Fold<S, A> {
@@ -26,5 +27,15 @@ public interface Getter<S, A> extends Fold<S, A> {
   @Override
   default Stream<A> getAll(final S source) {
     return Stream.of(get(source));
+  }
+
+  /**
+   * Compose with another {@code Getter} to read deeper. {@code this.then(next).get(s)} is
+   * equivalent to {@code next.get(this.get(s))} — the canonical Getter-composition shape from the
+   * lattice. Used by {@link io.github.eschizoid.telescope.conversion.ForwardMapper#then} to keep
+   * forward-only composition lattice-routed instead of an ad-hoc {@code Function} closure.
+   */
+  default <B> Getter<S, B> then(final Getter<A, B> next) {
+    return s -> next.get(get(s));
   }
 }


### PR DESCRIPTION
## Summary

Adds a typed forward-only mapper companion to the existing bidirectional `Mapper<A, B>`.

```java
ForwardMapper<UserEntity, UserDto> projector = Telescope.mapperForward(
    UserEntity.class, UserDto.class,
    to(UserEntity::id, UserDto::id),
    into(UserEntity::createdAt, UserDto::createdAtIso, Instant::toString),
    constant(UserDto::tenant, "production"));

UserDto dto = projector.forward(entity);
projector.backward(dto);  // compile error — no such method
```

The "this mapper is one-way" contract is enforced at the **type level**, not by a runtime throw. MapStruct cannot reach this — annotations don't lift "forward-only" to the result type.

## Lattice-routed read substrate

`ForwardMapper.forward: Getter<A, B>` — the internal lattice's read-only optic primitive, not a raw `Function<A, B>`. Composition routes through the lattice via `.then(ForwardMapper<B, C>)` for pipeline-style forward chains.

```java
ForwardMapper<Entity, AuditEvent> pipeline = entityToDto.then(dtoToAudit);
```

## Implementation

Reuses the existing `DeepMap.resolveMapper` engine — no duplicate row routing. The bidirectional `Mapper` is constructed normally (rows from `into(...)` etc. don't fire backward because backward is never called); the forward function is adapted to `Getter<A, B>` and wrapped in `ForwardMapper`.

`ForwardMapper.create(...)` is documented as a module-internal seam — external callers route through `Telescope.mapperForward(...)`.

## Test plan

- [x] `ForwardMapperTest` — happy path with `into` + `constant` rows; `read` aliases `forward`; `sourceClass` / `targetClass` metadata; `.then` composes via the `Getter` lattice substrate.
- [x] Full `./gradlew test` green.
