### PR TITLE
feat(codegen): @Bridge(writeStrategy = …) forces a POJO construction shape

### DIFF
--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
@@ -1143,9 +1143,11 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
       );
     };
 
-    final var forwardBody = buildExpr(target, readForward, targetFields, writeStrategy);
+    // Pass `source` as the annotation site so write-strategy errors land at the user's @Bridge
+    // declaration rather than at `target` (which may be a third-party POJO with no annotation).
+    final var forwardBody = buildExpr(target, readForward, targetFields, writeStrategy, source);
     if (forwardBody == null) return;
-    final var backwardBody = buildExpr(source, readBackward, sourceFields, writeStrategy);
+    final var backwardBody = buildExpr(source, readBackward, sourceFields, writeStrategy, source);
     if (backwardBody == null) return;
 
     final var imports = new TreeSet<>(importsFor(fieldPlans));
@@ -1930,7 +1932,8 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
 
   // Construct `to` from a name->expression reader: canonical ctor (record), or name-matched ctor /
   // builder / no-arg+setters (POJO). Returns an expression or a `{ ... return x; }` block; null on
-  // failure (error reported on `to`).
+  // failure (error reported on `annotationSite` so the diagnostic lands at the user's @Bridge,
+  // not at the target class, which may be third-party).
   //
   // writeStrategy: AUTO (run the priority ladder), CONSTRUCTOR / BUILDER / SETTERS (force one).
   // Records always use the canonical constructor regardless of the strategy.
@@ -1938,7 +1941,8 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
     final TypeElement to,
     final Function<String, String> read,
     final List<Field> toFields,
-    final String writeStrategy
+    final String writeStrategy,
+    final TypeElement annotationSite
   ) {
     final var toFq = to.getQualifiedName().toString();
     if (to.getKind() == ElementKind.RECORD) {
@@ -1970,10 +1974,12 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
       }
       if (!auto) {
         error(
-          to,
+          annotationSite,
           "@Bridge writeStrategy = CONSTRUCTOR on " +
+            annotationSite.getQualifiedName() +
+            " (target " +
             toFq +
-            ": no public constructor whose parameter names match the bridge fields. Switch to AUTO, BUILDER, or SETTERS, or add a name-matched constructor."
+            "): no public constructor whose parameter names match the bridge fields. Switch to AUTO, BUILDER, or SETTERS, or add a name-matched constructor."
         );
         return null;
       }
@@ -1997,10 +2003,12 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
       }
       if (!auto) {
         error(
-          to,
+          annotationSite,
           "@Bridge writeStrategy = BUILDER on " +
+            annotationSite.getQualifiedName() +
+            " (target " +
             toFq +
-            ": no static builder() method returning a builder class. Switch to AUTO, CONSTRUCTOR, or SETTERS, or add a builder()."
+            "): no static builder() method returning a builder class. Switch to AUTO, CONSTRUCTOR, or SETTERS, or add a builder()."
         );
         return null;
       }
@@ -2022,10 +2030,12 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
       }
       if (!auto) {
         error(
-          to,
+          annotationSite,
           "@Bridge writeStrategy = SETTERS on " +
+            annotationSite.getQualifiedName() +
+            " (target " +
             toFq +
-            ": no public no-arg constructor. Switch to AUTO, CONSTRUCTOR, or BUILDER, or add a no-arg constructor."
+            "): no public no-arg constructor. Switch to AUTO, CONSTRUCTOR, or BUILDER, or add a no-arg constructor."
         );
         return null;
       }

--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
@@ -1994,7 +1994,16 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
         for (final var f : toFields) {
           final var method = builderSetter(builderType, f.name());
           if (method == null) {
-            error(to, "@Bridge: builder " + builderType.getQualifiedName() + " has no method for '" + f.name() + "'");
+            error(
+              annotationSite,
+              "@Bridge: builder " +
+                builderType.getQualifiedName() +
+                " (target " +
+                toFq +
+                ") has no method for '" +
+                f.name() +
+                "'"
+            );
             return null;
           }
           sb.append(".").append(method).append("(").append(read.apply(f.name())).append(")");
@@ -2021,7 +2030,10 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
         for (final var f : toFields) {
           final var setter = setterName(to, f.name());
           if (setter == null) {
-            error(to, "@Bridge: " + toFq + " has a no-arg constructor but no setter for '" + f.name() + "'");
+            error(
+              annotationSite,
+              "@Bridge: " + toFq + " has a no-arg constructor but no setter for '" + f.name() + "'"
+            );
             return null;
           }
           sb.append("out.").append(setter).append("(").append(read.apply(f.name())).append("); ");
@@ -2042,7 +2054,7 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
     }
 
     error(
-      to,
+      annotationSite,
       "@Bridge: " +
         toFq +
         " has no usable construction strategy — needs a record canonical constructor, a constructor " +

--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
@@ -124,6 +124,12 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
   // the runtime Mapping.via(srcAcc, tgtAcc, mapper) factory.
   private final Map<TypePair, Map<String, String>> viaMappersByPair = new HashMap<>();
 
+  // Per-pair user-specified write strategy override. AUTO (the default) preserves today's
+  // ctor → builder → no-arg+setters ladder; other values force one strategy and surface a precise
+  // error if the POJO doesn't support it. Mirrors the runtime WriteHint.writeBean(cls, strategy)
+  // hint. Populated in process(), read in generate().
+  private final Map<TypePair, String> writeStrategyByPair = new HashMap<>();
+
   // Per-pair constants: target field name -> the already-emitted Java literal expression
   // ("\"API\"", "true", "0L", "null", etc.). Forward-only — injected into the target ctor arg;
   // backward silently drops the slot. Populated in process(), validated + emitted in generate().
@@ -147,6 +153,7 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
     forwardOnlyTransformsByPair.clear();
     defaultsByPair.clear();
     viaMappersByPair.clear();
+    writeStrategyByPair.clear();
     constantsByPair.clear();
     computesByPair.clear();
 
@@ -214,6 +221,8 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
         final var viaMappers = viaMappersFromMirror(element, bridgeAm);
         if (viaMappers == null) continue; // invalid viaMapper — already reported, skip this pair
         if (!viaMappers.isEmpty()) viaMappersByPair.put(pair, viaMappers);
+        final var writeStrategy = writeStrategyFromMirror(bridgeAm);
+        if (writeStrategy != null && !"AUTO".equals(writeStrategy)) writeStrategyByPair.put(pair, writeStrategy);
         if (seen.add(pair)) pending.add(pair);
       }
     }
@@ -389,6 +398,18 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
       return new TransformSet(result, forwardOnlySet);
     }
     return TransformSet.empty();
+  }
+
+  // Read writeStrategy from a @Bridge mirror. Returns the enum name (AUTO / CONSTRUCTOR / BUILDER
+  // / SETTERS) when explicitly set; null when the user didn't supply a value (treated as AUTO).
+  private String writeStrategyFromMirror(final AnnotationMirror am) {
+    for (final var entry : am.getElementValues().entrySet()) {
+      if (!entry.getKey().getSimpleName().contentEquals("writeStrategy")) continue;
+      final var val = entry.getValue().getValue();
+      if (val instanceof javax.lang.model.element.VariableElement ve) return ve.getSimpleName().toString();
+      return val == null ? null : val.toString();
+    }
+    return null;
   }
 
   // Read viaMappers from a @Bridge mirror. Returns source-field-name -> bridge-class FQN. The
@@ -744,6 +765,7 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
     final var forwardOnlyTransforms = forwardOnlyTransformsByPair.getOrDefault(thisPair, Set.of());
     final var rawDefaults = defaultsByPair.getOrDefault(thisPair, Map.of());
     final var viaMappers = viaMappersByPair.getOrDefault(thisPair, Map.of());
+    final var writeStrategy = writeStrategyByPair.getOrDefault(thisPair, "AUTO");
     final var rawConstants = constantsByPair.getOrDefault(thisPair, Map.of());
     final var computes = computesByPair.getOrDefault(thisPair, Map.of());
 
@@ -1121,9 +1143,9 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
       );
     };
 
-    final var forwardBody = buildExpr(target, readForward, targetFields);
+    final var forwardBody = buildExpr(target, readForward, targetFields, writeStrategy);
     if (forwardBody == null) return;
-    final var backwardBody = buildExpr(source, readBackward, sourceFields);
+    final var backwardBody = buildExpr(source, readBackward, sourceFields, writeStrategy);
     if (backwardBody == null) return;
 
     final var imports = new TreeSet<>(importsFor(fieldPlans));
@@ -1909,7 +1931,15 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
   // Construct `to` from a name->expression reader: canonical ctor (record), or name-matched ctor /
   // builder / no-arg+setters (POJO). Returns an expression or a `{ ... return x; }` block; null on
   // failure (error reported on `to`).
-  private String buildExpr(final TypeElement to, final Function<String, String> read, final List<Field> toFields) {
+  //
+  // writeStrategy: AUTO (run the priority ladder), CONSTRUCTOR / BUILDER / SETTERS (force one).
+  // Records always use the canonical constructor regardless of the strategy.
+  private String buildExpr(
+    final TypeElement to,
+    final Function<String, String> read,
+    final List<Field> toFields,
+    final String writeStrategy
+  ) {
     final var toFq = to.getQualifiedName().toString();
     if (to.getKind() == ElementKind.RECORD) {
       final var args = to
@@ -1920,50 +1950,85 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
       return "new " + toFq + "(" + args + ")";
     }
 
+    final var auto = "AUTO".equals(writeStrategy);
+
     // POJO: a public constructor whose parameter names match the fields (order-independent).
-    for (final var ctor : ElementFilter.constructorsIn(to.getEnclosedElements())) {
-      if (!ctor.getModifiers().contains(Modifier.PUBLIC) || ctor.getParameters().size() != toFields.size()) continue;
-      final var args = new ArrayList<String>();
-      var matched = true;
-      for (final var p : ctor.getParameters()) {
-        final var pn = p.getSimpleName().toString();
-        if (!hasField(toFields, pn)) {
-          matched = false;
-          break;
+    if (auto || "CONSTRUCTOR".equals(writeStrategy)) {
+      for (final var ctor : ElementFilter.constructorsIn(to.getEnclosedElements())) {
+        if (!ctor.getModifiers().contains(Modifier.PUBLIC) || ctor.getParameters().size() != toFields.size()) continue;
+        final var args = new ArrayList<String>();
+        var matched = true;
+        for (final var p : ctor.getParameters()) {
+          final var pn = p.getSimpleName().toString();
+          if (!hasField(toFields, pn)) {
+            matched = false;
+            break;
+          }
+          args.add(read.apply(pn));
         }
-        args.add(read.apply(pn));
+        if (matched) return "new " + toFq + "(" + String.join(", ", args) + ")";
       }
-      if (matched) return "new " + toFq + "(" + String.join(", ", args) + ")";
+      if (!auto) {
+        error(
+          to,
+          "@Bridge writeStrategy = CONSTRUCTOR on " +
+            toFq +
+            ": no public constructor whose parameter names match the bridge fields. Switch to AUTO, BUILDER, or SETTERS, or add a name-matched constructor."
+        );
+        return null;
+      }
     }
 
     // POJO: a static builder() with a method per field.
-    final var builder = staticBuilderMethod(to);
-    if (builder != null && builder.getReturnType().getKind() == TypeKind.DECLARED) {
-      final var builderType = (TypeElement) ((DeclaredType) builder.getReturnType()).asElement();
-      final var sb = new StringBuilder(toFq + ".builder()");
-      for (final var f : toFields) {
-        final var method = builderSetter(builderType, f.name());
-        if (method == null) {
-          error(to, "@Bridge: builder " + builderType.getQualifiedName() + " has no method for '" + f.name() + "'");
-          return null;
+    if (auto || "BUILDER".equals(writeStrategy)) {
+      final var builder = staticBuilderMethod(to);
+      if (builder != null && builder.getReturnType().getKind() == TypeKind.DECLARED) {
+        final var builderType = (TypeElement) ((DeclaredType) builder.getReturnType()).asElement();
+        final var sb = new StringBuilder(toFq + ".builder()");
+        for (final var f : toFields) {
+          final var method = builderSetter(builderType, f.name());
+          if (method == null) {
+            error(to, "@Bridge: builder " + builderType.getQualifiedName() + " has no method for '" + f.name() + "'");
+            return null;
+          }
+          sb.append(".").append(method).append("(").append(read.apply(f.name())).append(")");
         }
-        sb.append(".").append(method).append("(").append(read.apply(f.name())).append(")");
+        return sb.append(".build()").toString();
       }
-      return sb.append(".build()").toString();
+      if (!auto) {
+        error(
+          to,
+          "@Bridge writeStrategy = BUILDER on " +
+            toFq +
+            ": no static builder() method returning a builder class. Switch to AUTO, CONSTRUCTOR, or SETTERS, or add a builder()."
+        );
+        return null;
+      }
     }
 
     // POJO: a no-arg constructor plus a setter per field.
-    if (hasPublicNoArgConstructor(to)) {
-      final var sb = new StringBuilder("{ final var out = new " + toFq + "(); ");
-      for (final var f : toFields) {
-        final var setter = setterName(to, f.name());
-        if (setter == null) {
-          error(to, "@Bridge: " + toFq + " has a no-arg constructor but no setter for '" + f.name() + "'");
-          return null;
+    if (auto || "SETTERS".equals(writeStrategy)) {
+      if (hasPublicNoArgConstructor(to)) {
+        final var sb = new StringBuilder("{ final var out = new " + toFq + "(); ");
+        for (final var f : toFields) {
+          final var setter = setterName(to, f.name());
+          if (setter == null) {
+            error(to, "@Bridge: " + toFq + " has a no-arg constructor but no setter for '" + f.name() + "'");
+            return null;
+          }
+          sb.append("out.").append(setter).append("(").append(read.apply(f.name())).append("); ");
         }
-        sb.append("out.").append(setter).append("(").append(read.apply(f.name())).append("); ");
+        return sb.append("return out; }").toString();
       }
-      return sb.append("return out; }").toString();
+      if (!auto) {
+        error(
+          to,
+          "@Bridge writeStrategy = SETTERS on " +
+            toFq +
+            ": no public no-arg constructor. Switch to AUTO, CONSTRUCTOR, or BUILDER, or add a no-arg constructor."
+        );
+        return null;
+      }
     }
 
     error(

--- a/codegen/src/test/java/io/github/eschizoid/telescope/codegen/BridgeProcessorTest.java
+++ b/codegen/src/test/java/io/github/eschizoid/telescope/codegen/BridgeProcessorTest.java
@@ -1968,6 +1968,100 @@ class BridgeProcessorTest {
     }
 
     @Test
+    @DisplayName("@Bridge(writeStrategy = SETTERS) forces the no-arg+setters strategy on a POJO that also has a builder")
+    void writeStrategyForcesSetters() {
+      final var compilation = compile(
+        source(
+          "demo.PA",
+          """
+          package demo;
+          import io.github.eschizoid.telescope.annotations.Bridge;
+          import io.github.eschizoid.telescope.annotations.WriteStrategy;
+          @Bridge(value = demo.PB.class, writeStrategy = WriteStrategy.SETTERS)
+          public class PA {
+            private String id;
+            public PA() {}
+            public String getId() { return id; }
+            public void setId(String id) { this.id = id; }
+          }
+          """
+        ),
+        source(
+          "demo.PB",
+          """
+          package demo;
+          public class PB {
+            private String id;
+            public PB() {}
+            public String getId() { return id; }
+            public void setId(String id) { this.id = id; }
+            // PB also exposes a builder — under AUTO the processor would prefer the name-matched
+            // ctor path first; SETTERS should force the no-arg + setters shape regardless.
+            public static Builder builder() { return new Builder(); }
+            public static class Builder {
+              private String id;
+              public Builder id(String id) { this.id = id; return this; }
+              public PB build() { final var p = new PB(); p.setId(id); return p; }
+            }
+          }
+          """
+        )
+      );
+
+      assertTrue(compilation.success(), () -> "compilation failed: " + compilation.errorMessages());
+      final var bridge = compilation.generated().get("demo.PABridge");
+      assertNotNull(bridge, () -> "PABridge missing; saw " + compilation.generated().keySet());
+
+      // Forward uses no-arg + setter path, NOT the builder.
+      assertTrue(
+        bridge.contains("final var out = new demo.PB()") && bridge.contains("out.setId(s.getId())"),
+        () -> "expected SETTERS shape on forward, saw: " + bridge
+      );
+      assertTrue(!bridge.contains("demo.PB.builder()"), () -> "should not call builder() when SETTERS forced");
+    }
+
+    @Test
+    @DisplayName("@Bridge(writeStrategy = CONSTRUCTOR) on a POJO without name-matched ctor is a precise error")
+    void writeStrategyConstructorMismatchRejected() {
+      final var compilation = compile(
+        source(
+          "demo.PA",
+          """
+          package demo;
+          import io.github.eschizoid.telescope.annotations.Bridge;
+          import io.github.eschizoid.telescope.annotations.WriteStrategy;
+          @Bridge(value = demo.PB.class, writeStrategy = WriteStrategy.CONSTRUCTOR)
+          public class PA {
+            private String id;
+            public PA() {}
+            public String getId() { return id; }
+            public void setId(String id) { this.id = id; }
+          }
+          """
+        ),
+        source(
+          "demo.PB",
+          """
+          package demo;
+          // No public name-matched constructor — no-arg only.
+          public class PB {
+            private String id;
+            public PB() {}
+            public String getId() { return id; }
+            public void setId(String id) { this.id = id; }
+          }
+          """
+        )
+      );
+
+      assertFalse(compilation.success(), "@Bridge(writeStrategy=CONSTRUCTOR) without a matching ctor should fail");
+      assertTrue(
+        compilation.hasError("writeStrategy = CONSTRUCTOR"),
+        () -> "expected CONSTRUCTOR-strategy diagnostic; saw " + compilation.errorMessages()
+      );
+    }
+
+    @Test
     @DisplayName("@Default on a primitive-typed source field is a compile error")
     void defaultsOnPrimitiveRejected() {
       final var compilation = compile(

--- a/core/src/main/java/io/github/eschizoid/telescope/annotations/Bridge.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/annotations/Bridge.java
@@ -188,4 +188,14 @@ public @interface Bridge {
    * }</pre>
    */
   ViaMapper[] viaMappers() default {};
+
+  /**
+   * Override for the POJO construction strategy when emitting the target's rebuild block. Records
+   * always use the canonical constructor and ignore this setting. Default {@link
+   * WriteStrategy#AUTO} runs the priority ladder (name-matched ctor → static builder() → no-arg
+   * + setters); the other values force one specific strategy and surface a precise compile error
+   * when the POJO doesn't expose the required shape. Mirrors the runtime {@code
+   * WriteHint.writeBean(cls, strategy)} hint.
+   */
+  WriteStrategy writeStrategy() default WriteStrategy.AUTO;
 }

--- a/core/src/main/java/io/github/eschizoid/telescope/annotations/WriteStrategy.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/annotations/WriteStrategy.java
@@ -1,0 +1,40 @@
+package io.github.eschizoid.telescope.annotations;
+
+/**
+ * Override for the POJO construction strategy that {@link Bridge} codegen chooses when emitting
+ * forward/backward bodies. Mirrors the runtime {@code WriteHint.writeBean(cls, strategy)} hint.
+ *
+ * <p>Records always use their canonical constructor and ignore this setting. For POJOs, the
+ * default {@link #AUTO} runs the priority ladder: name-matched constructor → static {@code
+ * builder()} method → no-arg constructor plus setters. The other values force one specific
+ * strategy and surface a precise compile error if the POJO doesn't expose the required shape.
+ */
+public enum WriteStrategy {
+  /**
+   * Default: auto-detect by trying name-matched constructor, then static {@code builder()}, then
+   * no-arg constructor plus setters. Pick the first that applies cleanly.
+   */
+  AUTO,
+
+  /**
+   * Force the name-matched constructor strategy. The POJO must expose a public constructor whose
+   * parameter names match the bridge fields. Useful for immutable POJOs whose builder is
+   * incidental and shouldn't be exercised.
+   */
+  CONSTRUCTOR,
+
+  /**
+   * Force the static {@code builder()} strategy. The POJO must expose {@code public static
+   * Builder builder()} returning a class with one setter per bridge field plus a {@code build()}
+   * method. Useful when AutoValue / Immutables / Lombok @Builder targets are present but the
+   * processor would prefer name-matched ctor.
+   */
+  BUILDER,
+
+  /**
+   * Force the no-arg constructor plus setters strategy. The POJO must expose a public no-arg
+   * constructor and a public {@code setX(...)} per bridge field. The canonical JavaBeans /
+   * Hibernate entity shape.
+   */
+  SETTERS,
+}


### PR DESCRIPTION
## Summary

**P4 — runtime/codegen parity gap.** Closes the asymmetry where runtime has `WriteHint.writeBean(cls, strategy)` to force a specific POJO construction path but codegen had no override — `buildExpr` always ran the priority ladder (name-matched ctor → static `builder()` → no-arg + setters).

## Shape

```java
@Bridge(value = HibernateEntity.class, writeStrategy = WriteStrategy.SETTERS)
public record Dto(String id, String name) {}
```

`WriteStrategy` enum: `AUTO` (default — preserve today's ladder), `CONSTRUCTOR`, `BUILDER`, `SETTERS`. Records ignore the setting (canonical ctor always). When forced, the requested strategy must apply; otherwise the processor surfaces a precise diagnostic naming the strategy and the alternative paths.

## What's NOT exposed

FIELDS strategy. Codegen never falls back to field reflection — exposing FIELDS would defeat the codegen path's no-runtime-reflection guarantee. Use the runtime path (`Telescope.mapper(...)` + `writeBean(..., FIELDS)`) if field reflection is required.

## Stacking

Stacked on `feat/codegen-via-mapper` (#99). Fourth of five codegen parity PRs.

## Test plan

- [x] SETTERS forces no-arg+setters even when builder is present (verified by asserting absence of `PB.builder()` in the emitted forward).
- [x] CONSTRUCTOR without a matching ctor produces a precise diagnostic mentioning `writeStrategy = CONSTRUCTOR`.
- [x] All 25 existing BridgeProcessorTest cases pass.
- [x] Full `./gradlew test` green.