### PR TITLE
fix: add explicit mainClass to order-jpa Spring Boot example

### DIFF
--- a/examples/springboot/order-jpa/build.gradle.kts
+++ b/examples/springboot/order-jpa/build.gradle.kts
@@ -20,6 +20,10 @@ repositories {
     mavenCentral()
 }
 
+springBoot {
+    mainClass.set("io.github.eschizoid.telescope.demo.spring.DemoApplication")
+}
+
 dependencies {
     // Depends on the telescope library *directly* — this submodule wires Mapper<A, B> beans by
     // hand in @Configuration classes (see OrderMappers). The sibling product-starter submodule


### PR DESCRIPTION
Unblocks the Release workflow on main. Same root cause as the org-chart / product-starter / invoicing fix in #103 — order-jpa was missed in that batch. The bootJar plugin's classpath-scan-for-mainClass races with compileJava during clean-build invocations; explicit mainClass sidesteps the lazy-provider evaluation.