### PR TITLE
feat(mapping): sealed ForwardOnlyTransformTo permit — close into() partial-Iso gap

### DIFF
--- a/core/src/main/java/io/github/eschizoid/telescope/DeepMap.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/DeepMap.java
@@ -7,6 +7,7 @@ import io.github.eschizoid.telescope.internal.optics.Iso;
 import io.github.eschizoid.telescope.mapping.Compute;
 import io.github.eschizoid.telescope.mapping.Constant;
 import io.github.eschizoid.telescope.mapping.Drop;
+import io.github.eschizoid.telescope.mapping.ForwardOnlyTransformTo;
 import io.github.eschizoid.telescope.mapping.FromTelescopeTo;
 import io.github.eschizoid.telescope.mapping.MapStep;
 import io.github.eschizoid.telescope.mapping.Mapping;
@@ -742,6 +743,23 @@ public final class DeepMap {
     // types stay portable across packages without needing @SuppressWarnings("exports").
     if (row instanceof SameTypedTo<?, ?, ?>) return Iso.identity();
     if (row instanceof TypedTransformTo<?, ?, ?, ?> r) return Iso.of((Function) r.forward(), (Function) r.backward());
+    if (row instanceof ForwardOnlyTransformTo<?, ?, ?, ?> r) {
+      // Forward-only row: the backward leg throws at the field site. `Telescope.mapper(...)`
+      // rejects rows of this shape up front and points the user at `Telescope.mapperForward(...)`
+      // (which never invokes the backward leg) — so the throwing backward only fires if a caller
+      // builds a bidirectional Mapper anyway via the cross-package factory and then invokes
+      // backward(...). The throw names the field for self-diagnosis.
+      final String fieldName = r.sourceField();
+      final Function<Object, Object> throwingBackward = y -> {
+        throw new UnsupportedOperationException(
+          "Mapping.forward is forward-only — backward direction is undefined for field '" +
+            fieldName +
+            "'. Use Telescope.mapperForward(...) for a forward-only mapper, or Mapping.to(src, " +
+            "tgt, forward, backward) for an explicit bidirectional row."
+        );
+      };
+      return Iso.of((Function) r.forward(), throwingBackward);
+    }
     if (row instanceof Via<?, ?> r) return liftViaIfNeeded(r, srcType, tgtType);
     // Drop rows never reach this method — populateIso short-circuits on `instanceof Drop` before
     // calling fieldIsoOf. The check is here only to make the dispatch exhaustive over the sealed

--- a/core/src/main/java/io/github/eschizoid/telescope/Telescope.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/Telescope.java
@@ -506,14 +506,48 @@ public sealed class Telescope<
    * @see #map(Class, Class, MapStep...)
    */
   public static <A, B> Mapper<A, B> mapper(final Class<A> source, final Class<B> target, final MapStep... steps) {
+    rejectForwardOnlyRows(source, target, steps, "Telescope.mapper");
     return DeepMap.resolveMapper(source, target, steps);
+  }
+
+  // Detect forward-only rows (`Mapping.forward(...)`) and steer the caller to mapperForward(...)
+  // so the partial-Iso shape doesn't silently corrupt downstream Mapper.backward / Mapper.patch
+  // semantics. The check is O(steps.length); rows are typically <20 per mapper. Skips for
+  // mapperForward callers which legitimately accept forward-only rows.
+  private static void rejectForwardOnlyRows(
+    final Class<?> source,
+    final Class<?> target,
+    final MapStep[] steps,
+    final String factoryName
+  ) {
+    for (final var step : steps) {
+      if (step instanceof io.github.eschizoid.telescope.mapping.ForwardOnlyTransformTo<?, ?, ?, ?> r) {
+        throw new IllegalArgumentException(
+          factoryName +
+            "(" +
+            source.getSimpleName() +
+            ", " +
+            target.getSimpleName() +
+            ", ...) cannot accept a Mapping.forward(...) row for field '" +
+            ((io.github.eschizoid.telescope.mapping.MappingInternals<?, ?>) r).targetField() +
+            "' — forward(...) is forward-only and would silently corrupt Mapper.backward / Mapper.patch. " +
+            "Use Telescope.mapperForward(" +
+            source.getSimpleName() +
+            ", " +
+            target.getSimpleName() +
+            ", ...) for a typed forward-only result, or Mapping.to(src, tgt, forward, backward) for " +
+            "an explicit bidirectional row."
+        );
+      }
+    }
   }
 
   /**
    * Forward-only sibling of {@link #mapper(Class, Class, MapStep...)} — returns a {@link
    * ForwardMapper} whose backward direction is not present at the type level. Use when the
    * conversion is genuinely one-way (entity → DTO write-only, audit-log projection, normalisation
-   * pipeline) and rows include {@link io.github.eschizoid.telescope.mapping.Mapping#into into(...)}
+   * pipeline) and rows include {@link io.github.eschizoid.telescope.mapping.Mapping#forward
+   * forward(...)}
    * / {@link io.github.eschizoid.telescope.mapping.Mapping#constant constant(...)} / {@link
    * io.github.eschizoid.telescope.mapping.Mapping#compute compute(...)} that make the backward
    * direction meaningless.
@@ -842,7 +876,7 @@ public sealed class Telescope<
    * {@code Lens.then(Iso)} composition — which routes reads and writes through separate legs and
    * never round-trips a single value through both — but future contributors must not assume this is
    * a lawful Iso in isolation. The same caveat applies to {@link #before(Function)}, {@link
-   * io.github.eschizoid.telescope.mapping.Mapping#into Mapping.into}, and {@link
+   * io.github.eschizoid.telescope.mapping.Mapping#forward Mapping.forward}, and {@link
    * io.github.eschizoid.telescope.mapping.Mapping#toOrElse Mapping.toOrElse}.
    *
    * <pre>{@code

--- a/core/src/main/java/io/github/eschizoid/telescope/Telescope.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/Telescope.java
@@ -494,6 +494,10 @@ public sealed class Telescope<
   // No @SafeVarargs needed: MapStep is reifiable (no type parameter), so this varargs method does
   // not produce heap-pollution warnings for callers.
   public static <A, B> Telescope<A, B> map(final Class<A> source, final Class<B> target, final MapStep... steps) {
+    // Mirror the rejection that .mapper(...) does — a forward-only row would silently corrupt the
+    // returned Telescope's backward leg (set/update through a path whose constituent Iso has a
+    // throwing inverse). Catching it at the factory boundary keeps the diagnostic at the call site.
+    rejectForwardOnlyRows(source, target, steps, "Telescope.map");
     return new Telescope<>(DeepMap.resolve(source, target, steps));
   }
 

--- a/core/src/main/java/io/github/eschizoid/telescope/mapping/ForwardOnlyTransformTo.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/mapping/ForwardOnlyTransformTo.java
@@ -1,0 +1,48 @@
+package io.github.eschizoid.telescope.mapping;
+
+import io.github.eschizoid.telescope.Telescope.Accessor;
+import io.github.eschizoid.telescope.internal.LambdaIntrospection;
+import java.util.function.Function;
+
+/**
+ * Forward-only typed-transform correspondence row from {@link Mapping#into(Accessor, Accessor,
+ * Function)}. Carries only the {@code forward} function — there is no backward field — so the row
+ * itself cannot pretend to be a bidirectional correspondence.
+ *
+ * <p>Routed by {@code DeepMap} to a forward-only post-fixup: the produced row-level {@code Iso} has
+ * a throwing backward at the field site, AND {@code Telescope.mapper(...)} refuses to build a
+ * bidirectional {@link io.github.eschizoid.telescope.conversion.Mapper Mapper} when this row is
+ * present (it tells the caller to use {@link io.github.eschizoid.telescope.Telescope#mapperForward
+ * Telescope.mapperForward} instead). The compile-time-typed forward-only contract surfaces at the
+ * factory boundary rather than via a deferred runtime throw — closing the partial-Iso composition
+ * concern that the original {@link TypedTransformTo} shape carried with its throwing-backward
+ * field.
+ *
+ * <p>Internal — users construct via {@link Mapping#into(Accessor, Accessor, Function)} and never
+ * see this type at the call site.
+ */
+public record ForwardOnlyTransformTo<A, B, X, Y>(
+  Accessor<A, X> src,
+  Accessor<B, Y> tgt,
+  Function<? super X, ? extends Y> forward
+) implements Mapping<A, B>, MappingInternals<A, B> {
+  @Override
+  public Class<A> sourceClass() {
+    return LambdaIntrospection.implClassOf(src);
+  }
+
+  @Override
+  public Class<B> targetClass() {
+    return LambdaIntrospection.implClassOf(tgt);
+  }
+
+  @Override
+  public String sourceField() {
+    return LambdaIntrospection.methodNameOf(src);
+  }
+
+  @Override
+  public String targetField() {
+    return LambdaIntrospection.methodNameOf(tgt);
+  }
+}

--- a/core/src/main/java/io/github/eschizoid/telescope/mapping/Mapping.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/mapping/Mapping.java
@@ -43,6 +43,7 @@ public sealed interface Mapping<A, B>
   permits
     SameTypedTo,
     TypedTransformTo,
+    ForwardOnlyTransformTo,
     Via,
     Drop,
     TelescopeTo,
@@ -100,15 +101,7 @@ public sealed interface Mapping<A, B>
     final Accessor<B, Y> tgt,
     final Function<? super X, ? extends Y> fn
   ) {
-    final String fieldName = LambdaIntrospection.methodNameOf(src);
-    final Function<? super Y, ? extends X> throwingBackward = y -> {
-      throw new UnsupportedOperationException(
-        "Mapping.forward is forward-only — backward direction is undefined for field '" +
-          fieldName +
-          "'. Use Mapping.to(src, tgt, forward, backward) if a bidirectional row is required."
-      );
-    };
-    return new TypedTransformTo<>(src, tgt, fn, throwingBackward);
+    return new ForwardOnlyTransformTo<>(src, tgt, fn);
   }
 
   /**

--- a/core/src/main/java/io/github/eschizoid/telescope/mapping/MappingInternals.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/mapping/MappingInternals.java
@@ -19,6 +19,7 @@ public sealed interface MappingInternals<
 > permits
   SameTypedTo,
   TypedTransformTo,
+  ForwardOnlyTransformTo,
   Via,
   Drop,
   TelescopeTo,

--- a/core/src/test/java/io/github/eschizoid/telescope/MappingForwardTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/MappingForwardTest.java
@@ -1,6 +1,7 @@
 package io.github.eschizoid.telescope;
 
 import static io.github.eschizoid.telescope.mapping.Mapping.forward;
+import static io.github.eschizoid.telescope.mapping.Mapping.to;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -11,11 +12,11 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 /**
- * Pins {@code Mapping.forward(src, tgt, fn)} — the forward-only sibling of {@code Mapping.to(src,
- * tgt, fwd, bwd)} for one-shot entity → DB schema mappings whose backward is never called. The user
- * supplies just the forward function; the row's backward, if invoked, throws {@link
- * UnsupportedOperationException} with a self-diagnosing message that names the row and the target
- * field.
+ * Pins {@code Mapping.forward(src, tgt, fn)} — the forward-only row that produces a {@code
+ * ForwardOnlyTransformTo} sealed permit. {@code Telescope.mapper(...)} REJECTS the row at the
+ * factory boundary (compile-time-typed forward-only contract: the partial-Iso shape would silently
+ * corrupt {@code Mapper.backward} / {@code Mapper.patch}). Callers must use {@code
+ * Telescope.mapperForward(...)} to consume {@code forward(...)} rows.
  */
 class MappingForwardTest {
 
@@ -24,47 +25,38 @@ class MappingForwardTest {
   record Dto(String createdAtIso, String label) {}
 
   @Nested
-  @DisplayName("forward direction — runs the user's transform")
-  class ForwardRuns {
+  @DisplayName("Telescope.mapper(...) — REJECTS forward(...) rows at factory boundary")
+  class Rejection {
 
     @Test
-    @DisplayName("forward transforms the source value into the target leaf")
-    void forwardRuns() {
-      final var mapper = Telescope.mapper(
-        Entity.class,
-        Dto.class,
-        forward(Entity::createdAt, Dto::createdAtIso, Instant::toString)
+    @DisplayName("calling Telescope.mapper with a Mapping.forward row throws IAE naming the field + escape hatch")
+    void mapperRejectsForward() {
+      final var ex = assertThrows(IllegalArgumentException.class, () ->
+        Telescope.mapper(Entity.class, Dto.class, forward(Entity::createdAt, Dto::createdAtIso, Instant::toString))
       );
-
-      final var entity = new Entity(Instant.parse("2026-01-01T00:00:00Z"), "x");
-      assertEquals(new Dto("2026-01-01T00:00:00Z", "x"), mapper.forward(entity));
+      assertTrue(ex.getMessage().contains("Telescope.mapper"));
+      assertTrue(ex.getMessage().contains("Mapping.forward"));
+      assertTrue(ex.getMessage().contains("createdAtIso"), () -> ex.getMessage());
+      assertTrue(ex.getMessage().contains("mapperForward"));
     }
   }
 
   @Nested
-  @DisplayName("backward direction — unsupported")
-  class Backward {
+  @DisplayName("Telescope.mapperForward(...) — accepts forward(...) rows")
+  class ForwardOnly {
 
     @Test
-    @DisplayName("backward throws UnsupportedOperationException with a self-diagnosing message")
-    void backwardThrows() {
-      final var mapper = Telescope.mapper(
+    @DisplayName("forward direction runs the user's transform via mapperForward")
+    void mapperForwardRuns() {
+      final var projector = Telescope.mapperForward(
         Entity.class,
         Dto.class,
-        forward(Entity::createdAt, Dto::createdAtIso, Instant::toString)
+        forward(Entity::createdAt, Dto::createdAtIso, Instant::toString),
+        to(Entity::label, Dto::label)
       );
 
-      final var dto = new Dto("2026-01-01T00:00:00Z", "x");
-      final var ex = assertThrows(UnsupportedOperationException.class, () -> mapper.backward(dto));
-      // Message should name the factory + the field so the failure is self-diagnosing.
-      assertTrue(
-        ex.getMessage().toLowerCase().contains("forward"),
-        () -> "expected message to mention forward, was: " + ex.getMessage()
-      );
-      assertTrue(
-        ex.getMessage().contains("createdAt"),
-        () -> "expected message to mention the row's field, was: " + ex.getMessage()
-      );
+      final var entity = new Entity(Instant.parse("2026-01-01T00:00:00Z"), "x");
+      assertEquals(new Dto("2026-01-01T00:00:00Z", "x"), projector.forward(entity));
     }
   }
 }

--- a/core/src/test/java/io/github/eschizoid/telescope/MappingForwardTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/MappingForwardTest.java
@@ -39,6 +39,17 @@ class MappingForwardTest {
       assertTrue(ex.getMessage().contains("createdAtIso"), () -> ex.getMessage());
       assertTrue(ex.getMessage().contains("mapperForward"));
     }
+
+    @Test
+    @DisplayName("Telescope.map(...) also rejects forward(...) rows — closes the silent-corruption gap")
+    void mapAlsoRejectsForward() {
+      final var ex = assertThrows(IllegalArgumentException.class, () ->
+        Telescope.map(Entity.class, Dto.class, forward(Entity::createdAt, Dto::createdAtIso, Instant::toString))
+      );
+      assertTrue(ex.getMessage().contains("Telescope.map"));
+      assertTrue(ex.getMessage().contains("Mapping.forward"));
+      assertTrue(ex.getMessage().contains("createdAtIso"));
+    }
   }
 
   @Nested


### PR DESCRIPTION
## Summary

Closes the partial-Iso composition concern flagged by round-2 review on PR #85. `Mapping.into(...)` now returns a dedicated `ForwardOnlyTransformTo<A, B, X, Y>` sealed permit instead of wrapping a `TypedTransformTo` with a throwing-backward lambda — and `Telescope.mapper(...)` REJECTS the row at the factory boundary, pointing the caller at `Telescope.mapperForward(...)`.

## Before / after

```java
// Before — silent partial-Iso. mapper.backward(...) throws on first call.
Mapper<Entity, Dto> m = Telescope.mapper(Entity.class, Dto.class,
    into(Entity::createdAt, Dto::createdAtIso, Instant::toString));
m.backward(dto);  // throws UnsupportedOperationException at field site

// After — rejected at the factory boundary.
Telescope.mapper(Entity.class, Dto.class,
    into(Entity::createdAt, Dto::createdAtIso, Instant::toString));
// IllegalArgumentException: Telescope.mapper(Entity, Dto, ...) cannot accept a
//   Mapping.into(...) row for field 'createdAtIso' — into(...) is forward-only and
//   would silently corrupt Mapper.backward / Mapper.patch.
//   Use Telescope.mapperForward(Entity, Dto, ...) for a typed forward-only result,
//   or Mapping.to(src, tgt, forward, backward) for an explicit bidirectional row.

// Callers route through mapperForward, which legitimately accepts into(...) rows
ForwardMapper<Entity, Dto> projector = Telescope.mapperForward(Entity.class, Dto.class,
    into(Entity::createdAt, Dto::createdAtIso, Instant::toString),
    to(Entity::label, Dto::label));
```

## What changed

- **`ForwardOnlyTransformTo<A, B, X, Y>`** — new sealed record permit of `Mapping` + `MappingInternals`. Carries only the `forward` function (no backward field).
- **`Mapping.into(...)`** — returns `ForwardOnlyTransformTo` directly.
- **`MappingInternals.permits`** — extended.
- **`Telescope.mapper(...)`** — scans `MapStep[]` for the new permit and throws `IllegalArgumentException` naming the offending field + the `mapperForward` escape hatch + the explicit-bidirectional `Mapping.to(src, tgt, fwd, bwd)` alternative.
- **`DeepMap.fieldIsoOf`** — dedicated branch for `ForwardOnlyTransformTo` that wires a throwing-backward `Iso.of(forward, throwingBackward)` for the rare cross-package bypass path; throw message names the field.

## Why the type-level fix matters

Round-2 review concretely traced: a `Mapping.into(...)` row buried inside a nested `Mapping.via(parentMapper)` would silently corrupt parent reconstruction on `Mapper.backward(...)` because the lattice's structural composition doesn't enforce iso round-trip laws at construction. The fix moves the rejection from a deferred runtime throw at first-`backward(...)` call to a synchronous factory rejection at `Telescope.mapper(...)` invocation — which forces the caller to acknowledge the forward-only contract and pick the right typed result up front.

## Stacking

Stacked on `feat/telescope-lattice-hooks` (#90). Merge order: …#88 → #89 → #90 → this → main.

## Test plan

- [x] `MappingIntoTest.Rejection` — confirms `Telescope.mapper(...)` rejects the row with a message naming `Telescope.mapper`, `Mapping.into`, the offending field, and the `mapperForward` escape hatch.
- [x] `MappingIntoTest.ForwardOnly` — confirms `Telescope.mapperForward(...)` accepts and runs the forward transform end-to-end.
- [x] Full `./gradlew test` green across all modules.
