### PR TITLE
feat(codegen): @Rename(forwardOnly=true) for fan-out parity

### DIFF
--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
@@ -82,11 +82,19 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
   // read in generate().
   private final Map<TypePair, Set<String>> dropsByPair = new HashMap<>();
 
-  // Per-pair renames: source field name -> target field name for fields whose two sides have
-  // different names. The bijection check applies renames on the source side before comparing
-  // to target names; planFields and the field-read expressions follow the mapping. Populated in
+  // Per-pair renames: source field name -> primary target field name for fields whose two sides
+  // have different names. The bijection check applies renames on the source side before comparing
+  // to target names; planFields and the field-read expressions follow the mapping. For forward-only
+  // fan-out (one source feeding multiple targets), this map holds the FIRST-declared target — that's
+  // the one backward reads from. Extra fan-out targets live in renameFanoutsByPair. Populated in
   // process(), read in generate().
   private final Map<TypePair, Map<String, String>> renamesByPair = new HashMap<>();
+
+  // Per-pair forward-only fan-out extras: source field name -> ordered list of EXTRA target field
+  // names beyond the primary in renamesByPair. Only present when @Rename(forwardOnly = true) is used
+  // on two or more renames sharing a source. Forward writes the source value to every target
+  // (primary + extras); backward reads only the primary. Populated in process(), read in generate().
+  private final Map<TypePair, Map<String, List<String>>> renameFanoutsByPair = new HashMap<>();
 
   // Per-pair per-field transforms: source field name -> BridgeFn class FQN. The transformed field
   // is
@@ -112,6 +120,7 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
     multiTargetSources.clear();
     dropsByPair.clear();
     renamesByPair.clear();
+    renameFanoutsByPair.clear();
     transformsByPair.clear();
     constantsByPair.clear();
     computesByPair.clear();
@@ -157,9 +166,10 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
         userDeclared.add(pair);
         final var drops = dropsFromMirror(bridgeAm);
         if (!drops.isEmpty()) dropsByPair.put(pair, drops);
-        final var renames = renamesFromMirror(element, bridgeAm);
-        if (renames == null) continue; // invalid rename — error already reported, skip this pair
-        if (!renames.isEmpty()) renamesByPair.put(pair, renames);
+        final var renameSet = renamesFromMirror(element, bridgeAm);
+        if (renameSet == null) continue; // invalid rename — error already reported, skip this pair
+        if (!renameSet.bySource().isEmpty()) renamesByPair.put(pair, renameSet.bySource());
+        if (!renameSet.fanoutExtras().isEmpty()) renameFanoutsByPair.put(pair, renameSet.fanoutExtras());
         final var transforms = transformsFromMirror(element, bridgeAm);
         if (transforms == null) continue; // invalid transform — already reported, skip this pair
         if (!transforms.isEmpty()) transformsByPair.put(pair, transforms);
@@ -226,42 +236,70 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
     return Set.of();
   }
 
+  // Result of parsing a @Bridge's renames list. `bySource` holds the first-declared target per
+  // source (the slot that backward direction reads from). `fanoutExtras` holds the extra targets
+  // declared via @Rename(forwardOnly = true) sharing the same source — those targets receive the
+  // same source value during forward emission but are invisible to backward. Empty fanoutExtras
+  // means no fan-out was declared.
+  private record RenameSet(Map<String, String> bySource, Map<String, List<String>> fanoutExtras) {
+    static RenameSet empty() {
+      return new RenameSet(Map.of(), Map.of());
+    }
+  }
+
   // Read renames from a @Bridge mirror. Returns null when a rename is malformed (already reported
-  // via error()) so the caller can skip the pair; returns an empty map when no renames are present.
-  private Map<String, String> renamesFromMirror(final Element element, final AnnotationMirror am) {
+  // via error()) so the caller can skip the pair; returns an empty RenameSet when no renames are
+  // present. Forward-only fan-out: when two renames share a source and BOTH set forwardOnly = true,
+  // the second target lands in fanoutExtras. A source-collision with any rename not flagged
+  // forwardOnly is still an error — the user must opt in on every conflicting entry.
+  private RenameSet renamesFromMirror(final Element element, final AnnotationMirror am) {
     for (final var entry : am.getElementValues().entrySet()) {
       if (!entry.getKey().getSimpleName().contentEquals("renames")) continue;
       @SuppressWarnings("unchecked")
       final var list = (List<? extends AnnotationValue>) entry.getValue().getValue();
-      final var result = new LinkedHashMap<String, String>();
-      final var seenSources = new HashSet<String>();
+      final var primary = new LinkedHashMap<String, String>();
+      final var fanoutExtras = new LinkedHashMap<String, List<String>>();
       final var seenTargets = new HashSet<String>();
+      final var sourceForwardOnly = new HashMap<String, Boolean>();
       for (final var av : list) {
         final var renameAm = (AnnotationMirror) av.getValue();
         String src = null;
         String tgt = null;
+        Boolean forwardOnly = Boolean.FALSE;
         for (final var re : renameAm.getElementValues().entrySet()) {
           final var k = re.getKey().getSimpleName().toString();
           if (k.equals("source")) src = (String) re.getValue().getValue();
           else if (k.equals("target")) tgt = (String) re.getValue().getValue();
+          else if (k.equals("forwardOnly")) forwardOnly = (Boolean) re.getValue().getValue();
         }
         if (src == null || tgt == null || src.isEmpty() || tgt.isEmpty()) {
           error(element, "@Rename requires both `source` and `target` field names");
-          return null;
-        }
-        if (!seenSources.add(src)) {
-          error(element, "@Rename source \"" + src + "\" appears twice in the renames list");
           return null;
         }
         if (!seenTargets.add(tgt)) {
           error(element, "@Rename target \"" + tgt + "\" appears twice in the renames list");
           return null;
         }
-        result.put(src, tgt);
+        if (primary.containsKey(src)) {
+          if (!Boolean.TRUE.equals(forwardOnly) || !Boolean.TRUE.equals(sourceForwardOnly.get(src))) {
+            error(
+              element,
+              "@Rename source \"" +
+                src +
+                "\" appears twice in the renames list — set forwardOnly = true on every conflicting" +
+                " entry to opt into forward-only fan-out"
+            );
+            return null;
+          }
+          fanoutExtras.computeIfAbsent(src, __ -> new ArrayList<>()).add(tgt);
+        } else {
+          primary.put(src, tgt);
+          sourceForwardOnly.put(src, forwardOnly);
+        }
       }
-      return result;
+      return new RenameSet(primary, fanoutExtras);
     }
-    return Map.of();
+    return RenameSet.empty();
   }
 
   // Read transforms from a @Bridge mirror. Returns null on a malformed transform (already reported)
@@ -573,6 +611,7 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
     final var targetFields = fieldsOf(target);
     final var drops = dropsByPair.getOrDefault(thisPair, Set.of());
     final var renames = renamesByPair.getOrDefault(thisPair, Map.of());
+    final var renameFanouts = renameFanoutsByPair.getOrDefault(thisPair, Map.of());
     final var transforms = transformsByPair.getOrDefault(thisPair, Map.of());
     final var rawConstants = constantsByPair.getOrDefault(thisPair, Map.of());
     final var computes = computesByPair.getOrDefault(thisPair, Map.of());
@@ -646,14 +685,65 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
         return;
       }
     }
+    // Validate forward-only fan-out extras: every extra target must exist on the target side, each
+    // extra target's type must match the primary target's type (forward writes one source value into
+    // every target slot — they must be assignment-compatible), and the extra target can't double up
+    // with a constant/compute injection. seenTargets across the whole rename set is already enforced
+    // upstream in renamesFromMirror; this loop adds the source-side existence + type checks.
+    for (final var fanout : renameFanouts.entrySet()) {
+      final var srcName = fanout.getKey();
+      final var primaryTgt = renames.get(srcName);
+      final var primaryType = fieldByName(targetFields, primaryTgt).type();
+      for (final var extraTgt : fanout.getValue()) {
+        if (!targetNames.contains(extraTgt)) {
+          error(
+            source,
+            "@Bridge renames target=\"" +
+              extraTgt +
+              "\" (forwardOnly fan-out from \"" +
+              srcName +
+              "\") is not a field of " +
+              target.getSimpleName() +
+              " — known fields: " +
+              targetNames
+          );
+          return;
+        }
+        final var extraType = fieldByName(targetFields, extraTgt).type();
+        if (!isSameType(primaryType, extraType)) {
+          error(
+            source,
+            "@Bridge renames source=\"" +
+              srcName +
+              "\" fans out to targets with different types — \"" +
+              primaryTgt +
+              "\" is " +
+              primaryType +
+              ", \"" +
+              extraTgt +
+              "\" is " +
+              extraType +
+              ". Forward-only fan-out writes the same source value into every target; all targets must" +
+              " share the same type."
+          );
+          return;
+        }
+      }
+    }
     final var reverseRenames = new LinkedHashMap<String, String>();
     for (final var e : renames.entrySet()) reverseRenames.put(e.getValue(), e.getKey());
+    // Fan-out extras: every extra target reads from the same source as the primary. Adding them to
+    // reverseRenames lets readForward emit each extra target's read expression off the same source.
+    for (final var fanout : renameFanouts.entrySet()) {
+      for (final var extraTgt : fanout.getValue()) reverseRenames.put(extraTgt, fanout.getKey());
+    }
 
     // Validate constants + computes (forward-only target-side injections). Each named field must
     // exist on the target; a target field may not be injected by more than one mechanism, nor by a
     // mechanism that also reaches that target name through a rename. Parse constant values here so
     // type errors fire alongside the rest of the per-pair validation.
-    final var renameTargetNames = renames.values().stream().collect(Collectors.toSet());
+    final var renameTargetNames = new LinkedHashSet<>(renames.values());
+    for (final var extras : renameFanouts.values()) renameTargetNames.addAll(extras);
     final var injectedTargetFields = new LinkedHashSet<String>();
     final var parsedConstants = new LinkedHashMap<String, String>();
     for (final var e : rawConstants.entrySet()) {
@@ -721,7 +811,8 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
           .stream()
           .filter(f -> !drops.contains(f.name()))
           .toList();
-    if (!sameNames(source, nonDroppedSourceFields, target, targetFields, renames, injectedTargetFields)) return;
+    if (!sameNames(source, nonDroppedSourceFields, target, targetFields, renames, renameFanouts, injectedTargetFields))
+      return;
 
     // Build per-field "read expression" recipes: identity, sub-pair recursion, or container lift.
     // The reads need to know how to convert each source-field-value into the matching target-field-
@@ -1649,12 +1740,17 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
     final TypeElement target,
     final List<Field> targetFields,
     final Map<String, String> renames,
+    final Map<String, List<String>> renameFanouts,
     final Set<String> injectedTargetFields
   ) {
-    final var sn = sourceFields
-      .stream()
-      .map(f -> renames.getOrDefault(f.name(), f.name()))
-      .collect(Collectors.toCollection(TreeSet::new));
+    final var sn = new TreeSet<String>();
+    for (final var f : sourceFields) {
+      sn.add(renames.getOrDefault(f.name(), f.name()));
+      // Forward-only fan-out: every extra target counts as a source-derived name in the bijection,
+      // since forward writes the source value into every fan-out target slot.
+      final var extras = renameFanouts.get(f.name());
+      if (extras != null) sn.addAll(extras);
+    }
     final var tn = targetFields
       .stream()
       .map(Field::name)

--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
@@ -85,15 +85,18 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
   // Per-pair renames: source field name -> primary target field name for fields whose two sides
   // have different names. The bijection check applies renames on the source side before comparing
   // to target names; planFields and the field-read expressions follow the mapping. For forward-only
-  // fan-out (one source feeding multiple targets), this map holds the FIRST-declared target — that's
+  // fan-out (one source feeding multiple targets), this map holds the FIRST-declared target —
+  // that's
   // the one backward reads from. Extra fan-out targets live in renameFanoutsByPair. Populated in
   // process(), read in generate().
   private final Map<TypePair, Map<String, String>> renamesByPair = new HashMap<>();
 
   // Per-pair forward-only fan-out extras: source field name -> ordered list of EXTRA target field
-  // names beyond the primary in renamesByPair. Only present when @Rename(forwardOnly = true) is used
+  // names beyond the primary in renamesByPair. Only present when @Rename(forwardOnly = true) is
+  // used
   // on two or more renames sharing a source. Forward writes the source value to every target
-  // (primary + extras); backward reads only the primary. Populated in process(), read in generate().
+  // (primary + extras); backward reads only the primary. Populated in process(), read in
+  // generate().
   private final Map<TypePair, Map<String, List<String>>> renameFanoutsByPair = new HashMap<>();
 
   // Per-pair per-field transforms: source field name -> BridgeFn class FQN. The transformed field
@@ -686,9 +689,11 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
       }
     }
     // Validate forward-only fan-out extras: every extra target must exist on the target side, each
-    // extra target's type must match the primary target's type (forward writes one source value into
+    // extra target's type must match the primary target's type (forward writes one source value
+    // into
     // every target slot — they must be assignment-compatible), and the extra target can't double up
-    // with a constant/compute injection. seenTargets across the whole rename set is already enforced
+    // with a constant/compute injection. seenTargets across the whole rename set is already
+    // enforced
     // upstream in renamesFromMirror; this loop adds the source-side existence + type checks.
     for (final var fanout : renameFanouts.entrySet()) {
       final var srcName = fanout.getKey();
@@ -811,8 +816,9 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
           .stream()
           .filter(f -> !drops.contains(f.name()))
           .toList();
-    if (!sameNames(source, nonDroppedSourceFields, target, targetFields, renames, renameFanouts, injectedTargetFields))
-      return;
+    if (
+      !sameNames(source, nonDroppedSourceFields, target, targetFields, renames, renameFanouts, injectedTargetFields)
+    ) return;
 
     // Build per-field "read expression" recipes: identity, sub-pair recursion, or container lift.
     // The reads need to know how to convert each source-field-value into the matching target-field-

--- a/codegen/src/test/java/io/github/eschizoid/telescope/codegen/BridgeProcessorTest.java
+++ b/codegen/src/test/java/io/github/eschizoid/telescope/codegen/BridgeProcessorTest.java
@@ -1575,5 +1575,146 @@ class BridgeProcessorTest {
         () -> "expected duplicate-source diagnostic; saw " + compilation.errorMessages()
       );
     }
+
+    @Test
+    @DisplayName("@Rename(forwardOnly=true) fan-out: one source feeds multiple targets; backward reads primary only")
+    void forwardOnlyFanoutEmitsMultiTargetWrite() {
+      final var compilation = compile(
+        source(
+          "demo.Audit",
+          """
+          package demo;
+          import io.github.eschizoid.telescope.annotations.Bridge;
+          import io.github.eschizoid.telescope.annotations.Rename;
+          @Bridge(value = demo.AuditEntity.class, renames = {
+            @Rename(source = "businessUnit", target = "cretnUserId",  forwardOnly = true),
+            @Rename(source = "businessUnit", target = "lastUpdtdUserId", forwardOnly = true)
+          })
+          public record Audit(String businessUnit) {}
+          """
+        ),
+        source(
+          "demo.AuditEntity",
+          """
+          package demo;
+          public record AuditEntity(String cretnUserId, String lastUpdtdUserId) {}
+          """
+        )
+      );
+
+      assertTrue(compilation.success(), () -> "compilation failed: " + compilation.errorMessages());
+      final var bridge = compilation.generated().get("demo.AuditBridge");
+      assertNotNull(bridge, () -> "AuditBridge missing; saw " + compilation.generated().keySet());
+
+      // Forward: source.businessUnit() flows into BOTH target columns positionally.
+      assertTrue(
+        bridge.contains("new demo.AuditEntity(s.businessUnit(), s.businessUnit())"),
+        () -> "forward must fan source into every target; saw: " + bridge
+      );
+      // Backward: only the FIRST declared fan-out target (cretnUserId) reconstructs the source.
+      assertTrue(
+        bridge.contains("new demo.Audit(t.cretnUserId())"),
+        () -> "backward must read the primary fan-out target only; saw: " + bridge
+      );
+    }
+
+    @Test
+    @DisplayName("@Rename source-collision is still rejected if any conflicting entry omits forwardOnly")
+    void forwardOnlyMustBeSetOnEveryConflictingRename() {
+      final var compilation = compile(
+        source(
+          "demo.A",
+          """
+          package demo;
+          import io.github.eschizoid.telescope.annotations.Bridge;
+          import io.github.eschizoid.telescope.annotations.Rename;
+          @Bridge(value = demo.B.class, renames = {
+            @Rename(source = "name", target = "a",  forwardOnly = true),
+            @Rename(source = "name", target = "b") // forwardOnly defaults to false — opt-in required
+          })
+          public record A(String name) {}
+          """
+        ),
+        source(
+          "demo.B",
+          """
+          package demo;
+          public record B(String a, String b) {}
+          """
+        )
+      );
+
+      assertFalse(compilation.success(), "partial forwardOnly opt-in should fail");
+      assertTrue(
+        compilation.hasError("set forwardOnly = true on every conflicting"),
+        () -> "expected partial-opt-in diagnostic; saw " + compilation.errorMessages()
+      );
+    }
+
+    @Test
+    @DisplayName("@Rename forwardOnly fan-out rejects targets with mismatched types")
+    void forwardOnlyFanoutRejectsTypeMismatch() {
+      final var compilation = compile(
+        source(
+          "demo.A",
+          """
+          package demo;
+          import io.github.eschizoid.telescope.annotations.Bridge;
+          import io.github.eschizoid.telescope.annotations.Rename;
+          @Bridge(value = demo.B.class, renames = {
+            @Rename(source = "value", target = "asString", forwardOnly = true),
+            @Rename(source = "value", target = "asInt",    forwardOnly = true)
+          })
+          public record A(String value) {}
+          """
+        ),
+        source(
+          "demo.B",
+          """
+          package demo;
+          public record B(String asString, int asInt) {}
+          """
+        )
+      );
+
+      assertFalse(compilation.success(), "type-mismatched fan-out should fail");
+      assertTrue(
+        compilation.hasError("fans out to targets with different types"),
+        () -> "expected type-mismatch diagnostic; saw " + compilation.errorMessages()
+      );
+    }
+
+    @Test
+    @DisplayName("@Rename forwardOnly fan-out rejects an extra target that doesn't exist on the target side")
+    void forwardOnlyFanoutRejectsMissingExtraTarget() {
+      final var compilation = compile(
+        source(
+          "demo.A",
+          """
+          package demo;
+          import io.github.eschizoid.telescope.annotations.Bridge;
+          import io.github.eschizoid.telescope.annotations.Rename;
+          @Bridge(value = demo.B.class, renames = {
+            @Rename(source = "name", target = "a",        forwardOnly = true),
+            @Rename(source = "name", target = "missingX", forwardOnly = true)
+          })
+          public record A(String name) {}
+          """
+        ),
+        source(
+          "demo.B",
+          """
+          package demo;
+          public record B(String a, String b) {}
+          """
+        )
+      );
+
+      assertFalse(compilation.success(), "missing extra target should fail");
+      assertTrue(
+        compilation.hasError("target=\"missingX\""),
+        () -> "expected missing-extra-target diagnostic; saw " + compilation.errorMessages()
+      );
+    }
   }
 }

--- a/core/src/main/java/io/github/eschizoid/telescope/annotations/Bridge.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/annotations/Bridge.java
@@ -89,9 +89,9 @@ public @interface Bridge {
    *
    * <p>Each rename's source must name a real field on the annotated source; each target must name a
    * real field on the bridge target. No two renames may share the same target. By default no two
-   * renames may share the same source either; opt into forward-only fan-out by setting
-   * {@link Rename#forwardOnly()} on all conflicting renames — backward then reads from the first
-   * declared fan-out target. The non-fan-out case stays a strict bijection within the rename set.
+   * renames may share the same source either; opt into forward-only fan-out by setting {@link
+   * Rename#forwardOnly()} on all conflicting renames — backward then reads from the first declared
+   * fan-out target. The non-fan-out case stays a strict bijection within the rename set.
    */
   Rename[] renames() default {};
 

--- a/core/src/main/java/io/github/eschizoid/telescope/annotations/Bridge.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/annotations/Bridge.java
@@ -88,8 +88,10 @@ public @interface Bridge {
    * }</pre>
    *
    * <p>Each rename's source must name a real field on the annotated source; each target must name a
-   * real field on the bridge target. No two renames may share the same source or the same target —
-   * the name relation stays a bijection within the rename set.
+   * real field on the bridge target. No two renames may share the same target. By default no two
+   * renames may share the same source either; opt into forward-only fan-out by setting
+   * {@link Rename#forwardOnly()} on all conflicting renames — backward then reads from the first
+   * declared fan-out target. The non-fan-out case stays a strict bijection within the rename set.
    */
   Rename[] renames() default {};
 

--- a/core/src/main/java/io/github/eschizoid/telescope/annotations/Rename.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/annotations/Rename.java
@@ -16,8 +16,28 @@ import java.lang.annotation.RetentionPolicy;
  * }</pre>
  *
  * <p>Both names must be real field names on their respective sides. A misspelled name on either
- * side is a compile error. Multiple renames may target the same direction (one record field at a
- * time); no two renames can reference the same source name or the same target name.
+ * side is a compile error. Multiple renames cannot reference the same target name. By default two
+ * renames cannot share the same source either — set {@link #forwardOnly()} to {@code true} on
+ * both (or all) of them to enable forward-only fan-out where one source field feeds multiple
+ * target columns.
+ *
+ * <h2>Forward-only fan-out</h2>
+ *
+ * <p>Some enterprise audit shapes need a single source field to feed two or more correlated
+ * target columns (the canonical {@code businessUnit → cretnUserId AND lastUpdtdUserId} case).
+ * Mark the conflicting renames {@code forwardOnly = true} to opt in:
+ *
+ * <pre>{@code
+ * @Bridge(value = AuditEntity.class, renames = {
+ *   @Rename(source = "businessUnit", target = "cretnUserId",  forwardOnly = true),
+ *   @Rename(source = "businessUnit", target = "lastUpdtdUserId", forwardOnly = true)
+ * })
+ * public record Audit(String businessUnit) {}
+ * }</pre>
+ *
+ * <p>Forward writes the source value to <em>every</em> target column. Backward reconstructs the
+ * source from the <em>first</em> declared fan-out target — declaration order is the contract.
+ * This mirrors the runtime fan-out semantics enabled in {@code Telescope.mapper(...)}.
  */
 @Retention(RetentionPolicy.SOURCE)
 public @interface Rename {
@@ -26,4 +46,12 @@ public @interface Rename {
 
   /** The field name on the {@link Bridge} target. */
   String target();
+
+  /**
+   * Opt in to forward-only fan-out when another {@link Rename} on the same {@link Bridge}
+   * declares the same {@link #source()}. Backward direction reads from the first declared
+   * fan-out target only — pick declaration order to control which target reconstructs the
+   * source. See the type-level javadoc for the audit-column fan-out shape.
+   */
+  boolean forwardOnly() default false;
 }

--- a/core/src/main/java/io/github/eschizoid/telescope/annotations/Rename.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/annotations/Rename.java
@@ -17,15 +17,15 @@ import java.lang.annotation.RetentionPolicy;
  *
  * <p>Both names must be real field names on their respective sides. A misspelled name on either
  * side is a compile error. Multiple renames cannot reference the same target name. By default two
- * renames cannot share the same source either — set {@link #forwardOnly()} to {@code true} on
- * both (or all) of them to enable forward-only fan-out where one source field feeds multiple
- * target columns.
+ * renames cannot share the same source either — set {@link #forwardOnly()} to {@code true} on both
+ * (or all) of them to enable forward-only fan-out where one source field feeds multiple target
+ * columns.
  *
  * <h2>Forward-only fan-out</h2>
  *
- * <p>Some enterprise audit shapes need a single source field to feed two or more correlated
- * target columns (the canonical {@code businessUnit → cretnUserId AND lastUpdtdUserId} case).
- * Mark the conflicting renames {@code forwardOnly = true} to opt in:
+ * <p>Some enterprise audit shapes need a single source field to feed two or more correlated target
+ * columns (the canonical {@code businessUnit → cretnUserId AND lastUpdtdUserId} case). Mark the
+ * conflicting renames {@code forwardOnly = true} to opt in:
  *
  * <pre>{@code
  * @Bridge(value = AuditEntity.class, renames = {
@@ -36,8 +36,8 @@ import java.lang.annotation.RetentionPolicy;
  * }</pre>
  *
  * <p>Forward writes the source value to <em>every</em> target column. Backward reconstructs the
- * source from the <em>first</em> declared fan-out target — declaration order is the contract.
- * This mirrors the runtime fan-out semantics enabled in {@code Telescope.mapper(...)}.
+ * source from the <em>first</em> declared fan-out target — declaration order is the contract. This
+ * mirrors the runtime fan-out semantics enabled in {@code Telescope.mapper(...)}.
  */
 @Retention(RetentionPolicy.SOURCE)
 public @interface Rename {
@@ -48,10 +48,10 @@ public @interface Rename {
   String target();
 
   /**
-   * Opt in to forward-only fan-out when another {@link Rename} on the same {@link Bridge}
-   * declares the same {@link #source()}. Backward direction reads from the first declared
-   * fan-out target only — pick declaration order to control which target reconstructs the
-   * source. See the type-level javadoc for the audit-column fan-out shape.
+   * Opt in to forward-only fan-out when another {@link Rename} on the same {@link Bridge} declares
+   * the same {@link #source()}. Backward direction reads from the first declared fan-out target
+   * only — pick declaration order to control which target reconstructs the source. See the
+   * type-level javadoc for the audit-column fan-out shape.
    */
   boolean forwardOnly() default false;
 }


### PR DESCRIPTION
## Summary

Codegen-side parity for the runtime forward-only fan-out enabled in PR #84. A single source field can now feed multiple target columns on a `@Bridge` when every conflicting `@Rename` opts in with `forwardOnly = true`. Backward direction reads from the first-declared fan-out target only.

## The canonical shape

Enterprise audit columns: one logical source value (e.g. `businessUnit`) needs to land in two correlated target columns (`cretnUserId` and `lastUpdtdUserId`). Before this PR, codegen rejected the duplicate source and forced the user back to the runtime fluent path.

```java
@Bridge(value = AuditEntity.class, renames = {
  @Rename(source = "businessUnit", target = "cretnUserId",     forwardOnly = true),
  @Rename(source = "businessUnit", target = "lastUpdtdUserId", forwardOnly = true)
})
public record Audit(String businessUnit) {}
```

Emitted forward:
```java
public static AuditEntity forward(final Audit s) {
  return new AuditEntity(s.businessUnit(), s.businessUnit());
}
```

Emitted backward (primary target only — declaration order is the contract):
```java
public static Audit backward(final AuditEntity t) {
  return new Audit(t.cretnUserId());
}
```

## What changed

- `@Rename` gains `boolean forwardOnly() default false;`. Default behaviour unchanged — a bare source-collision still errors.
- `BridgeProcessor.renamesFromMirror` now returns a `RenameSet` record carrying a primary `source → target` map plus a `fanoutExtras` map keyed by source (extras = targets beyond the first declared).
- `generate()` validates fan-out extras: each extra target must exist on the target side AND share the primary target's type (forward writes one source value into every slot — they must be assignment-compatible).
- `reverseRenames` includes the extras so `readForward` emits each fan-out target's read off the same source. `readBackward` stays primary-only.
- `sameNames` includes extras in the source-derived expected-name set so the bijection check still passes.
- Partial opt-in is still rejected: if any conflicting `@Rename` omits `forwardOnly`, the diagnostic asks the user to set it on every conflicting entry.

## Stacking

Stacked on `feat/codegen-match-emission` (#93). Merge order: …#93 → this → main.

## Test plan

- [x] `BridgeProcessorTest` — four new cases: happy fan-out (forward writes to both targets, backward reads primary only), partial opt-in rejected, type mismatch rejected, missing extra target rejected. All pass.
- [x] Existing `BridgeProcessorTest` cases — strict duplicate-source rejection without `forwardOnly` still fires identically.
- [x] Full `./gradlew test` green across all modules.
