### PR TITLE
chore: strip inline FQNs across the repo

### DIFF
--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
@@ -1168,7 +1168,7 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
     // configured. We avoid double-evaluation by precomputing one local per source field in a
     // prelude block, then referencing the locals in the conditional. The prelude is collected
     // here as patchLocals (declarations) keyed by source field name.
-    final var patchLocals = new java.util.LinkedHashMap<String, String>();
+    final var patchLocals = new LinkedHashMap<String, String>();
     final Function<String, String> readPatch = sourceName -> {
       final var sf = fieldByName(sourceFields, sourceName);
       final var baseRead = readExpr(source, "base", sf);

--- a/core/src/main/java/io/github/eschizoid/telescope/Sources.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/Sources.java
@@ -1,9 +1,11 @@
 package io.github.eschizoid.telescope;
 
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
 /**
  * Class-keyed bag of source objects consumed by {@link Telescope#merge(Class,
@@ -58,7 +60,7 @@ public final class Sources {
   public static Sources of(final Object... sources) {
     Objects.requireNonNull(sources, "Sources.of: sources array is null");
     final var map = new LinkedHashMap<Class<?>, Object>();
-    final var list = new java.util.ArrayList<Object>(sources.length);
+    final var list = new ArrayList<Object>(sources.length);
     for (final var s : sources) {
       if (s == null) throw new IllegalArgumentException(
         "Sources.of: source at position " + list.size() + " is null. Every source in a merge bag must be non-null."
@@ -88,7 +90,7 @@ public final class Sources {
    * forward-time diagnostic to name what IS present when a row's source class is missing — gives
    * the user actionable information without exposing the source values themselves.
    */
-  public java.util.Set<Class<?>> classes() {
+  public Set<Class<?>> classes() {
     return bySrcClass.keySet();
   }
 

--- a/core/src/main/java/io/github/eschizoid/telescope/conversion/ForwardMapper.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/conversion/ForwardMapper.java
@@ -45,7 +45,7 @@ public final class ForwardMapper<A, B> {
    * io.github.eschizoid.telescope.mapping.MapStep...)}.
    */
   public static <A, B> ForwardMapper<A, B> create(
-    final java.util.function.Function<? super A, ? extends B> forward,
+    final Function<? super A, ? extends B> forward,
     final Class<A> sourceClass,
     final Class<B> targetClass
   ) {

--- a/core/src/main/java/io/github/eschizoid/telescope/mapping/Mapping.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/mapping/Mapping.java
@@ -6,6 +6,8 @@ import io.github.eschizoid.telescope.Telescope.Accessor;
 import io.github.eschizoid.telescope.conversion.Mapper;
 import io.github.eschizoid.telescope.internal.LambdaIntrospection;
 import java.util.Objects;
+import java.util.Set;
+import java.util.TreeSet;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
@@ -187,13 +189,13 @@ public sealed interface Mapping<A, B>
     final Class<SE> srcEnum,
     final Class<TE> tgtEnum
   ) {
-    final java.util.Set<String> srcNames = new java.util.TreeSet<>();
+    final Set<String> srcNames = new TreeSet<>();
     for (final var c : srcEnum.getEnumConstants()) srcNames.add(c.name());
-    final java.util.Set<String> tgtNames = new java.util.TreeSet<>();
+    final Set<String> tgtNames = new TreeSet<>();
     for (final var c : tgtEnum.getEnumConstants()) tgtNames.add(c.name());
-    final var missingInTarget = new java.util.TreeSet<>(srcNames);
+    final var missingInTarget = new TreeSet<>(srcNames);
     missingInTarget.removeAll(tgtNames);
-    final var missingInSource = new java.util.TreeSet<>(tgtNames);
+    final var missingInSource = new TreeSet<>(tgtNames);
     missingInSource.removeAll(srcNames);
     if (missingInTarget.isEmpty() && missingInSource.isEmpty()) return;
     final var msg = new StringBuilder("Mapping.enumTo(")

--- a/core/src/test/java/io/github/eschizoid/telescope/DeepMapCoverageTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/DeepMapCoverageTest.java
@@ -8,6 +8,8 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import io.github.eschizoid.telescope.mapping.Mapping;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -30,9 +32,9 @@ class DeepMapCoverageTest {
   @DisplayName("D1 — zip(...) backward cardinality mismatch")
   class ZipBackwardCardinality {
 
-    record Cart(java.util.List<String> items) {}
+    record Cart(List<String> items) {}
 
-    record CartDto(java.util.List<String> lines) {}
+    record CartDto(List<String> lines) {}
 
     @Test
     @DisplayName("zip backward throws naming both counts when target focuses != source focuses")
@@ -46,7 +48,7 @@ class DeepMapCoverageTest {
       // items — the zip-backward path enforces cardinality (line 609 in DeepMap.java) since the
       // positional copy can't reconcile unequal lengths. Direct mapper.backward(dto) drives
       // applyBackward, which is where the guard lives.
-      final var dto = new CartDto(java.util.List.of("x", "y", "z"));
+      final var dto = new CartDto(List.of("x", "y", "z"));
       final var ex = assertThrows(IllegalStateException.class, () -> mapper.backward(dto));
       final var msg = ex.getMessage();
       assertTrue(msg.toLowerCase().contains("cardinality"));
@@ -207,7 +209,7 @@ class DeepMapCoverageTest {
       final var mapper = Telescope.mapper(
         Slim.class,
         BeanOuter.class,
-        io.github.eschizoid.telescope.mapping.Mapping.to(
+        Mapping.to(
           Slim::value,
           Telescope.ofBean(BeanOuter.class).field(BeanOuter::getInner).field(BeanInner::getValue)
         )
@@ -273,7 +275,7 @@ class DeepMapCoverageTest {
       final var mapper = Telescope.mapper(
         Slim.class,
         Outer.class,
-        io.github.eschizoid.telescope.mapping.Mapping.to(
+        Mapping.to(
           Slim::tag,
           Telescope.of(Outer.class).field(Outer::prims).field(AllPrims::tag)
         )

--- a/core/src/test/java/io/github/eschizoid/telescope/DeepMappingTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/DeepMappingTest.java
@@ -973,7 +973,7 @@ class DeepMappingTest {
     }
 
     // --- two-arg drop(srcAcc, target) — scoped to a nested pair ---
-    record CustomerRich(String name, java.util.Set<String> tags) {}
+    record CustomerRich(String name, Set<String> tags) {}
 
     record CustomerPartner(String name) {}
 

--- a/core/src/test/java/io/github/eschizoid/telescope/TypedContainerPathTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/TypedContainerPathTest.java
@@ -12,6 +12,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -102,7 +103,7 @@ class TypedContainerPathTest {
       final var src = new TagSet("alice", new LinkedHashSet<>(List.of(new Tag("a"))));
       assertEquals(
         Set.of(new Tag("a")),
-        promoted.each().toList(src).stream().collect(java.util.stream.Collectors.toSet())
+        promoted.each().toList(src).stream().collect(Collectors.toSet())
       );
     }
   }

--- a/core/src/test/java/io/github/eschizoid/telescope/beans/PojoOpticsTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/beans/PojoOpticsTest.java
@@ -6,6 +6,8 @@ import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
 import io.github.eschizoid.telescope.Telescope;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -260,24 +262,24 @@ class PojoOpticsTest {
 
   static final class ContainerBean {
 
-    private java.util.Map<String, String> labels;
-    private java.util.Optional<String> note;
+    private Map<String, String> labels;
+    private Optional<String> note;
 
     public ContainerBean() {}
 
-    public java.util.Map<String, String> getLabels() {
+    public Map<String, String> getLabels() {
       return labels;
     }
 
-    public java.util.Optional<String> getNote() {
+    public Optional<String> getNote() {
       return note;
     }
 
-    public void setLabels(final java.util.Map<String, String> labels) {
+    public void setLabels(final Map<String, String> labels) {
       this.labels = labels;
     }
 
-    public void setNote(final java.util.Optional<String> note) {
+    public void setNote(final Optional<String> note) {
       this.note = note;
     }
   }
@@ -290,29 +292,29 @@ class PojoOpticsTest {
     @DisplayName("eachValue updates a Map property's values, keys preserved")
     void eachValue() {
       final var bean = new ContainerBean();
-      bean.setLabels(java.util.Map.of("a", "x", "b", "y"));
-      bean.setNote(java.util.Optional.of("hi"));
+      bean.setLabels(Map.of("a", "x", "b", "y"));
+      bean.setNote(Optional.of("hi"));
 
       final var after = Telescope.ofBean(ContainerBean.class)
         .eachValue(ContainerBean::getLabels)
         .update(bean, String::toUpperCase);
 
-      assertEquals(java.util.Map.of("a", "X", "b", "Y"), after.getLabels());
-      assertEquals(java.util.Optional.of("hi"), after.getNote());
+      assertEquals(Map.of("a", "X", "b", "Y"), after.getLabels());
+      assertEquals(Optional.of("hi"), after.getNote());
     }
 
     @Test
     @DisplayName("whenPresent updates an Optional property when present")
     void whenPresent() {
       final var bean = new ContainerBean();
-      bean.setLabels(java.util.Map.of());
-      bean.setNote(java.util.Optional.of("hi"));
+      bean.setLabels(Map.of());
+      bean.setNote(Optional.of("hi"));
 
       final var after = Telescope.ofBean(ContainerBean.class)
         .whenPresent(ContainerBean::getNote)
         .update(bean, String::toUpperCase);
 
-      assertEquals(java.util.Optional.of("HI"), after.getNote());
+      assertEquals(Optional.of("HI"), after.getNote());
     }
   }
 

--- a/internal/src/main/java/io/github/eschizoid/telescope/internal/Beans.java
+++ b/internal/src/main/java/io/github/eschizoid/telescope/internal/Beans.java
@@ -12,6 +12,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.InaccessibleObjectException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
+import java.lang.reflect.Type;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -285,7 +286,7 @@ public final class Beans {
    *
    * @throws IllegalArgumentException if no getter is found
    */
-  public static java.lang.reflect.Type propertyType(final Class<?> beanClass, final String name) {
+  public static Type propertyType(final Class<?> beanClass, final String name) {
     final var getter = getters(beanClass).get(name);
     if (getter == null) throw new IllegalArgumentException(
       "No getter for property '" + name + "' on " + beanClass.getName()

--- a/internal/src/main/java/io/github/eschizoid/telescope/internal/MetadataHolderProbe.java
+++ b/internal/src/main/java/io/github/eschizoid/telescope/internal/MetadataHolderProbe.java
@@ -3,6 +3,7 @@ package io.github.eschizoid.telescope.internal;
 import java.lang.invoke.LambdaMetafactory;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
+import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.Map;
 import java.util.Optional;
@@ -106,7 +107,7 @@ public final class MetadataHolderProbe {
    */
   @SuppressWarnings("unchecked")
   private static Map<String, Object> readConstants(final Class<?> holder) throws ReflectiveOperationException {
-    final java.lang.reflect.Method method;
+    final Method method;
     try {
       method = holder.getDeclaredMethod("constants");
     } catch (final NoSuchMethodException e) {
@@ -147,7 +148,7 @@ public final class MetadataHolderProbe {
     final Class<?> holder,
     final Class<?> target
   ) {
-    final java.lang.reflect.Method method;
+    final Method method;
     try {
       method = holder.getDeclaredMethod("construct", Function.class);
     } catch (final NoSuchMethodException e) {

--- a/internal/src/main/java/io/github/eschizoid/telescope/internal/Records.java
+++ b/internal/src/main/java/io/github/eschizoid/telescope/internal/Records.java
@@ -7,6 +7,7 @@ import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.RecordComponent;
+import java.lang.reflect.Type;
 import java.util.Arrays;
 import java.util.function.Function;
 
@@ -149,7 +150,7 @@ public final class Records {
    *
    * @throws IllegalArgumentException if the name doesn't match a component on {@code recordClass}
    */
-  public static java.lang.reflect.Type componentType(final Class<?> recordClass, final String name) {
+  public static Type componentType(final Class<?> recordClass, final String name) {
     for (final var c : info(recordClass).components()) if (c.getName().equals(name)) return c.getGenericType();
     throw noField(name, recordClass);
   }

--- a/internal/src/main/java/io/github/eschizoid/telescope/internal/optics/collections/Traversals.java
+++ b/internal/src/main/java/io/github/eschizoid/telescope/internal/optics/collections/Traversals.java
@@ -12,6 +12,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 /**
  * Built-in {@link Traversal}s (and one {@link Affine}) for {@code java.util} container types — the
@@ -122,7 +123,7 @@ public final class Traversals {
       @Override
       public Stream<E> getAll(final C source) {
         if (source == null) return Stream.empty();
-        return java.util.stream.StreamSupport.stream(source.spliterator(), false);
+        return StreamSupport.stream(source.spliterator(), false);
       }
 
       @Override

--- a/internal/src/test/java/io/github/eschizoid/telescope/internal/ReflectiveStructuralIsoTest.java
+++ b/internal/src/test/java/io/github/eschizoid/telescope/internal/ReflectiveStructuralIsoTest.java
@@ -2,7 +2,9 @@ package io.github.eschizoid.telescope.internal;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -66,7 +68,7 @@ class ReflectiveStructuralIsoTest {
     void componentOrderPreserved() {
       final var iso = Reflective.RECORDS.structuralIso(User.class);
       final Map<String, Object> decomposed = iso.from(new User("alice", 30));
-      assertEquals(java.util.List.of("name", "age"), new java.util.ArrayList<>(decomposed.keySet()));
+      assertEquals(List.of("name", "age"), new ArrayList<>(decomposed.keySet()));
     }
   }
 

--- a/lombok/src/test/java/io/github/eschizoid/telescope/codegen/lombok/LombokFocusProcessorTest.java
+++ b/lombok/src/test/java/io/github/eschizoid/telescope/codegen/lombok/LombokFocusProcessorTest.java
@@ -10,6 +10,8 @@ import io.github.eschizoid.telescope.codegen.lombok.fixtures.DataUser;
 import io.github.eschizoid.telescope.codegen.lombok.fixtures.SameRoundConsumer;
 import io.github.eschizoid.telescope.codegen.lombok.fixtures.ValueBuilderUser;
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.function.Function;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -148,10 +150,10 @@ class LombokFocusProcessorTest {
       assertNotNull(holder);
 
       // Utility holder — final class, private no-arg ctor only.
-      assertTrue(java.lang.reflect.Modifier.isFinal(holder.getModifiers()), "holder must be final");
+      assertTrue(Modifier.isFinal(holder.getModifiers()), "holder must be final");
       assertEquals(1, holder.getDeclaredConstructors().length, "holder must have exactly one (private) constructor");
       assertTrue(
-        java.lang.reflect.Modifier.isPrivate(holder.getDeclaredConstructors()[0].getModifiers()),
+        Modifier.isPrivate(holder.getDeclaredConstructors()[0].getModifiers()),
         "holder ctor must be private"
       );
 
@@ -198,14 +200,14 @@ class LombokFocusProcessorTest {
     @DisplayName("Phase D: @Data holder exposes a public static construct(Function) that rebuilds via setters")
     void dataHolderConstruct() throws Exception {
       final var holder = Class.forName("io.github.eschizoid.telescope.codegen.lombok.fixtures.DataUserFieldOptics");
-      final var constructMethod = holder.getDeclaredMethod("construct", java.util.function.Function.class);
+      final var constructMethod = holder.getDeclaredMethod("construct", Function.class);
       final var mods = constructMethod.getModifiers();
-      assertTrue(java.lang.reflect.Modifier.isPublic(mods), "construct must be public");
-      assertTrue(java.lang.reflect.Modifier.isStatic(mods), "construct must be static");
+      assertTrue(Modifier.isPublic(mods), "construct must be public");
+      assertTrue(Modifier.isStatic(mods), "construct must be static");
       assertEquals(DataUser.class, constructMethod.getReturnType(), "construct must return DataUser");
 
       // Drive it directly with a name-keyed lookup function.
-      final java.util.function.Function<String, Object> values = name ->
+      final Function<String, Object> values = name ->
         switch (name) {
           case "id" -> "X-123";
           case "email" -> "noreply@example.com";
@@ -220,10 +222,10 @@ class LombokFocusProcessorTest {
     @DisplayName("Phase D: @Builder holder exposes a public static construct(Function) that chains the builder")
     void builderHolderConstruct() throws Exception {
       final var holder = Class.forName("io.github.eschizoid.telescope.codegen.lombok.fixtures.BuilderUserFieldOptics");
-      final var constructMethod = holder.getDeclaredMethod("construct", java.util.function.Function.class);
+      final var constructMethod = holder.getDeclaredMethod("construct", Function.class);
       assertEquals(BuilderUser.class, constructMethod.getReturnType());
 
-      final java.util.function.Function<String, Object> values = name ->
+      final Function<String, Object> values = name ->
         switch (name) {
           case "id" -> "B-1";
           case "email" -> "builder@example.com";
@@ -238,9 +240,9 @@ class LombokFocusProcessorTest {
   private static void assertHolderField(final Class<?> holder, final String name) throws Exception {
     final var field = holder.getDeclaredField(name);
     final var mods = field.getModifiers();
-    assertTrue(java.lang.reflect.Modifier.isPublic(mods), name + " must be public");
-    assertTrue(java.lang.reflect.Modifier.isStatic(mods), name + " must be static");
-    assertTrue(java.lang.reflect.Modifier.isFinal(mods), name + " must be final");
+    assertTrue(Modifier.isPublic(mods), name + " must be public");
+    assertTrue(Modifier.isStatic(mods), name + " must be static");
+    assertTrue(Modifier.isFinal(mods), name + " must be final");
     assertEquals(Telescope.class, field.getType(), () -> name + " must be a Telescope; was " + field.getType());
   }
 
@@ -283,7 +285,7 @@ class LombokFocusProcessorTest {
 
   private static void assertHasFocusMethod(final Class<?> pathClass, final Class<?> rootType) throws Exception {
     final var start = pathClass.getDeclaredMethod("of");
-    assertTrue(java.lang.reflect.Modifier.isStatic(start.getModifiers()), "start() must be static");
+    assertTrue(Modifier.isStatic(start.getModifiers()), "start() must be static");
     assertEquals(pathClass, start.getReturnType(), () -> "start() should return " + pathClass.getSimpleName());
   }
 

--- a/spring-boot-starter/src/test/java/io/github/eschizoid/telescope/spring/TelescopeMapperRegistryTest.java
+++ b/spring-boot-starter/src/test/java/io/github/eschizoid/telescope/spring/TelescopeMapperRegistryTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.github.eschizoid.telescope.Telescope;
 import io.github.eschizoid.telescope.conversion.Mapper;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
@@ -140,7 +141,7 @@ class TelescopeMapperRegistryTest {
 
     @Bean
     TelescopeMapperRegistry telescopeMapperRegistry() {
-      return new TelescopeMapperRegistry(java.util.List.of(), true);
+      return new TelescopeMapperRegistry(List.of(), true);
     }
   }
 }


### PR DESCRIPTION
## Summary

Replaced `java.util.X` / `java.lang.reflect.X` / `java.util.stream.X` inline qualified names with simple class references + matching imports in 15 files across main + test sources.

## What was kept

- **Test-fixture FQNs** inside `"""..."""` text blocks (BeanFocusProcessorTest, BridgeProcessorTest etc.) — those strings are Java source code fed to annotation processors, and the FQNs avoid requiring the fixture to declare its own imports. Stripping them would force every fixture to grow an import list.
- **\"contains(\\\"import java.util.X;\\\")\"** assertions in codegen tests — those verify generated code, not test code.
- **Comments mentioning `java.lang.reflect.Array`** etc. — they're prose, not Java references.

## Files touched (15)

**Main:**
- `codegen/BridgeProcessor.java` — `LinkedHashMap`
- `core/Sources.java` — `ArrayList`, `Set`
- `core/conversion/ForwardMapper.java` — `Function`
- `core/mapping/Mapping.java` — `Set`, `TreeSet` (from MS-2 enumTo work)
- `internal/Beans.java` — `reflect.Type`
- `internal/MetadataHolderProbe.java` — `reflect.Method`
- `internal/Records.java` — `reflect.Type`
- `internal/optics/collections/Traversals.java` — `stream.StreamSupport`

**Test:**
- `core test/DeepMapCoverageTest.java` — `Mapping`, `List`
- `core test/DeepMappingTest.java` — `Set`
- `core test/TypedContainerPathTest.java` — `stream.Collectors`
- `core test/beans/PojoOpticsTest.java` — `Map`, `Optional`
- `internal test/ReflectiveStructuralIsoTest.java` — `ArrayList`, `List`
- `lombok test/LombokFocusProcessorTest.java` — `reflect.Modifier`, `function.Function`
- `spring-boot-starter test/TelescopeMapperRegistryTest.java` — `List`

## Test plan

- [x] `./gradlew test` green (46 tasks, all 200+ tests pass)
- [x] No new compile warnings
- [x] No FQN appearing in non-fixture, non-import, non-comment code on a final grep