### PR TITLE
docs(readme): bump install snippets to telescope-core 0.13.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Quarkus extension ship as separate artifacts.
 ```kotlin
 // Gradle (Kotlin DSL)
 dependencies {
-  implementation("io.github.eschizoid:telescope-core:0.10.0")
+  implementation("io.github.eschizoid:telescope-core:0.13.0")
 }
 ```
 
@@ -32,7 +32,7 @@ dependencies {
 <dependency>
   <groupId>io.github.eschizoid</groupId>
   <artifactId>telescope-core</artifactId>
-  <version>0.10.0</version>
+  <version>0.13.0</version>
 </dependency>
 ```
 
@@ -457,8 +457,8 @@ Gradle (Kotlin DSL):
 
 ```kotlin
 dependencies {
-    implementation("io.github.eschizoid:telescope-core:0.10.0")
-    annotationProcessor("io.github.eschizoid:telescope-codegen:0.10.0")
+    implementation("io.github.eschizoid:telescope-core:0.13.0")
+    annotationProcessor("io.github.eschizoid:telescope-codegen:0.13.0")
 }
 ```
 
@@ -468,7 +468,7 @@ Maven:
 <dependency>
   <groupId>io.github.eschizoid</groupId>
   <artifactId>telescope-core</artifactId>
-  <version>0.10.0</version>
+  <version>0.13.0</version>
 </dependency>
 
 <build>
@@ -481,7 +481,7 @@ Maven:
           <path>
             <groupId>io.github.eschizoid</groupId>
             <artifactId>telescope-codegen</artifactId>
-            <version>0.10.0</version>
+            <version>0.13.0</version>
           </path>
         </annotationProcessorPaths>
       </configuration>
@@ -1234,8 +1234,8 @@ The return type degrades to a terminal `Telescope<R, Target>` when the target is
 Gradle wiring:
 
 ```kotlin
-implementation("io.github.eschizoid:telescope-core:0.10.0")
-annotationProcessor("io.github.eschizoid:telescope-codegen:0.10.0")
+implementation("io.github.eschizoid:telescope-core:0.13.0")
+annotationProcessor("io.github.eschizoid:telescope-codegen:0.13.0")
 ```
 
 `@Focus` and `@BeanFocus` are source-retention and inert without the processor, so annotating costs nothing if you don't

--- a/codegen/README.md
+++ b/codegen/README.md
@@ -47,8 +47,8 @@ that chains the generated bridge constant.
 ```kotlin
 // Gradle
 dependencies {
-    implementation("io.github.eschizoid:telescope:0.4.1")
-    annotationProcessor("io.github.eschizoid:telescope-codegen:0.4.1")
+    implementation("io.github.eschizoid:telescope-core:0.13.0")
+    annotationProcessor("io.github.eschizoid:telescope-codegen:0.13.0")
 }
 ```
 
@@ -56,8 +56,8 @@ dependencies {
 <!-- Maven -->
 <dependency>
   <groupId>io.github.eschizoid</groupId>
-  <artifactId>telescope</artifactId>
-  <version>0.4.1</version>
+  <artifactId>telescope-core</artifactId>
+  <version>0.13.0</version>
 </dependency>
 <!-- annotationProcessorPaths on maven-compiler-plugin -->
 <plugin>
@@ -68,7 +68,7 @@ dependencies {
       <path>
         <groupId>io.github.eschizoid</groupId>
         <artifactId>telescope-codegen</artifactId>
-        <version>0.4.1</version>
+        <version>0.13.0</version>
       </path>
     </annotationProcessorPaths>
   </configuration>

--- a/lombok/README.md
+++ b/lombok/README.md
@@ -40,7 +40,7 @@ classpath.)
 ```kotlin
 // Gradle
 dependencies {
-    implementation("io.github.eschizoid:telescope:0.4.1")
+    implementation("io.github.eschizoid:telescope-core:0.13.0")
 
     // Lombok itself
     compileOnly("org.projectlombok:lombok:1.18.42")
@@ -48,7 +48,7 @@ dependencies {
 
     // Telescope's Lombok-aware codegen — must come AFTER Lombok in the processor list so
     // Lombok's AST patches have fired when telescope reads the synthesized members.
-    annotationProcessor("io.github.eschizoid:telescope-lombok:0.4.1")
+    annotationProcessor("io.github.eschizoid:telescope-lombok:0.13.0")
 }
 ```
 
@@ -67,7 +67,7 @@ dependencies {
       <path>
         <groupId>io.github.eschizoid</groupId>
         <artifactId>telescope-lombok</artifactId>
-        <version>0.4.1</version>
+        <version>0.13.0</version>
       </path>
     </annotationProcessorPaths>
   </configuration>

--- a/quarkus/README.md
+++ b/quarkus/README.md
@@ -5,7 +5,7 @@ nothing else. Mirrors the [`spring-boot-starter`](../spring-boot-starter/README.
 
 ```kotlin
 dependencies {
-    implementation("io.github.eschizoid:telescope-quarkus:0.4.1")
+    implementation("io.github.eschizoid:telescope-quarkus:0.13.0")
 }
 ```
 
@@ -32,7 +32,7 @@ archive ... is being scanned without a Jandex index" warning.
 // Gradle (Quarkus 3 BOM picks up Quarkus's version)
 dependencies {
     implementation(platform("io.quarkus.platform:quarkus-bom:3.20.0"))
-    implementation("io.github.eschizoid:telescope-quarkus:0.4.1")
+    implementation("io.github.eschizoid:telescope-quarkus:0.13.0")
 }
 ```
 
@@ -41,7 +41,7 @@ dependencies {
 <dependency>
   <groupId>io.github.eschizoid</groupId>
   <artifactId>telescope-quarkus</artifactId>
-  <version>0.4.1</version>
+  <version>0.13.0</version>
 </dependency>
 ```
 

--- a/spring-boot-starter/README.md
+++ b/spring-boot-starter/README.md
@@ -5,7 +5,7 @@ Drop-in Spring Boot 4 auto-config for [telescope](../README.md). Adds one bean t
 
 ```kotlin
 dependencies {
-    implementation("io.github.eschizoid:telescope-spring-boot-starter:0.4.1")
+    implementation("io.github.eschizoid:telescope-spring-boot-starter:0.13.0")
 }
 ```
 
@@ -25,7 +25,7 @@ your `@Configuration` and they show up in the registry; the registry resolves th
 // Gradle (Spring Boot 4 BOM picks up Boot's version)
 dependencies {
     implementation(platform("org.springframework.boot:spring-boot-dependencies:4.0.1"))
-    implementation("io.github.eschizoid:telescope-spring-boot-starter:0.4.1")
+    implementation("io.github.eschizoid:telescope-spring-boot-starter:0.13.0")
 }
 ```
 
@@ -34,7 +34,7 @@ dependencies {
 <dependency>
   <groupId>io.github.eschizoid</groupId>
   <artifactId>telescope-spring-boot-starter</artifactId>
-  <version>0.4.1</version>
+  <version>0.13.0</version>
 </dependency>
 ```
 


### PR DESCRIPTION
The per-module READMEs still pointed at the legacy `io.github.eschizoid:telescope:0.4.1` coordinate (the old artifact only ever reached 0.5.0 and is now retired) and the main README pinned 0.10.0 — three patch versions behind the current Central release.

Bumping every Gradle / Maven install block to:
- `telescope-core:0.13.0` (replaces stale `telescope:0.4.1` and `telescope-core:0.10.0`)
- `telescope-codegen:0.13.0`
- `telescope-lombok:0.13.0`
- `telescope-quarkus:0.13.0`
- `telescope-spring-boot-starter:0.13.0`

Files touched: `README.md`, `codegen/README.md`, `lombok/README.md`, `quarkus/README.md`, `spring-boot-starter/README.md`. Install snippets only — no behaviour change.

The GitHub repo's `homepageUrl` is already correctly pointing at `https://central.sonatype.com/artifact/io.github.eschizoid/telescope-core`. The follow-up to refresh the runtime ns numbers across both READMEs and the public Discussion lands separately (PR #118's Object[] structural intermediate moved them ~50% on the runtime path).