### PR TITLE
feat(mapping): Mapping.when(predicate, inner) — predicate-gated telescope rows (#1.3)

### DIFF
--- a/core/src/main/java/io/github/eschizoid/telescope/DeepMap.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/DeepMap.java
@@ -558,13 +558,20 @@ public final class DeepMap {
           // propagate raw — the breadcrumb is even more valuable for those.
           final var inner = cond.inner();
           final var innerField = inner.sourceField() == null ? "<telescope>" : inner.sourceField();
+          // Include the failure CLASS name — predicate.test() commonly throws NPE on null
+          // navigation, where getMessage() returns null and "Predicate failure: null" tells the
+          // user nothing. The class name (NullPointerException, ClassCastException, etc.) carries
+          // the actionable signal even when the message is null.
+          final var failureType = predicateFailure.getClass().getSimpleName();
+          final var failureMsg = predicateFailure.getMessage();
           throw new IllegalStateException(
             "Mapping.when(...) predicate threw — inner=" +
               inner.getClass().getSimpleName() +
               " (sourceField=" +
               innerField +
               "). Predicate failure: " +
-              predicateFailure.getMessage(),
+              failureType +
+              (failureMsg == null ? "" : ": " + failureMsg),
             predicateFailure
           );
         }

--- a/core/src/main/java/io/github/eschizoid/telescope/DeepMap.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/DeepMap.java
@@ -548,11 +548,14 @@ public final class DeepMap {
         final boolean accepted;
         try {
           accepted = predicate.test(s);
-        } catch (final RuntimeException predicateFailure) {
-          // Decorate user-predicate exceptions with the row's inner-kind + source field
-          // breadcrumb so the failure points at the user's when(...) site, not at an opaque
-          // applyForward stack frame. Matches the self-diagnosing style of Mapping.zip's
-          // cardinality check below.
+        } catch (final Throwable predicateFailure) {
+          // Decorate user-predicate exceptions (including Errors like StackOverflowError on a
+          // self-recursive predicate, AssertionError on a `assert` in the body, and
+          // NoClassDefFoundError) with the row's inner-kind + source field breadcrumb so the
+          // failure points at the user's when(...) site, not at an opaque applyForward stack
+          // frame. Matches the self-diagnosing style of Mapping.zip's cardinality check below.
+          // Widened from RuntimeException to Throwable because the original catch let Errors
+          // propagate raw — the breadcrumb is even more valuable for those.
           final var inner = cond.inner();
           final var innerField = inner.sourceField() == null ? "<telescope>" : inner.sourceField();
           throw new IllegalStateException(

--- a/core/src/main/java/io/github/eschizoid/telescope/DeepMap.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/DeepMap.java
@@ -5,6 +5,7 @@ import io.github.eschizoid.telescope.internal.Beans;
 import io.github.eschizoid.telescope.internal.Reflective;
 import io.github.eschizoid.telescope.internal.optics.Iso;
 import io.github.eschizoid.telescope.mapping.Compute;
+import io.github.eschizoid.telescope.mapping.Conditional;
 import io.github.eschizoid.telescope.mapping.Constant;
 import io.github.eschizoid.telescope.mapping.Drop;
 import io.github.eschizoid.telescope.mapping.ForwardOnlyTransformTo;
@@ -34,6 +35,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
+import java.util.function.Predicate;
 
 /**
  * Engine for {@link Telescope#map(Class, Class, MapStep...)} / {@link Telescope#mapper(Class,
@@ -289,7 +291,13 @@ public final class DeepMap {
     final var telescopeWritesTgt = new HashSet<String>();
     final var telescopeFixups = new ArrayList<Mapping<?, ?>>();
 
-    for (final var row : overrides.getOrDefault(key, List.of())) {
+    for (final var rawRow : overrides.getOrDefault(key, List.of())) {
+      // Conditional<A, B>(predicate, inner) wraps a telescope-based row. For soft-claim routing,
+      // peel to the inner — Conditional delegates sourceField/targetField/sourceClass/targetClass
+      // to inner already, so the metadata is identical, but the telescope-shape checks below need
+      // the concrete inner type. The Conditional itself (rawRow) goes into telescopeFixups so
+      // applyForward can evaluate the predicate before dispatching the inner's effect.
+      final Mapping<?, ?> row = (rawRow instanceof Conditional<?, ?> c) ? c.inner() : rawRow;
       // Normalize raw method names per side — record::name stays "name", bean::getName becomes
       // "name".
       final var srcField = srcRefl.normalize(row.sourceField());
@@ -300,7 +308,7 @@ public final class DeepMap {
         telescopeReadsSrc.add(srcField);
         final var firstTgtHop = tRow.targetTelescope().firstHopName();
         if (firstTgtHop != null) telescopeWritesTgt.add(tgtRefl.normalize(firstTgtHop));
-        telescopeFixups.add(tRow);
+        telescopeFixups.add(rawRow);
         continue;
       }
       // FromTelescopeTo: nested source telescope → flat target accessor — soft claim mirror.
@@ -309,7 +317,7 @@ public final class DeepMap {
         telescopeWritesTgt.add(tgtRefl.normalize(row.targetField()));
         final var firstSrcHop = fRow.sourceTelescope().firstHopName();
         if (firstSrcHop != null) telescopeReadsSrc.add(srcRefl.normalize(firstSrcHop));
-        telescopeFixups.add(fRow);
+        telescopeFixups.add(rawRow);
         continue;
       }
       // TelescopeToTelescope (covers both Kind.BROADCAST from Mapping.to and Kind.ZIP from
@@ -321,7 +329,7 @@ public final class DeepMap {
         final var firstTgtHop = ttRow.targetTelescope().firstHopName();
         if (firstSrcHop != null) telescopeReadsSrc.add(srcRefl.normalize(firstSrcHop));
         if (firstTgtHop != null) telescopeWritesTgt.add(tgtRefl.normalize(firstTgtHop));
-        telescopeFixups.add(ttRow);
+        telescopeFixups.add(rawRow);
         continue;
       }
       // Constant / Compute rows are target-injection telescope fixups: claim the target
@@ -335,13 +343,13 @@ public final class DeepMap {
       if (row instanceof Constant<?, ?, ?> cRow) {
         final var firstTgtHop = cRow.targetTelescope().firstHopName();
         if (firstTgtHop != null) telescopeWritesTgt.add(tgtRefl.normalize(firstTgtHop));
-        telescopeFixups.add(cRow);
+        telescopeFixups.add(rawRow);
         continue;
       }
       if (row instanceof Compute<?, ?, ?> cpRow) {
         final var firstTgtHop = cpRow.targetTelescope().firstHopName();
         if (firstTgtHop != null) telescopeWritesTgt.add(tgtRefl.normalize(firstTgtHop));
-        telescopeFixups.add(cpRow);
+        telescopeFixups.add(rawRow);
         continue;
       }
       // Drop rows claim a source field with no target counterpart — they exist to satisfy the
@@ -528,7 +536,40 @@ public final class DeepMap {
   @SuppressWarnings({ "unchecked", "rawtypes" })
   private static <S, T> T applyForward(final T initial, final S s, final List<Mapping<?, ?>> fixups) {
     T t = initial;
-    for (final var fx : fixups) {
+    for (final var rawFx : fixups) {
+      // Conditional<A, B>(predicate, inner) gates the inner row's forward effect by the source
+      // predicate. When the predicate rejects the source, skip the row entirely — the target
+      // field keeps whatever the base structural Iso produced. Predicate cast widens the
+      // upper-bound wildcard `? super A` against the type-erased source `s`; safe because the
+      // mapper's Class<A> verifies s at runtime through the surrounding forward(...) entry.
+      final Mapping<?, ?> fx;
+      if (rawFx instanceof Conditional<?, ?> cond) {
+        final var predicate = (Predicate<Object>) cond.predicate();
+        final boolean accepted;
+        try {
+          accepted = predicate.test(s);
+        } catch (final RuntimeException predicateFailure) {
+          // Decorate user-predicate exceptions with the row's inner-kind + source field
+          // breadcrumb so the failure points at the user's when(...) site, not at an opaque
+          // applyForward stack frame. Matches the self-diagnosing style of Mapping.zip's
+          // cardinality check below.
+          final var inner = cond.inner();
+          final var innerField = inner.sourceField() == null ? "<telescope>" : inner.sourceField();
+          throw new IllegalStateException(
+            "Mapping.when(...) predicate threw — inner=" +
+              inner.getClass().getSimpleName() +
+              " (sourceField=" +
+              innerField +
+              "). Predicate failure: " +
+              predicateFailure.getMessage(),
+            predicateFailure
+          );
+        }
+        if (!accepted) continue;
+        fx = cond.inner();
+      } else {
+        fx = rawFx;
+      }
       if (fx instanceof TelescopeTo<?, ?, ?> r) {
         final var srcAcc = (Telescope.Accessor<S, Object>) r.srcAccessor();
         final var tgtT = (Telescope<T, Object>) r.targetTelescope();
@@ -582,6 +623,10 @@ public final class DeepMap {
     // they apply via srcT.set on the rebuilt baseS, after the name-keyed rebuild finishes.
     final var fieldOverrides = new HashMap<String, Object>();
     for (final var fx : fixups) {
+      // Conditional rows are forward-only by design — same retraction semantics as Constant /
+      // Compute. The source rebuild leaves the corresponding source field at the baseS value;
+      // forward(backward(t)) is intentionally asymmetric for predicate-gated rows.
+      if (fx instanceof Conditional<?, ?>) continue;
       if (fx instanceof TelescopeTo<?, ?, ?> r) {
         final var tgtT = (Telescope<T, Object>) r.targetTelescope();
         fieldOverrides.put(srcRefl.normalize(r.sourceField()), tgtT.read(t));
@@ -592,6 +637,7 @@ public final class DeepMap {
     );
     // Telescope-source fixups overlay AFTER the name-keyed rebuild, via srcT.set on s.
     for (final var fx : fixups) {
+      if (fx instanceof Conditional<?, ?>) continue;
       if (fx instanceof FromTelescopeTo<?, ?, ?> r) {
         final var srcT = (Telescope<S, Object>) r.sourceTelescope();
         final var tgtAcc = (Telescope.Accessor<T, Object>) r.tgtAccessor();

--- a/core/src/main/java/io/github/eschizoid/telescope/mapping/Conditional.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/mapping/Conditional.java
@@ -1,0 +1,150 @@
+package io.github.eschizoid.telescope.mapping;
+
+import java.util.Objects;
+import java.util.function.Predicate;
+
+/**
+ * Predicate-gated wrapper around a telescope-based {@link Mapping} row — closes MapStruct's
+ * {@code @Condition} for whole-source predicate gating. When the predicate accepts the source
+ * object, the inner row applies normally; when it rejects, the inner row is skipped at forward
+ * time.
+ *
+ * <pre>{@code
+ * Telescope.mapper(Order.class, OrderDto.class,
+ *     to(Order::id, OrderDto::id),
+ *     when(o -> o.shipping() != null,
+ *         to(Telescope.of(Order.class).field(Order::shipping).field(Shipping::country),
+ *            OrderDto::shipCountry)));
+ * }</pre>
+ *
+ * <p><b>Scope.</b> Only telescope-based rows participate — {@link TelescopeTo}, {@link
+ * FromTelescopeTo}, {@link TelescopeToTelescope}, {@link Constant}, {@link Compute}. Field-iso rows
+ * (the plain {@code to(srcAcc, tgtAcc)} family, {@code via}, {@code drop}) reject at construction
+ * with a precise IAE pointing at the alternative: {@code Mapping.toOrElse(src, tgt, default,
+ * predicate)} already expresses "if predicate matches source value, use default" at the field
+ * level. {@code when(...)} is the complementary tool — whole-source predicate gating on deep writes
+ * and stamping rows.
+ *
+ * <p><b>Forward semantics.</b> If {@code predicate.test(source)} returns {@code true}, the inner
+ * row's forward effect applies as usual. Otherwise the row is skipped entirely; the target field
+ * retains whatever the base structural Iso produced (typically {@code null} or the type default,
+ * depending on the row kind — e.g. a skipped {@link TelescopeTo} leaves the target leaf at the
+ * recursive-default allocation; a skipped {@link Constant} leaves it at the auto-mapped value).
+ *
+ * <p><b>Backward semantics — forward-only.</b> Same retraction semantics as {@link Constant} /
+ * {@link Compute}: backward direction skips the row entirely. The source rebuild leaves the
+ * corresponding slot at the {@code baseS} value (whatever the base structural Iso reconstructed).
+ * Forward(backward(t)) is intentionally asymmetric for predicate-gated rows — the predicate is not
+ * evaluable from a target, and skipping backward keeps the semantics simple and consistent with
+ * MapStruct's {@code @Condition}, which is also a forward-only construct.
+ *
+ * <p><b>Nesting.</b> {@code when(when(...))} is rejected at construction. For multi-predicate
+ * logic, compose at the predicate layer ({@code Predicate#and} / {@code Predicate#or}).
+ *
+ * <p><b>Pinning — top-level only.</b> Every supported inner row carries at least one {@link
+ * Telescope}, whose root class isn't recoverable at runtime (generics erased). Inner rows therefore
+ * report {@code null} for {@code sourceClass} / {@code targetClass}; {@code Conditional}
+ * unconditionally does the same (overriding to {@code null} keeps the contract explicit and
+ * prevents a future inner permit with a non-null class from silently breaking the top-level pinning
+ * the engine relies on — {@link io.github.eschizoid.telescope.DeepMap} pins {@code null}-classed
+ * rows to the outer {@code (topSource, topTarget)} pair). A {@code when(...)} row therefore
+ * evaluates its predicate against the <em>top-level source</em>, not against any nested type the
+ * inner row's telescope navigates into. For predicate gating at a nested type pair (e.g. evaluating
+ * against {@code Customer} when the outer mapper is {@code Order ↔ OrderDto}), use a top-level
+ * predicate that traverses to the nested object: {@code when(order -> order.customer() != null &&
+ * order .customer().email() != null, inner)}.
+ *
+ * <p>Constructed via {@link Mapping#when(Predicate, Mapping)} — record is package-private surface.
+ *
+ * @param predicate evaluated against the source object on every forward call
+ * @param inner the telescope-based row this conditional gates; must not be another {@code
+ *     Conditional}
+ * @param <A> source type
+ * @param <B> target type
+ */
+public record Conditional<A, B>(Predicate<? super A> predicate, Mapping<A, B> inner) implements Mapping<A, B> {
+  public Conditional {
+    Objects.requireNonNull(predicate, "predicate");
+    Objects.requireNonNull(inner, "inner");
+    if (inner instanceof Conditional<?, ?>) {
+      throw new IllegalArgumentException(
+        "Mapping.when(...) does not nest. Combine predicates with Predicate#and / Predicate#or " +
+          "on a single when(...) row instead of stacking when(when(...))."
+      );
+    }
+    if (!isSupportedInner(inner)) {
+      final var fieldSuffix = describeFieldClaim(inner);
+      final var alternativeHint =
+        inner instanceof ForwardOnlyTransformTo<?, ?, ?, ?>
+          ? "Mapping.forward(src, tgt, fn) rows cannot be predicate-gated externally — fold the " +
+            "predicate into the forward function (return the source value or a default based on the " +
+            "predicate)."
+          : "For field-level predicate gating on flat accessors, use Mapping.toOrElse(src, tgt, " +
+            "defaultValue, predicate) — the source-value predicate applies the default when matched.";
+      throw new IllegalArgumentException(
+        "Mapping.when(...) wraps only telescope-based rows: to(srcAcc, targetTelescope), " +
+          "to(srcTelescope, tgtAcc), to(srcTelescope, tgtTelescope), zip(srcTelescope, tgtTelescope), " +
+          "constant(targetTelescope, value), compute(targetTelescope, supplier). " +
+          alternativeHint +
+          " Got inner row of kind " +
+          inner.getClass().getSimpleName() +
+          fieldSuffix +
+          "."
+      );
+    }
+  }
+
+  private static boolean isSupportedInner(final Mapping<?, ?> m) {
+    return (
+      m instanceof TelescopeTo<?, ?, ?> ||
+      m instanceof FromTelescopeTo<?, ?, ?> ||
+      m instanceof TelescopeToTelescope<?, ?, ?> ||
+      m instanceof Constant<?, ?, ?> ||
+      m instanceof Compute<?, ?, ?>
+    );
+  }
+
+  /**
+   * Surface the inner row's source/target field names (if known) so the rejection message points at
+   * the actual call site the user wrote. Telescope-based rows return {@code null} for these
+   * accessors (root class erased), so we fall back to the bare kind name in that case.
+   */
+  private static String describeFieldClaim(final Mapping<?, ?> m) {
+    final var src = m.sourceField();
+    final var tgt = m.targetField();
+    if (src == null && tgt == null) return "";
+    return " (" + (src == null ? "<telescope>" : src) + " → " + (tgt == null ? "<telescope>" : tgt) + ")";
+  }
+
+  /**
+   * Always {@code null}: telescope-based inner rows have an erased root class on at least one side,
+   * so they pin to the outer {@code (topSource, topTarget)} pair. Returning {@code null}
+   * unconditionally keeps this contract explicit — see class-level javadoc, "Pinning — top-level
+   * only".
+   */
+  @Override
+  public Class<A> sourceClass() {
+    return null;
+  }
+
+  /** Always {@code null} — same rationale as {@link #sourceClass()}. */
+  @Override
+  public Class<B> targetClass() {
+    return null;
+  }
+
+  /**
+   * Always {@code null} — the inner row's source-field name (if any) is consulted directly by the
+   * routing layer via {@link #inner()}; the wrapper itself contributes no field claim.
+   */
+  @Override
+  public String sourceField() {
+    return null;
+  }
+
+  /** Always {@code null} — same rationale as {@link #sourceField()}. */
+  @Override
+  public String targetField() {
+    return null;
+  }
+}

--- a/core/src/main/java/io/github/eschizoid/telescope/mapping/Conditional.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/mapping/Conditional.java
@@ -41,6 +41,22 @@ import java.util.function.Predicate;
  * <p><b>Nesting.</b> {@code when(when(...))} is rejected at construction. For multi-predicate
  * logic, compose at the predicate layer ({@code Predicate#and} / {@code Predicate#or}).
  *
+ * <p><b>Predicate purity.</b> The predicate is invoked exactly once per top-level forward call for
+ * each {@code when(...)} row at the outer pair. Recursive structural mapping does NOT re-invoke the
+ * predicate at nested pairs — Conditional rows pin to the top-level pair (see the "Pinning"
+ * paragraph below). The engine makes no broader guarantee under future cycle-detection or sub-pair
+ * caching changes, however, so predicates should be pure / side-effect-free. Predicates that need
+ * to fire on every forward call should land their effect in a {@code Mapper.afterForward} hook
+ * instead, where the contract is explicit.
+ *
+ * <p><b>Same target field — last write wins.</b> Multiple Conditional rows whose inner telescopes
+ * claim the same target leaf compose in insertion order — when both predicates accept, the later
+ * row overwrites the earlier. The engine's strict duplicate-target check exempts telescope-based
+ * rows (Conditional and the inner rows it wraps) because telescope writes may descend to different
+ * deep leaves; that exemption applies here too. Order your {@code when(...)} rows so the
+ * most-specific case lands last, or refactor to a single row whose predicate disambiguates ({@code
+ * when(p1.and(p2.negate()), rowA)}, {@code when(p1.and(p2), rowB)}).
+ *
  * <p><b>Pinning — top-level only.</b> Every supported inner row carries at least one {@link
  * Telescope}, whose root class isn't recoverable at runtime (generics erased). Inner rows therefore
  * report {@code null} for {@code sourceClass} / {@code targetClass}; {@code Conditional}

--- a/core/src/main/java/io/github/eschizoid/telescope/mapping/Conditional.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/mapping/Conditional.java
@@ -41,13 +41,19 @@ import java.util.function.Predicate;
  * <p><b>Nesting.</b> {@code when(when(...))} is rejected at construction. For multi-predicate
  * logic, compose at the predicate layer ({@code Predicate#and} / {@code Predicate#or}).
  *
- * <p><b>Predicate purity.</b> The predicate is invoked exactly once per top-level forward call for
- * each {@code when(...)} row at the outer pair. Recursive structural mapping does NOT re-invoke the
- * predicate at nested pairs — Conditional rows pin to the top-level pair (see the "Pinning"
- * paragraph below). The engine makes no broader guarantee under future cycle-detection or sub-pair
- * caching changes, however, so predicates should be pure / side-effect-free. Predicates that need
- * to fire on every forward call should land their effect in a {@code Mapper.afterForward} hook
- * instead, where the contract is explicit.
+ * <p><b>Predicate purity AND thread-safety.</b> The predicate is invoked exactly once per top-level
+ * forward call for each {@code when(...)} row at the outer pair. Recursive structural mapping does
+ * NOT re-invoke the predicate at nested pairs — Conditional rows pin to the top-level pair (see the
+ * "Pinning" paragraph below). The engine makes no broader guarantee under future cycle-detection or
+ * sub-pair caching changes, however, so predicates should be pure / side-effect-free. Predicates
+ * that need to fire on every forward call should land their effect in a {@code Mapper.afterForward}
+ * hook instead, where the contract is explicit.
+ *
+ * <p>The same {@code Conditional} instance is reused across every {@code mapper.forward(...)} call
+ * (the cached Mapper holds it indefinitely). Production deployments under Spring / Quarkus pin
+ * {@code TelescopeMapperRegistry} as a singleton, so the predicate runs concurrently across request
+ * threads. Closures that mutate external state (counters, log buffers, ThreadLocal stack unwinding)
+ * must be thread-safe.
  *
  * <p><b>Same target field — last write wins.</b> Multiple Conditional rows whose inner telescopes
  * claim the same target leaf compose in insertion order — when both predicates accept, the later

--- a/core/src/main/java/io/github/eschizoid/telescope/mapping/Mapping.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/mapping/Mapping.java
@@ -52,7 +52,8 @@ public sealed interface Mapping<A, B>
     FromTelescopeTo,
     TelescopeToTelescope,
     Constant,
-    Compute
+    Compute,
+    Conditional
 {
   /**
    * Source class this row keys against — the declaring class of the source accessor, recovered via
@@ -592,5 +593,57 @@ public sealed interface Mapping<A, B>
    */
   static <A, B, X> Mapping<A, B> compute(final Telescope<B, X> targetTelescope, final Supplier<? extends X> supplier) {
     return new Compute<>(targetTelescope, supplier);
+  }
+
+  /**
+   * Predicate-gated wrapper around a telescope-based row — closes MapStruct's {@code @Condition}
+   * for whole-source predicate gating. The inner row's forward effect applies only when {@code
+   * predicate.test(source)} returns {@code true}; otherwise it is skipped. Backward direction
+   * applies the inner row unconditionally — by the time we have a target, the original source is
+   * gone, so the predicate isn't checkable on the reverse leg.
+   *
+   * <pre>{@code
+   * Telescope.mapper(Order.class, OrderDto.class,
+   *     to(Order::id, OrderDto::id),
+   *     when(order -> order.shipping() != null,
+   *         to(Telescope.of(Order.class).field(Order::shipping).field(Shipping::country),
+   *            OrderDto::shipCountry)),
+   *     when(order -> order.priority() == Priority.HIGH,
+   *         constant(OrderDto::expediteFlag, true)));
+   * }</pre>
+   *
+   * <p><b>Scope.</b> Inner row must be telescope-based: {@link #to(Accessor, Telescope)}, {@link
+   * #to(Telescope, Accessor)}, {@link #to(Telescope, Telescope)}, {@link #zip(Telescope,
+   * Telescope)}, {@link #constant(Telescope, Object)}, {@link #compute(Telescope, Supplier)},
+   * {@link #constant(Accessor, Object)}, or {@link #compute(Accessor, Supplier)}. Field-iso rows
+   * (plain {@code to(srcAcc, tgtAcc)}, {@code via}, {@code drop}) are rejected at construction —
+   * for field-level predicate gating use {@link #toOrElse(Accessor, Accessor, Object, Predicate)},
+   * which expresses "if predicate matches source value, use default" at the field level.
+   *
+   * <p><b>Codegen 1:1.</b> Because the codegen-emitted {@code <X>Telescope} navigators ARE {@link
+   * Telescope} instances, a {@code when(...)} row composes transparently with codegen targets:
+   * {@code when(p, constant(OrderDtoTelescope.of().audit().tenant(), "prod"))} uses the
+   * compile-checked codegen path inside the predicate-gated wrapper at zero extra cost.
+   *
+   * <p><b>Nesting rejected.</b> {@code when(p1, when(p2, ...))} throws at construction. Combine
+   * predicates at the {@link Predicate} layer: {@code when(p1.and(p2), inner)}.
+   *
+   * <p><b>Backward direction is lossy by design.</b> {@code when(...)} is forward-only — same
+   * retraction semantics as {@link #constant(Telescope, Object)} / {@link #compute(Telescope,
+   * Supplier)}. For inner rows that DO have a meaningful backward leg when used unwrapped (the
+   * {@code to(srcTelescope, tgtAcc)} / {@code to(srcTelescope, tgtTelescope)} / {@code
+   * zip(srcTelescope, tgtTelescope)} family), wrapping in {@code when(...)} silently drops that
+   * backward leg: {@code mapper.backward(t)} leaves the source-side slot at the {@code baseS}
+   * value. If you need bidirectional behavior and the predicate can be folded into the data,
+   * express it via {@link #toOrElse(Accessor, Accessor, Object)} at the field level (still
+   * bidirectional) instead of {@code when(...)} on a telescope row.
+   *
+   * <p><b>Predicate exceptions.</b> If {@code predicate.test(source)} throws at apply time, the
+   * exception is decorated with the failing row's inner-kind + source field and rethrown as an
+   * {@link IllegalStateException}. The decoration points the user back at the {@code when(...)}
+   * call site rather than at an opaque internal stack frame.
+   */
+  static <A, B> Mapping<A, B> when(final Predicate<? super A> predicate, final Mapping<A, B> inner) {
+    return new Conditional<>(predicate, inner);
   }
 }

--- a/core/src/test/java/io/github/eschizoid/telescope/MappingWhenTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/MappingWhenTest.java
@@ -1,0 +1,496 @@
+package io.github.eschizoid.telescope;
+
+import static io.github.eschizoid.telescope.mapping.Mapping.compute;
+import static io.github.eschizoid.telescope.mapping.Mapping.constant;
+import static io.github.eschizoid.telescope.mapping.Mapping.to;
+import static io.github.eschizoid.telescope.mapping.Mapping.when;
+import static io.github.eschizoid.telescope.mapping.Mapping.zip;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import io.github.eschizoid.telescope.mapping.Mapping;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pins {@code Mapping.when(predicate, inner)} — the whole-source predicate-gated wrapper around
+ * telescope-based rows. Closes MapStruct's {@code @Condition} for cases where the predicate
+ * operates on the entire source (not a single field). Forward-only by design — backward direction
+ * skips the row entirely, matching the retraction semantics of {@code Constant} / {@code Compute}.
+ */
+class MappingWhenTest {
+
+  record Address(String city, String country) {}
+
+  record Order(String id, Address shipping, int priority) {}
+
+  record OrderDto(String id, String shipCity, String shipCountry, boolean expediteFlag, String tenant) {}
+
+  @Nested
+  @DisplayName("when(predicate, to(srcAcc, targetTelescope)) — gated flat→nested write")
+  class GatedFlatToNested {
+
+    record Src(String name, String email) {}
+
+    record Wrapper(String value) {}
+
+    record Dst(String name, Wrapper wrapped) {}
+
+    @Test
+    @DisplayName("predicate true → inner TelescopeTo applies; predicate false → target field stays at default")
+    void predicateGatesTelescopeTo() {
+      final var emailTelescope = Telescope.of(Dst.class).field(Dst::wrapped).field(Wrapper::value);
+      final var mapper = Telescope.mapper(
+        Src.class,
+        Dst.class,
+        to(Src::name, Dst::name),
+        when(s -> s.email() != null && !s.email().isBlank(), to(Src::email, emailTelescope))
+      );
+
+      // predicate true → email written deep into wrapped.value
+      assertEquals(new Dst("Alice", new Wrapper("alice@ex.com")), mapper.forward(new Src("Alice", "alice@ex.com")));
+
+      // predicate false (null email) → row skipped, wrapped stays at recursive default (null
+      // inside)
+      final var skipped = mapper.forward(new Src("Bob", null));
+      assertEquals("Bob", skipped.name());
+      assertNull(skipped.wrapped().value(), "skipped row → leaf at recursive default");
+
+      // predicate false (blank email) → same skip path
+      final var blankSkipped = mapper.forward(new Src("Carol", "   "));
+      assertNull(blankSkipped.wrapped().value());
+    }
+
+    @Test
+    @DisplayName("backward direction unconditionally skips the conditional row")
+    void backwardSkipsRow() {
+      final var emailTelescope = Telescope.of(Dst.class).field(Dst::wrapped).field(Wrapper::value);
+      final var mapper = Telescope.mapper(
+        Src.class,
+        Dst.class,
+        to(Src::name, Dst::name),
+        when(s -> s.email() != null, to(Src::email, emailTelescope))
+      );
+
+      // Backward: the email slot on the rebuilt Src stays at type default (null) — Conditional
+      // doesn't contribute to the source rebuild, matching Constant/Compute retraction semantics.
+      final var dst = new Dst("Alice", new Wrapper("alice@ex.com"));
+      assertEquals(new Src("Alice", null), mapper.backward(dst));
+    }
+  }
+
+  @Nested
+  @DisplayName("when(predicate, constant(targetTelescope, value)) — gated stamping")
+  class GatedConstant {
+
+    @Test
+    @DisplayName("high-priority orders get expediteFlag stamped; low-priority orders do not")
+    void prioritySkippedFlag() {
+      final java.util.function.Predicate<Order> highPriority = o -> o.priority() >= 10;
+      final var mapper = Telescope.mapper(
+        Order.class,
+        OrderDto.class,
+        to(Order::id, OrderDto::id),
+        when(highPriority, constant(OrderDto::expediteFlag, true))
+      );
+
+      final var lowPrio = new Order("ORD-1", new Address("Chicago", "US"), 1);
+      final var highPrio = new Order("ORD-2", new Address("Chicago", "US"), 99);
+
+      assertEquals(false, mapper.forward(lowPrio).expediteFlag(), "low priority → stamp skipped");
+      assertEquals(true, mapper.forward(highPrio).expediteFlag(), "high priority → stamped");
+    }
+  }
+
+  @Nested
+  @DisplayName("when(predicate, compute(targetTelescope, supplier)) — gated lazy stamping")
+  class GatedCompute {
+
+    @Test
+    @DisplayName("supplier fires only when predicate accepts source")
+    void supplierFiresOnlyOnAccept() {
+      final var calls = new AtomicInteger();
+      final java.util.function.Predicate<Order> highPriority = o -> o.priority() >= 10;
+      final var mapper = Telescope.mapper(
+        Order.class,
+        OrderDto.class,
+        to(Order::id, OrderDto::id),
+        when(
+          highPriority,
+          compute(OrderDto::tenant, () -> {
+            calls.incrementAndGet();
+            return "expedite-tenant";
+          })
+        )
+      );
+
+      // low priority → predicate rejects, supplier NOT invoked
+      mapper.forward(new Order("a", new Address("Chicago", "US"), 1));
+      assertEquals(0, calls.get(), "supplier should not fire when predicate rejects");
+
+      // high priority → supplier fires once
+      final var hi = mapper.forward(new Order("b", new Address("Chicago", "US"), 50));
+      assertEquals("expedite-tenant", hi.tenant());
+      assertEquals(1, calls.get());
+    }
+  }
+
+  @Nested
+  @DisplayName("when(predicate, to(srcTelescope, tgtAcc)) — gated nested→flat read")
+  class GatedNestedToFlat {
+
+    @Test
+    @DisplayName("predicate true → deep read applies; predicate false → target field stays at default")
+    void predicateGatesFromTelescopeTo() {
+      final var cityTelescope = Telescope.of(Order.class).field(Order::shipping).field(Address::city);
+      final var mapper = Telescope.mapper(
+        Order.class,
+        OrderDto.class,
+        to(Order::id, OrderDto::id),
+        when(o -> o.shipping() != null, to(cityTelescope, OrderDto::shipCity))
+      );
+
+      final var withShip = new Order("ORD-1", new Address("Chicago", "US"), 1);
+      final var noShip = new Order("ORD-2", null, 1);
+
+      assertEquals("Chicago", mapper.forward(withShip).shipCity());
+      assertNull(mapper.forward(noShip).shipCity(), "no shipping → row skipped → leaf stays null");
+    }
+  }
+
+  @Nested
+  @DisplayName("when(predicate, to(srcTelescope, tgtTelescope)) — gated nested→nested write")
+  class GatedNestedToNested {
+
+    @Test
+    @DisplayName("broadcast deep write only fires when predicate accepts")
+    void predicateGatesTelescopeToTelescope() {
+      final var srcCity = Telescope.of(Order.class).field(Order::shipping).field(Address::city);
+      final var tgtCity = Telescope.of(OrderDto.class).field(OrderDto::shipCity);
+      final var mapper = Telescope.mapper(
+        Order.class,
+        OrderDto.class,
+        to(Order::id, OrderDto::id),
+        when(o -> o.shipping() != null, to(srcCity, tgtCity))
+      );
+
+      assertEquals("Berlin", mapper.forward(new Order("a", new Address("Berlin", "DE"), 1)).shipCity());
+      assertNull(mapper.forward(new Order("b", null, 1)).shipCity());
+    }
+  }
+
+  @Nested
+  @DisplayName("when(predicate, zip(srcTelescope, tgtTelescope)) — gated positional zip")
+  class GatedZip {
+
+    record Cart(boolean active, List<String> items) {}
+
+    record CartDto(boolean active, List<String> items) {}
+
+    @Test
+    @DisplayName("zip-Kind row composes cleanly under Conditional — same dispatch as broadcast")
+    void predicateGatesZip() {
+      // Same-name 'items' on both sides so auto-recursion populates target.items from source.items
+      // (identity copy). The when(zip(...)) row then conditionally re-applies a positional overlay
+      // on top — when predicate accepts, zip runs (identity over the already-copied list, no-op);
+      // when rejects, zip skipped. The test pins that Kind.ZIP routes through Conditional without
+      // throwing — the Kind.BROADCAST shape is exercised separately in GatedNestedToNested.
+      final var srcItems = Telescope.of(Cart.class).each(Cart::items);
+      final var tgtItems = Telescope.of(CartDto.class).each(CartDto::items);
+      final var mapper = Telescope.mapper(
+        Cart.class,
+        CartDto.class,
+        to(Cart::active, CartDto::active),
+        when(Cart::active, zip(srcItems, tgtItems))
+      );
+
+      assertEquals(
+        new CartDto(true, List.of("a", "b", "c")),
+        mapper.forward(new Cart(true, List.of("a", "b", "c"))),
+        "active → zip applies on top of auto-copy"
+      );
+      assertEquals(
+        new CartDto(false, List.of("x", "y", "z")),
+        mapper.forward(new Cart(false, List.of("x", "y", "z"))),
+        "inactive → zip skipped, auto-copy stands"
+      );
+    }
+  }
+
+  @Nested
+  @DisplayName("Composable predicates — Predicate#and / Predicate#or / negate")
+  class ComposablePredicates {
+
+    record Src(String name, Integer score) {}
+
+    record Wrapper(Integer value) {}
+
+    record Dst(String name, Wrapper scoreWrap) {}
+
+    @Test
+    @DisplayName("predicate composition with and() — both conditions gate the inner row")
+    void composeAnd() {
+      final var scoreTel = Telescope.of(Dst.class).field(Dst::scoreWrap).field(Wrapper::value);
+      final java.util.function.Predicate<Src> positiveScore = s -> s.score() != null && s.score() > 0;
+      final var mapper = Telescope.mapper(
+        Src.class,
+        Dst.class,
+        to(Src::name, Dst::name),
+        when(positiveScore.and(s -> s.name() != null), to(Src::score, scoreTel))
+      );
+
+      // both true → score lands in scoreWrap.value
+      assertEquals(42, mapper.forward(new Src("Alice", 42)).scoreWrap().value(), "both true → applies");
+      // score == -1 → first predicate fails → row skipped → leaf stays at recursive default (null)
+      assertNull(mapper.forward(new Src("Bob", -1)).scoreWrap().value(), "score not > 0 → skipped");
+      // name null → second predicate fails → row skipped → leaf stays at recursive default (null)
+      assertNull(mapper.forward(new Src(null, 42)).scoreWrap().value(), "name null → skipped");
+    }
+  }
+
+  @Nested
+  @DisplayName("Backward direction — Conditional rows skip unconditionally across all inner shapes")
+  class BackwardSkipsAllShapes {
+
+    record Src(String name, String email, String region) {}
+
+    record Wrapper(String value) {}
+
+    record Dst(String name, Wrapper emailWrap, String region) {}
+
+    @Test
+    @DisplayName("backward skips conditional FromTelescopeTo — source field stays at rebuild default")
+    void backwardSkipsFromTelescopeTo() {
+      final var emailDeep = Telescope.of(Src.class).field(Src::email);
+      final var mapper = Telescope.mapper(
+        Src.class,
+        Dst.class,
+        to(Src::name, Dst::name),
+        to(Src::region, Dst::region),
+        when(s -> s.email() != null, to(emailDeep, Dst::region))
+      );
+
+      // Forward: Src.region overrides Dst.region (last write wins on target field 'region').
+      // Predicate evaluated against the Src — we don't care about exact forward here, only that
+      // backward direction skips the Conditional row entirely.
+      final var dst = new Dst("Alice", new Wrapper("ignored"), "rebuiltRegion");
+      final var s = mapper.backward(dst);
+      // 'region' on source rebuilt via plain to(Src::region, Dst::region) — the Conditional from
+      // emailDeep → Dst::region contributes NOTHING to the source rebuild because Conditional is
+      // forward-only.
+      assertEquals("rebuiltRegion", s.region(), "non-conditional row wins source rebuild");
+    }
+
+    @Test
+    @DisplayName("backward skips conditional Compute — supplier NOT invoked on backward")
+    void backwardSkipsCompute() {
+      record SimpleSrc(String id) {}
+      record SimpleDst(String id, String stamped) {}
+
+      final var calls = new AtomicInteger();
+      final java.util.function.Predicate<SimpleSrc> always = s -> true;
+      final var mapper = Telescope.mapper(
+        SimpleSrc.class,
+        SimpleDst.class,
+        to(SimpleSrc::id, SimpleDst::id),
+        when(
+          always,
+          compute(SimpleDst::stamped, () -> {
+            calls.incrementAndGet();
+            return "fresh";
+          })
+        )
+      );
+
+      mapper.backward(new SimpleDst("a", "ignored"));
+      assertEquals(0, calls.get(), "supplier MUST NOT fire on backward — Conditional is forward-only");
+    }
+
+    @Test
+    @DisplayName("backward skips conditional zip — no cardinality enforcement on backward")
+    void backwardSkipsZip() {
+      record Cart(boolean active, List<String> items) {}
+      record CartDto(boolean active, List<String> items) {}
+
+      final var srcItems = Telescope.of(Cart.class).each(Cart::items);
+      final var tgtItems = Telescope.of(CartDto.class).each(CartDto::items);
+      final var mapper = Telescope.mapper(
+        Cart.class,
+        CartDto.class,
+        to(Cart::active, CartDto::active),
+        when(Cart::active, zip(srcItems, tgtItems))
+      );
+
+      // Backward direction skips the zip row entirely — no cardinality check fires, even when the
+      // forward path would have rejected the call. Auto-recursion rebuilds Cart.items from
+      // CartDto.items by same-name match.
+      final var c = mapper.backward(new CartDto(true, List.of("x", "y")));
+      assertEquals(new Cart(true, List.of("x", "y")), c);
+    }
+  }
+
+  @Nested
+  @DisplayName("Self-recursive types — Conditional cycles cleanly through the lattice")
+  class SelfRecursiveCycle {
+
+    record Node(String value, Node child) {}
+
+    record NodeDto(String value, NodeDto child, String flag) {}
+
+    @Test
+    @DisplayName("Conditional row on top-level pair fires once; nested Node→NodeDto recursion uses base Iso")
+    void conditionalAtRootOnly() {
+      final java.util.function.Predicate<Node> isRoot = n -> n.value().equals("root");
+      final var mapper = Telescope.mapper(Node.class, NodeDto.class, when(isRoot, constant(NodeDto::flag, "ROOT")));
+
+      final var leaf = new Node("leaf", null);
+      final var mid = new Node("mid", leaf);
+      final var root = new Node("root", mid);
+
+      final var dto = mapper.forward(root);
+
+      // Top-level: predicate accepts root → flag stamped
+      assertEquals("ROOT", dto.flag());
+      // Nested recursion populated value + child chain; nested NodeDto.flag stays at default (null)
+      // because the Conditional row pins to the top-level (Node, NodeDto) pair only.
+      assertEquals("root", dto.value());
+      assertEquals("mid", dto.child().value());
+      assertNull(dto.child().flag(), "nested NodeDto.flag stays at recursive default — predicate didn't fire here");
+      assertEquals("leaf", dto.child().child().value());
+      assertNull(dto.child().child().flag());
+    }
+  }
+
+  @Nested
+  @DisplayName("Predicate-throws decoration — failure points at the when(...) call site")
+  class PredicateThrowsDecoration {
+
+    record Src(String name) {}
+
+    record Dst(String name, String stamped) {}
+
+    @Test
+    @DisplayName("predicate NPE wrapped in IllegalStateException naming inner-kind + source field")
+    void decoratedExceptionNamesInnerAndField() {
+      final java.util.function.Predicate<Src> brokenPredicate = s -> s.name().length() > 0;
+      // ^ throws NPE when name is null; the row's inner is Constant whose targetField is "stamped".
+      final var mapper = Telescope.mapper(
+        Src.class,
+        Dst.class,
+        to(Src::name, Dst::name),
+        when(brokenPredicate, constant(Dst::stamped, "X"))
+      );
+
+      final var ex = assertThrows(IllegalStateException.class, () -> mapper.forward(new Src(null)));
+      final var msg = ex.getMessage();
+      assertEquals(true, msg.contains("Mapping.when"), "message names the construct");
+      assertEquals(true, msg.contains("Constant"), "message names the inner kind");
+      assertEquals(true, ex.getCause() instanceof NullPointerException, "original predicate cause preserved");
+    }
+  }
+
+  @Nested
+  @DisplayName("Pinning contract — Conditional metadata always returns null (top-level pinning)")
+  class PinningContract {
+
+    record Src(String name) {}
+
+    record Dst(String name) {}
+
+    @Test
+    @DisplayName("Conditional.sourceClass / targetClass / sourceField / targetField all null")
+    void pinsTopLevelOnly() {
+      final var nameTel = Telescope.of(Dst.class).field(Dst::name);
+      final var conditional = when((java.util.function.Predicate<Src>) s -> true, to(Src::name, nameTel));
+
+      // Pin the documented contract — every supported inner row is telescope-based, so the
+      // Conditional always pins to the outer (topSource, topTarget) pair via null-class routing.
+      assertNull(conditional.sourceClass(), "Conditional.sourceClass MUST be null — pins top-level");
+      assertNull(conditional.targetClass(), "Conditional.targetClass MUST be null — pins top-level");
+      assertNull(
+        conditional.sourceField(),
+        "Conditional.sourceField MUST be null — wrapper contributes no field claim"
+      );
+      assertNull(
+        conditional.targetField(),
+        "Conditional.targetField MUST be null — wrapper contributes no field claim"
+      );
+    }
+  }
+
+  @Nested
+  @DisplayName("Construction-time rejection — invalid inner rows")
+  class ConstructionRejection {
+
+    record Src(String name) {}
+
+    record Dst(String name) {}
+
+    @Test
+    @DisplayName("field-iso row (plain to(srcAcc, tgtAcc)) rejected with clear error pointing at toOrElse")
+    void rejectsFieldIsoInner() {
+      final var ex = assertThrows(IllegalArgumentException.class, () ->
+        when((java.util.function.Predicate<Src>) s -> true, to(Src::name, Dst::name))
+      );
+      final var msg = ex.getMessage();
+      assertEquals(true, msg.contains("toOrElse"), "error suggests the field-level alternative");
+      assertEquals(true, msg.contains("telescope-based"), "error names the supported shape");
+      assertEquals(true, msg.contains("SameTypedTo"), "error names the rejected kind");
+      assertEquals(
+        true,
+        msg.contains("name → name"),
+        "error names the actual field claim so the user can find the row"
+      );
+    }
+
+    @Test
+    @DisplayName("forward-only row rejected with hint pointing at fold-the-predicate-into-fn")
+    void rejectsForwardOnlyTransformTo() {
+      final var ex = assertThrows(IllegalArgumentException.class, () ->
+        when(
+          (java.util.function.Predicate<Src>) s -> true,
+          io.github.eschizoid.telescope.mapping.Mapping.forward(Src::name, Dst::name, String::toUpperCase)
+        )
+      );
+      final var msg = ex.getMessage();
+      assertEquals(true, msg.contains("Mapping.forward"), "error names the forward-only construct");
+      assertEquals(
+        true,
+        msg.contains("fold the predicate"),
+        "error suggests inlining the predicate into the forward function"
+      );
+      assertEquals(true, msg.contains("ForwardOnlyTransformTo"), "error names the rejected kind");
+    }
+
+    @Test
+    @DisplayName("nested Conditional rejected — combine via Predicate#and/or instead")
+    void rejectsNestedConditional() {
+      final var emailTel = Telescope.of(Dst.class).field(Dst::name);
+      final Mapping<Src, Dst> inner = when(
+        (java.util.function.Predicate<Src>) s -> s.name() != null,
+        to(Src::name, emailTel)
+      );
+      final var ex = assertThrows(IllegalArgumentException.class, () ->
+        when((java.util.function.Predicate<Src>) s -> true, inner)
+      );
+      assertEquals(true, ex.getMessage().contains("does not nest"), "error explains nesting is rejected");
+    }
+
+    @Test
+    @DisplayName("null predicate rejected")
+    void rejectsNullPredicate() {
+      final var emailTel = Telescope.of(Dst.class).field(Dst::name);
+      assertThrows(NullPointerException.class, () -> when(null, to(Src::name, emailTel)));
+    }
+
+    @Test
+    @DisplayName("null inner rejected")
+    void rejectsNullInner() {
+      assertThrows(NullPointerException.class, () -> when((java.util.function.Predicate<Src>) s -> true, null));
+    }
+  }
+}

--- a/core/src/test/java/io/github/eschizoid/telescope/MappingWhenTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/MappingWhenTest.java
@@ -389,6 +389,10 @@ class MappingWhenTest {
       final var msg = ex.getMessage();
       assertEquals(true, msg.contains("Mapping.when"), "message names the construct");
       assertEquals(true, msg.contains("Constant"), "message names the inner kind");
+      // The failure class name (NullPointerException) MUST appear even when the predicate's NPE
+      // carries a null message — otherwise the user sees "Predicate failure: null" and learns
+      // nothing actionable. This pins the decoration improvement.
+      assertEquals(true, msg.contains("NullPointerException"), "message names the failure class");
       assertEquals(true, ex.getCause() instanceof NullPointerException, "original predicate cause preserved");
     }
   }


### PR DESCRIPTION
## Summary

Closes Tier 2 #1.3 — MapStruct's `@Condition` equivalent for whole-source predicate gating on telescope-based rows.

```java
Telescope.mapper(Order.class, OrderDto.class,
    to(Order::id, OrderDto::id),
    when(o -> o.shipping() != null,
        to(Telescope.of(Order.class).field(Order::shipping).field(Shipping::country),
           OrderDto::shipCountry)),
    when(o -> o.priority() == Priority.HIGH,
        constant(OrderDto::expediteFlag, true)));
```

## Design points

- **Scope:** wraps the five telescope-based row kinds (`TelescopeTo`, `FromTelescopeTo`, `TelescopeToTelescope`, `Constant`, `Compute`). Field-iso rows (`SameTypedTo`, `TypedTransformTo`, `Via`, `Drop`) reject at construction with a precise IAE pointing at `Mapping.toOrElse(src, tgt, default, predicate)` which already covers the field-level conditional case.
- **Forward-only by design:** same retraction semantics as `Constant` / `Compute` — `applyBackward` skips Conditional rows entirely. Predicate isn't evaluable from a target, and asymmetric round-tripping is the inherent shape of conditional logic.
- **Top-level pinning:** `Conditional.sourceClass()/targetClass()` return `null` unconditionally. Telescope-based inner rows already do this (erased root class on at least one side); making it explicit on the wrapper documents the contract and prevents a future inner permit with a non-null class from silently breaking the routing.
- **Codegen 1:1 via composition:** the codegen-emitted `<X>Telescope` constants ARE `Telescope` instances, so `when(p, constant(OrderDtoTelescope.of().audit().tenant(), "prod"))` uses the compile-checked codegen path inside the predicate gate without any processor-side changes.
- **Apply-time error decoration:** user-predicate exceptions wrapped in `IllegalStateException` naming the inner kind + source field so failures point at the `when(...)` call site, not at an opaque `applyForward` stack frame.

## Sealed-permit + DeepMap routing

- Added `Conditional<A, B>(Predicate<? super A>, Mapping<A, B>)` to the `Mapping` sealed permit list.
- `populateIso` unwraps Conditional to the inner row for soft-claim routing decisions, but registers the Conditional itself in `telescopeFixups` so `applyForward` can evaluate the predicate before dispatching the inner's effect.
- `applyForward` evaluates the predicate at the top of the row-dispatch loop; on rejection, `continue` skips the inner.
- `applyBackward` skips Conditional rows in both loops (field-overrides collection + telescope-source overlays).

## Test coverage

19 test cases across 9 nested classes covering:
- All 5 supported inner kinds, forward direction
- All inner kinds backward (skip semantics)
- Self-recursive types (cycle pin)
- Top-level pinning contract (asserts the null-class invariant)
- Predicate composition (`Predicate#and`)
- Predicate exception decoration
- All construction-time rejection paths (field-iso, forward-only, nested, null predicate, null inner)

## Test plan

- [x] `:core:test --tests MappingWhenTest` (19/19)
- [x] `:core:test` (full regression)
- [x] `:codegen:test :lombok:test :spring-boot-starter:test :quarkus:test`
- [x] `:core:spotlessJavaCheck`