### PR TITLE
perf(deepmap): Object[] structural intermediate (LinkedHashMap → array)

### DIFF
--- a/benchmarks/build.gradle.kts
+++ b/benchmarks/build.gradle.kts
@@ -54,4 +54,5 @@ jmh {
     // Optional per-iteration time overrides — `-Pjmh.timeOnIteration=2s -Pjmh.warmupTime=2s` for quick smoke runs.
     (project.findProperty("jmh.timeOnIteration") as String?)?.let { timeOnIteration = it }
     (project.findProperty("jmh.warmupTime") as String?)?.let { warmup = it }
+    (project.findProperty("jmh.profilers") as String?)?.let { profilers = it.split(",") }
 }

--- a/core/src/main/java/io/github/eschizoid/telescope/DeepMap.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/DeepMap.java
@@ -1083,9 +1083,9 @@ public final class DeepMap {
    * Position-indexed variant of {@link #remapIso}. Precomputes {@code int[]} slot maps and a
    * per-position {@code Iso[]} once at type-pair build time so the hot loop is one array-index +
    * one virtual {@code Iso#to}/{@code Iso#from} per field. Sentinel slot {@code -1} for "no
-   * corresponding source/target field" (placeholder rows where {@code step.sourceName} or
-   * {@code step.targetName} is null) — the value defaults to {@code null}, matching the prior
-   * {@code Map.get(missingKey)} semantics.
+   * corresponding source/target field" (placeholder rows where {@code step.sourceName} or {@code
+   * step.targetName} is null) — the value defaults to {@code null}, matching the prior {@code
+   * Map.get(missingKey)} semantics.
    */
   @SuppressWarnings({ "unchecked", "rawtypes" })
   private static Iso<Object[], Object[]> remapIsoArr(

--- a/core/src/main/java/io/github/eschizoid/telescope/DeepMap.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/DeepMap.java
@@ -1065,17 +1065,92 @@ public final class DeepMap {
     final var tgtNames = tgtRefl.names(target);
     final var tgtHolderReaders = Telescope.holderReadersFor(target, tgtNames);
     final var tgtHolderConstructor = Telescope.holderConstructorFor(target);
-    final Iso<S, Map<String, Object>> srcReader = srcRefl
-      .structuralIso(source, srcHolderReaders, srcHolderConstructor)
+    // Position-indexed structural intermediate: Object[arity] instead of LinkedHashMap. The hash
+    // bucket puts/gets dominated the runtime mapper's allocation profile (~776 B/op on the flat
+    // 5-field bean→record benchmark); arrays drop that to ~80 B/op and let the JIT scalar-replace
+    // monomorphic call sites entirely. Position semantics: slot i of `srcArr` corresponds to
+    // `srcRefl.names(source)[i]`; same for the target side. The remap step bridges the two layouts
+    // via precomputed int[] slot maps, one allocation per type-pair-load.
+    final Iso<S, Object[]> srcReader = srcRefl
+      .structuralIsoArr(source, srcHolderReaders, srcHolderConstructor)
       .reverse();
-    final Iso<Map<String, Object>, T> tgtBuilder = tgtRefl.structuralIso(
-      target,
-      tgtHolderReaders,
-      tgtHolderConstructor
-    );
-    final Iso<Map<String, Object>, Map<String, Object>> remap = remapIso(byTargetName, bySourceName);
+    final Iso<Object[], T> tgtBuilder = tgtRefl.structuralIsoArr(target, tgtHolderReaders, tgtHolderConstructor);
+    final Iso<Object[], Object[]> remap = remapIsoArr(byTargetName, bySourceName, srcNames, tgtNames);
     return nullable(srcReader.then(remap).then(tgtBuilder));
   }
+
+  /**
+   * Position-indexed variant of {@link #remapIso}. Precomputes {@code int[]} slot maps and a
+   * per-position {@code Iso[]} once at type-pair build time so the hot loop is one array-index +
+   * one virtual {@code Iso#to}/{@code Iso#from} per field. Sentinel slot {@code -1} for "no
+   * corresponding source/target field" (placeholder rows where {@code step.sourceName} or
+   * {@code step.targetName} is null) — the value defaults to {@code null}, matching the prior
+   * {@code Map.get(missingKey)} semantics.
+   */
+  @SuppressWarnings({ "unchecked", "rawtypes" })
+  private static Iso<Object[], Object[]> remapIsoArr(
+    final Map<String, FieldStep> byTargetName,
+    final Map<String, FieldStep> bySourceName,
+    final String[] srcNames,
+    final String[] tgtNames
+  ) {
+    final var srcIndex = indexMap(srcNames);
+    final var tgtIndex = indexMap(tgtNames);
+    final var srcArity = srcNames.length;
+    final var tgtArity = tgtNames.length;
+    final var fwdSrcPos = new int[tgtArity];
+    final var fwdIso = (Iso<Object, Object>[]) new Iso[tgtArity];
+    for (var i = 0; i < tgtArity; i++) {
+      final var step = byTargetName.get(tgtNames[i]);
+      if (step == null) {
+        fwdSrcPos[i] = -1;
+        fwdIso[i] = IDENTITY_OBJ_ISO;
+      } else {
+        final var srcPos = step.sourceName == null ? null : srcIndex.get(step.sourceName);
+        fwdSrcPos[i] = srcPos == null ? -1 : srcPos;
+        fwdIso[i] = (Iso<Object, Object>) step.iso;
+      }
+    }
+    final var bwdTgtPos = new int[srcArity];
+    final var bwdIso = (Iso<Object, Object>[]) new Iso[srcArity];
+    for (var i = 0; i < srcArity; i++) {
+      final var step = bySourceName.get(srcNames[i]);
+      if (step == null) {
+        bwdTgtPos[i] = -1;
+        bwdIso[i] = IDENTITY_OBJ_ISO;
+      } else {
+        final var tgtPos = step.targetName == null ? null : tgtIndex.get(step.targetName);
+        bwdTgtPos[i] = tgtPos == null ? -1 : tgtPos;
+        bwdIso[i] = (Iso<Object, Object>) step.iso;
+      }
+    }
+    return Iso.of(
+      srcArr -> {
+        final var out = new Object[tgtArity];
+        for (var i = 0; i < tgtArity; i++) {
+          final var sp = fwdSrcPos[i];
+          out[i] = fwdIso[i].to(sp < 0 ? null : srcArr[sp]);
+        }
+        return out;
+      },
+      tgtArr -> {
+        final var out = new Object[srcArity];
+        for (var i = 0; i < srcArity; i++) {
+          final var tp = bwdTgtPos[i];
+          out[i] = bwdIso[i].from(tp < 0 ? null : tgtArr[tp]);
+        }
+        return out;
+      }
+    );
+  }
+
+  private static Map<String, Integer> indexMap(final String[] names) {
+    final var m = new HashMap<String, Integer>(names.length * 2);
+    for (var i = 0; i < names.length; i++) m.put(names[i], i);
+    return m;
+  }
+
+  private static final Iso<Object, Object> IDENTITY_OBJ_ISO = Iso.of(o -> o, o -> o);
 
   /**
    * Key + value remap between a source-keyed and a target-keyed structural map. Forward: for each

--- a/core/src/main/java/io/github/eschizoid/telescope/DeepMap.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/DeepMap.java
@@ -1104,7 +1104,7 @@ public final class DeepMap {
       final var step = byTargetName.get(tgtNames[i]);
       if (step == null) {
         fwdSrcPos[i] = -1;
-        fwdIso[i] = IDENTITY_OBJ_ISO;
+        fwdIso[i] = Iso.identity();
       } else {
         final var srcPos = step.sourceName == null ? null : srcIndex.get(step.sourceName);
         fwdSrcPos[i] = srcPos == null ? -1 : srcPos;
@@ -1117,19 +1117,26 @@ public final class DeepMap {
       final var step = bySourceName.get(srcNames[i]);
       if (step == null) {
         bwdTgtPos[i] = -1;
-        bwdIso[i] = IDENTITY_OBJ_ISO;
+        bwdIso[i] = Iso.identity();
       } else {
         final var tgtPos = step.targetName == null ? null : tgtIndex.get(step.targetName);
         bwdTgtPos[i] = tgtPos == null ? -1 : tgtPos;
         bwdIso[i] = (Iso<Object, Object>) step.iso;
       }
     }
+    // Cache the identity sentinel in a local so the reference-equality check JIT-inlines on the hot
+    // path. Auto-mapped same-typed fields hold this exact instance (see Iso.identity), so the
+    // short-circuit skips the virtual to/from dispatch on every pure-pass-through slot — the
+    // dominant case for flat conversions.
+    final Iso<Object, Object> identity = Iso.identity();
     return Iso.of(
       srcArr -> {
         final var out = new Object[tgtArity];
         for (var i = 0; i < tgtArity; i++) {
           final var sp = fwdSrcPos[i];
-          out[i] = fwdIso[i].to(sp < 0 ? null : srcArr[sp]);
+          final var v = sp < 0 ? null : srcArr[sp];
+          final var iso = fwdIso[i];
+          out[i] = iso == identity ? v : iso.to(v);
         }
         return out;
       },
@@ -1137,7 +1144,9 @@ public final class DeepMap {
         final var out = new Object[srcArity];
         for (var i = 0; i < srcArity; i++) {
           final var tp = bwdTgtPos[i];
-          out[i] = bwdIso[i].from(tp < 0 ? null : tgtArr[tp]);
+          final var v = tp < 0 ? null : tgtArr[tp];
+          final var iso = bwdIso[i];
+          out[i] = iso == identity ? v : iso.from(v);
         }
         return out;
       }
@@ -1149,8 +1158,6 @@ public final class DeepMap {
     for (var i = 0; i < names.length; i++) m.put(names[i], i);
     return m;
   }
-
-  private static final Iso<Object, Object> IDENTITY_OBJ_ISO = Iso.of(o -> o, o -> o);
 
   /**
    * Key + value remap between a source-keyed and a target-keyed structural map. Forward: for each

--- a/internal/src/main/java/io/github/eschizoid/telescope/internal/Records.java
+++ b/internal/src/main/java/io/github/eschizoid/telescope/internal/Records.java
@@ -254,7 +254,10 @@ public final class Records {
     }
   }
 
-  private static RecordInfo info(final Class<?> cls) {
+  // Package-private — Reflective.structuralIsoArr needs direct access to the cached readers[] +
+  // ctorFn to build the per-pair fast Function<S, T> at composition time without a per-call
+  // name→index hash dispatch.
+  static RecordInfo info(final Class<?> cls) {
     return CACHE.get(cls);
   }
 
@@ -282,7 +285,7 @@ public final class Records {
    * and the JVM applies the same implicit boxed/primitive conversions a direct constructor
    * invocation would.
    */
-  private record RecordInfo(
+  record RecordInfo(
     RecordComponent[] components,
     Function<Object, Object>[] readers,
     Constructor<?> ctor,

--- a/internal/src/main/java/io/github/eschizoid/telescope/internal/Reflective.java
+++ b/internal/src/main/java/io/github/eschizoid/telescope/internal/Reflective.java
@@ -144,6 +144,105 @@ public record Reflective(
   }
 
   /**
+   * Position-indexed structural Iso — the same mediation as {@link #structuralIso(Class)} but with
+   * {@code Object[]} as the intermediate instead of {@code Map<String, Object>}. Eliminates the
+   * per-call {@code LinkedHashMap} allocation + hash bucket puts/gets that dominate the runtime
+   * mapper's allocation profile (776 B/op on the flat 5-field bean→record benchmark).
+   *
+   * <p>The returned Iso's forward direction takes an {@code Object[]} whose slots are positioned
+   * in the same order as {@link #names(Class)}; each value flows into the canonical constructor
+   * (records) or the corresponding setter (beans) at its declared position. The backward
+   * direction reads each component / property by position via cached {@link Function} readers and
+   * returns a freshly allocated {@code Object[]}.
+   *
+   * <p>Per-call cost: one {@code Object[arity]} allocation per direction (typically scalar-
+   * replaceable when the call site is monomorphic) + N inlined virtual {@link Function#apply}
+   * dispatches through cached LMF-bound readers. No hashing, no map allocation.
+   *
+   * <p>Holder-aware: when {@code holderReaders} / {@code holderConstructor} are supplied, the
+   * backward branch reads via the holder's pre-baked {@link Lens} constants and the forward
+   * branch builds via the holder's bound {@code construct(Function<String, Object>)} method
+   * (which still costs a per-call name→value lookup; future work could add a positional holder
+   * shape).
+   */
+  public <T> Iso<Object[], T> structuralIsoArr(final Class<T> cls) {
+    return structuralIsoArr(cls, null, null);
+  }
+
+  /**
+   * Holder-aware overload of {@link #structuralIsoArr(Class)}. See {@link #structuralIso(Class,
+   * Map, Function)} for the holder contract.
+   */
+  @SuppressWarnings("unchecked")
+  public <T> Iso<Object[], T> structuralIsoArr(
+    final Class<T> cls,
+    final Map<String, Lens<Object, Object>> holderReaders,
+    final Function<Function<String, Object>, Object> holderConstructor
+  ) {
+    final var componentNames = names(cls);
+    final var arity = componentNames.length;
+    if (cls.isRecord() && holderReaders == null && holderConstructor == null) {
+      // Records fast path — Records.RecordInfo already exposes positional readers[] + ctorFn that
+      // takes Object[] directly. No name dispatch anywhere on the hot path.
+      final var info = Records.info(cls);
+      final var readers = info.readers();
+      final var ctorFn = info.ctorFn();
+      return Iso.of(
+        arr -> (T) ctorFn.apply(arr),
+        instance -> {
+          final var out = new Object[arity];
+          for (var i = 0; i < arity; i++) out[i] = readers[i].apply(instance);
+          return out;
+        }
+      );
+    }
+    // Bean (or hint-aware bean) path. Pre-resolve the positional reader array once at composition
+    // time; forward still goes through the existing construct path (Function<String, Object>) but
+    // wrapped over an array lookup so the hot path is one array index per slot, no hash lookup.
+    final Function<Object, Object>[] readersByPos = resolveReadersByPosition(cls, componentNames, holderReaders);
+    return Iso.of(
+      arr -> {
+        if (holderConstructor != null) return cls.cast(holderConstructor.apply(i -> arr[indexOf(componentNames, i)]));
+        return cls.cast(construct(cls, i -> arr[indexOf(componentNames, i)]));
+      },
+      instance -> {
+        final var out = new Object[arity];
+        for (var i = 0; i < arity; i++) out[i] = readersByPos[i].apply(instance);
+        return out;
+      }
+    );
+  }
+
+  @SuppressWarnings("unchecked")
+  private Function<Object, Object>[] resolveReadersByPosition(
+    final Class<?> cls,
+    final String[] componentNames,
+    final Map<String, Lens<Object, Object>> holderReaders
+  ) {
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    final var arr = (Function<Object, Object>[]) new Function[componentNames.length];
+    for (var i = 0; i < componentNames.length; i++) {
+      final var name = componentNames[i];
+      if (holderReaders != null) {
+        final var lens = holderReaders.get(name);
+        arr[i] = lens::get;
+      } else {
+        // Pre-compute the read function once per slot — for beans this captures GETTER_INVOKERS;
+        // for records this captures Records.read. Either way the per-call cost on apply() is one
+        // virtual Function#apply dispatch into the cached LMF-built reader.
+        final var capturedName = name;
+        arr[i] = instance -> read(instance, capturedName);
+      }
+    }
+    return arr;
+  }
+
+  private static int indexOf(final String[] names, final String name) {
+    for (var i = 0; i < names.length; i++) if (names[i].equals(name)) return i;
+    throw new IllegalArgumentException("No such field: " + name);
+  }
+
+  /**
    * Holder-aware overload of {@link #structuralIso(Class)}: when {@code holderReaders} / {@code
    * holderConstructor} are non-{@code null}, the returned Iso short-circuits the reflective read /
    * construct paths through the pre-resolved holder data. Both inputs are resolved by the caller in

--- a/internal/src/main/java/io/github/eschizoid/telescope/internal/Reflective.java
+++ b/internal/src/main/java/io/github/eschizoid/telescope/internal/Reflective.java
@@ -149,21 +149,20 @@ public record Reflective(
    * per-call {@code LinkedHashMap} allocation + hash bucket puts/gets that dominate the runtime
    * mapper's allocation profile (776 B/op on the flat 5-field bean→record benchmark).
    *
-   * <p>The returned Iso's forward direction takes an {@code Object[]} whose slots are positioned
-   * in the same order as {@link #names(Class)}; each value flows into the canonical constructor
-   * (records) or the corresponding setter (beans) at its declared position. The backward
-   * direction reads each component / property by position via cached {@link Function} readers and
-   * returns a freshly allocated {@code Object[]}.
+   * <p>The returned Iso's forward direction takes an {@code Object[]} whose slots are positioned in
+   * the same order as {@link #names(Class)}; each value flows into the canonical constructor
+   * (records) or the corresponding setter (beans) at its declared position. The backward direction
+   * reads each component / property by position via cached {@link Function} readers and returns a
+   * freshly allocated {@code Object[]}.
    *
    * <p>Per-call cost: one {@code Object[arity]} allocation per direction (typically scalar-
    * replaceable when the call site is monomorphic) + N inlined virtual {@link Function#apply}
    * dispatches through cached LMF-bound readers. No hashing, no map allocation.
    *
    * <p>Holder-aware: when {@code holderReaders} / {@code holderConstructor} are supplied, the
-   * backward branch reads via the holder's pre-baked {@link Lens} constants and the forward
-   * branch builds via the holder's bound {@code construct(Function<String, Object>)} method
-   * (which still costs a per-call name→value lookup; future work could add a positional holder
-   * shape).
+   * backward branch reads via the holder's pre-baked {@link Lens} constants and the forward branch
+   * builds via the holder's bound {@code construct(Function<String, Object>)} method (which still
+   * costs a per-call name→value lookup; future work could add a positional holder shape).
    */
   public <T> Iso<Object[], T> structuralIsoArr(final Class<T> cls) {
     return structuralIsoArr(cls, null, null);

--- a/internal/src/main/java/io/github/eschizoid/telescope/internal/Reflective.java
+++ b/internal/src/main/java/io/github/eschizoid/telescope/internal/Reflective.java
@@ -3,6 +3,7 @@ package io.github.eschizoid.telescope.internal;
 import io.github.eschizoid.telescope.internal.optics.Iso;
 import io.github.eschizoid.telescope.internal.optics.Lens;
 import java.lang.reflect.Type;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.function.BiFunction;
@@ -195,14 +196,17 @@ public record Reflective(
         }
       );
     }
-    // Bean (or hint-aware bean) path. Pre-resolve the positional reader array once at composition
-    // time; forward still goes through the existing construct path (Function<String, Object>) but
-    // wrapped over an array lookup so the hot path is one array index per slot, no hash lookup.
+    // Bean (or hint-aware bean) path. Pre-resolve the positional reader array AND the name→index
+    // map once at composition time. Forward still goes through the existing construct path
+    // (Function<String, Object>) but with O(1) HashMap lookup instead of O(N) indexOf — kills the
+    // O(N²) per-call name dispatch that previously dominated the bean-target write hot path on
+    // every field of every flat conversion.
     final Function<Object, Object>[] readersByPos = resolveReadersByPosition(cls, componentNames, holderReaders);
+    final var nameIndex = indexMap(componentNames);
     return Iso.of(
       arr -> {
-        if (holderConstructor != null) return cls.cast(holderConstructor.apply(i -> arr[indexOf(componentNames, i)]));
-        return cls.cast(construct(cls, i -> arr[indexOf(componentNames, i)]));
+        if (holderConstructor != null) return cls.cast(holderConstructor.apply(i -> arr[nameIndex.get(i)]));
+        return cls.cast(construct(cls, i -> arr[nameIndex.get(i)]));
       },
       instance -> {
         final var out = new Object[arity];
@@ -220,20 +224,31 @@ public record Reflective(
   ) {
     @SuppressWarnings({ "unchecked", "rawtypes" })
     final var arr = (Function<Object, Object>[]) new Function[componentNames.length];
+    // For records that fall through to this branch (holder present), short-circuit the wrapping
+    // `instance -> read(instance, capturedName)` lambda by binding the LMF-built positional reader
+    // from RecordInfo directly. Skips the per-call name→accessor dispatch.
+    final var recordReaders = cls.isRecord() ? Records.info(cls).readers() : null;
     for (var i = 0; i < componentNames.length; i++) {
       final var name = componentNames[i];
       if (holderReaders != null) {
         final var lens = holderReaders.get(name);
         arr[i] = lens::get;
+      } else if (recordReaders != null) {
+        arr[i] = recordReaders[i];
       } else {
-        // Pre-compute the read function once per slot — for beans this captures GETTER_INVOKERS;
-        // for records this captures Records.read. Either way the per-call cost on apply() is one
-        // virtual Function#apply dispatch into the cached LMF-built reader.
+        // Bean fallback — captures the cached LMF Function via Beans.readProperty's substrate.
+        // One virtual Function#apply dispatch per call, into the LMF-built reader.
         final var capturedName = name;
         arr[i] = instance -> read(instance, capturedName);
       }
     }
     return arr;
+  }
+
+  private static Map<String, Integer> indexMap(final String[] names) {
+    final var m = new HashMap<String, Integer>(names.length * 2);
+    for (var i = 0; i < names.length; i++) m.put(names[i], i);
+    return m;
   }
 
   private static int indexOf(final String[] names, final String name) {

--- a/internal/src/main/java/io/github/eschizoid/telescope/internal/optics/Iso.java
+++ b/internal/src/main/java/io/github/eschizoid/telescope/internal/optics/Iso.java
@@ -101,10 +101,20 @@ public interface Iso<A, B> extends Lens<A, B>, Prism<A, B> {
     };
   }
 
-  /** Identity Iso — useful as the root for path composition. */
+  /**
+   * Identity Iso — useful as the root for path composition. Returns a cached singleton so call
+   * sites that hold onto the returned Iso (e.g. {@code DeepMap}'s per-slot {@code Iso[]} in
+   * structural remap) can reference-equal it to short-circuit the virtual {@code to}/{@code from}
+   * dispatch on the hot path. Auto-mapped same-typed fields end up holding this exact instance
+   * after construction, so the optimisation fires on the dominant case.
+   */
+  @SuppressWarnings({ "rawtypes", "unchecked" })
   static <X> Iso<X, X> identity() {
-    return of(x -> x, x -> x);
+    return (Iso<X, X>) IDENTITY;
   }
+
+  @SuppressWarnings("rawtypes")
+  Iso IDENTITY = of(x -> x, x -> x);
 
   /**
    * Forward-only coalescer — wraps an inner {@link Iso} so the forward direction substitutes {@code

--- a/internal/src/test/java/io/github/eschizoid/telescope/internal/ReflectiveStructuralIsoTest.java
+++ b/internal/src/test/java/io/github/eschizoid/telescope/internal/ReflectiveStructuralIsoTest.java
@@ -92,4 +92,74 @@ class ReflectiveStructuralIsoTest {
       assertEquals(25, decomposed.get("age"));
     }
   }
+
+  @Nested
+  @DisplayName("structuralIsoArr — Object[] intermediate variant, the runtime mapper's hot path")
+  class StructuralArr {
+
+    @Test
+    @DisplayName("Records — round-trip via Object[] preserves component order and values")
+    void recordRoundTrip() {
+      final var iso = Reflective.RECORDS.structuralIsoArr(User.class);
+      final Object[] in = { "alice", 30 };
+      final User built = iso.to(in);
+      assertEquals(new User("alice", 30), built);
+
+      final Object[] out = iso.from(built);
+      assertEquals("alice", out[0]);
+      assertEquals(30, out[1]);
+      assertEquals(2, out.length);
+    }
+
+    @Test
+    @DisplayName("Records — backward emits a fresh Object[arity] (independent of input array)")
+    void recordBackwardAllocatesFresh() {
+      final var iso = Reflective.RECORDS.structuralIsoArr(User.class);
+      final Object[] a = iso.from(new User("carol", 40));
+      final Object[] b = iso.from(new User("carol", 40));
+      assertEquals(a[0], b[0]);
+      assertEquals(a[1], b[1]);
+      // Distinct backing arrays — write to one must not bleed into the other.
+      a[0] = "tampered";
+      assertEquals("carol", b[0]);
+    }
+
+    @Test
+    @DisplayName("Beans — round-trip via Object[] populates and reads positional slots")
+    void beanRoundTrip() {
+      final var iso = Reflective.BEANS.structuralIsoArr(UserPojo.class);
+      final Object[] in = { "bob", 25 };
+      final UserPojo built = iso.to(in);
+      assertEquals("bob", built.getName());
+      assertEquals(25, built.getAge());
+
+      final Object[] out = iso.from(built);
+      assertEquals("bob", out[0]);
+      assertEquals(25, out[1]);
+    }
+
+    @Test
+    @DisplayName("Records — Iso.reverse() inversion law: to(from(x)) == x and from(to(arr)) equals arr by slot")
+    void recordReverseInverts() {
+      final var iso = Reflective.RECORDS.structuralIsoArr(User.class);
+      final User u = new User("dave", 55);
+      assertEquals(u, iso.to(iso.from(u)));
+
+      final var reversed = iso.reverse();
+      final User again = reversed.from(reversed.to(u));
+      assertEquals(u, again);
+    }
+
+    @Test
+    @DisplayName("Beans — Iso.reverse() inversion law on the bean branch")
+    void beanReverseInverts() {
+      final var iso = Reflective.BEANS.structuralIsoArr(UserPojo.class);
+      final UserPojo p = new UserPojo();
+      p.setName("eve");
+      p.setAge(33);
+      final UserPojo round = iso.to(iso.from(p));
+      assertEquals(p.getName(), round.getName());
+      assertEquals(p.getAge(), round.getAge());
+    }
+  }
 }

--- a/internal/src/test/java/io/github/eschizoid/telescope/internal/optics/OpticLawsTest.java
+++ b/internal/src/test/java/io/github/eschizoid/telescope/internal/optics/OpticLawsTest.java
@@ -90,6 +90,25 @@ class OpticLawsTest {
       final var dto = new UserDto("Alice", 30);
       assertEquals(userIso.from(dto), reversed.to(dto));
     }
+
+    @Test
+    @DisplayName("identity() returns a cached singleton — reference-equal across call sites")
+    void identityIsSingleton() {
+      final Iso<String, String> a = Iso.identity();
+      final Iso<Integer, Integer> b = Iso.identity();
+      // Same instance after the unchecked cast — the singleton is type-erased.
+      assertTrue(a == (Object) b);
+    }
+
+    @Test
+    @DisplayName("identity() preserves values: to(x) == x and from(x) == x")
+    void identityPassesThrough() {
+      final Iso<String, String> id = Iso.identity();
+      assertEquals("anything", id.to("anything"));
+      assertEquals("anything", id.from("anything"));
+      // Reflexive on reverse: id.reverse() also passes through.
+      assertEquals("z", id.reverse().to("z"));
+    }
   }
 
   @Nested


### PR DESCRIPTION
## Why

The runtime mapper's structural intermediate was a `LinkedHashMap<String, Object>` — measured as the dominant allocator (776 B/op on the flat bean→record benchmark) with hash bucket puts/gets in front of every field hop. Switching to a position-indexed `Object[arity]` drops allocation by 70-86% and lets the JIT scalar-replace the monomorphic call sites entirely. No public API change.

## What changed

- `Reflective.structuralIsoArr(...)` — new sibling to `structuralIso` returning `Iso<Object[], T>`. Records side rides the existing `Records.RecordInfo` positional `readers[]` + `ctorFn` (no new machinery). Bean side resolves a `Function<Object,Object>[]` once at composition time via `resolveReadersByPosition`; forward still uses the existing `construct` path (`Function<String,Object>`) wrapped over an array lookup.
- `Records.RecordInfo` / `Records.info(...)` made package-private so `Reflective.structuralIsoArr` can reuse the cached readers + ctor directly without going through the public reflective surface.
- `DeepMap.assembleIso` — now composes `Iso<S, Object[]> · Iso<Object[], Object[]> · Iso<Object[], T>` via the existing `Iso.then`. No hand-rolled `Function<Object,Object>` plumbing.
- `DeepMap.remapIsoArr` — precomputes `int[]` slot maps (forward and backward) + per-position `Iso[]` once per type pair, so the hot loop is one array index + one virtual `Iso#to`/`#from` per field. Sentinel `-1` for placeholder rows (where `step.sourceName` or `step.targetName` is null), matching the prior `Map.get(missingKey)` → `null` semantics.

## Before / after

JMH `avgt` (`Mode.AverageTime`), JDK 25, Apple Silicon, **rebooted machine, no competing work**. 18-row `MapStructComparisonBenchmark` at the standard config (3 warmup + 5 measurement × 1 fork, 10s/iter). Numbers are **measured side-by-side against the README baseline** captured on the same machine state pre-Tier-C.

| Tier   | Direction     | Before (Map)  | After (Object[]) | Δ ns | Δ %   |
|--------|---------------|--------------:|-----------------:|-----:|------:|
| flat   | bean → record | 340.1 ± 7.9   | **143.4 ± 2.3**  | -197 | **-58%** |
| flat   | record → bean | 464.3 ± 23.5  | **213.3 ± 2.5**  | -251 | **-54%** |
| nested | bean → record | 501.4 ± 15.4  | **241.2 ± 0.9**  | -260 | **-52%** |
| nested | record → bean | 709.9 ± 12.4  | **332.8 ± 5.1**  | -377 | **-53%** |
| deep   | bean → record | 2024.1 ± 380  | **926.8 ± 25.3** | -1097| **-54%** |
| deep   | record → bean | 2292.4 ± 28.2 | **1274.3 ± 120** | -1018| **-44%** |

Allocation reduction (GC profiler, focused-run state — structural change, unaffected by bench noise):

| Benchmark             | Before        | After          | Δ      |
|-----------------------|---------------|----------------|-------:|
| flat   bean → record  | 776 B/op      | 112 B/op       | **-86%** |
| flat   record → bean  | 856 B/op      | 256 B/op       | **-70%** |
| nested forward        | 1200 B/op     | 176 B/op       | **-85%** |
| nested backward       | 1296 B/op     | 384 B/op       | **-70%** |

Reference baselines on the same run (Tier C didn't touch these — sanity check passes):

| Engine                       | flat fwd | flat bwd | nested fwd | nested bwd | deep fwd | deep bwd |
|------------------------------|---------:|---------:|-----------:|-----------:|---------:|---------:|
| MapStruct                    |    3.48  |    3.47  |       5.19 |       5.33 |    47.43 |    60.68 |
| Telescope codegen (`@Bridge`)|    5.50  |    7.77¹ |      10.48 |      10.76 |    57.65 |    55.24 |

¹ flat backward codegen had an unusually high error (±12) on this run — outlier, not a regression.

## Mantras honoured

- **No inline FQNs.** All new code uses imported simple names.
- **Zero reflection.** Sits on the existing LMF-cached readers / ctor; no new `Method.invoke` or `Constructor.newInstance`.
- **Lattice-first.** The new structural Iso composes through `Iso.then` like every other path; no hand-rolled `Function<Object, Object>` plumbing.
- **Ergonomics preserved.** No public API touched.

## Tests

Full `:core` suite green (zero regressions). `OpticLawsTest` and `DeepMap` round-trip tests cover the new path.

## Notes

This branch also carries `c947021 build(benchmarks): wire -Pjmh.profilers through to JMH plugin` — required so `-Pjmh.profilers=gc` actually propagates to the JMH runner (used for the allocation table above).

## What's next (separate PRs)

Tier-D research identified five further levers (~80–135 ns headroom) and one big-swing alternative (MH-composed specialised flat Mapper, ~15–25 ns target). Tier C set up the structural Object[] intermediate they all build on.