### PR TITLE
chore: LMF-cache bean intermediate allocator + IntelliJ warning sweep

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ final var userCity = Telescope.of(User.class).field(User::address).field(Address
 
 // 2. Use it for reading, updating, anything else.
 String city = userCity.read(alice); // → "Springfield"
+
 User shouted = userCity.update(alice, String::toUpperCase); // → city becomes "SPRINGFIELD"
 ```
 

--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
@@ -748,7 +748,7 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
 
     // Validate every transform field is a real source field (drops would mask the validation).
     for (final var t : transforms.keySet()) {
-      if (!sourceFields.stream().anyMatch(f -> f.name().equals(t))) {
+      if (sourceFields.stream().noneMatch(f -> f.name().equals(t))) {
         error(
           source,
           "@Bridge transforms field=\"" +
@@ -773,7 +773,7 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
     // default-overlap passes a literal-typed value to the bridge expecting the source type. Both
     // are silent-wrong paths until the user hits the generated-file diagnostic — too late.
     for (final var v : viaMappers.keySet()) {
-      if (!sourceFields.stream().anyMatch(f -> f.name().equals(v))) {
+      if (sourceFields.stream().noneMatch(f -> f.name().equals(v))) {
         error(
           source,
           "@Bridge viaMappers field=\"" +
@@ -1384,7 +1384,8 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
         } else if (caseBridges.size() == 1) {
           // Single @Bridge whose target isn't in the sealed-target permits — name it explicitly.
           final var only = targetTypeFromMirror(caseBridges.get(0));
-          final var onlyEl = (TypeElement) ((DeclaredType) only).asElement();
+          if (!(only instanceof DeclaredType decl)) continue;
+          final var onlyEl = (TypeElement) decl.asElement();
           error(
             source,
             "Subtype " +
@@ -1521,11 +1522,6 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
         );
       }
     );
-  }
-
-  private static String camelLower(final String simpleName) {
-    if (simpleName.isEmpty()) return simpleName;
-    return Character.toLowerCase(simpleName.charAt(0)) + simpleName.substring(1);
   }
 
   /**

--- a/core/src/main/java/io/github/eschizoid/telescope/DeepMap.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/DeepMap.java
@@ -17,7 +17,6 @@ import io.github.eschizoid.telescope.mapping.TelescopeToTelescope;
 import io.github.eschizoid.telescope.mapping.TypedTransformTo;
 import io.github.eschizoid.telescope.mapping.Via;
 import io.github.eschizoid.telescope.mapping.WriteHint;
-import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
@@ -1081,31 +1080,12 @@ public final class DeepMap {
     // pattern (Lombok @Builder, Immutables-style). Skip JDK scalars / containers entirely so the
     // records path stays unchanged. Telescope-row writes go through the bean's setters at each
     // hop, so each intermediate just needs to be non-null; the setters overwrite the
-    // default-initialised fields. If neither strategy works, return null — same behaviour as
-    // before bean-intermediate support.
+    // default-initialised fields. If neither strategy works, the cached supplier yields null —
+    // same behaviour as before bean-intermediate support, but no per-call
+    // `getDeclaredConstructor` / `getMethod("builder")` reflection: both shapes are LMF-cached
+    // per class via {@link Beans#intermediateAllocator}.
     if (beanIntermediateAllocatable(type)) {
-      try {
-        return type.getDeclaredConstructor().newInstance();
-      } catch (
-        final NoSuchMethodException
-        | InstantiationException
-        | IllegalAccessException
-        | InvocationTargetException ignored
-      ) {
-        // no public no-arg ctor — try the builder pattern
-      }
-      try {
-        final var builderMethod = type.getMethod("builder");
-        if (Modifier.isStatic(builderMethod.getModifiers()) && Modifier.isPublic(builderMethod.getModifiers())) {
-          final var builder = builderMethod.invoke(null);
-          if (builder != null) {
-            final var buildMethod = builder.getClass().getMethod("build");
-            return buildMethod.invoke(builder);
-          }
-        }
-      } catch (final NoSuchMethodException | IllegalAccessException | InvocationTargetException ignored) {
-        // fall through to null
-      }
+      return Beans.intermediateAllocator(type).get();
     }
     return null;
   }

--- a/core/src/main/java/io/github/eschizoid/telescope/Merge.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/Merge.java
@@ -141,9 +141,8 @@ final class Merge {
           ". Add an explicit MergeStep.from(...) row with a converter, or rename to break the name match if this row was unintentional."
       );
       claimedTgt.add(name);
-      final String capturedName = name;
-      final Getter<Object, Object> reader = src -> sourceRefl.read(src, capturedName);
-      out.add(new ResolvedStep(sourceClass, reader, capturedName));
+      final Getter<Object, Object> reader = src -> sourceRefl.read(src, name);
+      out.add(new ResolvedStep(sourceClass, reader, name));
     }
   }
 

--- a/core/src/main/java/io/github/eschizoid/telescope/Sources.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/Sources.java
@@ -60,7 +60,7 @@ public final class Sources {
   public static Sources of(final Object... sources) {
     Objects.requireNonNull(sources, "Sources.of: sources array is null");
     final var map = new LinkedHashMap<Class<?>, Object>();
-    final var list = new ArrayList<Object>(sources.length);
+    final var list = new ArrayList<>(sources.length);
     for (final var s : sources) {
       if (s == null) throw new IllegalArgumentException(
         "Sources.of: source at position " + list.size() + " is null. Every source in a merge bag must be non-null."

--- a/core/src/main/java/io/github/eschizoid/telescope/Telescope.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/Telescope.java
@@ -228,7 +228,7 @@ public sealed class Telescope<
    * @see BridgeFn
    */
   public static <A, B> Telescope<A, B> bridge(final BridgeFn<A, B> fn) {
-    final Iso<A, B> iso = new Iso<A, B>() {
+    final Iso<A, B> iso = new Iso<>() {
       @Override
       public B to(final A source) {
         return fn.forward(source);
@@ -1502,7 +1502,7 @@ public sealed class Telescope<
         holder.holderClass().getName() +
         "). Re-run the @Focus / @BeanFocus processor."
     );
-    return (Lens<S, A>) (Lens<?, ?>) ((Telescope<?, ?>) constant).optic;
+    return (Lens<S, A>) ((Telescope<?, ?>) constant).optic;
   }
 
   /**
@@ -1526,7 +1526,7 @@ public sealed class Telescope<
     for (final var name : componentNames) {
       final var constant = holder.constantsByName().get(name);
       if (constant == null) return null;
-      readers.put(name, (Lens<Object, Object>) (Lens<?, ?>) ((Telescope<?, ?>) constant).optic);
+      readers.put(name, (Lens<Object, Object>) ((Telescope<?, ?>) constant).optic);
     }
     return readers;
   }

--- a/core/src/main/java/io/github/eschizoid/telescope/conversion/ForwardMapper.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/conversion/ForwardMapper.java
@@ -91,7 +91,7 @@ public final class ForwardMapper<A, B> {
    * {@code Getter<A, A>} and composing it before the existing read. Chains compose left-to-right.
    */
   public ForwardMapper<A, B> beforeForward(final Function<? super A, ? extends A> hook) {
-    final Getter<A, A> pre = a -> hook.apply(a);
+    final Getter<A, A> pre = hook::apply;
     return new ForwardMapper<>(pre.then(forward), sourceClass, targetClass);
   }
 
@@ -103,7 +103,7 @@ public final class ForwardMapper<A, B> {
    * <p>Lattice-native: routes through {@code Getter.then(Getter)}.
    */
   public ForwardMapper<A, B> afterForward(final Function<? super B, ? extends B> hook) {
-    final Getter<B, B> post = b -> hook.apply(b);
+    final Getter<B, B> post = hook::apply;
     return new ForwardMapper<>(forward.then(post), sourceClass, targetClass);
   }
 

--- a/core/src/main/java/io/github/eschizoid/telescope/conversion/Mapper.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/conversion/Mapper.java
@@ -251,7 +251,7 @@ public final class Mapper<A, B> {
    */
   public Mapper<A, B> beforeForward(final Function<? super A, ? extends A> hook) {
     final Function<A, A> prev = this.preForward;
-    final Function<A, A> next = prev == null ? a -> hook.apply(a) : a -> hook.apply(prev.apply(a));
+    final Function<A, A> next = prev == null ? hook::apply : a -> hook.apply(prev.apply(a));
     return new Mapper<>(
       iso,
       sourceClass,
@@ -304,8 +304,7 @@ public final class Mapper<A, B> {
    */
   public Mapper<A, B> afterForward(final BiFunction<? super A, ? super B, ? extends B> hook) {
     final BiFunction<A, B, B> prev = this.postForward;
-    final BiFunction<A, B, B> next =
-      prev == null ? (a, b) -> hook.apply(a, b) : (a, b) -> hook.apply(a, prev.apply(a, b));
+    final BiFunction<A, B, B> next = prev == null ? hook::apply : (a, b) -> hook.apply(a, prev.apply(a, b));
     return new Mapper<>(iso, sourceClass, targetClass, patchByTargetField, preForward, next, preBackward, postBackward);
   }
 
@@ -325,7 +324,7 @@ public final class Mapper<A, B> {
    */
   public Mapper<A, B> beforeBackward(final Function<? super B, ? extends B> hook) {
     final Function<B, B> prev = this.preBackward;
-    final Function<B, B> next = prev == null ? b -> hook.apply(b) : b -> hook.apply(prev.apply(b));
+    final Function<B, B> next = prev == null ? hook::apply : b -> hook.apply(prev.apply(b));
     return new Mapper<>(iso, sourceClass, targetClass, patchByTargetField, preForward, postForward, next, postBackward);
   }
 
@@ -359,8 +358,7 @@ public final class Mapper<A, B> {
    */
   public Mapper<A, B> afterBackward(final BiFunction<? super B, ? super A, ? extends A> hook) {
     final BiFunction<B, A, A> prev = this.postBackward;
-    final BiFunction<B, A, A> next =
-      prev == null ? (b, a) -> hook.apply(b, a) : (b, a) -> hook.apply(b, prev.apply(b, a));
+    final BiFunction<B, A, A> next = prev == null ? hook::apply : (b, a) -> hook.apply(b, prev.apply(b, a));
     return new Mapper<>(iso, sourceClass, targetClass, patchByTargetField, preForward, postForward, preBackward, next);
   }
 

--- a/core/src/main/java/io/github/eschizoid/telescope/effects/Either.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/effects/Either.java
@@ -92,7 +92,6 @@ public sealed interface Either<L, R> {
    *     company -> "saved " + company.name());
    * }</pre>
    */
-  @SuppressWarnings("unchecked")
   default <T> T fold(final Function<? super L, ? extends T> onLeft, final Function<? super R, ? extends T> onRight) {
     // Sealed-aware dispatch: a single instanceof + a guaranteed-safe cast on the other branch.
     // Avoids the dead "second instanceof always true" branch the explicit double-instanceof pattern
@@ -125,9 +124,8 @@ public sealed interface Either<L, R> {
    * Either<String, Integer> parsed = Either.right("42").flatMap(s -> parseInt(s));  // parseInt returns Either
    * }</pre>
    */
-  @SuppressWarnings("unchecked")
   default <T> Either<L, T> flatMap(final Function<? super R, ? extends Either<L, T>> f) {
-    return fold(Either::left, r -> (Either<L, T>) f.apply(r));
+    return fold(Either::left, f);
   }
 
   /**

--- a/core/src/main/java/io/github/eschizoid/telescope/effects/Validated.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/effects/Validated.java
@@ -115,7 +115,6 @@ public sealed interface Validated<E, A> {
    *     company -> "saved " + company.name());
    * }</pre>
    */
-  @SuppressWarnings("unchecked")
   default <T> T fold(
     final Function<? super List<E>, ? extends T> onInvalid,
     final Function<? super A, ? extends T> onValid
@@ -165,9 +164,8 @@ public sealed interface Validated<E, A> {
    * final Validated<String, Integer> v = parse(input).andThen(this::inRange);
    * }</pre>
    */
-  @SuppressWarnings("unchecked")
   default <B> Validated<E, B> andThen(final Function<? super A, ? extends Validated<E, B>> f) {
-    return fold(Validated::invalid, v -> (Validated<E, B>) f.apply(v));
+    return fold(Validated::invalid, f);
   }
 
   /**

--- a/core/src/test/java/io/github/eschizoid/telescope/DeepMapCoverageTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/DeepMapCoverageTest.java
@@ -209,10 +209,7 @@ class DeepMapCoverageTest {
       final var mapper = Telescope.mapper(
         Slim.class,
         BeanOuter.class,
-        Mapping.to(
-          Slim::value,
-          Telescope.ofBean(BeanOuter.class).field(BeanOuter::getInner).field(BeanInner::getValue)
-        )
+        Mapping.to(Slim::value, Telescope.ofBean(BeanOuter.class).field(BeanOuter::getInner).field(BeanInner::getValue))
       );
 
       final var out = mapper.forward(new Slim("hello"));
@@ -275,10 +272,7 @@ class DeepMapCoverageTest {
       final var mapper = Telescope.mapper(
         Slim.class,
         Outer.class,
-        Mapping.to(
-          Slim::tag,
-          Telescope.of(Outer.class).field(Outer::prims).field(AllPrims::tag)
-        )
+        Mapping.to(Slim::tag, Telescope.of(Outer.class).field(Outer::prims).field(AllPrims::tag))
       );
 
       // Slim has no fields matching long/byte/short/char/float; the AllPrims intermediate is

--- a/core/src/test/java/io/github/eschizoid/telescope/TypedContainerPathTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/TypedContainerPathTest.java
@@ -101,10 +101,7 @@ class TypedContainerPathTest {
       final Telescope<TagSet, Set<Tag>> raw = Telescope.of(TagSet.class).field(TagSet::tags);
       final SetTelescope<TagSet, Tag> promoted = Telescope.asSet(raw);
       final var src = new TagSet("alice", new LinkedHashSet<>(List.of(new Tag("a"))));
-      assertEquals(
-        Set.of(new Tag("a")),
-        promoted.each().toList(src).stream().collect(Collectors.toSet())
-      );
+      assertEquals(Set.of(new Tag("a")), promoted.each().toList(src).stream().collect(Collectors.toSet()));
     }
   }
 

--- a/internal/src/main/java/io/github/eschizoid/telescope/internal/Beans.java
+++ b/internal/src/main/java/io/github/eschizoid/telescope/internal/Beans.java
@@ -89,6 +89,21 @@ public final class Beans {
   };
 
   /**
+   * Per-class cached {@link Supplier} that returns a fresh allocation of {@code cls}: tries a
+   * public no-arg constructor first, then a public static {@code builder().build()} pair, and
+   * finally yields {@code null} if neither shape works. Used by {@code DeepMap} for intermediate
+   * bean allocations during recursive default-tree materialisation. LMF-cached so the per-call cost
+   * is one virtual {@code Supplier.get()} regardless of which shape applies — no per-call {@code
+   * Class.getDeclaredConstructor} / {@code Method.getMethod("build")} reflection.
+   */
+  private static final ClassValue<Supplier<Object>> INTERMEDIATE_ALLOCATORS = new ClassValue<>() {
+    @Override
+    protected Supplier<Object> computeValue(final Class<?> type) {
+      return computeIntermediateAllocator(type);
+    }
+  };
+
+  /**
    * The {@code org.hibernate.proxy.HibernateProxy} interface, or {@code null} when Hibernate isn't
    * on the classpath. Resolved once via reflection so the {@code :core} module stays free of any
    * Hibernate dependency.
@@ -115,6 +130,85 @@ public final class Beans {
       return Class.forName(fqn, false, Beans.class.getClassLoader());
     } catch (final ClassNotFoundException e) {
       return null;
+    }
+  }
+
+  /**
+   * Public, cached entry point for intermediate bean allocation during recursive default-tree
+   * materialisation in {@code DeepMap.recursiveDefault}. Returns a {@link Supplier} that yields a
+   * fresh instance via either a public no-arg constructor or a public static {@code
+   * builder().build()} pair; yields {@code null} when neither shape works. Cached per class via
+   * {@link ClassValue} — the per-call cost is one virtual {@code Supplier.get()}.
+   */
+  public static Supplier<Object> intermediateAllocator(final Class<?> cls) {
+    return INTERMEDIATE_ALLOCATORS.get(cls);
+  }
+
+  private static Supplier<Object> computeIntermediateAllocator(final Class<?> type) {
+    // Try a public no-arg ctor first — matches DeepMap.recursiveDefault's prior strategy.
+    try {
+      final var ctor = type.getDeclaredConstructor();
+      if (Modifier.isPublic(ctor.getModifiers())) {
+        final var lookup = MethodHandles.privateLookupIn(type, MethodHandles.lookup());
+        return buildCtorSupplier(type, ctor, lookup);
+      }
+    } catch (final NoSuchMethodException | IllegalAccessException ignored) {
+      // No public no-arg ctor — try the builder pattern.
+    }
+    try {
+      final var builderMethod = type.getMethod("builder");
+      if (Modifier.isStatic(builderMethod.getModifiers()) && Modifier.isPublic(builderMethod.getModifiers())) {
+        return buildBuilderBuildSupplier(type, builderMethod);
+      }
+    } catch (final NoSuchMethodException ignored) {
+      // No static builder() — fall through to the null supplier.
+    }
+    return () -> null;
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Supplier<Object> buildBuilderBuildSupplier(final Class<?> type, final Method builderMethod) {
+    try {
+      // privateLookupIn lets the lookup cross JPMS module + package boundaries to reach the
+      // user's builder method. The user's package must be `opens io.github.eschizoid.telescope`
+      // (same JPMS requirement as the rest of the runtime path); without it, the unreflect
+      // throws IllegalAccessException and we fall through to the null supplier.
+      final var lookup = MethodHandles.privateLookupIn(type, MethodHandles.lookup());
+      final var builderHandle = lookup.unreflect(builderMethod);
+      final var builderReturnType = builderMethod.getReturnType();
+      final var builderCallSite = LambdaMetafactory.metafactory(
+        lookup,
+        "get",
+        MethodType.methodType(Supplier.class),
+        MethodType.methodType(Object.class),
+        builderHandle,
+        MethodType.methodType(builderReturnType)
+      );
+      final var builderFn = (Supplier<Object>) builderCallSite.getTarget().invoke();
+      final var buildMethod = builderReturnType.getMethod("build");
+      // The Builder class itself usually lives in the same package as `type`, but for nested
+      // builders (Builder is an inner class of the enclosing type) the same lookup already
+      // covers it. For builders in different packages we'd need a second privateLookupIn keyed
+      // on the builder class; the tests cover the common nested-Builder shape that the same
+      // lookup handles.
+      final var buildLookup =
+        builderReturnType == type ? lookup : MethodHandles.privateLookupIn(builderReturnType, MethodHandles.lookup());
+      final var buildHandle = buildLookup.unreflect(buildMethod);
+      final var buildCallSite = LambdaMetafactory.metafactory(
+        buildLookup,
+        "apply",
+        MethodType.methodType(Function.class),
+        MethodType.methodType(Object.class, Object.class),
+        buildHandle,
+        MethodType.methodType(buildMethod.getReturnType(), builderReturnType)
+      );
+      final var buildFn = (Function<Object, Object>) buildCallSite.getTarget().invoke();
+      return () -> buildFn.apply(builderFn.get());
+    } catch (final Throwable t) {
+      // If we can't bind either half of the chain, yield null instead of failing eagerly — the
+      // caller (DeepMap.recursiveDefault) treats null as "no intermediate available" and skips
+      // that branch of the default tree.
+      return () -> null;
     }
   }
 

--- a/lombok/src/test/java/io/github/eschizoid/telescope/codegen/lombok/LombokFocusProcessorTest.java
+++ b/lombok/src/test/java/io/github/eschizoid/telescope/codegen/lombok/LombokFocusProcessorTest.java
@@ -152,10 +152,7 @@ class LombokFocusProcessorTest {
       // Utility holder — final class, private no-arg ctor only.
       assertTrue(Modifier.isFinal(holder.getModifiers()), "holder must be final");
       assertEquals(1, holder.getDeclaredConstructors().length, "holder must have exactly one (private) constructor");
-      assertTrue(
-        Modifier.isPrivate(holder.getDeclaredConstructors()[0].getModifiers()),
-        "holder ctor must be private"
-      );
+      assertTrue(Modifier.isPrivate(holder.getDeclaredConstructors()[0].getModifiers()), "holder ctor must be private");
 
       assertHolderField(holder, "id");
       assertHolderField(holder, "email");


### PR DESCRIPTION
## Summary

Two-part cleanup ahead of cutting 1.0:

### 1. Closes the last per-call reflective dispatch in the runtime hot path

\`DeepMap.recursiveDefault\` was calling \`type.getDeclaredConstructor().newInstance()\` on every forward invocation of an intermediate bean allocation, plus \`type.getMethod(\"builder\").invoke(null)\` + \`builder.getClass().getMethod(\"build\").invoke(builder)\` for the builder fallback. All three are now LMF-cached per class via a new \`Beans.intermediateAllocator(Class) → Supplier<Object>\`, mirroring the existing pattern in \`buildCtorSupplier\`. The supplier is \`ClassValue\`-cached; per-call cost drops to one virtual \`Supplier.get()\`.

Closes the ADR-0006 carve-out (\"metadata-probing reflection still in Reflective.java\"). Every runtime hot-path dispatch is now LMF-bound for annotated AND unannotated types.

### 2. IntelliJ MCP warning sweep across production source

~30 warnings fixed across \`core\`, \`internal\`, \`codegen\`. Highlights:

- Redundant double-casts in \`Telescope.singleHolderLens\` / \`holderReadersFor\`
- Lambda-to-method-ref in all \`Mapper\`/\`ForwardMapper\` hook composition (\`hook::apply\`)
- Defensive \`instanceof DeclaredType\` guard in \`BridgeProcessor\` against potential NPE on \`asElement()\`
- \`!stream.anyMatch\` → \`stream.noneMatch\` x2 in \`BridgeProcessor\` field validation
- Removed unused private \`camelLower\` helper
- Removed redundant \`@SuppressWarnings(\"unchecked\")\` + redundant casts in \`Either.fold\`/\`flatMap\` and \`Validated.fold\`/\`andThen\`
- Diamond operator wins where IntelliJ flagged them

### What was skipped (and why)

- **\"Unused\" warnings on public-API methods** (\`Sources.arity\`, \`Mapper.liftSet/liftOptional/liftMapValues\`, \`ForwardMapper\` hooks) — public API; IntelliJ can't see external callers
- **Cross-module \`@link\` javadoc errors** (\`Method#invoke\`, \`Class#forName\`) — IntelliJ misreads JPMS qualified-exports; the \`@link\` targets resolve fine in actual javadoc generation
- **Quarkus \`@All List<Mapper<?,?>>\` unsatisfied-dependency** — Arc DI resolves at runtime
- **\"Could extract method\" / \"Duplicated code fragment\"** weak warnings — refactoring suggestions, not defects

## Test plan

- [x] \`./gradlew test\` green (46 actionable tasks, all 200+ tests pass)
- [x] \`MappingIntermediateAllocationTest\` — builder-fallback test exercises the new \`buildBuilderBuildSupplier\` LMF chain end-to-end (previously failed during dev because plain \`MethodHandles.lookup()\` doesn't cross JPMS module boundaries; fixed with \`privateLookupIn\`)
- [x] Spotless clean