### PR TITLE
feat(codegen): @Transform(forwardOnly=true) closes runtime parity gap

### DIFF
--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
@@ -105,6 +105,12 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
   // the same-type bijection check. Populated in process(), read in generate().
   private final Map<TypePair, Map<String, String>> transformsByPair = new HashMap<>();
 
+  // Per-pair set of source field names whose @Transform was declared with forwardOnly = true.
+  // Backward direction emits a zero-value fill for these slots (the same shape `drops` uses) and
+  // never invokes the user's BridgeFn.backward. Mirrors the runtime Mapping.forward(...) semantics.
+  // Populated in process(), read in generate().
+  private final Map<TypePair, Set<String>> forwardOnlyTransformsByPair = new HashMap<>();
+
   // Per-pair constants: target field name -> the already-emitted Java literal expression
   // ("\"API\"", "true", "0L", "null", etc.). Forward-only — injected into the target ctor arg;
   // backward silently drops the slot. Populated in process(), validated + emitted in generate().
@@ -125,6 +131,7 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
     renamesByPair.clear();
     renameFanoutsByPair.clear();
     transformsByPair.clear();
+    forwardOnlyTransformsByPair.clear();
     constantsByPair.clear();
     computesByPair.clear();
 
@@ -173,9 +180,13 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
         if (renameSet == null) continue; // invalid rename — error already reported, skip this pair
         if (!renameSet.bySource().isEmpty()) renamesByPair.put(pair, renameSet.bySource());
         if (!renameSet.fanoutExtras().isEmpty()) renameFanoutsByPair.put(pair, renameSet.fanoutExtras());
-        final var transforms = transformsFromMirror(element, bridgeAm);
-        if (transforms == null) continue; // invalid transform — already reported, skip this pair
-        if (!transforms.isEmpty()) transformsByPair.put(pair, transforms);
+        final var transformSet = transformsFromMirror(element, bridgeAm);
+        if (transformSet == null) continue; // invalid transform — already reported, skip this pair
+        if (!transformSet.byField().isEmpty()) transformsByPair.put(pair, transformSet.byField());
+        if (!transformSet.forwardOnlyFields().isEmpty()) forwardOnlyTransformsByPair.put(
+          pair,
+          transformSet.forwardOnlyFields()
+        );
         final var constants = constantsFromMirror(element, bridgeAm);
         if (constants == null) continue; // invalid constant — already reported, skip this pair
         if (!constants.isEmpty()) constantsByPair.put(pair, constants);
@@ -305,23 +316,34 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
     return RenameSet.empty();
   }
 
+  // Result of parsing a @Bridge's transforms list. `byField` carries the source-field → BridgeFn
+  // class FQN map (the long-standing shape); `forwardOnlyFields` carries the subset of source
+  // field names whose @Transform was declared with forwardOnly = true.
+  private record TransformSet(Map<String, String> byField, Set<String> forwardOnlyFields) {
+    static TransformSet empty() {
+      return new TransformSet(Map.of(), Set.of());
+    }
+  }
+
   // Read transforms from a @Bridge mirror. Returns null on a malformed transform (already reported)
-  // so the caller can skip the pair. Empty map when no transforms are present. The map keys are
-  // source field names; values are the BridgeFn class FQN to instantiate at emit time.
-  private Map<String, String> transformsFromMirror(final Element element, final AnnotationMirror am) {
+  // so the caller can skip the pair. Empty TransformSet when no transforms are present.
+  private TransformSet transformsFromMirror(final Element element, final AnnotationMirror am) {
     for (final var entry : am.getElementValues().entrySet()) {
       if (!entry.getKey().getSimpleName().contentEquals("transforms")) continue;
       @SuppressWarnings("unchecked")
       final var list = (List<? extends AnnotationValue>) entry.getValue().getValue();
       final var result = new LinkedHashMap<String, String>();
+      final var forwardOnlySet = new LinkedHashSet<String>();
       for (final var av : list) {
         final var transformAm = (AnnotationMirror) av.getValue();
         String field = null;
         TypeMirror using = null;
+        Boolean forwardOnly = Boolean.FALSE;
         for (final var te : transformAm.getElementValues().entrySet()) {
           final var k = te.getKey().getSimpleName().toString();
           if (k.equals("field")) field = (String) te.getValue().getValue();
           else if (k.equals("using")) using = (TypeMirror) te.getValue().getValue();
+          else if (k.equals("forwardOnly")) forwardOnly = (Boolean) te.getValue().getValue();
         }
         if (field == null || field.isEmpty()) {
           error(element, "@Transform requires a non-empty `field` name");
@@ -341,10 +363,11 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
           return null;
         }
         result.put(field, usingEl.getQualifiedName().toString());
+        if (Boolean.TRUE.equals(forwardOnly)) forwardOnlySet.add(field);
       }
-      return result;
+      return new TransformSet(result, forwardOnlySet);
     }
-    return Map.of();
+    return TransformSet.empty();
   }
 
   // Read constants from a @Bridge mirror. Returns the raw target-field-name -> raw-string-value
@@ -616,6 +639,7 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
     final var renames = renamesByPair.getOrDefault(thisPair, Map.of());
     final var renameFanouts = renameFanoutsByPair.getOrDefault(thisPair, Map.of());
     final var transforms = transformsByPair.getOrDefault(thisPair, Map.of());
+    final var forwardOnlyTransforms = forwardOnlyTransformsByPair.getOrDefault(thisPair, Set.of());
     final var rawConstants = constantsByPair.getOrDefault(thisPair, Map.of());
     final var computes = computesByPair.getOrDefault(thisPair, Map.of());
 
@@ -851,10 +875,15 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
         readExpr(source, "s", fieldByName(nonDroppedSourceFields, srcName))
       );
     };
-    // readBackward is called with SOURCE field names. For drops, emit the type's zero value.
-    // Otherwise forward-rename the source name to find the matching target field for the read.
+    // readBackward is called with SOURCE field names. For drops AND forward-only transforms, emit
+    // the type's zero value — both mechanisms have no defined backward and the source slot must be
+    // filled with something. Otherwise forward-rename the source name to find the matching target
+    // field for the read.
     final Function<String, String> readBackward = sourceName -> {
       if (drops.contains(sourceName)) return defaultLiteralFor(fieldByName(sourceFields, sourceName).type());
+      if (forwardOnlyTransforms.contains(sourceName)) return defaultLiteralFor(
+        fieldByName(sourceFields, sourceName).type()
+      );
       final var tgtName = renames.getOrDefault(sourceName, sourceName);
       return applyBackward(
         sourceName,

--- a/codegen/src/test/java/io/github/eschizoid/telescope/codegen/BridgeProcessorTest.java
+++ b/codegen/src/test/java/io/github/eschizoid/telescope/codegen/BridgeProcessorTest.java
@@ -1302,6 +1302,65 @@ class BridgeProcessorTest {
     }
 
     @Test
+    @DisplayName("@Transform(forwardOnly=true) — backward zero-fills the slot, BridgeFn.backward is never invoked")
+    void transformForwardOnlyEmitsZeroFill() {
+      final var compilation = compile(
+        source(
+          "demo.AuditTimestampFn",
+          """
+          package demo;
+          import io.github.eschizoid.telescope.conversion.BridgeFn;
+          import java.time.Instant;
+          public final class AuditTimestampFn implements BridgeFn<Instant, String> {
+            public AuditTimestampFn() {}
+            @Override public String forward(Instant x) { return x.toString(); }
+            // Backward stubbed — never invoked when forwardOnly=true. The generated bridge
+            // emits a zero-fill instead of calling this method.
+            @Override public Instant backward(String s) { throw new UnsupportedOperationException(); }
+          }
+          """
+        ),
+        source(
+          "demo.Audit",
+          """
+          package demo;
+          import io.github.eschizoid.telescope.annotations.Bridge;
+          import io.github.eschizoid.telescope.annotations.Transform;
+          import java.time.Instant;
+          @Bridge(value = demo.AuditEntity.class, transforms = {
+            @Transform(field = "createdAt", using = demo.AuditTimestampFn.class, forwardOnly = true)
+          })
+          public record Audit(String id, Instant createdAt) {}
+          """
+        ),
+        source(
+          "demo.AuditEntity",
+          """
+          package demo;
+          public record AuditEntity(String id, String createdAt) {}
+          """
+        )
+      );
+
+      assertTrue(compilation.success(), () -> "compilation failed: " + compilation.errorMessages());
+      final var bridge = compilation.generated().get("demo.AuditBridge");
+      assertNotNull(bridge, () -> "AuditBridge missing; saw " + compilation.generated().keySet());
+
+      // Forward routes through the BridgeFn unchanged.
+      assertTrue(bridge.contains("new demo.AuditEntity(s.id(), __tx_createdAt.forward(s.createdAt()))"), bridge);
+      // Backward emits null (the reference-type zero-fill) for the forward-only slot — does NOT
+      // call __tx_createdAt.backward(t.createdAt()).
+      assertTrue(
+        bridge.contains("new demo.Audit(t.id(), null)"),
+        () -> "expected backward zero-fill for forwardOnly transform slot, saw: " + bridge
+      );
+      assertTrue(
+        !bridge.contains("__tx_createdAt.backward"),
+        () -> "backward must NOT invoke BridgeFn.backward for forwardOnly transform, saw: " + bridge
+      );
+    }
+
+    @Test
     @DisplayName("misspelled transform field is a compile error pointing at the source")
     void misspelledTransformFieldIsRejected() {
       final var compilation = compile(

--- a/core/src/main/java/io/github/eschizoid/telescope/annotations/Transform.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/annotations/Transform.java
@@ -33,6 +33,18 @@ import java.lang.annotation.RetentionPolicy;
  *
  * <p>{@code field} names the source side. Pair with a sibling {@link Rename} when the target's
  * matching field has a different name.
+ *
+ * <h2>Forward-only transforms</h2>
+ *
+ * <p>Set {@link #forwardOnly()} to {@code true} when the conversion is genuinely one-way and the
+ * {@code BridgeFn} should not be required to implement backward. The processor emits a zero-value
+ * fallback in the backward direction (mirroring the {@code @Bridge(drops = ...)} backward fill)
+ * and skips the {@code __tx_<field>.backward(...)} call-site. The user's {@code BridgeFn} can
+ * implement {@code backward} as a stub (e.g. throwing {@link UnsupportedOperationException}); the
+ * generated bridge never invokes it.
+ *
+ * <p>This mirrors the runtime {@code Mapping.forward(srcAcc, tgtAcc, fn)} factory — same forward-
+ * only semantics, same "this slot's backward is undefined" contract.
  */
 @Retention(RetentionPolicy.SOURCE)
 public @interface Transform {
@@ -48,4 +60,12 @@ public @interface Transform {
    */
   @SuppressWarnings("rawtypes")
   Class<? extends BridgeFn> using();
+
+  /**
+   * Opt in to forward-only semantics: the generated bridge emits a zero-value fill in the backward
+   * direction for this field, the same way {@code @Bridge(drops = ...)} fills dropped sources on
+   * backward. The user's {@code BridgeFn#backward} is never invoked; implementations may stub it
+   * or throw. Mirrors the runtime {@code Mapping.forward(srcAcc, tgtAcc, fn)} factory.
+   */
+  boolean forwardOnly() default false;
 }

--- a/core/src/main/java/io/github/eschizoid/telescope/annotations/Transform.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/annotations/Transform.java
@@ -66,6 +66,10 @@ public @interface Transform {
    * direction for this field, the same way {@code @Bridge(drops = ...)} fills dropped sources on
    * backward. The user's {@code BridgeFn#backward} is never invoked; implementations may stub it
    * or throw. Mirrors the runtime {@code Mapping.forward(srcAcc, tgtAcc, fn)} factory.
+   *
+   * <p>The generated {@code patch(base, partial)} method also skips the backward read for this
+   * slot and preserves {@code base.field()} unchanged — a forward-only transform has no defined
+   * inverse, so there is no way to overlay a partial value back onto the source.
    */
   boolean forwardOnly() default false;
 }


### PR DESCRIPTION
## Summary

**P1 — runtime/codegen parity gap.** Closes the asymmetry where runtime has `Mapping.forward(srcAcc, tgtAcc, fn)` for forward-only typed transforms but codegen's `@Transform` was always bidirectional. Users who needed a one-way field conversion had to write a `BridgeFn` whose backward stubbed or threw, and the generated bridge would faithfully call it on every backward direction.

## What changed

`@Transform` gains `boolean forwardOnly() default false`. When true:

- **Forward emission** unchanged — routes through `BridgeFn.forward` as before.
- **Backward emission** skips the `__tx_<field>.backward(...)` call and emits the type's zero value instead (mirrors how `@Bridge(drops = …)` fills dropped sources on backward).

```java
@Bridge(value = AuditEntity.class, transforms = {
  @Transform(field = "createdAt", using = AuditTimestampFn.class, forwardOnly = true)
})
public record Audit(String id, Instant createdAt) {}

// Generated AuditBridge:
public static AuditEntity forward(final Audit s) {
  return new AuditEntity(s.id(), __tx_createdAt.forward(s.createdAt()));  // forward via BridgeFn
}
public static Audit backward(final AuditEntity t) {
  return new Audit(t.id(), null);  // zero-fill — BridgeFn.backward NOT invoked
}
```

The user's `BridgeFn.backward` can stub or throw; the generated bridge never invokes it. End-to-end mirrors the runtime `Mapping.forward(...)` semantics.

## Stacking

Stacked on `feat/deepmap-coverage` (#96). First of five codegen parity PRs (P1-P5 from the round-2 parity audit).

## Test plan

- [x] New BridgeProcessorTest case asserts forward routing, backward zero-fill, AND absence of `__tx_<field>.backward` call site.
- [x] All 20 existing BridgeProcessorTest cases pass.
- [x] Full `./gradlew test` green.