### PR TITLE
feat(codegen): emit patch(base, partial) on generated *Bridge classes

### DIFF
--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
@@ -1149,6 +1149,29 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
     if (forwardBody == null) return;
     final var backwardBody = buildExpr(source, readBackward, sourceFields, writeStrategy, source);
     if (backwardBody == null) return;
+    // Patch emits a sparse overlay: for each source field, read from `partial` (the user's
+    // partially-populated target) when the target's component is non-null, else fall back to the
+    // corresponding read on `base`. Primitive target components are always treated as
+    // patch-present (matching runtime Mapper#patch semantics: a boxed primitive is never null).
+    final Function<String, String> readPatch = sourceName -> {
+      final var sf = fieldByName(sourceFields, sourceName);
+      final var baseRead = readExpr(source, "base", sf);
+      if (drops.contains(sourceName)) return baseRead;
+      if (forwardOnlyTransforms.contains(sourceName)) return baseRead;
+      final var tgtName = renames.getOrDefault(sourceName, sourceName);
+      final var tf = fieldByName(targetFields, tgtName);
+      final var partialRead = applyBackward(
+        sourceName,
+        fieldPlans.get(sourceName),
+        readExpr(target, "partial", tf)
+      );
+      // Primitive target components autobox to non-null wrappers on read — always patch them.
+      if (tf.type().getKind().isPrimitive()) return partialRead;
+      // Reference components: conditional on the target value being non-null.
+      return "(" + readExpr(target, "partial", tf) + " != null ? " + partialRead + " : " + baseRead + ")";
+    };
+    final var patchBody = buildExpr(source, readPatch, sourceFields, writeStrategy);
+    if (patchBody == null) return;
 
     final var imports = new TreeSet<>(importsFor(fieldPlans));
     imports.add("io.github.eschizoid.telescope.conversion.BridgeFn");
@@ -1200,6 +1223,16 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
         out.println();
         out.println("  public static " + sourceFq + " backward(final " + targetFq + " t) {");
         emitMethodBody(out, backwardBody);
+        out.println("  }");
+        out.println();
+        // Sparse-overlay patch: read non-null fields of `partial` (a partially-populated target)
+        // and apply them onto `base` via backward. Mirrors the runtime Mapper#patch(base, partial)
+        // semantics. Reference target components null-gate to base; primitive components autobox
+        // to non-null and are always overlaid.
+        out.println(
+          "  public static " + sourceFq + " patch(final " + sourceFq + " base, final " + targetFq + " partial) {"
+        );
+        emitMethodBody(out, patchBody);
         out.println("  }");
         out.println();
         out.println("  /** One concrete BridgeFn type per @Bridge — monomorphic dispatch site. */");

--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
@@ -1160,17 +1160,30 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
       if (forwardOnlyTransforms.contains(sourceName)) return baseRead;
       final var tgtName = renames.getOrDefault(sourceName, sourceName);
       final var tf = fieldByName(targetFields, tgtName);
-      final var partialRead = applyBackward(
-        sourceName,
-        fieldPlans.get(sourceName),
-        readExpr(target, "partial", tf)
-      );
+      // P5-3: nested RECURSE plans use SubBridge.patch(base.field, partial.field) instead of
+      // SubBridge.backward(partial.field) — recursive patch all the way down, so a sparse partial
+      // at a nested level only overlays its non-null sub-components.
+      final var plan = fieldPlans.get(sourceName);
+      final var partialReadExpr = readExpr(target, "partial", tf);
+      final String partialRead;
+      if (plan.kind() == FieldPlan.Kind.RECURSE) {
+        partialRead = plan.subBridgeName() + ".patch(" + baseRead + ", " + partialReadExpr + ")";
+      } else {
+        partialRead = applyBackward(sourceName, plan, partialReadExpr);
+      }
       // Primitive target components autobox to non-null wrappers on read — always patch them.
       if (tf.type().getKind().isPrimitive()) return partialRead;
-      // Reference components: conditional on the target value being non-null.
-      return "(" + readExpr(target, "partial", tf) + " != null ? " + partialRead + " : " + baseRead + ")";
+      // P5-5: when a @Default is configured for this source field, the outer ternary applies its
+      // null-coalesce so the fallback-from-base path still honors the default if base.field is
+      // also null. Without this, patch + @Default could yield null when forward + @Default would
+      // yield the default — inconsistency between bridge directions.
+      final var conditional = "(" + partialReadExpr + " != null ? " + partialRead + " : " + baseRead + ")";
+      if (parsedDefaults.containsKey(sourceName)) {
+        return "(" + conditional + " == null ? " + parsedDefaults.get(sourceName) + " : " + conditional + ")";
+      }
+      return conditional;
     };
-    final var patchBody = buildExpr(source, readPatch, sourceFields, writeStrategy);
+    final var patchBody = buildExpr(source, readPatch, sourceFields, writeStrategy, source);
     if (patchBody == null) return;
 
     final var imports = new TreeSet<>(importsFor(fieldPlans));
@@ -1226,12 +1239,16 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
         out.println("  }");
         out.println();
         // Sparse-overlay patch: read non-null fields of `partial` (a partially-populated target)
-        // and apply them onto `base` via backward. Mirrors the runtime Mapper#patch(base, partial)
-        // semantics. Reference target components null-gate to base; primitive components autobox
-        // to non-null and are always overlaid.
+        // and apply them onto `base`. Mirrors the runtime Mapper#patch(base, partial) semantics.
+        // Reference target components null-gate to base; primitive components autobox to non-null
+        // and are always overlaid; nested RECURSE plans recursively patch all the way down.
         out.println(
           "  public static " + sourceFq + " patch(final " + sourceFq + " base, final " + targetFq + " partial) {"
         );
+        // P5-1: match runtime Mapper#patch's null-guard. Without this guard, a sparse PATCH
+        // request that arrives with no body (partial == null) would NPE on the first
+        // partial.field() call; runtime returns `base` cleanly in the same situation.
+        out.println("    if (base == null || partial == null) return base;");
         emitMethodBody(out, patchBody);
         out.println("  }");
         out.println();
@@ -1407,6 +1424,31 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
         out.println();
         out.println("  public static " + sourceFq + " backward(final " + targetFq + " t) {");
         out.println("    return BACKWARD.apply(t);");
+        out.println("  }");
+        out.println();
+        // P5-6: sealed-umbrella patch — dispatch each (basePermit, partialPermit) pair to the
+        // per-case bridge's patch when both sides land on the matching sealed case. If the cases
+        // don't match (e.g. base is a CreditCard, partial is a BankTransferEntity), the umbrella
+        // falls back to backward(partial) — a full-conversion since there's no meaningful overlay
+        // across case boundaries. Matches the runtime Mapper#patch contract.
+        out.println(
+          "  public static " + sourceFq + " patch(final " + sourceFq + " base, final " + targetFq + " partial) {"
+        );
+        out.println("    if (base == null || partial == null) return base;");
+        for (final var e : entries) {
+          final var sCase = e.sourceCase().getQualifiedName();
+          final var tCase = e.targetCase().getQualifiedName();
+          out.println(
+            "    if (base instanceof " +
+            sCase +
+            " sb && partial instanceof " +
+            tCase +
+            " tp) return " +
+            e.bridgeFq() +
+            ".patch(sb, tp);"
+          );
+        }
+        out.println("    return BACKWARD.apply(partial);");
         out.println("  }");
         out.println();
         out.println("  /** One concrete BridgeFn type per @Bridge — monomorphic dispatch site. */");

--- a/codegen/src/test/java/io/github/eschizoid/telescope/codegen/BridgeProcessorTest.java
+++ b/codegen/src/test/java/io/github/eschizoid/telescope/codegen/BridgeProcessorTest.java
@@ -1998,6 +1998,11 @@ class BridgeProcessorTest {
         bridge.contains("public static demo.User patch(final demo.User base, final demo.UserDto partial)"),
         () -> "expected patch(base, partial) signature, saw: " + bridge
       );
+      // P5-1: null-guard at top of patch body — matches runtime Mapper#patch semantics.
+      assertTrue(
+        bridge.contains("if (base == null || partial == null) return base"),
+        () -> "expected null-guard at top of patch body, saw: " + bridge
+      );
       // String components: null-gate to base.
       assertTrue(
         bridge.contains("(partial.id() != null ? partial.id() : base.id())"),
@@ -2015,6 +2020,58 @@ class BridgeProcessorTest {
       assertTrue(
         !bridge.contains("partial.age() != null"),
         () -> "primitive int age must NOT be null-gated, saw: " + bridge
+      );
+    }
+
+    @Test
+    @DisplayName("P5-3/P5-4: nested RECURSE fields recursively patch, not full-backward")
+    void patchRecursesIntoNestedSubBridges() {
+      final var compilation = compile(
+        source(
+          "demo.Order",
+          """
+          package demo;
+          import io.github.eschizoid.telescope.annotations.Bridge;
+          @Bridge(demo.OrderDto.class)
+          public record Order(String id, demo.Customer customer) {}
+          """
+        ),
+        source("demo.Customer", "package demo; public record Customer(String name, String email) {}"),
+        source(
+          "demo.OrderDto",
+          """
+          package demo;
+          public record OrderDto(String id, demo.CustomerDto customer) {}
+          """
+        ),
+        source("demo.CustomerDto", "package demo; public record CustomerDto(String name, String email) {}")
+      );
+
+      assertTrue(compilation.success(), () -> "compilation failed: " + compilation.errorMessages());
+      final var bridge = compilation.generated().get("demo.OrderBridge");
+      assertNotNull(bridge, () -> "OrderBridge missing; saw " + compilation.generated().keySet());
+
+      // The nested customer slot should call SubBridge.patch(base.customer(), partial.customer())
+      // — recursive patch — not SubBridge.backward(partial.customer()) which would full-rebuild
+      // the customer and discard any sub-fields that the partial doesn't carry.
+      final var subBridge = "CustomerToCustomerDtoBridge";
+      assertTrue(
+        bridge.contains(subBridge + ".patch(base.customer(), partial.customer())"),
+        () ->
+          "expected nested patch delegation '" +
+          subBridge +
+          ".patch(base.customer(), partial.customer())', saw: " +
+          bridge
+      );
+      // And the null-gate still wraps the patch call so a null partial.customer() falls back to
+      // base.customer() unchanged.
+      assertTrue(
+        bridge.contains(
+          "(partial.customer() != null ? " +
+          subBridge +
+          ".patch(base.customer(), partial.customer()) : base.customer())"
+        ),
+        () -> "expected null-gate around nested patch, saw: " + bridge
       );
     }
 

--- a/codegen/src/test/java/io/github/eschizoid/telescope/codegen/BridgeProcessorTest.java
+++ b/codegen/src/test/java/io/github/eschizoid/telescope/codegen/BridgeProcessorTest.java
@@ -1968,6 +1968,57 @@ class BridgeProcessorTest {
     }
 
     @Test
+    @DisplayName("Generated *Bridge class includes a patch(base, partial) static for sparse overlay")
+    void patchEmitsSparseOverlay() {
+      final var compilation = compile(
+        source(
+          "demo.User",
+          """
+          package demo;
+          import io.github.eschizoid.telescope.annotations.Bridge;
+          @Bridge(demo.UserDto.class)
+          public record User(String id, String email, int age) {}
+          """
+        ),
+        source(
+          "demo.UserDto",
+          """
+          package demo;
+          public record UserDto(String id, String email, int age) {}
+          """
+        )
+      );
+
+      assertTrue(compilation.success(), () -> "compilation failed: " + compilation.errorMessages());
+      final var bridge = compilation.generated().get("demo.UserBridge");
+      assertNotNull(bridge, () -> "UserBridge missing; saw " + compilation.generated().keySet());
+
+      // Patch method exists with the right signature.
+      assertTrue(
+        bridge.contains("public static demo.User patch(final demo.User base, final demo.UserDto partial)"),
+        () -> "expected patch(base, partial) signature, saw: " + bridge
+      );
+      // String components: null-gate to base.
+      assertTrue(
+        bridge.contains("(partial.id() != null ? partial.id() : base.id())"),
+        () -> "expected null-gate on id, saw: " + bridge
+      );
+      assertTrue(
+        bridge.contains("(partial.email() != null ? partial.email() : base.email())"),
+        () -> "expected null-gate on email, saw: " + bridge
+      );
+      // Primitive component (int age): always overlaid from partial (no null gate).
+      assertTrue(
+        bridge.contains("new demo.User(") && bridge.contains("partial.age()"),
+        () -> "expected primitive int age always patched from partial, saw: " + bridge
+      );
+      assertTrue(
+        !bridge.contains("partial.age() != null"),
+        () -> "primitive int age must NOT be null-gated, saw: " + bridge
+      );
+    }
+
+    @Test
     @DisplayName("@Bridge(writeStrategy = SETTERS) forces the no-arg+setters strategy on a POJO that also has a builder")
     void writeStrategyForcesSetters() {
       final var compilation = compile(


### PR DESCRIPTION
## Summary

**P5 — runtime/codegen parity gap. The last one of Phase 4.** Runtime has `Mapper.patch(base, partial)` for sparse-overlay semantics (HTTP PATCH on a resource: only non-null target components affect the source). Codegen bridges were full-conversion only.

## Shape

The generated `*Bridge` class now exposes:

```java
public static Source patch(final Source base, final Target partial)
```

For each source component:

- **Reference-typed target components null-gate to base** — the classic sparse-PATCH shape (only non-null partial fields propagate).
- **Primitive target components are always overlaid from partial** — primitives autobox to non-null wrappers on read, so they can't signal "unset". Matches runtime `Mapper#patch` semantics exactly.
- **Drop / forward-only-transform slots** read from `base` (the partial has nothing meaningful for that slot).

Example for `record User(String id, String email, int age)`:

```java
public static User patch(final User base, final UserDto partial) {
  return new User(
    (partial.id()    != null ? partial.id()    : base.id()),
    (partial.email() != null ? partial.email() : base.email()),
    partial.age()  // primitive int — always overlaid
  );
}
```

## Implementation

Reuses `buildExpr` with a custom `readPatch` closure, so records get canonical-ctor rebuild and POJOs get the same writeStrategy ladder (CONSTRUCTOR → BUILDER → SETTERS) the forward / backward paths use. The user's `writeStrategy` attribute applies to all three emit paths uniformly.

## Stacking

Stacked on `feat/codegen-write-strategy` (#100). **Last of five codegen parity PRs.**

## Phase 4 complete

| PR | Closes |
|---|---|
| #97 | P1 `@Transform(forwardOnly=true)` |
| #98 | P2 `@Default(field, value)` |
| #99 | P3 `@ViaMapper(field, using)` |
| #100 | P4 `@Bridge(writeStrategy = …)` |
| **#101** | **P5 `patch(base, partial)` emission** |

After Phase 4 merges, the codegen surface reaches feature parity with the runtime surface modulo the few items that are legitimately runtime-only (hooks, ForwardMapper.then, nested-path `Mapping.to(Telescope...)`, Telescope.before/after).

## Test plan

- [x] New BridgeProcessorTest case: patch signature, reference fields null-gate, primitive int field doesn't null-gate.
- [x] All 26 existing BridgeProcessorTest cases pass.
- [x] Full `./gradlew test` green.