### PR TITLE
experiment: fuse src+remap — kill source Object[] intermediate (~14% flat fwd)

### DIFF
--- a/core/src/main/java/io/github/eschizoid/telescope/DeepMap.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/DeepMap.java
@@ -1066,19 +1066,100 @@ public final class DeepMap {
     final var tgtNames = tgtRefl.names(target);
     final var tgtHolderReaders = Telescope.holderReadersFor(target, tgtNames);
     final var tgtHolderConstructor = Telescope.holderConstructorFor(target);
-    // Position-indexed structural intermediate: Object[arity] instead of LinkedHashMap. The hash
-    // bucket puts/gets dominated the runtime mapper's allocation profile (~776 B/op on the flat
-    // 5-field bean→record benchmark); arrays drop that to ~80 B/op and let the JIT scalar-replace
-    // monomorphic call sites entirely. Position semantics: slot i of `srcArr` corresponds to
-    // `srcRefl.names(source)[i]`; same for the target side. The remap step bridges the two layouts
-    // via precomputed int[] slot maps, one allocation per type-pair-load.
-    final Iso<S, Object[]> srcReader = srcRefl
-      .structuralIsoArr(source, srcHolderReaders, srcHolderConstructor)
-      .reverse();
-    final Iso<Object[], T> tgtBuilder = tgtRefl.structuralIsoArr(target, tgtHolderReaders, tgtHolderConstructor);
-    final Iso<Object[], Object[]> remap = remapIsoArr(byTargetName, bySourceName, srcNames, tgtNames);
-    return nullable(srcReader.then(remap).then(tgtBuilder));
+    // Fused-source-and-remap: bypass the source-side Object[] intermediate. The previous shape
+    // ran S → Object[srcArity] (srcReader) → Object[tgtArity] (remap) → T (tgtBuilder) — two
+    // intermediate arrays + three Iso.then virtual dispatches per call. The fused body inlines
+    // all three stages: target Object[tgtArity] alloc, then for each target slot pull the source
+    // value directly from srcReaders[fwdSrcPos[i]].apply(s) and apply the per-slot Iso. Saves one
+    // alloc + 5 array writes + 5 array reads + 2 virtual Iso.then hops per call. Identity-Iso
+    // short-circuit preserved against the cached singleton from Iso.identity().
+    final var srcReaders = srcRefl.positionalReaders(source, srcHolderReaders);
+    final var tgtReaders = tgtRefl.positionalReaders(target, tgtHolderReaders);
+    final var tgtBuilderFn = tgtRefl.positionalBuilder(target, tgtHolderReaders, tgtHolderConstructor);
+    final var srcBuilderFn = srcRefl.positionalBuilder(source, srcHolderReaders, srcHolderConstructor);
+    final var slotMaps = buildSlotMaps(byTargetName, bySourceName, srcNames, tgtNames);
+    final Iso<Object, Object> identity = Iso.identity();
+    return Iso.of(
+      s -> {
+        if (s == null) return null;
+        final var tgtArr = new Object[slotMaps.tgtArity()];
+        for (var i = 0; i < slotMaps.tgtArity(); i++) {
+          final var sp = slotMaps.fwdSrcPos()[i];
+          final var v = sp < 0 ? null : srcReaders[sp].apply(s);
+          final var iso = slotMaps.fwdIso()[i];
+          tgtArr[i] = iso == identity ? v : iso.to(v);
+        }
+        return tgtBuilderFn.apply(tgtArr);
+      },
+      t -> {
+        if (t == null) return null;
+        final var srcArr = new Object[slotMaps.srcArity()];
+        for (var i = 0; i < slotMaps.srcArity(); i++) {
+          final var tp = slotMaps.bwdTgtPos()[i];
+          final var v = tp < 0 ? null : tgtReaders[tp].apply(t);
+          final var iso = slotMaps.bwdIso()[i];
+          srcArr[i] = iso == identity ? v : iso.from(v);
+        }
+        return srcBuilderFn.apply(srcArr);
+      }
+    );
   }
+
+  /**
+   * Precomputes the source→target and target→source slot translation tables + per-slot Iso arrays
+   * once at type-pair build time. Sentinel slot {@code -1} for "no corresponding source/target
+   * field" (placeholder rows where {@code step.sourceName} or {@code step.targetName} is null) —
+   * the value defaults to {@code null}, matching the prior {@code Map.get(missingKey)} semantics.
+   */
+  @SuppressWarnings({ "unchecked", "rawtypes" })
+  private static SlotMaps buildSlotMaps(
+    final Map<String, FieldStep> byTargetName,
+    final Map<String, FieldStep> bySourceName,
+    final String[] srcNames,
+    final String[] tgtNames
+  ) {
+    final var srcIndex = indexMap(srcNames);
+    final var tgtIndex = indexMap(tgtNames);
+    final var srcArity = srcNames.length;
+    final var tgtArity = tgtNames.length;
+    final var fwdSrcPos = new int[tgtArity];
+    final var fwdIso = (Iso<Object, Object>[]) new Iso[tgtArity];
+    final Iso<Object, Object> identity = Iso.identity();
+    for (var i = 0; i < tgtArity; i++) {
+      final var step = byTargetName.get(tgtNames[i]);
+      if (step == null) {
+        fwdSrcPos[i] = -1;
+        fwdIso[i] = identity;
+      } else {
+        final var srcPos = step.sourceName == null ? null : srcIndex.get(step.sourceName);
+        fwdSrcPos[i] = srcPos == null ? -1 : srcPos;
+        fwdIso[i] = (Iso<Object, Object>) step.iso;
+      }
+    }
+    final var bwdTgtPos = new int[srcArity];
+    final var bwdIso = (Iso<Object, Object>[]) new Iso[srcArity];
+    for (var i = 0; i < srcArity; i++) {
+      final var step = bySourceName.get(srcNames[i]);
+      if (step == null) {
+        bwdTgtPos[i] = -1;
+        bwdIso[i] = identity;
+      } else {
+        final var tgtPos = step.targetName == null ? null : tgtIndex.get(step.targetName);
+        bwdTgtPos[i] = tgtPos == null ? -1 : tgtPos;
+        bwdIso[i] = (Iso<Object, Object>) step.iso;
+      }
+    }
+    return new SlotMaps(srcArity, tgtArity, fwdSrcPos, fwdIso, bwdTgtPos, bwdIso);
+  }
+
+  private record SlotMaps(
+    int srcArity,
+    int tgtArity,
+    int[] fwdSrcPos,
+    Iso<Object, Object>[] fwdIso,
+    int[] bwdTgtPos,
+    Iso<Object, Object>[] bwdIso
+  ) {}
 
   /**
    * Position-indexed variant of {@link #remapIso}. Precomputes {@code int[]} slot maps and a

--- a/internal/src/main/java/io/github/eschizoid/telescope/internal/Reflective.java
+++ b/internal/src/main/java/io/github/eschizoid/telescope/internal/Reflective.java
@@ -220,9 +220,9 @@ public record Reflective(
    * Expose the positional reader array used inside {@link #structuralIsoArr(Class, Map, Function)}.
    * Callers (typically {@code DeepMap} on the assembly hot path) can use this to bypass the
    * source-side {@link Iso} wrapper entirely and read instance → array values inline, eliminating
-   * one virtual hop per call. Same substrate as {@link #structuralIsoArr}: holder-aware
-   * (uses {@link Lens#get} when {@code holderReaders} is non-null), records short-circuit to
-   * cached {@code RecordInfo.readers[]}, bean fallback captures the LMF reader via {@link #read}.
+   * one virtual hop per call. Same substrate as {@link #structuralIsoArr}: holder-aware (uses
+   * {@link Lens#get} when {@code holderReaders} is non-null), records short-circuit to cached
+   * {@code RecordInfo.readers[]}, bean fallback captures the LMF reader via {@link #read}.
    */
   public Function<Object, Object>[] positionalReaders(
     final Class<?> cls,
@@ -232,10 +232,11 @@ public record Reflective(
   }
 
   /**
-   * Expose the positional builder ({@code Object[arity] → T}) used inside {@link #structuralIsoArr}.
-   * Same shape as {@link #positionalReaders}: lets callers skip the Iso wrapper to invoke the
-   * canonical constructor (records — direct LMF-built {@code ctorFn}) or the named-construct path
-   * (beans — wrapped over an O(1) HashMap-indexed array lookup, no per-call name scan).
+   * Expose the positional builder ({@code Object[arity] → T}) used inside {@link
+   * #structuralIsoArr}. Same shape as {@link #positionalReaders}: lets callers skip the Iso wrapper
+   * to invoke the canonical constructor (records — direct LMF-built {@code ctorFn}) or the
+   * named-construct path (beans — wrapped over an O(1) HashMap-indexed array lookup, no per-call
+   * name scan).
    */
   @SuppressWarnings("unchecked")
   public <T> Function<Object[], T> positionalBuilder(

--- a/internal/src/main/java/io/github/eschizoid/telescope/internal/Reflective.java
+++ b/internal/src/main/java/io/github/eschizoid/telescope/internal/Reflective.java
@@ -216,6 +216,45 @@ public record Reflective(
     );
   }
 
+  /**
+   * Expose the positional reader array used inside {@link #structuralIsoArr(Class, Map, Function)}.
+   * Callers (typically {@code DeepMap} on the assembly hot path) can use this to bypass the
+   * source-side {@link Iso} wrapper entirely and read instance → array values inline, eliminating
+   * one virtual hop per call. Same substrate as {@link #structuralIsoArr}: holder-aware
+   * (uses {@link Lens#get} when {@code holderReaders} is non-null), records short-circuit to
+   * cached {@code RecordInfo.readers[]}, bean fallback captures the LMF reader via {@link #read}.
+   */
+  public Function<Object, Object>[] positionalReaders(
+    final Class<?> cls,
+    final Map<String, Lens<Object, Object>> holderReaders
+  ) {
+    return resolveReadersByPosition(cls, names(cls), holderReaders);
+  }
+
+  /**
+   * Expose the positional builder ({@code Object[arity] → T}) used inside {@link #structuralIsoArr}.
+   * Same shape as {@link #positionalReaders}: lets callers skip the Iso wrapper to invoke the
+   * canonical constructor (records — direct LMF-built {@code ctorFn}) or the named-construct path
+   * (beans — wrapped over an O(1) HashMap-indexed array lookup, no per-call name scan).
+   */
+  @SuppressWarnings("unchecked")
+  public <T> Function<Object[], T> positionalBuilder(
+    final Class<T> cls,
+    final Map<String, Lens<Object, Object>> holderReaders,
+    final Function<Function<String, Object>, Object> holderConstructor
+  ) {
+    if (cls.isRecord() && holderReaders == null && holderConstructor == null) {
+      final var ctorFn = Records.info(cls).ctorFn();
+      return arr -> (T) ctorFn.apply(arr);
+    }
+    final var componentNames = names(cls);
+    final var nameIndex = indexMap(componentNames);
+    if (holderConstructor != null) {
+      return arr -> (T) holderConstructor.apply(i -> arr[nameIndex.get(i)]);
+    }
+    return arr -> cls.cast(construct(cls, i -> arr[nameIndex.get(i)]));
+  }
+
   @SuppressWarnings("unchecked")
   private Function<Object, Object>[] resolveReadersByPosition(
     final Class<?> cls,


### PR DESCRIPTION
**Experiment 1 of overnight Tier-D autonomous run.**

## Hypothesis

The runtime `Mapper.forward(s)` hot path threads `s → Object[srcArity] → Object[tgtArity] → T` via three composed Isos (`srcReader.then(remap).then(tgtBuilder)`). The source-side `Object[]` is pure intermediate — every value gets re-read by `remap` via `fwdSrcPos[i]` and never escapes. Fusing all three into a single `Iso<S, T>` body would eliminate one allocation + 5 array writes + 5 array reads + 2 virtual `Iso.then` hops per call.

## Implementation

- Added `Reflective.positionalReaders(Class, holderReaders)` and `Reflective.positionalBuilder(Class, holderReaders, holderConstructor)` to expose the primitives that previously lived only inside `structuralIsoArr`.
- Rewrote `DeepMap.assembleIso` to build a single `Iso<S, T>` whose forward body inlines:
  - `s == null` guard (previously the `nullable` wrap — 1 extra virtual hop)
  - `Object[tgtArity]` allocation
  - per-target-slot: gather from `srcReaders[fwdSrcPos[i]].apply(s)` directly, no source intermediate
  - identity short-circuit (reference-equal `Iso.identity()` from PR #118's Round 2)
  - apply per-slot Iso `.to(v)` for non-identity slots
  - hand `tgtArr` to `tgtBuilderFn` (either `RecordInfo.ctorFn` directly or the bean-side holder/construct path)
- Backward mirrors the forward shape.
- Factored the slot-table precompute into `buildSlotMaps(...)` returning a `SlotMaps` record (kept testable, no API change).
- `remapIsoArr` still defined but no longer called — left in place for the experimental branch; will delete in the final PR.

## Measured (JMH avgt, JDK 25, Apple Silicon, focused 4-row run)

| Bench | 1.0 baseline | Exp1 | Δ ns | Δ % |
|---|---:|---:|---:|---:|
| flat fwd | 124.04 ± 2.21 | **106.18 ± 3.30** | -17.9 | **-14.4%** |
| flat bwd | 188.08 ± 3.07 | **172.96 ± 2.43** | -15.1 | **-8.0%** |
| nested fwd | 204.30 ± 3.01 | **188.08 ± 3.79** | -16.2 | **-7.9%** |
| nested bwd | 277.92 ± 3.78 | **254.10 ± 8.34** | -23.8 | **-8.6%** |

Agent prediction (from the ns-budget analysis): 6-8 ns + alloc reduction. **Measured 15-24 ns.** The alloc reduction helped escape analysis / scalar replacement more than predicted.

## Mantras

- ✅ Lattice-first: still composes through `Iso.of` — the new `positionalReaders` / `positionalBuilder` are substrate primitives, not a parallel composition system.
- ✅ Zero new reflection — sits on the existing LMF substrate.
- ✅ No FQNs.
- ✅ No public API change.

## Tests

Full `:internal:test :core:test` suite green.

## Drafted because

This is part of an autonomous overnight Tier-D experiment run. Multiple experiments stack — the cumulative win will be evaluated against the 1.0 baseline once all branches are measured. Not for direct merge.