### PR TITLE
feat(codegen): @Transform(method = ...) — @Named qualifier dispatch (#1.1)

### DIFF
--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
@@ -387,11 +387,69 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
           error(element, "@Transform field=\"" + field + "\" is declared more than once");
           return null;
         }
+        // Validate `method` is either empty (legacy BridgeFn shape) or a syntactically valid Java
+        // identifier — whitespace, punctuation, or reserved-word inputs would otherwise produce
+        // emit-time syntactic garbage at the generated bridge body that javac surfaces with a
+        // cryptic "identifier expected" pointing at synthetic source the user never wrote.
+        final boolean hasMethod = method != null && !method.isBlank();
+        if (method != null && !method.isEmpty() && !hasMethod) {
+          error(element, "@Transform `method` must not be blank (was \"" + method + "\")");
+          return null;
+        }
+        if (hasMethod && !javax.lang.model.SourceVersion.isIdentifier(method)) {
+          error(element, "@Transform `method` must be a valid Java identifier (was \"" + method + "\")");
+          return null;
+        }
+        if (hasMethod) {
+          // Validate the named method exists, is static, and takes exactly one argument. Defers the
+          // parameter / return type compatibility check to javac at the generated bridge body —
+          // that depends on the source/target field types and javac resolves it precisely there.
+          // What we catch here: typos, instance methods (would emit static-call syntax against an
+          // instance method → cryptic generated-source error), arity mismatches, and the
+          // surprisingly common "method exists on a superclass with restricted visibility" case.
+          final var matches = new java.util.ArrayList<javax.lang.model.element.ExecutableElement>();
+          for (final var e : usingEl.getEnclosedElements()) {
+            if (!(e instanceof javax.lang.model.element.ExecutableElement m)) continue;
+            if (!m.getSimpleName().contentEquals(method)) continue;
+            if (m.getParameters().size() != 1) continue;
+            matches.add(m);
+          }
+          if (matches.isEmpty()) {
+            error(
+              element,
+              "@Transform `method` not found: " +
+                usingEl.getQualifiedName() +
+                "." +
+                method +
+                "(<one arg>) does not exist. Add a public static method with exactly one parameter."
+            );
+            return null;
+          }
+          // Pick the first match that is static; report a clear error if none are static.
+          javax.lang.model.element.ExecutableElement staticMatch = null;
+          for (final var m : matches) {
+            if (m.getModifiers().contains(javax.lang.model.element.Modifier.STATIC)) {
+              staticMatch = m;
+              break;
+            }
+          }
+          if (staticMatch == null) {
+            error(
+              element,
+              "@Transform `method` " +
+                usingEl.getQualifiedName() +
+                "." +
+                method +
+                "(...) exists but is not static. Qualifier dispatch emits a static-method call; mark it `public static`."
+            );
+            return null;
+          }
+        }
         result.put(field, usingEl.getQualifiedName().toString());
         // Qualifier dispatch (method != "") is inherently forward-only. forwardOnly = true is the
         // user-explicit form; non-empty method implies the same.
-        if (Boolean.TRUE.equals(forwardOnly) || (method != null && !method.isEmpty())) forwardOnlySet.add(field);
-        if (method != null && !method.isEmpty()) methodsByField.put(field, method);
+        if (Boolean.TRUE.equals(forwardOnly) || hasMethod) forwardOnlySet.add(field);
+        if (hasMethod) methodsByField.put(field, method);
       }
       return new TransformSet(result, forwardOnlySet, methodsByField);
     }

--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
@@ -98,7 +98,12 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
     Map<String, String> viaMappers,
     String writeStrategy,
     Map<String, String> constants,
-    Map<String, String> computes
+    Map<String, String> computes,
+    // Per-source-field qualifier method name. Set when @Transform supplies a non-empty `method`
+    // attribute — codegen emits a direct {@code UsingClass.methodName(value)} call instead of
+    // instantiating a BridgeFn. Always implicitly forward-only; the source field also lands in
+    // forwardOnlyTransforms when this map carries an entry for it.
+    Map<String, String> transformMethods
   ) {
     static final BridgeConfig EMPTY = new BridgeConfig(
       Set.of(),
@@ -109,6 +114,7 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
       Map.of(),
       Map.of(),
       "AUTO",
+      Map.of(),
       Map.of(),
       Map.of()
     );
@@ -196,7 +202,8 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
             viaMappers,
             writeStrategy,
             constants,
-            computes
+            computes,
+            transformSet.methodsByField()
           )
         );
         if (seen.add(pair)) pending.add(pair);
@@ -322,12 +329,18 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
     return RenameSet.empty();
   }
 
-  // Result of parsing a @Bridge's transforms list. `byField` carries the source-field → BridgeFn
+  // Result of parsing a @Bridge's transforms list. `byField` carries the source-field → using
   // class FQN map (the long-standing shape); `forwardOnlyFields` carries the subset of source
-  // field names whose @Transform was declared with forwardOnly = true.
-  private record TransformSet(Map<String, String> byField, Set<String> forwardOnlyFields) {
+  // field names whose @Transform was declared with forwardOnly = true or with a non-empty `method`
+  // attribute (qualifier dispatch is implicitly forward-only); `methodsByField` carries the
+  // qualifier method name when set, empty when the row uses the BridgeFn shape.
+  private record TransformSet(
+    Map<String, String> byField,
+    Set<String> forwardOnlyFields,
+    Map<String, String> methodsByField
+  ) {
     static TransformSet empty() {
-      return new TransformSet(Map.of(), Set.of());
+      return new TransformSet(Map.of(), Set.of(), Map.of());
     }
   }
 
@@ -340,23 +353,29 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
       final var list = (List<? extends AnnotationValue>) entry.getValue().getValue();
       final var result = new LinkedHashMap<String, String>();
       final var forwardOnlySet = new LinkedHashSet<String>();
+      final var methodsByField = new LinkedHashMap<String, String>();
       for (final var av : list) {
         final var transformAm = (AnnotationMirror) av.getValue();
         String field = null;
         TypeMirror using = null;
         Boolean forwardOnly = Boolean.FALSE;
+        String method = "";
         for (final var te : transformAm.getElementValues().entrySet()) {
           final var k = te.getKey().getSimpleName().toString();
           if (k.equals("field")) field = (String) te.getValue().getValue();
           else if (k.equals("using")) using = (TypeMirror) te.getValue().getValue();
           else if (k.equals("forwardOnly")) forwardOnly = (Boolean) te.getValue().getValue();
+          else if (k.equals("method")) method = (String) te.getValue().getValue();
         }
         if (field == null || field.isEmpty()) {
           error(element, "@Transform requires a non-empty `field` name");
           return null;
         }
         if (using == null || using.getKind() != TypeKind.DECLARED) {
-          error(element, "@Transform `using` must be a class implementing BridgeFn");
+          error(
+            element,
+            "@Transform `using` must be a class (BridgeFn implementor, or any class when `method` is set)"
+          );
           return null;
         }
         final var usingEl = (TypeElement) ((DeclaredType) using).asElement();
@@ -369,9 +388,12 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
           return null;
         }
         result.put(field, usingEl.getQualifiedName().toString());
-        if (Boolean.TRUE.equals(forwardOnly)) forwardOnlySet.add(field);
+        // Qualifier dispatch (method != "") is inherently forward-only. forwardOnly = true is the
+        // user-explicit form; non-empty method implies the same.
+        if (Boolean.TRUE.equals(forwardOnly) || (method != null && !method.isEmpty())) forwardOnlySet.add(field);
+        if (method != null && !method.isEmpty()) methodsByField.put(field, method);
       }
-      return new TransformSet(result, forwardOnlySet);
+      return new TransformSet(result, forwardOnlySet, methodsByField);
     }
     return TransformSet.empty();
   }
@@ -1110,6 +1132,7 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
       targetFields,
       renames,
       transforms,
+      cfg.transformMethods(),
       viaMappers,
       pending,
       seen,
@@ -1248,13 +1271,19 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
         // named `__tx_<sourceField>`. applyForward / applyBackward emit
         // `__tx_<field>.forward(...)`
         // / `.backward(...)` on the transformed slot.
+        //
+        // Qualifier-dispatch rows (cfg.transformMethods()) skip the singleton declaration — the
+        // emitted code calls UsingClass.methodName(...) directly, so no instance is needed.
         if (!transforms.isEmpty()) {
+          boolean anyEmitted = false;
           for (final var e : transforms.entrySet()) {
+            if (cfg.transformMethods().containsKey(e.getKey())) continue;
             out.println(
               "  private static final " + e.getValue() + " __tx_" + e.getKey() + " = new " + e.getValue() + "();"
             );
+            anyEmitted = true;
           }
-          out.println();
+          if (anyEmitted) out.println();
         }
         // Per-field @Compute: one static instance of each user-declared Supplier implementation,
         // named `__cp_<targetField>`. readForward emits `__cp_<field>.get()` for the forward
@@ -1558,7 +1587,7 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
    *   <li>{@code NULLABLE_TO_OPTIONAL} — mirror direction.
    * </ul>
    */
-  private record FieldPlan(Kind kind, String subBridgeName) {
+  private record FieldPlan(Kind kind, String subBridgeName, String qualifierMethod) {
     enum Kind {
       IDENTITY,
       RECURSE,
@@ -1572,15 +1601,22 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
     }
 
     static FieldPlan identity() {
-      return new FieldPlan(Kind.IDENTITY, null);
+      return new FieldPlan(Kind.IDENTITY, null, null);
     }
 
     static FieldPlan recurse(final String subBridgeName) {
-      return new FieldPlan(Kind.RECURSE, Objects.requireNonNull(subBridgeName));
+      return new FieldPlan(Kind.RECURSE, Objects.requireNonNull(subBridgeName), null);
     }
 
     static FieldPlan ofKind(final Kind kind, final String subBridgeName) {
-      return new FieldPlan(kind, Objects.requireNonNull(subBridgeName));
+      return new FieldPlan(kind, Objects.requireNonNull(subBridgeName), null);
+    }
+
+    // Qualifier-dispatch TRANSFORM variant: the `using` class hosts a named static method, NOT a
+    // BridgeFn implementor. Codegen emits a direct {@code UsingClass.methodName(value)} call and
+    // does not declare a {@code __tx_<field>} singleton instance.
+    static FieldPlan ofTransformQualified(final String usingClassFqn, final String method) {
+      return new FieldPlan(Kind.TRANSFORM, Objects.requireNonNull(usingClassFqn), Objects.requireNonNull(method));
     }
   }
 
@@ -1622,6 +1658,7 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
     final List<Field> targetFields,
     final Map<String, String> renames,
     final Map<String, String> transforms,
+    final Map<String, String> transformMethods,
     final Map<String, String> viaMappers,
     final Deque<TypePair> pending,
     final Set<TypePair> seen,
@@ -1631,7 +1668,13 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
     for (final var sf : sourceFields) {
       // Per-field transform supersedes the type-match logic — the transform IS the contract.
       if (transforms.containsKey(sf.name())) {
-        plans.put(sf.name(), FieldPlan.ofKind(FieldPlan.Kind.TRANSFORM, transforms.get(sf.name())));
+        final var method = transformMethods.get(sf.name());
+        if (method != null && !method.isEmpty()) {
+          // Qualifier-dispatch variant: emit a direct UsingClass.methodName(...) call.
+          plans.put(sf.name(), FieldPlan.ofTransformQualified(transforms.get(sf.name()), method));
+        } else {
+          plans.put(sf.name(), FieldPlan.ofKind(FieldPlan.Kind.TRANSFORM, transforms.get(sf.name())));
+        }
         continue;
       }
       // Per-field viaMapper supersedes auto-recursion — the user-supplied bridge class IS the
@@ -1839,7 +1882,11 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
         : "__fwd_" + fieldName + "(" + readExpr + ")";
       case OPTIONAL_TO_NULLABLE -> readExpr + ".map(" + fwdElement + ").orElse(null)";
       case NULLABLE_TO_OPTIONAL -> "Optional.ofNullable(" + readExpr + ").map(" + fwdElement + ")";
-      case TRANSFORM -> "__tx_" + fieldName + ".forward(" + readExpr + ")";
+      // Qualifier dispatch: emit a direct {@code UsingClass.methodName(value)} call. Otherwise
+      // dispatch through the {@code __tx_<field>} BridgeFn singleton instance (legacy shape).
+      case TRANSFORM -> plan.qualifierMethod() != null
+        ? plan.subBridgeName() + "." + plan.qualifierMethod() + "(" + readExpr + ")"
+        : "__tx_" + fieldName + ".forward(" + readExpr + ")";
     };
   }
 

--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
@@ -23,6 +23,7 @@ import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.AnnotationValue;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
+import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.Modifier;
 import javax.lang.model.element.NestingKind;
 import javax.lang.model.element.TypeElement;
@@ -387,16 +388,26 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
           error(element, "@Transform field=\"" + field + "\" is declared more than once");
           return null;
         }
-        // Validate `method` is either empty (legacy BridgeFn shape) or a syntactically valid Java
+        // Validate `method` is either empty (legacy BridgeFn shape) or a syntactically clean Java
         // identifier — whitespace, punctuation, or reserved-word inputs would otherwise produce
         // emit-time syntactic garbage at the generated bridge body that javac surfaces with a
         // cryptic "identifier expected" pointing at synthetic source the user never wrote.
-        final boolean hasMethod = method != null && !method.isBlank();
-        if (method != null && !method.isEmpty() && !hasMethod) {
+        //
+        // Diagnostic shape, in order: BLANK > WHITESPACE-PADDED > INVALID-IDENTIFIER > MISSING-
+        // METHOD > NON-STATIC. Each level gives the user a precise fix to apply.
+        final var hasMethod = method != null && !method.isEmpty();
+        if (hasMethod && method.isBlank()) {
           error(element, "@Transform `method` must not be blank (was \"" + method + "\")");
           return null;
         }
-        if (hasMethod && !javax.lang.model.SourceVersion.isIdentifier(method)) {
+        if (hasMethod && !method.equals(method.strip())) {
+          error(
+            element,
+            "@Transform `method` must not have leading/trailing whitespace (was \"" + method + "\"). Trim and retry."
+          );
+          return null;
+        }
+        if (hasMethod && !SourceVersion.isIdentifier(method)) {
           error(element, "@Transform `method` must be a valid Java identifier (was \"" + method + "\")");
           return null;
         }
@@ -405,11 +416,10 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
           // parameter / return type compatibility check to javac at the generated bridge body —
           // that depends on the source/target field types and javac resolves it precisely there.
           // What we catch here: typos, instance methods (would emit static-call syntax against an
-          // instance method → cryptic generated-source error), arity mismatches, and the
-          // surprisingly common "method exists on a superclass with restricted visibility" case.
-          final var matches = new java.util.ArrayList<javax.lang.model.element.ExecutableElement>();
+          // instance method → cryptic generated-source error), and arity mismatches.
+          final var matches = new ArrayList<ExecutableElement>();
           for (final var e : usingEl.getEnclosedElements()) {
-            if (!(e instanceof javax.lang.model.element.ExecutableElement m)) continue;
+            if (!(e instanceof ExecutableElement m)) continue;
             if (!m.getSimpleName().contentEquals(method)) continue;
             if (m.getParameters().size() != 1) continue;
             matches.add(m);
@@ -426,9 +436,9 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
             return null;
           }
           // Pick the first match that is static; report a clear error if none are static.
-          javax.lang.model.element.ExecutableElement staticMatch = null;
+          ExecutableElement staticMatch = null;
           for (final var m : matches) {
-            if (m.getModifiers().contains(javax.lang.model.element.Modifier.STATIC)) {
+            if (m.getModifiers().contains(Modifier.STATIC)) {
               staticMatch = m;
               break;
             }

--- a/codegen/src/test/java/io/github/eschizoid/telescope/codegen/BridgeProcessorTest.java
+++ b/codegen/src/test/java/io/github/eschizoid/telescope/codegen/BridgeProcessorTest.java
@@ -1512,6 +1512,125 @@ class BridgeProcessorTest {
     }
 
     @Test
+    @DisplayName("@Transform(method = \"  \") — whitespace method name rejected at processor time")
+    void transformBlankMethodRejected() {
+      final var compilation = compile(
+        source(
+          "demo.Helpers",
+          """
+          package demo;
+          public final class Helpers {
+            public static String identity(String s) { return s; }
+          }
+          """
+        ),
+        source(
+          "demo.A",
+          """
+          package demo;
+          import io.github.eschizoid.telescope.annotations.Bridge;
+          import io.github.eschizoid.telescope.annotations.Transform;
+          @Bridge(value = demo.B.class, transforms = {
+            @Transform(field = "name", using = demo.Helpers.class, method = "  ")
+          })
+          public record A(String name) {}
+          """
+        ),
+        source(
+          "demo.B",
+          """
+          package demo;
+          public record B(String name) {}
+          """
+        )
+      );
+      assertTrue(
+        !compilation.success() && compilation.hasError("must not be blank"),
+        () -> "expected 'must not be blank' diagnostic; saw " + compilation.errorMessages()
+      );
+    }
+
+    @Test
+    @DisplayName("@Transform(method = \"missing\") — non-existent method rejected at processor time")
+    void transformMissingMethodRejected() {
+      final var compilation = compile(
+        source(
+          "demo.Helpers",
+          """
+          package demo;
+          public final class Helpers {
+            public static String identity(String s) { return s; }
+          }
+          """
+        ),
+        source(
+          "demo.A",
+          """
+          package demo;
+          import io.github.eschizoid.telescope.annotations.Bridge;
+          import io.github.eschizoid.telescope.annotations.Transform;
+          @Bridge(value = demo.B.class, transforms = {
+            @Transform(field = "name", using = demo.Helpers.class, method = "nonexistent")
+          })
+          public record A(String name) {}
+          """
+        ),
+        source(
+          "demo.B",
+          """
+          package demo;
+          public record B(String name) {}
+          """
+        )
+      );
+      assertTrue(
+        !compilation.success() && compilation.hasError("method` not found"),
+        () -> "expected 'method not found' diagnostic; saw " + compilation.errorMessages()
+      );
+    }
+
+    @Test
+    @DisplayName("@Transform(method = \"instanceMethod\") — non-static method rejected at processor time")
+    void transformNonStaticMethodRejected() {
+      final var compilation = compile(
+        source(
+          "demo.Helpers",
+          """
+          package demo;
+          public final class Helpers {
+            public Helpers() {}
+            // instance method — qualifier dispatch needs static
+            public String mutate(String s) { return s; }
+          }
+          """
+        ),
+        source(
+          "demo.A",
+          """
+          package demo;
+          import io.github.eschizoid.telescope.annotations.Bridge;
+          import io.github.eschizoid.telescope.annotations.Transform;
+          @Bridge(value = demo.B.class, transforms = {
+            @Transform(field = "name", using = demo.Helpers.class, method = "mutate")
+          })
+          public record A(String name) {}
+          """
+        ),
+        source(
+          "demo.B",
+          """
+          package demo;
+          public record B(String name) {}
+          """
+        )
+      );
+      assertTrue(
+        !compilation.success() && compilation.hasError("is not static"),
+        () -> "expected 'is not static' diagnostic; saw " + compilation.errorMessages()
+      );
+    }
+
+    @Test
     @DisplayName("misspelled transform field is a compile error pointing at the source")
     void misspelledTransformFieldIsRejected() {
       final var compilation = compile(

--- a/codegen/src/test/java/io/github/eschizoid/telescope/codegen/BridgeProcessorTest.java
+++ b/codegen/src/test/java/io/github/eschizoid/telescope/codegen/BridgeProcessorTest.java
@@ -1361,6 +1361,157 @@ class BridgeProcessorTest {
     }
 
     @Test
+    @DisplayName(
+      "@Transform(method = \"...\") — qualifier dispatch emits direct static-method call, no BridgeFn instance"
+    )
+    void transformQualifierDispatchEmitsDirectStaticCall() {
+      final var compilation = compile(
+        source(
+          "demo.DateHelpers",
+          """
+          package demo;
+          import java.time.Instant;
+          import java.time.ZoneOffset;
+          import java.time.format.DateTimeFormatter;
+          public final class DateHelpers {
+            private DateHelpers() {}
+            public static String expiry(Instant i)    { return DateTimeFormatter.ISO_INSTANT.format(i); }
+            public static String createdAt(Instant i) { return i.atZone(ZoneOffset.UTC).toString(); }
+          }
+          """
+        ),
+        source(
+          "demo.UserEntity",
+          """
+          package demo;
+          import io.github.eschizoid.telescope.annotations.Bridge;
+          import io.github.eschizoid.telescope.annotations.Transform;
+          import java.time.Instant;
+          @Bridge(value = demo.UserDto.class, transforms = {
+            @Transform(field = "expiresAt", using = demo.DateHelpers.class, method = "expiry"),
+            @Transform(field = "registeredAt", using = demo.DateHelpers.class, method = "createdAt")
+          })
+          public record UserEntity(String id, Instant expiresAt, Instant registeredAt) {}
+          """
+        ),
+        source(
+          "demo.UserDto",
+          """
+          package demo;
+          public record UserDto(String id, String expiresAt, String registeredAt) {}
+          """
+        )
+      );
+
+      assertTrue(compilation.success(), () -> "compilation failed: " + compilation.errorMessages());
+      final var bridge = compilation.generated().get("demo.UserEntityBridge");
+      assertNotNull(bridge, () -> "UserEntityBridge missing; saw " + compilation.generated().keySet());
+
+      // NO __tx_ singleton — qualifier dispatch calls the static method directly.
+      assertTrue(
+        !bridge.contains("__tx_expiresAt"),
+        () -> "qualifier dispatch must NOT emit __tx_ field; saw: " + bridge
+      );
+      assertTrue(
+        !bridge.contains("new demo.DateHelpers()"),
+        () -> "qualifier dispatch must NOT instantiate the helper class; saw: " + bridge
+      );
+
+      // Forward emits direct UsingClass.methodName(value) calls per qualified field.
+      assertTrue(
+        bridge.contains("demo.DateHelpers.expiry(s.expiresAt())"),
+        () -> "expected demo.DateHelpers.expiry(...) call; saw: " + bridge
+      );
+      assertTrue(
+        bridge.contains("demo.DateHelpers.createdAt(s.registeredAt())"),
+        () -> "expected demo.DateHelpers.createdAt(...) call; saw: " + bridge
+      );
+
+      // Qualifier dispatch is implicitly forward-only — backward zero-fills.
+      assertTrue(
+        bridge.contains("new demo.UserEntity(t.id(), null, null)"),
+        () -> "expected backward zero-fill on qualifier-dispatch slots; saw: " + bridge
+      );
+    }
+
+    @Test
+    @DisplayName("@Transform(using=BridgeFn) and @Transform(method=...) coexist on the same bridge")
+    void transformBridgeFnAndQualifierCoexist() {
+      final var compilation = compile(
+        source(
+          "demo.CentsConverter",
+          """
+          package demo;
+          import io.github.eschizoid.telescope.conversion.BridgeFn;
+          import java.math.BigDecimal;
+          public final class CentsConverter implements BridgeFn<BigDecimal, Long> {
+            public CentsConverter() {}
+            @Override public Long forward(BigDecimal x) { return x.movePointRight(2).longValueExact(); }
+            @Override public BigDecimal backward(Long c) { return BigDecimal.valueOf(c).movePointLeft(2); }
+          }
+          """
+        ),
+        source(
+          "demo.Helpers",
+          """
+          package demo;
+          import java.time.Instant;
+          public final class Helpers {
+            private Helpers() {}
+            public static String asIso(Instant i) { return i.toString(); }
+          }
+          """
+        ),
+        source(
+          "demo.Order",
+          """
+          package demo;
+          import io.github.eschizoid.telescope.annotations.Bridge;
+          import io.github.eschizoid.telescope.annotations.Transform;
+          import java.math.BigDecimal;
+          import java.time.Instant;
+          @Bridge(value = demo.OrderEntity.class, transforms = {
+            @Transform(field = "price", using = demo.CentsConverter.class),
+            @Transform(field = "createdAt", using = demo.Helpers.class, method = "asIso")
+          })
+          public record Order(String id, BigDecimal price, Instant createdAt) {}
+          """
+        ),
+        source(
+          "demo.OrderEntity",
+          """
+          package demo;
+          public record OrderEntity(String id, Long price, String createdAt) {}
+          """
+        )
+      );
+
+      assertTrue(compilation.success(), () -> "compilation failed: " + compilation.errorMessages());
+      final var bridge = compilation.generated().get("demo.OrderBridge");
+      assertNotNull(bridge, () -> "OrderBridge missing; saw " + compilation.generated().keySet());
+
+      // BridgeFn-shape: __tx_price singleton + .forward/.backward calls
+      assertTrue(
+        bridge.contains("private static final demo.CentsConverter __tx_price = new demo.CentsConverter();"),
+        bridge
+      );
+      assertTrue(bridge.contains("__tx_price.forward(s.price())"), bridge);
+      assertTrue(bridge.contains("__tx_price.backward(t.price())"), bridge);
+
+      // Qualifier dispatch: no __tx_createdAt, direct method call
+      assertTrue(
+        !bridge.contains("__tx_createdAt"),
+        () -> "qualifier field MUST NOT have a __tx_ singleton; saw: " + bridge
+      );
+      assertTrue(bridge.contains("demo.Helpers.asIso(s.createdAt())"), bridge);
+      // Forward-only on qualifier slot — backward zero-fills the createdAt slot
+      assertTrue(
+        !bridge.contains("Helpers.asIso(t.createdAt())"),
+        () -> "backward must NOT call qualifier method; saw: " + bridge
+      );
+    }
+
+    @Test
     @DisplayName("misspelled transform field is a compile error pointing at the source")
     void misspelledTransformFieldIsRejected() {
       final var compilation = compile(

--- a/core/src/main/java/io/github/eschizoid/telescope/annotations/Transform.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/annotations/Transform.java
@@ -56,10 +56,49 @@ public @interface Transform {
 
   /**
    * A {@link BridgeFn} implementation whose {@code forward}/{@code backward} convert this field's
-   * value in each direction. Must be a top-level type with a public no-arg constructor.
+   * value in each direction, OR — when {@link #method()} is set — any class containing a static
+   * method named {@link #method()} taking one argument and returning the converted value. The
+   * {@link BridgeFn} shape is the default; the {@code method}-named form unlocks MapStruct's
+   * {@code @Named} qualifier-dispatch pattern where a single helper class hosts several conversion
+   * methods (different fields point at different methods on the same class).
+   *
+   * <p>Without {@code method}: must be a top-level {@link BridgeFn} subtype with a public no-arg
+   * constructor — the generated bridge instantiates one static instance per transformed field.
+   *
+   * <p>With {@code method}: may be any top-level class. The generated bridge emits a direct {@code
+   * UsingClass.methodName(value)} call (no instantiation, no {@code BridgeFn} requirement). The
+   * named method must be static, take exactly one argument, and return the converted value. Always
+   * forward-only (qualifier dispatch is inherently asymmetric — the inverse method name isn't
+   * recoverable from a forward method name). {@link #forwardOnly()} is implicitly true when {@code
+   * method} is set.
    */
   @SuppressWarnings("rawtypes")
-  Class<? extends BridgeFn> using();
+  Class<?> using();
+
+  /**
+   * Optional named static method on {@link #using()} to invoke for the forward conversion. When
+   * non-empty, switches the row from the {@link BridgeFn}-shape to the qualifier-dispatch shape:
+   * {@code using} no longer needs to implement {@link BridgeFn}, and the generated bridge emits a
+   * direct {@code UsingClass.methodName(value)} call.
+   *
+   * <pre>{@code
+   * public final class DateHelpers {
+   *   public static String expiry(Instant i)   { return DateTimeFormatter.ISO_INSTANT.format(i); }
+   *   public static String createdAt(Instant i) { return i.atZone(ZoneOffset.UTC).toString(); }
+   * }
+   *
+   * @Bridge(value = UserDto.class, transforms = {
+   *   @Transform(field = "expiresAt", using = DateHelpers.class, method = "expiry"),
+   *   @Transform(field = "createdAt", using = DateHelpers.class, method = "createdAt")
+   * })
+   * public record UserEntity(String id, Instant expiresAt, Instant createdAt) {}
+   * }</pre>
+   *
+   * <p>Always implicitly forward-only — see {@link #using()} for the full contract.
+   *
+   * <p>Default empty ({@code ""}) preserves the existing {@link BridgeFn}-shape semantics.
+   */
+  String method() default "";
 
   /**
    * Opt in to forward-only semantics: the generated bridge emits a zero-value fill in the backward
@@ -70,6 +109,9 @@ public @interface Transform {
    * <p>The generated {@code patch(base, partial)} method also skips the backward read for this slot
    * and preserves {@code base.field()} unchanged — a forward-only transform has no defined inverse,
    * so there is no way to overlay a partial value back onto the source.
+   *
+   * <p>Implicitly {@code true} when {@link #method()} is set — qualifier dispatch is inherently
+   * one-direction (the inverse method name isn't recoverable from a forward method name).
    */
   boolean forwardOnly() default false;
 }


### PR DESCRIPTION
## Summary

Closes Tier 2 #1.1 — MapStruct's `@Named` qualifier dispatch for the codegen path. The runtime path already supports it via `Mapping.forward(srcAcc, tgtAcc, methodRef)`.

```java
public final class DateHelpers {
  public static String expiry(Instant i)    { return DateTimeFormatter.ISO_INSTANT.format(i); }
  public static String createdAt(Instant i) { return i.atZone(ZoneOffset.UTC).toString(); }
}

@Bridge(value = UserDto.class, transforms = {
  @Transform(field = "expiresAt",    using = DateHelpers.class, method = "expiry"),
  @Transform(field = "registeredAt", using = DateHelpers.class, method = "createdAt")
})
public record UserEntity(String id, Instant expiresAt, Instant registeredAt) {}
```

The "one BridgeFn class per transform" pattern doesn't scale when a codebase has 50+ field transforms sharing infrastructure (date formatting, currency, ID encoding). This unlocks the natural shape: one helper class hosting multiple static methods, different fields pointing at different methods.

## What changes

- New `String method() default ""` element on `@Transform`
- `using` relaxed from `Class<? extends BridgeFn>` to `Class<?>` — source-compatible (existing BridgeFn classes still satisfy)
- Generated bridge emits direct `UsingClass.methodName(value)` calls inline — NO `__tx_<field>` singleton, NO instantiation, NO BridgeFn requirement
- Qualifier rows implicitly forward-only: backward direction zero-fills (the inverse method name isn't recoverable from a forward method name)
- BridgeFn-shape and qualifier-shape rows coexist on the same `@Bridge` — pinned by test

## Backwards compatibility

Existing `@Transform(using = BridgeFnClass.class)` rows compile and behave identically — no migration required. The two shapes are routed at codegen-emission time based on whether `method` is non-empty.

## Implementation

- `TransformSet` extended with `methodsByField` alongside `byField`
- `BridgeConfig` extended with `transformMethods`
- `FieldPlan` extended with `qualifierMethod` field + new `ofTransformQualified` factory
- `planFields` routes to `ofTransformQualified` when `method` is set
- `applyForward` emits `UsingClass.methodName(...)` for qualifier rows
- Singleton declaration loop skips qualifier-dispatch fields
- Qualifier rows land in `forwardOnlyFields`, reusing the existing zero-fill backward path
- Processor-time validation (review pass): blank method name rejected, non-existent method rejected, non-static method rejected, method name must be a valid Java identifier

## Test coverage

Five BridgeProcessorTest cases:
1. **Pure qualifier dispatch** — no `__tx_` instance emitted, `DateHelpers.method()` calls inline, backward zero-fill
2. **Coexistence** — same `@Bridge` with one BridgeFn-shape row + one qualifier-shape row; both work independently
3. **Blank method name rejected** at processor time
4. **Non-existent method rejected** at processor time
5. **Non-static (instance) method rejected** at processor time

## Test plan

- [x] `:codegen:test` (regression + 5 new tests)
- [x] `:core:test`
- [x] `:lombok:test :spring-boot-starter:test :quarkus:test`
- [x] `:core:spotlessJavaCheck :codegen:spotlessJavaCheck`