### PR TITLE
feat(telescope): lattice-native before/after hooks

### DIFF
--- a/core/src/main/java/io/github/eschizoid/telescope/Telescope.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/Telescope.java
@@ -823,6 +823,63 @@ public sealed class Telescope<
   }
 
   /**
+   * Compose a post-read hook onto the path: every value flowing OUT of this telescope (via {@link
+   * #read}, {@link #find}, {@link #toList}, {@link #count}, {@link #exists}, the {@link #update}
+   * family's pre-hook leaf, or downstream {@link #then} composition) is passed through {@code hook}
+   * before reaching the caller / next stage. The lattice-native equivalent of {@link
+   * io.github.eschizoid.telescope.conversion.Mapper#afterForward(java.util.function.Function)
+   * Mapper.afterForward}, but applied at the path level — composes through {@code .then(...)},
+   * {@link Edit#over Edit.over}, {@link #updateAsync}, and codegen-generated navigators. MapStruct
+   * cannot reach this; its annotations bind to mapper methods, not paths.
+   *
+   * <p>Writes pass through unchanged — only the read side gets the hook. For symmetric write
+   * transformation, see {@link #before(Function)}.
+   *
+   * <p><b>Lattice note — one-sided shape.</b> The internal {@link
+   * io.github.eschizoid.telescope.internal.optics.Iso} composed here uses {@code hook} on the read
+   * side and identity on the write side, so the produced Iso does <em>not</em> satisfy the
+   * round-trip law ({@code from(to(a)) == a} only holds when {@code hook} is identity). Safe under
+   * {@code Lens.then(Iso)} composition — which routes reads and writes through separate legs and
+   * never round-trips a single value through both — but future contributors must not assume this is
+   * a lawful Iso in isolation. The same caveat applies to {@link #before(Function)}, {@link
+   * io.github.eschizoid.telescope.mapping.Mapping#into Mapping.into}, and {@link
+   * io.github.eschizoid.telescope.mapping.Mapping#toOrElse Mapping.toOrElse}.
+   *
+   * <pre>{@code
+   * Telescope.of(User.class).field(User::email).after(String::trim)
+   *     .read(user);                 // returns the trimmed email
+   * }</pre>
+   */
+  public Telescope<S, A> after(final Function<? super A, ? extends A> hook) {
+    return this.then(Telescope.iso(hook, a -> a));
+  }
+
+  /**
+   * Compose a pre-write hook onto the path: every value flowing IN to this telescope (via {@link
+   * #set}, {@link #update}, {@link #updateAsync}, {@link Edit#over Edit.over}'s write-leaf, or
+   * downstream {@link #then} composition) is passed through {@code hook} before reaching the
+   * underlying writer. The lattice-native equivalent of {@link
+   * io.github.eschizoid.telescope.conversion.Mapper#beforeBackward(java.util.function.Function)
+   * Mapper.beforeBackward}, applied at the path level.
+   *
+   * <p>Reads pass through unchanged — only the write side gets the hook. For symmetric read
+   * transformation, see {@link #after(Function)}.
+   *
+   * <p><b>Lattice note — one-sided shape.</b> Same caveat as {@link #after(Function)}: the composed
+   * Iso uses identity on the read side and {@code hook} on the write side, so the round-trip law
+   * holds only when {@code hook} is identity. Safe under {@code Lens.then(Iso)} composition; not a
+   * lawful Iso in isolation.
+   *
+   * <pre>{@code
+   * Telescope.of(User.class).field(User::email).before(String::toLowerCase)
+   *     .set(user, "ALICE@X.COM");   // writes "alice@x.com"
+   * }</pre>
+   */
+  public Telescope<S, A> before(final Function<? super A, ? extends A> hook) {
+    return this.then(Telescope.iso(a -> a, hook));
+  }
+
+  /**
    * Compose this telescope with another via the lattice's {@code .then}. Lets you build a path in
    * pieces and stitch them together, and is how reusable conversions ({@link #from}, {@link
    * #map(Class, Class, io.github.eschizoid.telescope.mapping.MapStep...)}) get threaded into a

--- a/core/src/test/java/io/github/eschizoid/telescope/TelescopeLatticeHooksTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/TelescopeLatticeHooksTest.java
@@ -1,0 +1,109 @@
+package io.github.eschizoid.telescope;
+
+import static io.github.eschizoid.telescope.Edit.over;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pins {@link Telescope#after(java.util.function.Function)} and {@link
+ * Telescope#before(java.util.function.Function)} — lattice-native hooks composed onto a path via
+ * the internal {@link io.github.eschizoid.telescope.internal.optics.Iso} substrate. These hooks
+ * thread through {@link Telescope#then}, {@link Edit#over Edit.over}, and the codegen-generated
+ * navigators — MapStruct's annotation-bound hooks cannot reach this because they bind to mapper
+ * methods, not paths.
+ */
+class TelescopeLatticeHooksTest {
+
+  record User(String email) {}
+
+  record Team(String name, List<User> users) {}
+
+  @Nested
+  @DisplayName("after — runs on the read side")
+  class AfterRead {
+
+    @Test
+    @DisplayName("read passes through the hook")
+    void readApplied() {
+      final var path = Telescope.of(User.class).field(User::email).after(String::trim);
+      assertEquals("alice@x.com", path.read(new User("  alice@x.com  ")));
+    }
+
+    @Test
+    @DisplayName("write side passes through unchanged — hook is one-sided")
+    void writeUnchanged() {
+      final var path = Telescope.of(User.class).field(User::email).after(String::trim);
+      assertEquals("  ALICE@X.COM  ", path.set(new User(""), "  ALICE@X.COM  ").email());
+    }
+
+    @Test
+    @DisplayName("hook composes through .then(...) — traversal threads it per element")
+    void composesThroughThen() {
+      final var trimmedEmails = Telescope.of(Team.class).each(Team::users).field(User::email).after(String::trim);
+
+      final var team = new Team("eng", List.of(new User("  a@x  "), new User("b@x"), new User("  c@x  ")));
+      assertEquals(List.of("a@x", "b@x", "c@x"), trimmedEmails.toList(team));
+    }
+  }
+
+  @Nested
+  @DisplayName("before — runs on the write side")
+  class BeforeWrite {
+
+    @Test
+    @DisplayName("set passes through the hook")
+    void setApplied() {
+      final var path = Telescope.of(User.class).field(User::email).before(String::toLowerCase);
+      assertEquals("alice@x.com", path.set(new User(""), "ALICE@X.COM").email());
+    }
+
+    @Test
+    @DisplayName("update's incoming function output is normalised by the hook")
+    void updateApplied() {
+      final var path = Telescope.of(User.class).field(User::email).before(String::toLowerCase);
+      assertEquals("alice@x.com", path.update(new User("a@x.com"), e -> "ALICE@X.COM").email());
+    }
+
+    @Test
+    @DisplayName("read side passes through unchanged — hook is one-sided")
+    void readUnchanged() {
+      final var path = Telescope.of(User.class).field(User::email).before(String::toLowerCase);
+      assertEquals("UPPERCASE@X.COM", path.read(new User("UPPERCASE@X.COM")));
+    }
+
+    @Test
+    @DisplayName("hook composes with Edit.over(...) — the multi-edit shape sees it")
+    void composesWithEditOver() {
+      final var emailsNormalised = Telescope.of(Team.class)
+        .each(Team::users)
+        .field(User::email)
+        .before(String::toLowerCase);
+
+      final var normalize = Telescope.<Team>all(over(emailsNormalised, e -> "MIXED@X.COM"));
+      final var team = new Team("eng", List.of(new User("a@x"), new User("b@x")));
+
+      assertEquals(
+        List.of("mixed@x.com", "mixed@x.com"),
+        normalize.apply(team).users().stream().map(User::email).toList()
+      );
+    }
+  }
+
+  @Nested
+  @DisplayName("before + after together — symmetric pair")
+  class BeforeAfterCombo {
+
+    @Test
+    @DisplayName("read uses after-hook only; write uses before-hook only")
+    void independentSides() {
+      final var path = Telescope.of(User.class).field(User::email).before(String::toLowerCase).after(String::trim);
+
+      assertEquals("alice@x.com", path.set(new User(""), "ALICE@X.COM").email());
+      assertEquals("trimmed", path.read(new User("  trimmed  ")));
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Lifts the post-mapping hook idea from `Mapper` (PR #87) to the `Telescope<S, A>` lattice itself.

```java
Telescope.of(User.class).field(User::email).after(String::trim).read(user);
Telescope.of(User.class).field(User::email).before(String::toLowerCase).set(user, "ALICE@X.COM");
```

The differentiator: because these hooks compose at the lattice level (via `.then(Telescope.iso(...))` — pure Iso composition), they thread through:

- `.then(...)` chains
- `Edit.over(...)` rows in `Telescope.all(...)`
- `updateAsync` / `updateOptional` / `updateEither` / `updateValidated`
- Codegen-generated `<X>Path<R>` navigators (they extend `Telescope`, inherit the hooks automatically)

## MapStruct cannot reach this

Its annotation-bound hooks attach to specific mapper methods. The lattice equivalent attaches to a *path* and participates in every operation that touches the path, regardless of which API surface invokes it.

## Lattice note — one-sided shape

Documented in the javadoc: the composed `Iso<A, A>` uses `hook` on one leg and identity on the other, so it's a partial-law Iso. Safe under `Lens.then(Iso)` composition (which never round-trips a single value through both legs); future contributors must not assume it's a lawful Iso in isolation.

## Implementation

Two five-line methods on `Telescope`, each delegating to `this.then(Telescope.iso(forward, backward))`. Zero new sealed permits, zero engine changes — pure lattice composition over the existing `Iso.of` substrate.

## Test plan

- [x] `TelescopeLatticeHooksTest` — 8 tests covering both hooks individually (one-sidedness), composition through `.then(...)` and `Edit.over(...)`, and the symmetric pair on one path.
- [x] Full `./gradlew test` green.
