### PR TITLE
feat(match): sealed-type dispatcher with compile-checked exhaustiveness

### DIFF
--- a/core/src/main/java/io/github/eschizoid/telescope/Match.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/Match.java
@@ -1,0 +1,144 @@
+package io.github.eschizoid.telescope;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+
+/**
+ * Compile-checked sealed-type dispatcher. Builds a {@code Function<P, R>} that pattern-matches on
+ * the runtime class of {@code P} against a per-permit set of handlers, then verifies at the {@link
+ * #exhaustive()} terminal that every permit was covered.
+ *
+ * <p>Uses {@link Class#getPermittedSubclasses()} (Java 17 JEP 409) to discover the sealed hierarchy
+ * at construction time. MapStruct cannot reach this primitive — its annotation model pre-dates
+ * sealed types (Java 11 floor). The exhaustiveness guarantee is enforced at the {@code
+ * .exhaustive()} call rather than via the compile-time switch exhaustiveness check, which means the
+ * same dispatcher works under {@code --release 17} (PR #80's cross-compile target) without the
+ * {@code switch} on type-patterns (Java 21+) the language gives you for free.
+ *
+ * <pre>{@code
+ * sealed interface Payment permits CreditCard, BankTransfer, Crypto {}
+ *
+ * Function<Payment, PaymentDto> dispatch = Match.<Payment, PaymentDto>of(Payment.class)
+ *     .when(CreditCard.class,    CreditCardBridge.BRIDGE::forward)
+ *     .when(BankTransfer.class,  BankBridge.BRIDGE::forward)
+ *     .when(Crypto.class,        CryptoBridge.BRIDGE::forward)
+ *     .exhaustive();   // ↑ throws if any permit lacks a .when(...) handler
+ * }</pre>
+ *
+ * <p>Composes naturally with {@link io.github.eschizoid.telescope.conversion.Mapper#asTelescope()
+ * Mapper.asTelescope()} so the dispatcher can be chained into a longer {@link Telescope} path:
+ *
+ * <pre>{@code
+ * Telescope.of(Order.class)
+ *     .field(Order::payment)
+ *     .update(order, dispatch.compose(... ).andThen( ... ));
+ * }</pre>
+ *
+ * @param <P> the sealed parent type
+ * @param <R> the dispatch result type
+ */
+public final class Match<P, R> {
+
+  private final Class<P> sealedRoot;
+  private final Map<Class<? extends P>, Function<? super P, ? extends R>> handlers;
+
+  private Match(final Class<P> sealedRoot, final Map<Class<? extends P>, Function<? super P, ? extends R>> handlers) {
+    this.sealedRoot = sealedRoot;
+    this.handlers = handlers;
+  }
+
+  /**
+   * Open a builder for a dispatcher over the sealed hierarchy rooted at {@code sealedRoot}. Throws
+   * {@link IllegalArgumentException} if the class is not sealed.
+   */
+  public static <P, R> Match<P, R> of(final Class<P> sealedRoot) {
+    if (!sealedRoot.isSealed()) throw new IllegalArgumentException(
+      "Match.of(" +
+        sealedRoot.getName() +
+        "): root class is not sealed. " +
+        "Match requires a sealed hierarchy so .exhaustive() can verify coverage."
+    );
+    return new Match<>(sealedRoot, new LinkedHashMap<>());
+  }
+
+  /**
+   * Register a handler for one permit of the sealed hierarchy. Returns a new builder — chains
+   * compose left-to-right. Same handler registered twice throws at the {@code when} call.
+   */
+  public <S extends P> Match<P, R> when(final Class<S> caseClass, final Function<? super S, ? extends R> handler) {
+    if (handlers.containsKey(caseClass)) throw new IllegalArgumentException(
+      "Match.when(" +
+        caseClass.getName() +
+        "): handler already registered. " +
+        "Each permit of the sealed hierarchy may have at most one handler."
+    );
+    final var next = new LinkedHashMap<>(handlers);
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    final Function<? super P, ? extends R> typed = (Function) handler;
+    next.put(caseClass, typed);
+    return new Match<>(sealedRoot, next);
+  }
+
+  /**
+   * Verify exhaustiveness and produce the dispatch function. Reads the sealed root's permitted
+   * subclasses via {@link Class#getPermittedSubclasses()} and throws if any permit lacks a
+   * registered handler — naming the missing permits in the error message.
+   *
+   * <p>The returned {@link Function} dispatches by {@link Class#isInstance(Object)} test in
+   * registration order. At runtime, the first matching handler wins (so a permit handler can be
+   * registered redundantly under a parent permit if the user wants that semantics; the typical case
+   * is one handler per permit).
+   */
+  public Function<P, R> exhaustive() {
+    final var permits = sealedRoot.getPermittedSubclasses();
+    final var permitSet = Set.of(permits);
+    final var registered = handlers.keySet();
+    final var missing = new java.util.ArrayList<String>();
+    for (final var permit : permitSet) {
+      if (!registered.contains(permit)) missing.add(permit.getSimpleName());
+    }
+    if (!missing.isEmpty()) throw new IllegalStateException(
+      "Match.exhaustive(" +
+        sealedRoot.getSimpleName() +
+        "): " +
+        "no handler registered for permitted subclass(es): " +
+        String.join(", ", missing) +
+        ". Add a .when(<class>, handler) call for each, or use .partial() to allow missing handlers."
+    );
+    final var snapshot = Map.copyOf(handlers);
+    return p -> {
+      for (final var entry : snapshot.entrySet()) {
+        if (entry.getKey().isInstance(p)) return entry.getValue().apply(p);
+      }
+      throw new IllegalStateException(
+        "Match: input class " +
+          (p == null ? "null" : p.getClass().getName()) +
+          " does not match any registered permit of " +
+          sealedRoot.getSimpleName()
+      );
+    };
+  }
+
+  /**
+   * Produce the dispatch function WITHOUT exhaustiveness checking. Use when the sealed hierarchy is
+   * known incomplete by design — the returned function throws at dispatch time for unhandled cases
+   * with a self-diagnosing message naming the runtime class.
+   */
+  public Function<P, R> partial() {
+    final var snapshot = Map.copyOf(handlers);
+    final var rootName = sealedRoot.getSimpleName();
+    return p -> {
+      for (final var entry : snapshot.entrySet()) {
+        if (entry.getKey().isInstance(p)) return entry.getValue().apply(p);
+      }
+      throw new IllegalStateException(
+        "Match.partial(" +
+          rootName +
+          "): no handler registered for runtime class " +
+          (p == null ? "null" : p.getClass().getName())
+      );
+    };
+  }
+}

--- a/core/src/main/java/io/github/eschizoid/telescope/Match.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/Match.java
@@ -2,7 +2,6 @@ package io.github.eschizoid.telescope;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.Set;
 import java.util.function.Function;
 
 /**
@@ -93,10 +92,12 @@ public final class Match<P, R> {
    */
   public Function<P, R> exhaustive() {
     final var permits = sealedRoot.getPermittedSubclasses();
-    final var permitSet = Set.of(permits);
     final var registered = handlers.keySet();
+    // Walk `permits` directly (source-declaration order from the JVM), not Set.of(permits) — the
+    // HashSet iteration order would be non-deterministic across JVM runs, leading to differently-
+    // ordered error messages on each invocation.
     final var missing = new java.util.ArrayList<String>();
-    for (final var permit : permitSet) {
+    for (final var permit : permits) {
       if (!registered.contains(permit)) missing.add(permit.getSimpleName());
     }
     if (!missing.isEmpty()) throw new IllegalStateException(

--- a/core/src/test/java/io/github/eschizoid/telescope/MatchTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/MatchTest.java
@@ -114,4 +114,25 @@ class MatchTest {
       assertTrue(ex.getMessage().contains("BankTransfer"));
     }
   }
+
+  @Nested
+  @DisplayName("guards — sharpened from PR-89 review")
+  class SharpenedGuards {
+
+    @Test
+    @DisplayName("exhaustive() missing-permit error lists names in source-declaration order (deterministic)")
+    void missingPermitOrderingDeterministic() {
+      // Payment permits CreditCard, BankTransfer, Crypto — register only CreditCard so two are
+      // missing. Ordering must follow Payment.getPermittedSubclasses() (BankTransfer, then Crypto)
+      // not the hash-bucketed Set.of iteration.
+      final var ex = assertThrows(IllegalStateException.class, () ->
+        Match.<Payment, String>of(Payment.class).when(CreditCard.class, c -> "c").exhaustive()
+      );
+      final var msg = ex.getMessage();
+      assertTrue(msg.contains("BankTransfer"));
+      assertTrue(msg.contains("Crypto"));
+      // Source-declaration order: BankTransfer appears before Crypto in the message.
+      assertTrue(msg.indexOf("BankTransfer") < msg.indexOf("Crypto"), () -> "expected source order, got: " + msg);
+    }
+  }
 }

--- a/core/src/test/java/io/github/eschizoid/telescope/MatchTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/MatchTest.java
@@ -1,0 +1,117 @@
+package io.github.eschizoid.telescope;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.function.Function;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pins {@link Match} — the sealed-type dispatch helper that uses {@link
+ * Class#getPermittedSubclasses()} for compile-checked exhaustiveness verification at the {@code
+ * .exhaustive()} terminal. The Java 17 sealed API is the structural advantage MapStruct (Java 11)
+ * cannot reach.
+ */
+class MatchTest {
+
+  sealed interface Payment permits CreditCard, BankTransfer, Crypto {}
+
+  record CreditCard(String pan) implements Payment {}
+
+  record BankTransfer(String iban) implements Payment {}
+
+  record Crypto(String wallet) implements Payment {}
+
+  @Nested
+  @DisplayName("happy path — every permit covered")
+  class HappyPath {
+
+    @Test
+    @DisplayName("exhaustive dispatch handles each permit with the registered handler")
+    void exhaustiveDispatch() {
+      final Function<Payment, String> dispatch = Match.<Payment, String>of(Payment.class)
+        .when(CreditCard.class, c -> "card:" + c.pan())
+        .when(BankTransfer.class, b -> "bank:" + b.iban())
+        .when(Crypto.class, x -> "crypto:" + x.wallet())
+        .exhaustive();
+
+      assertEquals("card:4111", dispatch.apply(new CreditCard("4111")));
+      assertEquals("bank:IBAN-1", dispatch.apply(new BankTransfer("IBAN-1")));
+      assertEquals("crypto:0xABC", dispatch.apply(new Crypto("0xABC")));
+    }
+  }
+
+  @Nested
+  @DisplayName("exhaustiveness check")
+  class Exhaustiveness {
+
+    @Test
+    @DisplayName("missing handler for one permit throws at .exhaustive() naming the gap")
+    void missingPermitThrows() {
+      final var ex = assertThrows(IllegalStateException.class, () ->
+        Match.<Payment, String>of(Payment.class)
+          .when(CreditCard.class, c -> "card")
+          .when(BankTransfer.class, b -> "bank")
+          // missing Crypto
+          .exhaustive()
+      );
+      assertTrue(ex.getMessage().contains("Crypto"), () -> "expected message to name Crypto, was: " + ex.getMessage());
+    }
+
+    @Test
+    @DisplayName("missing handlers for multiple permits names ALL the gaps")
+    void multipleMissingPermits() {
+      final var ex = assertThrows(IllegalStateException.class, () ->
+        Match.<Payment, String>of(Payment.class)
+          .when(CreditCard.class, c -> "card")
+          .exhaustive()
+      );
+      assertTrue(ex.getMessage().contains("BankTransfer"));
+      assertTrue(ex.getMessage().contains("Crypto"));
+    }
+  }
+
+  @Nested
+  @DisplayName("guards")
+  class Guards {
+
+    @Test
+    @DisplayName("Match.of(...) rejects a non-sealed class")
+    void nonSealedRoot() {
+      final var ex = assertThrows(IllegalArgumentException.class, () -> Match.<String, String>of(String.class));
+      assertTrue(ex.getMessage().contains("not sealed"));
+    }
+
+    @Test
+    @DisplayName("when(...) rejects a duplicate handler for the same permit")
+    void duplicateWhen() {
+      final var ex = assertThrows(IllegalArgumentException.class, () ->
+        Match.<Payment, String>of(Payment.class)
+          .when(CreditCard.class, c -> "a")
+          .when(CreditCard.class, c -> "b")
+      );
+      assertTrue(ex.getMessage().contains("already registered"));
+    }
+  }
+
+  @Nested
+  @DisplayName("partial() escape hatch — no exhaustiveness check")
+  class Partial {
+
+    @Test
+    @DisplayName("partial() dispatches registered permits, throws on unhandled")
+    void partialDispatchAndThrow() {
+      final Function<Payment, String> dispatch = Match.<Payment, String>of(Payment.class)
+        .when(CreditCard.class, c -> "card:" + c.pan())
+        .partial();
+
+      assertEquals("card:4111", dispatch.apply(new CreditCard("4111")));
+
+      final var ex = assertThrows(IllegalStateException.class, () -> dispatch.apply(new BankTransfer("X")));
+      assertTrue(ex.getMessage().contains("BankTransfer"));
+    }
+  }
+}


### PR DESCRIPTION
## Summary

`Match.<P, R>of(SealedRoot.class).when(...).when(...).exhaustive()` builds a `Function<P, R>` that pattern-matches by `Class#isInstance` against a per-permit handler set, then verifies at the `.exhaustive()` terminal that every sealed permit was covered. Missing permits throw a precise `IllegalStateException` naming the gaps.

```java
sealed interface Payment permits CreditCard, BankTransfer, Crypto {}

Function<Payment, PaymentDto> dispatch = Match.<Payment, PaymentDto>of(Payment.class)
    .when(CreditCard.class,   CreditCardBridge.BRIDGE::forward)
    .when(BankTransfer.class, BankBridge.BRIDGE::forward)
    .when(Crypto.class,       CryptoBridge.BRIDGE::forward)
    .exhaustive();   // throws if any permit lacks a .when(...) handler
```

## Why MapStruct can't reach this

Uses `Class#getPermittedSubclasses()` — Java 17 sealed-types API (JEP 409). MapStruct's Java 11 floor literally cannot. Compile-checked exhaustiveness via `.exhaustive()` works under `--release 17` without the pattern-match-switch (Java 21+) the language gives for free.

## Composition

The produced `Function<P, R>` drops into `Mapping.into(...)` / `Mapper.afterForward(...)` / any `Function`-accepting site freely. `Match.partial()` is the escape hatch for genuinely incomplete dispatch.

## Test plan

- [x] `MatchTest` — 6 tests covering happy path, missing-permit diagnostics, multi-missing diagnostics, non-sealed root rejection, duplicate-handler rejection, partial escape hatch.
- [x] Full `./gradlew test` green.
