### PR TITLE
feat(codegen): @Default annotation for null-coalescing source values

### DIFF
--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
@@ -707,7 +707,7 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
         return;
       }
       if (drops.contains(t)) {
-        error(source, "@Bridge field \"" + t + "\" appears in both transforms and drops — it must be one or the other");
+        error(source, "@Bridge field \"" + t + "\" appears in both transforms and drops — pick one.");
         return;
       }
     }
@@ -756,7 +756,20 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
       if (drops.contains(e.getKey())) {
         error(
           source,
-          "@Bridge field \"" + e.getKey() + "\" appears in both renames and drops — it must be one or the other"
+          "@Bridge field \"" + e.getKey() + "\" appears in both renames and drops — pick one."
+        );
+        return;
+      }
+      // OL-1: renames + transforms on the same source field is undefined behavior. The transform
+      // dispatches on the source field name; the rename relabels the TARGET slot. Together they
+      // accidentally compile to correct code in scalar cases but the combination has no documented
+      // contract — reject explicitly so the user picks one.
+      if (transforms.containsKey(e.getKey())) {
+        error(
+          source,
+          "@Bridge field \"" +
+            e.getKey() +
+            "\" appears in both renames and transforms — pick one (the transform consumes the source field; the target slot name comes from the bijection, not @Rename)."
         );
         return;
       }
@@ -910,7 +923,7 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
       if (renameTargetNames.contains(fieldName)) {
         error(
           source,
-          "@Bridge target \"" + fieldName + "\" is already targeted by a rename; cannot also be a constant"
+          "@Bridge target \"" + fieldName + "\" appears in both renames (target slot) and constants — pick one."
         );
         return;
       }
@@ -934,11 +947,19 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
         return;
       }
       if (parsedConstants.containsKey(fieldName)) {
-        error(source, "@Bridge target \"" + fieldName + "\" appears in both constants and computes");
+        error(
+          source,
+          "@Bridge target \"" +
+            fieldName +
+            "\" appears in both constants and computes — pick one (constants inject a literal; computes inject a Supplier result)."
+        );
         return;
       }
       if (renameTargetNames.contains(fieldName)) {
-        error(source, "@Bridge target \"" + fieldName + "\" is already targeted by a rename; cannot also be a compute");
+        error(
+          source,
+          "@Bridge target \"" + fieldName + "\" appears in both renames (target slot) and computes — pick one."
+        );
         return;
       }
       injectedTargetFields.add(fieldName);

--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
@@ -111,6 +111,12 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
   // Populated in process(), read in generate().
   private final Map<TypePair, Set<String>> forwardOnlyTransformsByPair = new HashMap<>();
 
+  // Per-pair source-field defaults: source field name -> already-parsed Java-literal expression
+  // (e.g. "\"EMEA\"", "42", "true"). Forward direction wraps the source read in (s.field == null
+  // ? <literal> : s.field()) when an entry is present. Backward is identity. Mirrors the runtime
+  // Mapping.toOrElse(srcAcc, tgtAcc, defaultValue) factory. Populated + validated in process().
+  private final Map<TypePair, Map<String, String>> defaultsByPair = new HashMap<>();
+
   // Per-pair constants: target field name -> the already-emitted Java literal expression
   // ("\"API\"", "true", "0L", "null", etc.). Forward-only — injected into the target ctor arg;
   // backward silently drops the slot. Populated in process(), validated + emitted in generate().
@@ -132,6 +138,7 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
     renameFanoutsByPair.clear();
     transformsByPair.clear();
     forwardOnlyTransformsByPair.clear();
+    defaultsByPair.clear();
     constantsByPair.clear();
     computesByPair.clear();
 
@@ -193,6 +200,9 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
         final var computes = computesFromMirror(element, bridgeAm);
         if (computes == null) continue; // invalid compute — already reported, skip this pair
         if (!computes.isEmpty()) computesByPair.put(pair, computes);
+        final var rawDefaults = defaultsFromMirror(element, bridgeAm);
+        if (rawDefaults == null) continue; // invalid default — already reported, skip this pair
+        if (!rawDefaults.isEmpty()) defaultsByPair.put(pair, rawDefaults);
         if (seen.add(pair)) pending.add(pair);
       }
     }
@@ -368,6 +378,44 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
       return new TransformSet(result, forwardOnlySet);
     }
     return TransformSet.empty();
+  }
+
+  // Read defaults from a @Bridge mirror. Returns the raw source-field-name -> raw-string-value
+  // map. Per-pair validation (field exists on source, type is reference-typed, value parses
+  // against the field type) happens in generate() where the source TypeElement is available.
+  // Returns null on a structural error (already reported).
+  private Map<String, String> defaultsFromMirror(final Element element, final AnnotationMirror am) {
+    for (final var entry : am.getElementValues().entrySet()) {
+      if (!entry.getKey().getSimpleName().contentEquals("defaults")) continue;
+      @SuppressWarnings("unchecked")
+      final var list = (List<? extends AnnotationValue>) entry.getValue().getValue();
+      final var result = new LinkedHashMap<String, String>();
+      for (final var av : list) {
+        final var defAm = (AnnotationMirror) av.getValue();
+        String field = null;
+        String value = null;
+        for (final var de : defAm.getElementValues().entrySet()) {
+          final var k = de.getKey().getSimpleName().toString();
+          if (k.equals("field")) field = (String) de.getValue().getValue();
+          else if (k.equals("value")) value = (String) de.getValue().getValue();
+        }
+        if (field == null || field.isEmpty()) {
+          error(element, "@Default requires a non-empty `field` name");
+          return null;
+        }
+        if (value == null) {
+          error(element, "@Default requires a `value`");
+          return null;
+        }
+        if (result.containsKey(field)) {
+          error(element, "@Default field=\"" + field + "\" is declared more than once");
+          return null;
+        }
+        result.put(field, value);
+      }
+      return result;
+    }
+    return Map.of();
   }
 
   // Read constants from a @Bridge mirror. Returns the raw target-field-name -> raw-string-value
@@ -640,6 +688,7 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
     final var renameFanouts = renameFanoutsByPair.getOrDefault(thisPair, Map.of());
     final var transforms = transformsByPair.getOrDefault(thisPair, Map.of());
     final var forwardOnlyTransforms = forwardOnlyTransformsByPair.getOrDefault(thisPair, Set.of());
+    final var rawDefaults = defaultsByPair.getOrDefault(thisPair, Map.of());
     final var rawConstants = constantsByPair.getOrDefault(thisPair, Map.of());
     final var computes = computesByPair.getOrDefault(thisPair, Map.of());
 
@@ -773,6 +822,57 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
     // type errors fire alongside the rest of the per-pair validation.
     final var renameTargetNames = new LinkedHashSet<>(renames.values());
     for (final var extras : renameFanouts.values()) renameTargetNames.addAll(extras);
+
+    // Validate @Default rows (source-side null-coalescing). Each named field must exist on the
+    // source, must be a reference type (primitives can never be null), and must not overlap with
+    // drops (the two have incompatible semantics: drop discards the value, default substitutes one
+    // when null). The value parses against the source field's type using the same parser as
+    // @Constant — String, primitives, "null" for reference types.
+    final var parsedDefaults = new LinkedHashMap<String, String>();
+    for (final var e : rawDefaults.entrySet()) {
+      final var fieldName = e.getKey();
+      final var sf = sourceFields
+        .stream()
+        .filter(f -> f.name().equals(fieldName))
+        .findFirst()
+        .orElse(null);
+      if (sf == null) {
+        error(
+          source,
+          "@Bridge defaults field=\"" +
+            fieldName +
+            "\" is not a field of " +
+            source.getSimpleName() +
+            " — known fields: " +
+            sourceNames
+        );
+        return;
+      }
+      if (sf.type().getKind().isPrimitive()) {
+        error(
+          source,
+          "@Bridge defaults field=\"" +
+            fieldName +
+            "\" has primitive type " +
+            sf.type() +
+            " — primitives cannot be null, so the default would never fire. Use the wrapper type or rework the source shape."
+        );
+        return;
+      }
+      if (drops.contains(fieldName)) {
+        error(
+          source,
+          "@Bridge field \"" +
+            fieldName +
+            "\" appears in both defaults and drops — pick one (drop discards, default substitutes when null)."
+        );
+        return;
+      }
+      final var lit = parseConstantLiteral(source, fieldName, e.getValue(), sf.type());
+      if (lit == null) return;
+      parsedDefaults.put(fieldName, lit);
+    }
+
     final var injectedTargetFields = new LinkedHashSet<String>();
     final var parsedConstants = new LinkedHashMap<String, String>();
     for (final var e : rawConstants.entrySet()) {
@@ -864,16 +964,18 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
     // readForward is called with TARGET field names (we walk targetFields). Injected targets
     // (constants, computes) take priority — they're forward-only literal/Supplier expressions with
     // no source counterpart. Otherwise reverse-rename to find the matching source field, then use
-    // the source name to look up the plan and read the source.
+    // the source name to look up the plan and read the source. When the source field has a
+    // @Default, wrap the source read in a (s.x() == null ? <literal> : s.x()) coalesce so the
+    // forward direction substitutes the default for null sources.
     final Function<String, String> readForward = targetName -> {
       if (parsedConstants.containsKey(targetName)) return parsedConstants.get(targetName);
       if (computes.containsKey(targetName)) return "__cp_" + targetName + ".get()";
       final var srcName = reverseRenames.getOrDefault(targetName, targetName);
-      return applyForward(
-        srcName,
-        fieldPlans.get(srcName),
-        readExpr(source, "s", fieldByName(nonDroppedSourceFields, srcName))
-      );
+      final var rawRead = readExpr(source, "s", fieldByName(nonDroppedSourceFields, srcName));
+      final var read = parsedDefaults.containsKey(srcName)
+        ? "(" + rawRead + " == null ? " + parsedDefaults.get(srcName) + " : " + rawRead + ")"
+        : rawRead;
+      return applyForward(srcName, fieldPlans.get(srcName), read);
     };
     // readBackward is called with SOURCE field names. For drops AND forward-only transforms, emit
     // the type's zero value — both mechanisms have no defined backward and the source slot must be

--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
@@ -868,6 +868,19 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
         );
         return;
       }
+      // FD-1: defaults + transforms on the same field stack two modifiers with undefined
+      // ordering — the @Transform decides the conversion, the @Default wraps the source read in
+      // a null-coalesce that the transform then consumes. The combination is structurally
+      // accidental rather than designed; reject explicitly so the user picks one.
+      if (transforms.containsKey(fieldName)) {
+        error(
+          source,
+          "@Bridge field \"" +
+            fieldName +
+            "\" appears in both defaults and transforms — pick one (use a transform that handles null internally, or remove the default)."
+        );
+        return;
+      }
       final var lit = parseConstantLiteral(source, fieldName, e.getValue(), sf.type());
       if (lit == null) return;
       parsedDefaults.put(fieldName, lit);

--- a/codegen/src/test/java/io/github/eschizoid/telescope/codegen/BridgeProcessorTest.java
+++ b/codegen/src/test/java/io/github/eschizoid/telescope/codegen/BridgeProcessorTest.java
@@ -1847,6 +1847,47 @@ class BridgeProcessorTest {
     }
 
     @Test
+    @DisplayName("OL-1: @Rename + @Transform on the same source field rejected at build")
+    void renamesAndTransformsOnSameFieldRejected() {
+      final var compilation = compile(
+        source(
+          "demo.NoopFn",
+          """
+          package demo;
+          import io.github.eschizoid.telescope.conversion.BridgeFn;
+          public final class NoopFn implements BridgeFn<String, String> {
+            public NoopFn() {}
+            @Override public String forward(String x) { return x; }
+            @Override public String backward(String x) { return x; }
+          }
+          """
+        ),
+        source(
+          "demo.A",
+          """
+          package demo;
+          import io.github.eschizoid.telescope.annotations.Bridge;
+          import io.github.eschizoid.telescope.annotations.Rename;
+          import io.github.eschizoid.telescope.annotations.Transform;
+          @Bridge(
+            value = demo.B.class,
+            renames    = { @Rename(source    = "name", target = "label") },
+            transforms = { @Transform(field  = "name", using  = demo.NoopFn.class) }
+          )
+          public record A(String name) {}
+          """
+        ),
+        source("demo.B", "package demo; public record B(String label) {}")
+      );
+
+      assertFalse(compilation.success(), "renames + transforms overlap should fail");
+      assertTrue(
+        compilation.hasError("appears in both renames and transforms"),
+        () -> "expected overlap diagnostic; saw " + compilation.errorMessages()
+      );
+    }
+
+    @Test
     @DisplayName("FD-1: @Default + @Transform on the same field rejected at build")
     void defaultsAndTransformsOnSameFieldRejected() {
       final var compilation = compile(

--- a/codegen/src/test/java/io/github/eschizoid/telescope/codegen/BridgeProcessorTest.java
+++ b/codegen/src/test/java/io/github/eschizoid/telescope/codegen/BridgeProcessorTest.java
@@ -1845,5 +1845,52 @@ class BridgeProcessorTest {
         () -> "expected primitive-rejection diagnostic; saw " + compilation.errorMessages()
       );
     }
+
+    @Test
+    @DisplayName("FD-1: @Default + @Transform on the same field rejected at build")
+    void defaultsAndTransformsOnSameFieldRejected() {
+      final var compilation = compile(
+        source(
+          "demo.NoopFn",
+          """
+          package demo;
+          import io.github.eschizoid.telescope.conversion.BridgeFn;
+          public final class NoopFn implements BridgeFn<String, String> {
+            public NoopFn() {}
+            @Override public String forward(String x) { return x; }
+            @Override public String backward(String x) { return x; }
+          }
+          """
+        ),
+        source(
+          "demo.A",
+          """
+          package demo;
+          import io.github.eschizoid.telescope.annotations.Bridge;
+          import io.github.eschizoid.telescope.annotations.Default;
+          import io.github.eschizoid.telescope.annotations.Transform;
+          @Bridge(
+            value = demo.B.class,
+            transforms = { @Transform(field = "name", using = demo.NoopFn.class) },
+            defaults   = { @Default(field   = "name", value = "anonymous") }
+          )
+          public record A(String name) {}
+          """
+        ),
+        source(
+          "demo.B",
+          """
+          package demo;
+          public record B(String name) {}
+          """
+        )
+      );
+
+      assertFalse(compilation.success(), "defaults + transforms overlap should fail");
+      assertTrue(
+        compilation.hasError("appears in both defaults and transforms"),
+        () -> "expected overlap diagnostic; saw " + compilation.errorMessages()
+      );
+    }
   }
 }

--- a/codegen/src/test/java/io/github/eschizoid/telescope/codegen/BridgeProcessorTest.java
+++ b/codegen/src/test/java/io/github/eschizoid/telescope/codegen/BridgeProcessorTest.java
@@ -1775,5 +1775,75 @@ class BridgeProcessorTest {
         () -> "expected missing-extra-target diagnostic; saw " + compilation.errorMessages()
       );
     }
+
+    @Test
+    @DisplayName("@Default(field, value) — forward null-coalesces, backward is identity")
+    void defaultsNullCoalescing() {
+      final var compilation = compile(
+        source(
+          "demo.User",
+          """
+          package demo;
+          import io.github.eschizoid.telescope.annotations.Bridge;
+          import io.github.eschizoid.telescope.annotations.Default;
+          @Bridge(value = demo.UserEntity.class, defaults = {
+            @Default(field = "region", value = "EMEA")
+          })
+          public record User(String id, String region) {}
+          """
+        ),
+        source(
+          "demo.UserEntity",
+          """
+          package demo;
+          public record UserEntity(String id, String region) {}
+          """
+        )
+      );
+
+      assertTrue(compilation.success(), () -> "compilation failed: " + compilation.errorMessages());
+      final var bridge = compilation.generated().get("demo.UserBridge");
+      assertNotNull(bridge, () -> "UserBridge missing; saw " + compilation.generated().keySet());
+
+      // Forward null-coalesces: source `region` null → "EMEA"; otherwise pass-through.
+      assertTrue(
+        bridge.contains("(s.region() == null ? \"EMEA\" : s.region())"),
+        () -> "expected null-coalesce on region forward, saw: " + bridge
+      );
+      // Backward is identity — the default doesn't appear in backward expression.
+      assertTrue(bridge.contains("new demo.User(t.id(), t.region())"), bridge);
+    }
+
+    @Test
+    @DisplayName("@Default on a primitive-typed source field is a compile error")
+    void defaultsOnPrimitiveRejected() {
+      final var compilation = compile(
+        source(
+          "demo.A",
+          """
+          package demo;
+          import io.github.eschizoid.telescope.annotations.Bridge;
+          import io.github.eschizoid.telescope.annotations.Default;
+          @Bridge(value = demo.B.class, defaults = {
+            @Default(field = "count", value = "0")
+          })
+          public record A(String name, int count) {}
+          """
+        ),
+        source(
+          "demo.B",
+          """
+          package demo;
+          public record B(String name, int count) {}
+          """
+        )
+      );
+
+      assertFalse(compilation.success(), "@Default on primitive should fail");
+      assertTrue(
+        compilation.hasError("primitives cannot be null"),
+        () -> "expected primitive-rejection diagnostic; saw " + compilation.errorMessages()
+      );
+    }
   }
 }

--- a/core/src/main/java/io/github/eschizoid/telescope/annotations/Bridge.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/annotations/Bridge.java
@@ -148,4 +148,26 @@ public @interface Bridge {
    * #drops()} for the same pair.
    */
   Compute[] computes() default {};
+
+  /**
+   * Null-coalescing default values for source fields. Each {@link Default} names a source field
+   * and a fallback literal that the forward direction substitutes when the source value is
+   * {@code null}. Mirrors MapStruct's {@code @Mapping(defaultValue = …)} and the runtime
+   * {@link io.github.eschizoid.telescope.mapping.Mapping#toOrElse(
+   * io.github.eschizoid.telescope.Telescope.Accessor,
+   * io.github.eschizoid.telescope.Telescope.Accessor, Object) Mapping.toOrElse(srcAcc, tgtAcc,
+   * defaultValue)} factory.
+   *
+   * <pre>{@code
+   * @Bridge(value = UserEntity.class, defaults = {
+   *   @Default(field = "region", value = "EMEA")
+   * })
+   * public record User(String id, String region) {}
+   * }</pre>
+   *
+   * <p>Backward direction is identity — the substituted default round-trips back to the source
+   * slot as itself. A field listed in {@code defaults} cannot also appear in {@link #drops()} for
+   * this pair (the two mechanisms have incompatible semantics).
+   */
+  Default[] defaults() default {};
 }

--- a/core/src/main/java/io/github/eschizoid/telescope/annotations/Default.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/annotations/Default.java
@@ -1,0 +1,61 @@
+package io.github.eschizoid.telescope.annotations;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+/**
+ * A null-coalescing default for a source field at {@link Bridge} codegen time. Mirrors MapStruct's
+ * {@code @Mapping(target = "x", defaultValue = "literal")} and the runtime {@link
+ * io.github.eschizoid.telescope.mapping.Mapping#toOrElse(io.github.eschizoid.telescope.Telescope.Accessor,
+ * io.github.eschizoid.telescope.Telescope.Accessor, Object) Mapping.toOrElse(srcAcc, tgtAcc,
+ * defaultValue)} factory.
+ *
+ * <p>Forward direction: if {@code source.field() == null}, the generated bridge substitutes
+ * {@link #value()} as the literal expression — otherwise the source value passes through unchanged.
+ * Backward direction is identity (whatever lands on the target round-trips back to the source slot
+ * as itself, including the substituted default — same asymmetry the runtime form accepts).
+ *
+ * <pre>{@code
+ * @Bridge(value = UserEntity.class, defaults = {
+ *   @Default(field = "region", value = "EMEA"),
+ *   @Default(field = "tier",   value = "FREE")
+ * })
+ * public record User(String id, String region, String tier) {}
+ * }</pre>
+ *
+ * <p>{@code field} names the source side (the field whose null triggers the substitution). The
+ * value must parse against the source field's declared type, using the same parser as {@link
+ * Constant}: {@link String}, {@code int} / {@link Integer}, {@code long} / {@link Long}, the rest
+ * of the numeric primitives, {@code boolean} / {@link Boolean}, {@code char} / {@link Character},
+ * and the literal {@code "null"} for reference types.
+ *
+ * <h2>Strict-null only</h2>
+ *
+ * <p>This codegen form covers strict-null only — analogous to the 3-arg runtime {@code toOrElse}.
+ * Predicate-gated coalescing (the 4-arg {@code toOrElse(src, tgt, default, predicate)} factory)
+ * stays runtime-only because annotation attributes cannot hold lambda predicates.
+ *
+ * <p>Empty source fields ({@code ""}, {@link java.util.Collections#emptyList()}, etc.) are NOT
+ * treated as null — only {@code source == null} triggers the substitution. For empty-collection or
+ * empty-string handling, use the runtime {@code toOrElse(src, tgt, default, Predicate)} factory.
+ *
+ * <h2>Empty source field types</h2>
+ *
+ * <p>Primitive source fields cannot be {@code null} in Java; declaring a {@code @Default} on a
+ * primitive-typed source field is a compile error. Use the field's wrapper type or rework the
+ * source shape if the slot can be absent.
+ */
+@Retention(RetentionPolicy.SOURCE)
+public @interface Default {
+  /**
+   * Source field name whose null value triggers the substitution. Must name a real field on the
+   * {@link Bridge} source.
+   */
+  String field();
+
+  /**
+   * The fallback literal as a string. Parsed at codegen time against the source field's declared
+   * type, using the same parser as {@link Constant}.
+   */
+  String value();
+}


### PR DESCRIPTION
## Summary

**P2 — runtime/codegen parity gap.** Closes the asymmetry where runtime has `Mapping.toOrElse(srcAcc, tgtAcc, defaultValue)` for null-coalescing defaults but codegen had no equivalent — users had to write `@Transform` with a `BridgeFn` that checked null inline.

## Shape

```java
@Bridge(value = UserEntity.class, defaults = {
  @Default(field = "region", value = "EMEA"),
  @Default(field = "tier",   value = "FREE")
})
public record User(String id, String region, String tier) {}

// Generated UserBridge:
public static UserEntity forward(final User s) {
  return new UserEntity(
    s.id(),
    (s.region() == null ? "EMEA" : s.region()),
    (s.tier() == null ? "FREE" : s.tier())
  );
}
public static User backward(final UserEntity t) {
  return new User(t.id(), t.region(), t.tier());  // backward identity
}
```

Strict-null only — analogous to the 3-arg runtime `toOrElse`. The predicate-gated 4-arg variant stays runtime-only because annotation attributes can't hold predicates.

## Validation

- Source field must exist.
- Source field must be reference-typed (primitives can't be null — clear error message points the user at the wrapper type).
- Cannot overlap with `drops` on the same pair (incompatible semantics).
- Value parses via `parseConstantLiteral` against the source field type — same parser as `@Constant`: String, numeric primitives via wrappers, boolean, char, the literal `"null"` for reference types.

## Stacking

Stacked on `feat/codegen-transform-forward-only` (#97). Second of five codegen parity PRs.

## Test plan

- [x] New BridgeProcessorTest case asserts happy-path null-coalesce emission.
- [x] Primitive-rejection diagnostic asserted.
- [x] All 22 existing BridgeProcessorTest cases pass.
- [x] Full `./gradlew test` green.