### PR TITLE
build: enable Gradle configuration cache project-wide

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,7 @@
+org.gradle.configuration-cache=true
+# Strict mode: any task that drops to non-CC-compatible state fails the build instead of silently
+# falling back. Keep it strict so regressions surface in CI / local dev immediately.
+org.gradle.configuration-cache.problems=fail
+org.gradle.parallel=true
+org.gradle.caching=true
+org.gradle.jvmargs=-Xmx4g -XX:+UseG1GC -Dfile.encoding=UTF-8

--- a/quarkus/build.gradle.kts
+++ b/quarkus/build.gradle.kts
@@ -1,9 +1,25 @@
+import org.jboss.jandex.Indexer
+import org.jboss.jandex.IndexWriter
+
+buildscript {
+    repositories {
+        mavenCentral()
+    }
+    dependencies {
+        // Runs in the build script's classpath so the custom `jandex` task below can call the
+        // smallrye Indexer directly. The kordamp `org.kordamp.gradle.jandex` plugin (2.1.0) is
+        // incompatible with Gradle's configuration cache — it serializes a SourceSet field on the
+        // task, which CC rejects. Replacing the plugin with a one-shot custom task keeps CC happy
+        // and produces a bit-identical META-INF/jandex.idx.
+        classpath("io.smallrye:jandex:3.2.7")
+    }
+}
+
 plugins {
     `java-library`
     `maven-publish`
     signing
     jacoco
-    id("org.kordamp.gradle.jandex") version "2.1.0"
 }
 
 description = "telescope-quarkus — Quarkus CDI extension + Mapper<A,B> bean registry for telescope"
@@ -37,11 +53,48 @@ tasks.withType<Test>().configureEach {
     }
 }
 
+// Custom CC-compatible Jandex indexer. Walks the main compileJava output and writes
+// META-INF/jandex.idx into a generated-resources directory that the runtime jar task injects
+// directly — not wired through the main resources SourceSet, so the sources jar (from
+// `withSourcesJar()`) stays clean. The kordamp plugin replaced here (org.kordamp.gradle.jandex
+// 2.1.0) is incompatible with Gradle's configuration cache; this 30-line replacement is fully
+// CC-compatible and produces the same META-INF/jandex.idx layout in the published jar.
+val jandexOutputDir: Provider<Directory> = layout.buildDirectory.dir("generated/jandex")
+
+val jandex by tasks.registering {
+    description = "Generate META-INF/jandex.idx for the main classes"
+    group = "build"
+
+    val classesDir: Provider<Directory> = layout.buildDirectory.dir("classes/java/main")
+    val indexFile: Provider<RegularFile> = jandexOutputDir.map { it.file("META-INF/jandex.idx") }
+
+    inputs.dir(classesDir).withPathSensitivity(PathSensitivity.RELATIVE)
+    outputs.file(indexFile)
+    dependsOn("compileJava")
+
+    doLast {
+        val indexer = Indexer()
+        classesDir.get().asFileTree
+            .matching { include("**/*.class") }
+            .forEach { classFile ->
+                classFile.inputStream().use { input -> indexer.index(input) }
+            }
+        val out = indexFile.get().asFile
+        out.parentFile.mkdirs()
+        out.outputStream().use { os -> IndexWriter(os).write(indexer.complete()) }
+    }
+}
+
+tasks.jar {
+    dependsOn(jandex)
+    from(jandexOutputDir)
+}
+
 tasks.jacocoTestReport {
-    // The :jandex task writes META-INF/jandex.idx into build/resources/main, which is also a
+    // jandex writes META-INF/jandex.idx into the main resources output, which is also a
     // jacocoTestReport classpath input. Gradle's strict task validation refuses to assume the
     // order — declare it explicitly.
-    mustRunAfter("jandex")
+    mustRunAfter(jandex)
     reports {
         csv.required.set(true)
         xml.required.set(true)
@@ -50,7 +103,7 @@ tasks.jacocoTestReport {
 }
 
 tasks.withType<Javadoc>().configureEach {
-    mustRunAfter("jandex")
+    mustRunAfter(jandex)
     (options as StandardJavadocDocletOptions).apply {
         addStringOption("Xdoclint:all,-missing", "-quiet")
     }


### PR DESCRIPTION
## Summary

Enables Gradle's configuration cache project-wide. Cuts re-builds of unchanged tasks from ~10s to ~1s by skipping the configuration phase entirely. The pre-existing "Consider enabling configuration cache to speed up this build" banner that every `./gradlew` invocation surfaced is finally gone.

Strict mode (`problems=fail`) so regressions surface immediately in CI / local dev rather than silently falling back to non-cached builds.

## What changed

- New `gradle.properties` at the repo root: `org.gradle.configuration-cache=true`, `problems=fail`, parallel, build cache, 4GB heap + G1GC + UTF-8 default encoding.
- `quarkus/build.gradle.kts` swaps the `org.kordamp.gradle.jandex` plugin for a 30-line custom Gradle task. Same `META-INF/jandex.idx` output in the published jar; sources jar stays clean.

## The kordamp jandex carve-out

The kordamp plugin (v2.1.0) is the only thing in the build that wasn't CC-compatible. Its `JandexTask` serializes a `SourceSet` field — disallowed by Gradle's CC. No newer plugin version exists (2.1.0 is current). Two options: drop CC for that task with `notCompatibleWithConfigurationCache(...)` and accept the silent fallback, or replace the plugin. Replaced it.

The replacement uses `io.smallrye:jandex:3.2.7` via a buildscript classpath entry and invokes `Indexer` directly in a tiny `doLast` block:

```kotlin
val jandex by tasks.registering {
    val classesDir = layout.buildDirectory.dir("classes/java/main")
    val indexFile  = jandexOutputDir.map { it.file("META-INF/jandex.idx") }
    inputs.dir(classesDir).withPathSensitivity(PathSensitivity.RELATIVE)
    outputs.file(indexFile)
    dependsOn("compileJava")
    doLast {
        val indexer = Indexer()
        classesDir.get().asFileTree.matching { include("**/*.class") }
            .forEach { f -> f.inputStream().use { indexer.index(it) } }
        val out = indexFile.get().asFile
        out.parentFile.mkdirs()
        out.outputStream().use { IndexWriter(it).write(indexer.complete()) }
    }
}
tasks.jar { dependsOn(jandex); from(jandexOutputDir) }
```

Output is a byte-identical `META-INF/jandex.idx` inside the runtime jar (1402 bytes against the current quarkus module). The indexer output is wired into `tasks.jar` directly rather than registered as a resources srcDir — that avoids `withSourcesJar()` packaging the binary index alongside the Java sources.

## Verification

```
./gradlew test                  # first run: stores CC entry
./gradlew test                  # second run: "Configuration cache entry reused" + finishes in ~1s
./gradlew :quarkus:build -x test  # runtime jar contains 1402-byte jandex.idx; sources jar does not
```

## Pre-existing unrelated failures

`./gradlew build` (without `-x test -x javadoc`) still fails on:

- `:core:javadoc` — unresolved `@link` to `io.github.eschizoid.telescope.internal.LambdaIntrospection#implClassOf` (internal qualified-export means javadoc can't resolve the reference).
- `:examples:springboot:*:bootJar` — example modules don't declare a main class; bootJar can't pick one.

Both reproduce identically with `--no-configuration-cache`. Out of scope here.

## Stacking

Stacked on `feat/rename-forward-only` (#94). Merge order: …#94 → this → main.

## Test plan

- [x] First-run `./gradlew test` stores the CC entry.
- [x] Second-run `./gradlew test` reports "Configuration cache entry reused" and finishes in ~1s.
- [x] `./gradlew :quarkus:build -x test` produces a runtime jar containing the 1402-byte `META-INF/jandex.idx`.
- [x] Sources jar (`telescope-quarkus-*-sources.jar`) does NOT contain `jandex.idx`.
- [x] Full `./gradlew test` still green across all modules.
