### PR TITLE
feat(mapping): MS-2 Mapping.enumTo + MS-3 cycle handling coverage

### DIFF
--- a/core/src/main/java/io/github/eschizoid/telescope/mapping/Mapping.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/mapping/Mapping.java
@@ -144,6 +144,83 @@ public sealed interface Mapping<A, B>
   }
 
   /**
+   * Enum correspondence by constant name. Maps each {@code SE} constant to the {@code TE} constant
+   * of the same {@link Enum#name() name}; backward direction is symmetric. Closes MapStruct's
+   * {@code @ValueMapping} gap for the common "status enums that line up by name" case without
+   * forcing the user to hand-write a 2-arg typed transform with {@code Enum.valueOf} on both sides
+   * — the exhaustiveness check that comes free here is the value-add.
+   *
+   * <pre>{@code
+   * enumTo(UserEntity::status, UserDto::status, EntityStatus.class, DtoStatus.class)
+   * }</pre>
+   *
+   * <p><b>Exhaustiveness validation runs at factory time.</b> Every constant of {@code srcEnum}
+   * must have a same-named constant in {@code tgtEnum}, and vice versa. Mismatches throw {@link
+   * IllegalArgumentException} naming the missing constants so the user sees a clear diff at
+   * mapper-build time instead of an {@link IllegalArgumentException} at the first call site that
+   * hits the unmatched constant. If your enums genuinely differ in cardinality, use {@link
+   * #to(Accessor, Accessor, Function, Function)} with explicit lambdas that handle the mismatch
+   * however you want (default, throw, map-to-null).
+   *
+   * <p><b>Lattice routing:</b> this is a thin convenience over {@link TypedTransformTo} — the
+   * forward and backward closures are {@code Enum.valueOf(targetClass, source.name())}. The
+   * existing lattice composition rules apply unchanged; codegen recognises the enum-shaped pair at
+   * the {@code @Bridge} processor and may in a future revision emit a switch expression for the
+   * per-pair dispatch instead of routing through the captured {@link Function}.
+   */
+  static <A, B, SE extends Enum<SE>, TE extends Enum<TE>> Mapping<A, B> enumTo(
+    final Accessor<A, SE> src,
+    final Accessor<B, TE> tgt,
+    final Class<SE> srcEnum,
+    final Class<TE> tgtEnum
+  ) {
+    validateEnumCorrespondence(srcEnum, tgtEnum);
+    return new TypedTransformTo<>(
+      src,
+      tgt,
+      (SE s) -> Enum.valueOf(tgtEnum, s.name()),
+      (TE t) -> Enum.valueOf(srcEnum, t.name())
+    );
+  }
+
+  private static <SE extends Enum<SE>, TE extends Enum<TE>> void validateEnumCorrespondence(
+    final Class<SE> srcEnum,
+    final Class<TE> tgtEnum
+  ) {
+    final java.util.Set<String> srcNames = new java.util.TreeSet<>();
+    for (final var c : srcEnum.getEnumConstants()) srcNames.add(c.name());
+    final java.util.Set<String> tgtNames = new java.util.TreeSet<>();
+    for (final var c : tgtEnum.getEnumConstants()) tgtNames.add(c.name());
+    final var missingInTarget = new java.util.TreeSet<>(srcNames);
+    missingInTarget.removeAll(tgtNames);
+    final var missingInSource = new java.util.TreeSet<>(tgtNames);
+    missingInSource.removeAll(srcNames);
+    if (missingInTarget.isEmpty() && missingInSource.isEmpty()) return;
+    final var msg = new StringBuilder("Mapping.enumTo(")
+      .append(srcEnum.getSimpleName())
+      .append(" ↔ ")
+      .append(tgtEnum.getSimpleName())
+      .append("): exhaustiveness check failed.");
+    if (!missingInTarget.isEmpty()) {
+      msg
+        .append(" Source constants missing on target: ")
+        .append(missingInTarget)
+        .append(" (add to ")
+        .append(tgtEnum.getSimpleName())
+        .append(" or use Mapping.to(src, tgt, fwd, bwd) with explicit fallback handling).");
+    }
+    if (!missingInSource.isEmpty()) {
+      msg
+        .append(" Target constants missing on source: ")
+        .append(missingInSource)
+        .append(" (add to ")
+        .append(srcEnum.getSimpleName())
+        .append(" or use Mapping.to(src, tgt, fwd, bwd) with explicit fallback handling).");
+    }
+    throw new IllegalArgumentException(msg.toString());
+  }
+
+  /**
    * Null-coalescing same-typed correspondence: when the source accessor returns {@code null}, the
    * target receives {@code defaultValue} instead. Source and target share the same leaf type {@code
    * X}; non-null source values pass through unchanged. Closes MapStruct's {@code defaultValue} gap

--- a/core/src/test/java/io/github/eschizoid/telescope/CycleHandlingTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/CycleHandlingTest.java
@@ -1,0 +1,88 @@
+package io.github.eschizoid.telescope;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pins {@link DeepMap}'s TypePair cycle cache against direct scalar cycles, container cycles, and
+ * mutual-recursion cycles. The org-chart example covers the Optional+List self-reference shape;
+ * these tests pin the harder shapes the cache also has to handle so a future refactor of the
+ * placeholder-then-fill-in mechanism doesn't silently regress to StackOverflow.
+ */
+class CycleHandlingTest {
+
+  @Nested
+  @DisplayName("Self-reference through container")
+  class OptionalSelfRef {
+
+    record Node(String id, Optional<Node> parent) {}
+
+    record NodeDto(String id, Optional<NodeDto> parent) {}
+
+    @Test
+    @DisplayName("Optional<Self> auto-mapper builds without StackOverflow")
+    void optionalSelfRefBuilds() {
+      final var mapper = Telescope.mapper(Node.class, NodeDto.class);
+      final var root = new Node("root", Optional.empty());
+      final var child = new Node("c", Optional.of(root));
+      final var dto = mapper.forward(child);
+      assertEquals("c", dto.id());
+      assertEquals("root", dto.parent().orElseThrow().id());
+    }
+  }
+
+  @Nested
+  @DisplayName("Self-reference through List")
+  class ListSelfRef {
+
+    record TreeNode(String name, List<TreeNode> children) {}
+
+    record TreeNodeDto(String name, List<TreeNodeDto> children) {}
+
+    @Test
+    @DisplayName("List<Self> auto-mapper builds + maps a 3-level tree without StackOverflow")
+    void listSelfRefBuilds() {
+      final var mapper = Telescope.mapper(TreeNode.class, TreeNodeDto.class);
+      final var leaf = new TreeNode("leaf", List.of());
+      final var mid = new TreeNode("mid", List.of(leaf));
+      final var root = new TreeNode("root", List.of(mid));
+      final var dto = mapper.forward(root);
+      assertEquals("root", dto.name());
+      assertEquals("mid", dto.children().get(0).name());
+      assertEquals("leaf", dto.children().get(0).children().get(0).name());
+    }
+  }
+
+  @Nested
+  @DisplayName("Mutual recursion A↔B")
+  class MutualRecursion {
+
+    record A(String label, Optional<B> b) {}
+
+    record B(String tag, Optional<A> a) {}
+
+    record ADto(String label, Optional<BDto> b) {}
+
+    record BDto(String tag, Optional<ADto> a) {}
+
+    @Test
+    @DisplayName("A→B→A mutual cycle builds via Optional containers without StackOverflow")
+    void mutualCycleBuilds() {
+      final var mapper = Telescope.mapper(A.class, ADto.class);
+      final var leaf = new A("leaf", Optional.empty());
+      final var mid = new B("mid", Optional.of(leaf));
+      final var root = new A("root", Optional.of(mid));
+      final var dto = mapper.forward(root);
+      assertNotNull(dto);
+      assertEquals("root", dto.label());
+      assertEquals("mid", dto.b().orElseThrow().tag());
+      assertEquals("leaf", dto.b().orElseThrow().a().orElseThrow().label());
+    }
+  }
+}

--- a/core/src/test/java/io/github/eschizoid/telescope/MappingEnumToTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/MappingEnumToTest.java
@@ -1,0 +1,121 @@
+package io.github.eschizoid.telescope;
+
+import static io.github.eschizoid.telescope.mapping.Mapping.enumTo;
+import static io.github.eschizoid.telescope.mapping.Mapping.to;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pins {@link io.github.eschizoid.telescope.mapping.Mapping#enumTo} — the convenience factory for
+ * by-name enum correspondence. Validates the happy-path round-trip + the exhaustiveness diagnostic
+ * fires at factory time with a clear message naming the missing constants on either side.
+ */
+class MappingEnumToTest {
+
+  enum EntityStatus {
+    ACTIVE,
+    SUSPENDED,
+    CLOSED,
+  }
+
+  enum DtoStatus {
+    ACTIVE,
+    SUSPENDED,
+    CLOSED,
+  }
+
+  enum DtoStatusMissingClosed {
+    ACTIVE,
+    SUSPENDED,
+  }
+
+  enum DtoStatusExtraPending {
+    ACTIVE,
+    SUSPENDED,
+    CLOSED,
+    PENDING,
+  }
+
+  record UserEntity(String id, EntityStatus status) {}
+
+  record UserDto(String id, DtoStatus status) {}
+
+  record UserDtoMissing(String id, DtoStatusMissingClosed status) {}
+
+  record UserDtoExtra(String id, DtoStatusExtraPending status) {}
+
+  @Nested
+  @DisplayName("Happy path — enums with identical constants line up by name")
+  class HappyPath {
+
+    @Test
+    @DisplayName("forward + backward round-trip via Enum.valueOf on both sides")
+    void roundTrip() {
+      final var mapper = Telescope.mapper(
+        UserEntity.class,
+        UserDto.class,
+        enumTo(UserEntity::status, UserDto::status, EntityStatus.class, DtoStatus.class)
+      );
+      final var entity = new UserEntity("u1", EntityStatus.SUSPENDED);
+      final var dto = mapper.forward(entity);
+      assertEquals(DtoStatus.SUSPENDED, dto.status());
+      assertEquals(entity, mapper.backward(dto));
+    }
+
+    @Test
+    @DisplayName("Composes with other Mapping rows on the same pair")
+    void composesWithOtherRows() {
+      final var mapper = Telescope.mapper(
+        UserEntity.class,
+        UserDto.class,
+        to(UserEntity::id, UserDto::id),
+        enumTo(UserEntity::status, UserDto::status, EntityStatus.class, DtoStatus.class)
+      );
+      assertEquals(DtoStatus.ACTIVE, mapper.forward(new UserEntity("u1", EntityStatus.ACTIVE)).status());
+    }
+  }
+
+  @Nested
+  @DisplayName("Exhaustiveness validation at factory time")
+  class Exhaustiveness {
+
+    @Test
+    @DisplayName("Source constant missing on target → IAE naming the missing constant")
+    void missingOnTarget() {
+      final var ex = assertThrows(IllegalArgumentException.class, () ->
+        enumTo(UserEntity::status, UserDtoMissing::status, EntityStatus.class, DtoStatusMissingClosed.class)
+      );
+      assertTrue(ex.getMessage().contains("CLOSED"), () -> ex.getMessage());
+      assertTrue(ex.getMessage().contains("missing on target"), () -> ex.getMessage());
+      assertTrue(ex.getMessage().contains("DtoStatusMissingClosed"), () -> ex.getMessage());
+    }
+
+    @Test
+    @DisplayName("Target constant missing on source → IAE naming the missing constant")
+    void missingOnSource() {
+      final var ex = assertThrows(IllegalArgumentException.class, () ->
+        enumTo(UserEntity::status, UserDtoExtra::status, EntityStatus.class, DtoStatusExtraPending.class)
+      );
+      assertTrue(ex.getMessage().contains("PENDING"), () -> ex.getMessage());
+      assertTrue(ex.getMessage().contains("missing on source"), () -> ex.getMessage());
+      assertTrue(ex.getMessage().contains("EntityStatus"), () -> ex.getMessage());
+    }
+
+    @Test
+    @DisplayName("Message points the user at the explicit-Function escape hatch for asymmetric enums")
+    void messageNamesEscapeHatch() {
+      final var ex = assertThrows(IllegalArgumentException.class, () ->
+        enumTo(UserEntity::status, UserDtoExtra::status, EntityStatus.class, DtoStatusExtraPending.class)
+      );
+      assertTrue(
+        ex.getMessage().contains("Mapping.to(src, tgt, fwd, bwd)"),
+        () -> "Diagnostic should point at the typed-transform escape hatch; saw: " + ex.getMessage()
+      );
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Two Tier 4 items pulled forward to pre-1.0:

### MS-2 — `Mapping.enumTo(srcAcc, tgtAcc, SrcEnum.class, TgtEnum.class)`

Convenience factory closing MapStruct's `@ValueMapping` gap for by-name enum correspondence. Eager exhaustiveness check at factory time names any missing constants on either side — the value-add over a hand-written `Mapping.to(...)` with two `Enum.valueOf` lambdas.

```java
Telescope.mapper(UserEntity.class, UserDto.class,
    enumTo(UserEntity::status, UserDto::status, EntityStatus.class, DtoStatus.class));
```

Asymmetric enums get a clear diagnostic pointing at `Mapping.to(src, tgt, fwd, bwd)` for the explicit-fallback escape hatch.

### MS-3 — Cycle handling: already implemented, now pinned

Investigation showed `DeepMap.populateIso` already handles cycles via the cache reservation at `DeepMap.java:271-272` (the `cache.put(key, null)` placeholder + `containsKey` short-circuit). The org-chart example demonstrates this in production for Optional/List self-references.

The earlier review framing — "bidirectional graphs currently StackOverflow" — was incorrect. No code change needed; just coverage tests pinning the additional shapes the cache must handle:

- Self-reference through `Optional<Self>`
- Self-reference through `List<Self>`
- Mutual recursion A↔B through Optional containers

## Test plan

- [x] `./gradlew test` green (46 tasks)
- [x] 5 new `MappingEnumToTest` cases (round-trip, composition, 3 exhaustiveness diagnostics)
- [x] 3 new `CycleHandlingTest` cases (Optional self-ref, List self-ref, mutual A↔B)
- [x] All existing tests unchanged

## Future work

Codegen path for `enumTo` (emit a switch expression at the `@Bridge` processor instead of routing through the captured `Function`) is mentioned in the javadoc as a future revision — runtime-first lands the API, codegen optimization can follow once usage is real.