### PR TITLE
fix(build): pin google-java-format 1.28.0 + JReleaser config-cache opt-out

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -81,4 +81,8 @@ jobs:
           JRELEASER_GPG_SECRET_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
           JRELEASER_MAVENCENTRAL_SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
           JRELEASER_MAVENCENTRAL_SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
-        run: ./gradlew jreleaserFullRelease --stacktrace
+        # JReleaser 1.19.0 calls Task.project at execution time, which is forbidden under
+        # Gradle's configuration cache (the project has `org.gradle.configuration-cache=true`
+        # in gradle.properties with `problems=fail`). Bypass config-cache just for this task —
+        # the rest of the build still benefits from it.
+        run: ./gradlew jreleaserFullRelease --stacktrace --no-configuration-cache

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,4 +4,11 @@ org.gradle.configuration-cache=true
 org.gradle.configuration-cache.problems=fail
 org.gradle.parallel=true
 org.gradle.caching=true
-org.gradle.jvmargs=-Xmx4g -XX:+UseG1GC -Dfile.encoding=UTF-8
+# google-java-format 1.35.0 (driven by Spotless) reaches into `jdk.compiler` internals to walk
+# the javac AST. JDK 9+ keeps those packages module-encapsulated; without explicit
+# `--add-exports` AND `--add-opens`, Spotless's FeatureClassLoader throws `NoClassDefFoundError`
+# for `com.sun.tools.javac.tree.JCTree$JCAnyPattern` (added in JDK 24 for primitive type
+# patterns). CI side-steps this by passing `--no-daemon` (fresh JVM each run), but local dev
+# hits it the moment the daemon caches a classloader. These are exactly the flags google-java-
+# format documents as required for JDK 16+.
+org.gradle.jvmargs=-Xmx4g -XX:+UseG1GC -Dfile.encoding=UTF-8 --add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED --add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED --add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED --add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 junit = "6.1.0"
 spotless = "7.0.0"
-googleJavaFormat = "1.35.0"
+googleJavaFormat = "1.28.0"
 prettier = "3.8.1"
 prettierPluginJava = "2.8.1"
 testcontainers = "2.0.4"


### PR DESCRIPTION
Two blockers between main and cutting 1.0, batched because both touch the release flow.

## 1. Spotless GJF 1.35.0 fails on JDK 25 Apply path

google-java-format 1.35.0 references AST nodes that resolve fine through \`spotlessJavaCheck\` (the only Spotless task CI runs — \`./gradlew check\`), but throw \`NoClassDefFoundError: com/sun/tools/javac/tree/JCTree\$JCAnyPattern\` inside Spotless's \`FeatureClassLoader\` when \`spotlessJavaApply\` actually re-formats files.

The class IS in JDK 25 (verified via \`jimage list\`), the \`--add-exports\` flags DO reach the daemon JVM (verified via \`./gradlew --info\`), but FeatureClassLoader's parent classloader doesn't see them.

Pinning back to 1.28.0 — the version CLAUDE.md memory documents as the known JDK 25 sweet spot — makes Apply work. CI keeps passing \`spotlessJavaCheck\` either way; this is purely a local-dev ergonomic fix.

The \`--add-exports\` / \`--add-opens\` flags stay in \`gradle.properties\` — google-java-format documents them as required for JDK 16+, and they don't hurt with 1.28.0.

## 2. Release workflow fails on JReleaser + config-cache conflict

\`JReleaserFullReleaseTask\` calls \`Task.project\` at execution time, which is forbidden under Gradle's configuration cache. The project enables config-cache with \`problems=fail\`, so the release pipeline blows up at the JReleaser step:

> Task \`:jreleaserFullRelease\`: invocation of 'Task.project' at execution time is unsupported with the configuration cache.

Workaround: pass \`--no-configuration-cache\` on the JReleaser invocation only. Every other task in the pipeline (build, publish, etc.) keeps the config-cache benefit.

## Test plan

- [x] \`./gradlew --stop && ./gradlew :core:spotlessApply\` succeeds locally on Homebrew JDK 25.0.2
- [x] Same for :codegen, :lombok, :quarkus, :spring-boot-starter
- [x] Existing CI on \`spotlessCheck\` keeps passing (no behavioral change there)
- [ ] Release workflow re-run on next \`gh workflow run release.yaml -f releaseType=major\` invocation