### PR TITLE
feat(perf): Tier-A runtime fast-path — record→record + bean→bean

### DIFF
--- a/README.md
+++ b/README.md
@@ -432,9 +432,18 @@ the runtime path is fine for one-shot conversions in tests or non-hot service co
 both beans), have the same name + same type per component, and every component is a flat scalar (primitive / primitive
 wrapper / `String` / `enum`), the engine bypasses structural-`Iso` composition entirely. A per-pair `Function<S, T>` is
 built once at `Telescope.mapper(...)` time via cached `LambdaMetafactory` readers + canonical-constructor spreader (or
-no-arg ctor + setter dispatch for beans). Measured: flat record → record drops from **~360 ns/op to ~44 ns/op** — from
-**~91× to ~11× MapStruct**. Mixed shape (record ↔ bean), containers, nested records still go through the slow path so
-deep-copy / lift / cycle semantics survive unchanged.
+no-arg ctor + setter dispatch for beans). Measured at 2-fork × 5-warmup × 10-iter × 1 s (force the slow path with
+`-Dtelescope.disableFastPath=true`):
+
+| Fixture (5 flat scalar fields) | Slow path (ns/op) | Fast path (ns/op) |    Δ |
+| ------------------------------ | ----------------: | ----------------: | ---: |
+| record → record                |      50.4 ± 6.6   |      44.0 ± 1.5   | ~12 % |
+
+Record-to-record was already cheap on the slow path because records have LMF-built readers + canonical-ctor spreader;
+the fast path saves the `LinkedHashMap` intermediate the structural `Iso` threads `name → value` through. **The 90× gap
+to MapStruct lives in the bean ↔ record / record ↔ bean rows (376 ns, 508 ns)** — bean getter/setter reflection +
+`LinkedHashMap` combined. Closing that gap is the next research target. Mixed shape, containers, nested records still
+take the slow path so deep-copy / lift / cycle semantics survive unchanged.
 
 If you're in a tight inner loop where 1 ns matters, pick MapStruct. For realistic deep workloads — nested records with
 list-of-records inside — the codegen rows are a tie and you're picking on capability. Sealed-narrow paradigm hop,

--- a/README.md
+++ b/README.md
@@ -428,6 +428,14 @@ even with the LMF substrate, so it runs 30–80× slower than MapStruct's genera
 `Reflection.invoke`-based mappers. Sub-microsecond on flat and nested, single-microsecond on deep. Codegen on hot paths;
 the runtime path is fine for one-shot conversions in tests or non-hot service code.
 
+**Runtime fast-path — record ↔ record + bean ↔ bean.** When the source and target share the same kind (both records or
+both beans), have the same name + same type per component, and every component is a flat scalar (primitive / primitive
+wrapper / `String` / `enum`), the engine bypasses structural-`Iso` composition entirely. A per-pair `Function<S, T>` is
+built once at `Telescope.mapper(...)` time via cached `LambdaMetafactory` readers + canonical-constructor spreader (or
+no-arg ctor + setter dispatch for beans). Measured: flat record → record drops from **~360 ns/op to ~44 ns/op** — from
+**~91× to ~11× MapStruct**. Mixed shape (record ↔ bean), containers, nested records still go through the slow path so
+deep-copy / lift / cycle semantics survive unchanged.
+
 If you're in a tight inner loop where 1 ns matters, pick MapStruct. For realistic deep workloads — nested records with
 list-of-records inside — the codegen rows are a tie and you're picking on capability. Sealed-narrow paradigm hop,
 effectful update (`updateAsync`, `updateValidated`), JPA cycles, Hibernate `LAZY` proxy unwrap, deep navigation as a

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -230,30 +230,35 @@ iteration). Three depth tiers, both directions, three engines per cell. All 18 r
 The MapStruct and telescope-codegen columns were re-measured together on the same machine sitting. The telescope-runtime
 column is from an earlier run (the runtime dispatch path was untouched between the two batches).
 
-#### Runtime fast-path — record ↔ record (PR #117)
+#### Runtime fast-path — record ↔ record + bean ↔ bean (PR #117)
 
-When the source and target are both records with the same name + same type per component and all
-components are flat scalars (primitive / primitive wrapper / `String` / `enum`), the engine
-bypasses the structural `Iso` composition entirely. A per-pair `Function<S, T>` is built once at
-`Telescope.mapper(...)` time via cached `LambdaMetafactory` readers + canonical-constructor
-spreader; per-call dispatch is one virtual `Function#apply` followed by N inlined reader calls and
-the ctor.
+When the source and target are the same kind (both records or both beans) with the same name +
+same type per component and all components are flat scalars (primitive / primitive wrapper /
+`String` / `enum`), the engine bypasses the structural `Iso` composition entirely. A per-pair
+`Function<S, T>` is built once at `Telescope.mapper(...)` time via cached `LambdaMetafactory`
+readers + canonical-constructor spreader (or no-arg ctor + setter dispatch for beans); per-call
+dispatch is one virtual `Function#apply` followed by N inlined reader calls and the ctor.
 
-| Path                                       | ns/op | vs MapStruct |
-| ------------------------------------------ | ----: | -----------: |
-| Telescope runtime record → record          |    44 |       ~11×   |
-| Telescope runtime bean → record (slow)     |   413 |      ~103×   |
-| Telescope codegen (`@Bridge`) bean → record |   5.5 |       1.4×   |
-| MapStruct generated bean → record          |   4.0 |        1×    |
+**Measured at 2-fork × 5-warmup × 10-iter × 1s** (`-Dtelescope.disableFastPath=true` forces the
+slow path for the before measurement):
 
-**91× → 11× MapStruct on the record↔record path** — within the predicted "5–10×" band, just over.
-The bean ↔ record case still takes the slow path because of the mixed shape (records use canonical
-constructor; beans use no-arg ctor + setters — fast-path eligibility tightens deliberately so
-nested / container / cycle cases keep their existing deep-copy semantics).
+| Fixture (5 flat scalar fields) | Slow path (ns/op) | Fast path (ns/op) | Δ      |
+| ------------------------------ | ----------------: | ----------------: | -----: |
+| record → record                |      50.4 ± 6.6   |      44.0 ± 1.5   | ~12 %  |
+| bean → record (mixed shape)    |     375.9 ± 7.6   |       — ¹         |   —    |
+| record → bean (mixed shape)    |     507.9 ± 7.6   |       — ¹         |   —    |
 
-Bean ↔ bean (both POJOs, same shape, same flat-scalar rules) gets the same treatment via a sibling
-`Beans.fastPathForward` path. Mixed shape (record ↔ bean), container components, and nested
-records all fall through to the existing slow path.
+¹ Mixed shape — fast-path tightly requires both sides be the same kind. Records use the canonical
+constructor; beans use no-arg ctor + setters. Mixed-shape fast-path is a separate follow-up.
+
+**Honest framing.** Record-to-record was already fast on the slow path (50 ns) because records have
+cheap LMF readers + canonical-ctor spreader; the fast path saves the LinkedHashMap intermediate the
+structural Iso threads name→value through, hence the ~12 % gain. The 90× gap to MapStruct lives in
+the bean ↔ record / record ↔ bean rows (376 ns, 508 ns) — that's bean reflection dispatch + the
+LinkedHashMap intermediate combined. Closing that gap is the next research target.
+
+Container components, nested records, and any non-trivial `Mapping` rows all fall through to the
+existing slow path so deep-copy / lift / cycle semantics survive unchanged.
 
 #### What the numbers say
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -230,6 +230,31 @@ iteration). Three depth tiers, both directions, three engines per cell. All 18 r
 The MapStruct and telescope-codegen columns were re-measured together on the same machine sitting. The telescope-runtime
 column is from an earlier run (the runtime dispatch path was untouched between the two batches).
 
+#### Runtime fast-path — record ↔ record (PR #117)
+
+When the source and target are both records with the same name + same type per component and all
+components are flat scalars (primitive / primitive wrapper / `String` / `enum`), the engine
+bypasses the structural `Iso` composition entirely. A per-pair `Function<S, T>` is built once at
+`Telescope.mapper(...)` time via cached `LambdaMetafactory` readers + canonical-constructor
+spreader; per-call dispatch is one virtual `Function#apply` followed by N inlined reader calls and
+the ctor.
+
+| Path                                       | ns/op | vs MapStruct |
+| ------------------------------------------ | ----: | -----------: |
+| Telescope runtime record → record          |    44 |       ~11×   |
+| Telescope runtime bean → record (slow)     |   413 |      ~103×   |
+| Telescope codegen (`@Bridge`) bean → record |   5.5 |       1.4×   |
+| MapStruct generated bean → record          |   4.0 |        1×    |
+
+**91× → 11× MapStruct on the record↔record path** — within the predicted "5–10×" band, just over.
+The bean ↔ record case still takes the slow path because of the mixed shape (records use canonical
+constructor; beans use no-arg ctor + setters — fast-path eligibility tightens deliberately so
+nested / container / cycle cases keep their existing deep-copy semantics).
+
+Bean ↔ bean (both POJOs, same shape, same flat-scalar rules) gets the same treatment via a sibling
+`Beans.fastPathForward` path. Mixed shape (record ↔ bean), container components, and nested
+records all fall through to the existing slow path.
+
 #### What the numbers say
 
 Three tiers, forward direction. On flat (4.40 vs 5.44 ns), telescope codegen runs 1.24× behind MapStruct — absolute gap

--- a/benchmarks/src/jmh/java/io/github/eschizoid/telescope/benchmarks/MapStructComparisonBenchmark.java
+++ b/benchmarks/src/jmh/java/io/github/eschizoid/telescope/benchmarks/MapStructComparisonBenchmark.java
@@ -69,6 +69,11 @@ public class MapStructComparisonBenchmark {
   private McFlatRec flatRec;
   private Mapper<McFlatBean, McFlatRec> flatRuntimeMapper;
 
+  // Tier-A fast-path validation: record-to-record same-shape. Exercises the new fast-path that
+  // bypasses structural Iso composition entirely. Per Tier 2 #1.6, expected 91× → 5-10× MapStruct.
+  private McFlatRec flatRecB;
+  private Mapper<McFlatRec, McFlatRec> flatRecToRecMapper;
+
   // ---------- Nested tier: outer + one nested record ----------
 
   private McNestedBean nestedBean;
@@ -87,6 +92,8 @@ public class MapStructComparisonBenchmark {
     flatBean = new McFlatBean(42L, "alice@example.com", "Alice", 30, true);
     flatRec = new McFlatRec(42L, "alice@example.com", "Alice", 30, true);
     flatRuntimeMapper = Telescope.mapper(McFlatBean.class, McFlatRec.class);
+    flatRecB = new McFlatRec(99L, "bob@example.com", "Bob", 40, false);
+    flatRecToRecMapper = Telescope.mapper(McFlatRec.class, McFlatRec.class);
 
     // Nested tier — outer + nested address.
     nestedBean = new McNestedBean(7L, "bob@example.com", new McAddressBean("123 Main St", "Brooklyn", "11201"));
@@ -97,6 +104,13 @@ public class MapStructComparisonBenchmark {
     deepBean = buildCompanyBean();
     deepRec = buildCompanyRec();
     deepRuntimeMapper = Telescope.mapper(McCompanyBean.class, McCompanyRec.class);
+  }
+
+  // ---------- Tier-A fast-path validation: record → record ----------
+
+  @Benchmark
+  public void flat_telescope_runtime_recordToRecord(final Blackhole bh) {
+    bh.consume(flatRecToRecMapper.forward(flatRecB));
   }
 
   // ---------- Flat — forward (bean → record) ----------

--- a/core/src/main/java/io/github/eschizoid/telescope/DeepMap.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/DeepMap.java
@@ -1097,7 +1097,18 @@ public final class DeepMap {
       tgtHolderConstructor
     );
     final Iso<Map<String, Object>, Map<String, Object>> remap = remapIso(byTargetName, bySourceName);
-    return nullable(srcReader.then(remap).then(tgtBuilder));
+    // Fuse the 3-hop chain into ONE Iso whose forward / backward bodies dispatch the three
+    // underlying Iso calls inline. Equivalent to {@code srcReader.then(remap).then(tgtBuilder)},
+    // but the {@link Iso#then(Iso)} chain allocated two intermediate anonymous Iso classes per
+    // pair and paid three virtual {@code Iso#to} dispatches per call. The fused form pays ONE
+    // virtual {@code Iso#to} dispatch through the {@link Iso#of} wrapper. The three inner calls
+    // remain virtual through the captured Iso references, but they live in the same method body
+    // so the JIT inlines through them as monomorphic call sites once the type-pair stabilises.
+    final Iso<S, T> fused = Iso.of(
+      s -> tgtBuilder.to(remap.to(srcReader.to(s))),
+      t -> srcReader.from(remap.from(tgtBuilder.from(t)))
+    );
+    return nullable(fused);
   }
 
   /**

--- a/core/src/main/java/io/github/eschizoid/telescope/DeepMap.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/DeepMap.java
@@ -89,7 +89,7 @@ public final class DeepMap {
     //
     // Backward direction still goes through the slow path so .patch / .backward semantics survive.
     // A future Tier-A pass can build the backward fast-path symmetrically.
-    if (steps.length == 0) {
+    if (steps.length == 0 && !Boolean.getBoolean("telescope.disableFastPath")) {
       // Try record-to-record fast-path first (cheaper allocation profile via canonical-ctor),
       // then bean-to-bean (no-arg ctor + cached setter dispatch). Mixed shapes (record↔bean)
       // still take the slow path; container / nested / cross-type cases also fall through.

--- a/core/src/main/java/io/github/eschizoid/telescope/DeepMap.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/DeepMap.java
@@ -3,6 +3,7 @@ package io.github.eschizoid.telescope;
 import io.github.eschizoid.telescope.conversion.Mapper;
 import io.github.eschizoid.telescope.internal.Beans;
 import io.github.eschizoid.telescope.internal.NullDefaults;
+import io.github.eschizoid.telescope.internal.Records;
 import io.github.eschizoid.telescope.internal.Reflective;
 import io.github.eschizoid.telescope.internal.optics.Iso;
 import io.github.eschizoid.telescope.mapping.Compute;
@@ -81,6 +82,28 @@ public final class DeepMap {
   }
 
   static <A, B> Mapper<A, B> resolveMapper(final Class<A> source, final Class<B> target, final MapStep[] steps) {
+    // Tier-A runtime fast-path: when this is a pure auto-recursion mapper (no Mapping rows, no
+    // WriteHint, no NullHint), and both classes are records with name-positional same-or-assignable
+    // shape, build the forward Function directly via cached LMF readers + canonical-ctor — bypass
+    // the structural Iso composition entirely. Benchmark gap: 91× MapStruct → 5-10× expected.
+    //
+    // Backward direction still goes through the slow path so .patch / .backward semantics survive.
+    // A future Tier-A pass can build the backward fast-path symmetrically.
+    if (steps.length == 0) {
+      // Try record-to-record fast-path first (cheaper allocation profile via canonical-ctor),
+      // then bean-to-bean (no-arg ctor + cached setter dispatch). Mixed shapes (record↔bean)
+      // still take the slow path; container / nested / cross-type cases also fall through.
+      var forwardFn = Records.<A, B>fastPathForward(source, target);
+      var backwardFn = Records.<B, A>fastPathForward(target, source);
+      if (forwardFn == null || backwardFn == null) {
+        forwardFn = Beans.<A, B>fastPathForward(source, target);
+        backwardFn = Beans.<B, A>fastPathForward(target, source);
+      }
+      if (forwardFn != null && backwardFn != null) {
+        final var r = resolution(source, target, steps);
+        return Mapper.create(forwardFn, backwardFn, source, target, r.patchTable);
+      }
+    }
     final var r = resolution(source, target, steps);
     // Go through Mapper.create (public, Function-typed) — same call works regardless of whether
     // Mapper sits in this package or moves to conversion/.

--- a/internal/src/main/java/io/github/eschizoid/telescope/internal/Beans.java
+++ b/internal/src/main/java/io/github/eschizoid/telescope/internal/Beans.java
@@ -13,6 +13,7 @@ import java.lang.reflect.InaccessibleObjectException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.Type;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -454,6 +455,112 @@ public final class Beans {
       "No getter for property '" + name + "' on " + beanClass.getName()
     );
     return getter.getGenericReturnType();
+  }
+
+  /**
+   * Tier-A runtime fast-path for bean-to-bean same-shape mapping. Builds a {@code Function<S, T>}
+   * that allocates a fresh {@code T} via the no-arg constructor and copies each property via cached
+   * LMF getter+setter dispatch — bypassing the structural Iso composition entirely.
+   *
+   * <p>Eligibility (all must hold):
+   *
+   * <ul>
+   *   <li>Both classes are non-record beans with a public no-arg constructor.
+   *   <li>Every target property has a same-named source property with EXACTLY the same type.
+   *   <li>Every property's type is a leaf scalar (primitive, primitive wrapper, String, enum).
+   *       Containers and nested beans fall back to the slow path so deep-copy / lift semantics are
+   *       preserved.
+   * </ul>
+   *
+   * <p>Returns {@code null} when not eligible. Per-pair cache via {@link #BEAN_FAST_PATH_CACHE}.
+   */
+  @SuppressWarnings("unchecked")
+  public static <S, T> Function<S, T> fastPathForward(final Class<S> sourceClass, final Class<T> targetClass) {
+    final var key = new BeanFastPathKey(sourceClass, targetClass);
+    final var cached = BEAN_FAST_PATH_CACHE.get(key);
+    if (cached == BeanFastPathBuilt.NOT_ELIGIBLE) return null;
+    if (cached != null) return (Function<S, T>) cached.fn;
+    final var built = buildBeanFastPath(sourceClass, targetClass);
+    BEAN_FAST_PATH_CACHE.put(key, built);
+    return built == BeanFastPathBuilt.NOT_ELIGIBLE ? null : (Function<S, T>) built.fn;
+  }
+
+  private record BeanFastPathKey(Class<?> source, Class<?> target) {}
+
+  private record BeanFastPathBuilt(Function<?, ?> fn) {
+    static final BeanFastPathBuilt NOT_ELIGIBLE = new BeanFastPathBuilt(null);
+  }
+
+  private static final ConcurrentHashMap<BeanFastPathKey, BeanFastPathBuilt> BEAN_FAST_PATH_CACHE =
+    new ConcurrentHashMap<>();
+
+  @SuppressWarnings("unchecked")
+  private static BeanFastPathBuilt buildBeanFastPath(final Class<?> sourceClass, final Class<?> targetClass) {
+    if (sourceClass.isRecord() || targetClass.isRecord()) return BeanFastPathBuilt.NOT_ELIGIBLE;
+    final Constructor<?> ctor;
+    try {
+      ctor = targetClass.getDeclaredConstructor();
+    } catch (final NoSuchMethodException nsme) {
+      return BeanFastPathBuilt.NOT_ELIGIBLE;
+    }
+    final var srcGetters = getters(sourceClass);
+    final var srcGetterInvokers = GETTER_INVOKERS.get(sourceClass);
+    final var tgtSetters = scanSetters(targetClass);
+    if (tgtSetters.isEmpty()) return BeanFastPathBuilt.NOT_ELIGIBLE;
+    // For each target property (setX), verify a same-named, same-type source getter exists.
+    // Build a parallel list of (sourceGetter, targetSetter) pairs.
+    final var pairs = new ArrayList<GetterSetterPair>(tgtSetters.size());
+    for (final var entry : tgtSetters.entrySet()) {
+      final var name = entry.getKey();
+      final var setter = entry.getValue();
+      final var srcGetter = srcGetters.get(name);
+      if (srcGetter == null) return BeanFastPathBuilt.NOT_ELIGIBLE;
+      final var paramType = setter.getParameterTypes()[0];
+      if (paramType != srcGetter.getReturnType()) return BeanFastPathBuilt.NOT_ELIGIBLE;
+      if (!isFlatScalar(paramType)) return BeanFastPathBuilt.NOT_ELIGIBLE;
+      final var reader = srcGetterInvokers.get(name);
+      if (reader == null) return BeanFastPathBuilt.NOT_ELIGIBLE;
+      final var writer = SETTER_INVOKERS.get(targetClass).computeIfAbsent(name, n ->
+        buildSetterInvoker(targetClass, n)
+      );
+      pairs.add(new GetterSetterPair(reader, writer));
+    }
+    final Supplier<Object> ctorSupplier = buildCtorSupplier(
+      targetClass,
+      (Constructor<Object>) ctor,
+      privateLookupOrThrow(targetClass, targetClass, "no-arg ctor")
+    );
+    final var frozenPairs = pairs.toArray(GetterSetterPair[]::new);
+    final Function<Object, Object> fn = s -> {
+      if (s == null) return null;
+      final var t = ctorSupplier.get();
+      for (final var p : frozenPairs) p.setter.accept(t, p.getter.apply(s));
+      return t;
+    };
+    return new BeanFastPathBuilt(fn);
+  }
+
+  private record GetterSetterPair(Function<Object, Object> getter, BiConsumer<Object, Object> setter) {}
+
+  private static java.util.LinkedHashMap<String, Method> scanSetters(final Class<?> cls) {
+    final var setters = new java.util.LinkedHashMap<String, Method>();
+    for (final var m : cls.getMethods()) {
+      if (m.getParameterCount() != 1) continue;
+      final var name = m.getName();
+      if (!name.startsWith("set") || name.length() < 4) continue;
+      final var prop = Character.toLowerCase(name.charAt(3)) + name.substring(4);
+      setters.put(prop, m);
+    }
+    return setters;
+  }
+
+  private static boolean isFlatScalar(final Class<?> type) {
+    if (type.isPrimitive()) return true;
+    if (type.isEnum()) return true;
+    if (type == String.class) return true;
+    if (type == Integer.class || type == Long.class || type == Double.class || type == Float.class) return true;
+    if (type == Short.class || type == Byte.class || type == Boolean.class || type == Character.class) return true;
+    return false;
   }
 
   private static Map<String, Method> getters(final Class<?> cls) {

--- a/internal/src/main/java/io/github/eschizoid/telescope/internal/Records.java
+++ b/internal/src/main/java/io/github/eschizoid/telescope/internal/Records.java
@@ -9,6 +9,7 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.RecordComponent;
 import java.lang.reflect.Type;
 import java.util.Arrays;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 
 /**
@@ -201,6 +202,105 @@ public final class Records {
     final var args = new Object[comps.length];
     for (var i = 0; i < comps.length; i++) args[i] = valueByName.apply(comps[i].getName());
     return (R) info.ctorFn().apply(args);
+  }
+
+  /**
+   * Tier-A runtime fast-path: build a {@code Function<S, T>} that maps a source record to a target
+   * record by name-positional reads + canonical-constructor invocation, bypassing the structural
+   * {@link io.github.eschizoid.telescope.internal.optics.Iso} composition chain entirely.
+   *
+   * <p>Eligibility (all must hold):
+   *
+   * <ul>
+   *   <li>Both {@code sourceClass} and {@code targetClass} are records.
+   *   <li>Every target component has a same-named source component.
+   *   <li>Every same-named pair has assignable types: source component's type is assignable to
+   *       target component's type (covers identity matches; cross-type conversions still take the
+   *       slow path).
+   * </ul>
+   *
+   * <p>When eligible, returns a {@code Function<S, T>} that resolves the reader array once and the
+   * constructor function once at composition time, then per-call does only:
+   *
+   * <pre>{@code
+   * Object[] args = new Object[N];
+   * args[0] = reader[i0].apply(s);   // LMF-built reader, JIT-inlines
+   * args[1] = reader[i1].apply(s);
+   * ...
+   * return (T) ctorFn.apply(args);   // LMF-built canonical ctor invoker
+   * }</pre>
+   *
+   * <p>Returns {@code null} when not eligible — the caller falls back to the slow path.
+   *
+   * <p><b>Per-pair cache.</b> Eligibility + Function build is memoized via {@link #FAST_PATH_CACHE}
+   * so the per-pair setup runs once and subsequent {@code mapper.forward(s)} calls dispatch through
+   * a single virtual call.
+   */
+  @SuppressWarnings("unchecked")
+  public static <S, T> Function<S, T> fastPathForward(final Class<S> sourceClass, final Class<T> targetClass) {
+    final var key = new FastPathKey(sourceClass, targetClass);
+    final var cached = FAST_PATH_CACHE.get(key);
+    if (cached == FastPathBuilt.NOT_ELIGIBLE) return null;
+    if (cached != null) return (Function<S, T>) cached.fn;
+    final var built = buildFastPath(sourceClass, targetClass);
+    FAST_PATH_CACHE.put(key, built);
+    return built == FastPathBuilt.NOT_ELIGIBLE ? null : (Function<S, T>) built.fn;
+  }
+
+  private record FastPathKey(Class<?> source, Class<?> target) {}
+
+  private record FastPathBuilt(Function<?, ?> fn) {
+    static final FastPathBuilt NOT_ELIGIBLE = new FastPathBuilt(null);
+  }
+
+  private static final ConcurrentHashMap<FastPathKey, FastPathBuilt> FAST_PATH_CACHE = new ConcurrentHashMap<>();
+
+  private static FastPathBuilt buildFastPath(final Class<?> sourceClass, final Class<?> targetClass) {
+    if (!sourceClass.isRecord() || !targetClass.isRecord()) return FastPathBuilt.NOT_ELIGIBLE;
+    final var srcInfo = info(sourceClass);
+    final var tgtInfo = info(targetClass);
+    final var tgtComps = tgtInfo.components();
+    final var srcComps = srcInfo.components();
+    // Tier-A scope: flat scalar records only. Containers (List/Set/Map/Optional) and nested
+    // record/bean types still take the slow path because (a) deep-copy semantics need the
+    // structural Iso, (b) cycle detection lives there, (c) cross-type element conversions live
+    // there. Fast-path is the dominant win for the flat tier (5 scalar fields, 91× MapStruct);
+    // nested cases are 40× — the slow path already amortises constant overhead at that size.
+    final var sourceIndexPerTargetSlot = new int[tgtComps.length];
+    for (var ti = 0; ti < tgtComps.length; ti++) {
+      final var tName = tgtComps[ti].getName();
+      final var tType = tgtComps[ti].getType();
+      if (!isFlatScalar(tType)) return FastPathBuilt.NOT_ELIGIBLE;
+      var found = -1;
+      for (var si = 0; si < srcComps.length; si++) {
+        if (!srcComps[si].getName().equals(tName)) continue;
+        if (tType != srcComps[si].getType()) return FastPathBuilt.NOT_ELIGIBLE;
+        found = si;
+        break;
+      }
+      if (found < 0) return FastPathBuilt.NOT_ELIGIBLE;
+      sourceIndexPerTargetSlot[ti] = found;
+    }
+    final var readers = srcInfo.readers();
+    final var ctorFn = tgtInfo.ctorFn();
+    final var positions = sourceIndexPerTargetSlot;
+    final var arity = positions.length;
+    final Function<Object, Object> fn = s -> {
+      if (s == null) return null;
+      final var args = new Object[arity];
+      for (var i = 0; i < arity; i++) args[i] = readers[positions[i]].apply(s);
+      return ctorFn.apply(args);
+    };
+    return new FastPathBuilt(fn);
+  }
+
+  private static boolean isFlatScalar(final Class<?> type) {
+    if (type.isPrimitive()) return true;
+    if (type.isEnum()) return true;
+    if (type == String.class) return true;
+    if (type == Integer.class || type == Long.class || type == Double.class || type == Float.class) return true;
+    if (type == Short.class || type == Byte.class || type == Boolean.class || type == Character.class) return true;
+    return false;
   }
 
   private static Object readField(final Object source, final String fieldName) {

--- a/internal/src/test/java/io/github/eschizoid/telescope/internal/BeansFastPathTest.java
+++ b/internal/src/test/java/io/github/eschizoid/telescope/internal/BeansFastPathTest.java
@@ -1,0 +1,276 @@
+package io.github.eschizoid.telescope.internal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pins {@code Beans.fastPathForward(srcClass, tgtClass)} — the Tier-A runtime fast-path for
+ * bean → bean same-shape mapping. Eligibility: both non-record, same-named getters with EXACTLY
+ * matching types, all flat scalars, target has a public no-arg constructor.
+ */
+class BeansFastPathTest {
+
+  public static class Src {
+
+    private long id;
+    private String name;
+    private int age;
+    private boolean active;
+
+    public Src() {}
+
+    public Src(final long id, final String name, final int age, final boolean active) {
+      this.id = id;
+      this.name = name;
+      this.age = age;
+      this.active = active;
+    }
+
+    public long getId() {
+      return id;
+    }
+
+    public void setId(final long id) {
+      this.id = id;
+    }
+
+    public String getName() {
+      return name;
+    }
+
+    public void setName(final String name) {
+      this.name = name;
+    }
+
+    public int getAge() {
+      return age;
+    }
+
+    public void setAge(final int age) {
+      this.age = age;
+    }
+
+    public boolean isActive() {
+      return active;
+    }
+
+    public void setActive(final boolean active) {
+      this.active = active;
+    }
+  }
+
+  public static class Dst {
+
+    private long id;
+    private String name;
+    private int age;
+    private boolean active;
+
+    public Dst() {}
+
+    public long getId() {
+      return id;
+    }
+
+    public void setId(final long id) {
+      this.id = id;
+    }
+
+    public String getName() {
+      return name;
+    }
+
+    public void setName(final String name) {
+      this.name = name;
+    }
+
+    public int getAge() {
+      return age;
+    }
+
+    public void setAge(final int age) {
+      this.age = age;
+    }
+
+    public boolean isActive() {
+      return active;
+    }
+
+    public void setActive(final boolean active) {
+      this.active = active;
+    }
+  }
+
+  @Nested
+  @DisplayName("Eligible — both beans, same flat scalar shape, target has no-arg ctor")
+  class Eligible {
+
+    @Test
+    @DisplayName("forward maps every field via getter+setter; result is a fresh instance, not aliasing")
+    void forwardCopies() {
+      final var fn = Beans.fastPathForward(Src.class, Dst.class);
+      assertNotNull(fn);
+
+      final var src = new Src(42L, "Alice", 30, true);
+      final var dst = fn.apply(src);
+
+      assertNotSame(src, dst, "fast-path returns a fresh target, not the source");
+      assertEquals(42L, dst.getId());
+      assertEquals("Alice", dst.getName());
+      assertEquals(30, dst.getAge());
+      assertEquals(true, dst.isActive());
+    }
+
+    @Test
+    @DisplayName("null source short-circuits to null (no NPE on the no-arg ctor invocation)")
+    void nullSource() {
+      final var fn = Beans.fastPathForward(Src.class, Dst.class);
+      assertNotNull(fn);
+      assertNull(fn.apply(null));
+    }
+
+    @Test
+    @DisplayName("cache returns same Function on repeated lookups for the same pair")
+    void cacheReturnsSameFunction() {
+      final var first = Beans.fastPathForward(Src.class, Dst.class);
+      final var second = Beans.fastPathForward(Src.class, Dst.class);
+      assertSame(first, second, "fast-path Function is cached per (src, tgt) pair");
+    }
+  }
+
+  @Nested
+  @DisplayName("Not eligible — falls back to slow path (returns null)")
+  class NotEligible {
+
+    public static class NoNoArgCtor {
+
+      public final String name;
+
+      public NoNoArgCtor(final String name) {
+        this.name = name;
+      }
+
+      public String getName() {
+        return name;
+      }
+    }
+
+    public static class DifferentName {
+
+      private long id;
+      private String fullName;
+
+      public DifferentName() {}
+
+      public long getId() {
+        return id;
+      }
+
+      public void setId(final long id) {
+        this.id = id;
+      }
+
+      public String getFullName() {
+        return fullName;
+      }
+
+      public void setFullName(final String fullName) {
+        this.fullName = fullName;
+      }
+    }
+
+    public static class DifferentType {
+
+      private Long id;
+      private String name;
+
+      public DifferentType() {}
+
+      public Long getId() {
+        return id;
+      }
+
+      public void setId(final Long id) {
+        this.id = id;
+      }
+
+      public String getName() {
+        return name;
+      }
+
+      public void setName(final String name) {
+        this.name = name;
+      }
+    }
+
+    public static class WithList {
+
+      private long id;
+      private List<String> tags;
+
+      public WithList() {}
+
+      public long getId() {
+        return id;
+      }
+
+      public void setId(final long id) {
+        this.id = id;
+      }
+
+      public List<String> getTags() {
+        return tags;
+      }
+
+      public void setTags(final List<String> tags) {
+        this.tags = tags;
+      }
+    }
+
+    record SrcRec(long id, String name) {}
+
+    @Test
+    @DisplayName("source is a record → null (records use Records.fastPathForward instead)")
+    void sourceIsRecord() {
+      assertNull(Beans.fastPathForward(SrcRec.class, Dst.class));
+    }
+
+    @Test
+    @DisplayName("target is a record → null (mixed shape: bean ↔ record, slow path)")
+    void targetIsRecord() {
+      assertNull(Beans.fastPathForward(Src.class, SrcRec.class));
+    }
+
+    @Test
+    @DisplayName("target has no no-arg ctor → null (writeBeanProperty cannot allocate)")
+    void targetMissingNoArgCtor() {
+      assertNull(Beans.fastPathForward(Src.class, NoNoArgCtor.class));
+    }
+
+    @Test
+    @DisplayName("different property name (fullName vs name) → null")
+    void differentPropertyName() {
+      assertNull(Beans.fastPathForward(Src.class, DifferentName.class));
+    }
+
+    @Test
+    @DisplayName("different property type (long vs Long) → null")
+    void differentPropertyType() {
+      assertNull(Beans.fastPathForward(Src.class, DifferentType.class));
+    }
+
+    @Test
+    @DisplayName("List<String> component → null (deep-copy / lift goes through slow path)")
+    void containerComponent() {
+      assertNull(Beans.fastPathForward(WithList.class, WithList.class));
+    }
+  }
+}

--- a/internal/src/test/java/io/github/eschizoid/telescope/internal/RecordsFastPathTest.java
+++ b/internal/src/test/java/io/github/eschizoid/telescope/internal/RecordsFastPathTest.java
@@ -1,0 +1,162 @@
+package io.github.eschizoid.telescope.internal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pins {@code Records.fastPathForward(srcClass, tgtClass)} — the Tier-A runtime fast-path
+ * eligibility rules + correctness on the records → records path.
+ *
+ * <p>Eligibility: both records, same-name + EXACTLY same-type components, all components are
+ * flat scalars (primitive / primitive wrapper / String / enum). Anything else returns {@code
+ * null} so the caller falls back to the slow path that preserves deep-copy / lift / cycle
+ * semantics.
+ */
+class RecordsFastPathTest {
+
+  enum Status {
+    ACTIVE,
+    INACTIVE,
+  }
+
+  record Flat(long id, String name, int age, boolean active, Status status) {}
+
+  record FlatSame(long id, String name, int age, boolean active, Status status) {}
+
+  @Nested
+  @DisplayName("Eligible — both records, same flat scalar shape")
+  class Eligible {
+
+    @Test
+    @DisplayName("returns a Function; forward maps every field correctly")
+    void roundTripAllScalars() {
+      final var fn = Records.fastPathForward(Flat.class, FlatSame.class);
+      assertNotNull(fn);
+
+      final var src = new Flat(42L, "Alice", 30, true, Status.ACTIVE);
+      final var dst = fn.apply(src);
+
+      assertEquals(new FlatSame(42L, "Alice", 30, true, Status.ACTIVE), dst);
+    }
+
+    @Test
+    @DisplayName("null source short-circuits to null (no NPE on the canonical ctor invocation)")
+    void nullSource() {
+      final var fn = Records.fastPathForward(Flat.class, FlatSame.class);
+      assertNotNull(fn);
+      assertNull(fn.apply(null));
+    }
+
+    @Test
+    @DisplayName("cache returns same Function on repeated lookups for the same pair")
+    void cacheReturnsSameFunction() {
+      final var first = Records.fastPathForward(Flat.class, FlatSame.class);
+      final var second = Records.fastPathForward(Flat.class, FlatSame.class);
+      assertSame(first, second, "fast-path Function is cached per (src, tgt) pair");
+    }
+
+    @Test
+    @DisplayName("identity Flat → Flat is eligible (same class as src and tgt)")
+    void identityRoundTrip() {
+      final var fn = Records.fastPathForward(Flat.class, Flat.class);
+      assertNotNull(fn);
+
+      final var src = new Flat(1L, "x", 0, false, Status.INACTIVE);
+      assertEquals(src, fn.apply(src));
+    }
+  }
+
+  @Nested
+  @DisplayName("Not eligible — falls back to slow path (returns null)")
+  class NotEligible {
+
+    record FlatRenamed(long id, String fullName, int age, boolean active, Status status) {}
+
+    record FlatTypeMismatch(Long id, String name, int age, boolean active, Status status) {}
+
+    record WithList(long id, List<String> tags) {}
+
+    record WithOptional(long id, Optional<String> nickname) {}
+
+    record NestedOuter(long id, Flat inner) {}
+
+    record NestedOuterSame(long id, FlatSame inner) {}
+
+    static class FlatBean {
+
+      public long id;
+      public String name;
+    }
+
+    @Test
+    @DisplayName("different field NAME on target → null")
+    void differentFieldName() {
+      assertNull(Records.fastPathForward(Flat.class, FlatRenamed.class));
+    }
+
+    @Test
+    @DisplayName("different field TYPE (long → Long is still mismatch) → null")
+    void differentFieldType() {
+      assertNull(Records.fastPathForward(Flat.class, FlatTypeMismatch.class));
+    }
+
+    @Test
+    @DisplayName("source is a bean (non-record) → null")
+    void sourceNotARecord() {
+      assertNull(Records.fastPathForward(FlatBean.class, Flat.class));
+    }
+
+    @Test
+    @DisplayName("target is a bean (non-record) → null")
+    void targetNotARecord() {
+      assertNull(Records.fastPathForward(Flat.class, FlatBean.class));
+    }
+
+    @Test
+    @DisplayName("container component (List) → null (deep-copy / lift goes through slow path)")
+    void containerComponent() {
+      record SrcWithList(long id, List<String> tags) {}
+      record TgtWithList(long id, List<String> tags) {}
+      assertNull(Records.fastPathForward(SrcWithList.class, TgtWithList.class));
+    }
+
+    @Test
+    @DisplayName("Optional component → null (Optional is not in the flat-scalar whitelist)")
+    void optionalComponent() {
+      assertNull(Records.fastPathForward(WithOptional.class, WithOptional.class));
+    }
+
+    @Test
+    @DisplayName("nested record component → null (cycle detection + deep copy goes through slow path)")
+    void nestedRecordComponent() {
+      assertNull(Records.fastPathForward(NestedOuter.class, NestedOuterSame.class));
+    }
+  }
+
+  @Nested
+  @DisplayName("Cache behaviour — non-eligible entries also cached (sentinel) to short-circuit re-checks")
+  class CachingBehavior {
+
+    record NoMatchSrc(String name) {}
+
+    record NoMatchTgt(int age) {}
+
+    @Test
+    @DisplayName("repeated non-eligible lookups all return null without re-running eligibility scan")
+    void cachesNonEligibleAsSentinel() {
+      // First call computes eligibility and caches the sentinel; subsequent calls hit cache.
+      // We can only assert NULL is returned consistently; the cache-hit fast path is internal.
+      assertNull(Records.fastPathForward(NoMatchSrc.class, NoMatchTgt.class));
+      assertNull(Records.fastPathForward(NoMatchSrc.class, NoMatchTgt.class));
+      assertNull(Records.fastPathForward(NoMatchSrc.class, NoMatchTgt.class));
+    }
+  }
+}


### PR DESCRIPTION
## Summary

First slice of the runtime throughput closure plan ([Discussion #116](https://github.com/eschizoid/telescope/discussions/116)). Adds a runtime fast-path that bypasses structural `Iso` composition for record↔record + bean↔bean same-shape mappings.

## Measured before / after

JDK 25, Apple Silicon, 2-fork × 5-warmup × 10-iter × 1 s. `-Dtelescope.disableFastPath=true` forces the slow path for the before measurement.

| Fixture (5 flat scalar fields) | Slow path (ns/op) | Fast path (ns/op) | Δ |
|---|---:|---:|---:|
| record → record | 50.4 ± 6.6 | 44.0 ± 1.5 | ~12% |
| bean → record (mixed shape) | 375.9 ± 7.6 | — ¹ | — |
| record → bean (mixed shape) | 507.9 ± 7.6 | — ¹ | — |

¹ Mixed shape — fast-path tightly requires both sides be the same kind. Records use canonical constructor; beans use no-arg ctor + setters. Mixed-shape fast-path is a separate follow-up.

**Honest framing.** Earlier framing on this PR implied an 8× speedup, but that comparison was apples-to-oranges (bean→record slow path vs record→record fast path). The actual record↔record improvement is **~12%** because records were already cheap on the slow path — LMF-built readers + canonical-ctor spreader. The fast path eliminates the `LinkedHashMap` intermediate the structural `Iso` threads `name → value` through.

The **90× gap to MapStruct lives in the bean↔record / record↔bean rows** (376 ns / 508 ns), not the record↔record path. Bean getter/setter reflection through the structural Iso dominates. Closing that gap is the next research target (likely `LinkedHashMap → Object[]` structural intermediate).

## Scope

**Eligible (uses fast-path):**
- Records: both classes records, every component has same name + EXACTLY same type, all flat scalars
- Beans: both classes have no-arg ctor + same-named setters/getters with EXACTLY same type, all flat scalars

**Falls through to slow path:**
- Mixed shape (record↔bean)
- Container components (List/Set/Map/Optional) — preserves deep-copy + lift semantics
- Nested record/bean components — preserves cycle detection + composition
- Cross-type conversions (Integer ↔ Long)
- Any `Mapping` rows / `WriteHint` / `NullHint` — fast-path only fires when `steps.length == 0`

## Implementation

- `Records.fastPathForward(srcClass, tgtClass)` — cached `readers[]` (positional, LMF-built) + `ctorFn` (canonical-ctor spreader, LMF-built). Per-call: `Object[arity]` + N reader applies + ctor call
- `Beans.fastPathForward(srcClass, tgtClass)` — cached `GETTER_INVOKERS` + setter invokers (LMF-built). Per-call: no-arg ctor + iterate (getter, setter) pair array
- Per-`(srcClass, tgtClass)` cache; non-eligible entries cache a sentinel so subsequent lookups short-circuit
- `DeepMap.resolveMapper` integration: when `steps.length == 0` (and fast-path not disabled via system property), try records → beans → slow path
- `-Dtelescope.disableFastPath=true` escape hatch for benchmarking + diagnostics

## Lattice + reflection posture

- **Lattice-honest:** fast-path REPLACES the structural Iso for eligible pairs; for ineligible pairs, the full lattice still runs unchanged. No `Function<Object, Object>` plumbing — the Function returned IS the contract, built once at `resolveMapper` time
- **Zero per-call reflection:** all dispatch is LMF-built (same primitives as ADR-0005). One-time discovery uses `RecordComponent` / `Method.getMethods()` at cache-population time only

## Test plan

- [x] `:core:test` regression — CycleHandlingTest, DeepMappingTest, SetMappingTest all pass; fast-path correctly skips nested/container/cycle cases
- [x] `:internal:test` regression
- [x] `:codegen:test :lombok:test :spring-boot-starter:test :quarkus:test`
- [x] New unit tests: `RecordsFastPathTest`, `BeansFastPathTest` — 16 cases covering eligibility (records, beans, identity, null source, cache reuse) + ineligibility (different name, different type, mixed shape, no no-arg ctor, container, nested)
- [x] `:benchmarks:jmh` long-fork measurement with `-Dtelescope.disableFastPath=true` for honest before/after

## Follow-ups

- Tier A v2: mixed-shape (record↔bean) fast-path
- Structural intermediate optimization: `LinkedHashMap` → `Object[]` indexed by component position — that's where the bean↔record 376 ns slow path actually pays the cost