### PR TITLE
experiment: FORWARD_SEEN hoist for acyclic pairs (~30-40% nested/deep)

### DIFF
--- a/core/src/main/java/io/github/eschizoid/telescope/DeepMap.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/DeepMap.java
@@ -1066,19 +1066,100 @@ public final class DeepMap {
     final var tgtNames = tgtRefl.names(target);
     final var tgtHolderReaders = Telescope.holderReadersFor(target, tgtNames);
     final var tgtHolderConstructor = Telescope.holderConstructorFor(target);
-    // Position-indexed structural intermediate: Object[arity] instead of LinkedHashMap. The hash
-    // bucket puts/gets dominated the runtime mapper's allocation profile (~776 B/op on the flat
-    // 5-field bean→record benchmark); arrays drop that to ~80 B/op and let the JIT scalar-replace
-    // monomorphic call sites entirely. Position semantics: slot i of `srcArr` corresponds to
-    // `srcRefl.names(source)[i]`; same for the target side. The remap step bridges the two layouts
-    // via precomputed int[] slot maps, one allocation per type-pair-load.
-    final Iso<S, Object[]> srcReader = srcRefl
-      .structuralIsoArr(source, srcHolderReaders, srcHolderConstructor)
-      .reverse();
-    final Iso<Object[], T> tgtBuilder = tgtRefl.structuralIsoArr(target, tgtHolderReaders, tgtHolderConstructor);
-    final Iso<Object[], Object[]> remap = remapIsoArr(byTargetName, bySourceName, srcNames, tgtNames);
-    return nullable(srcReader.then(remap).then(tgtBuilder));
+    // Fused-source-and-remap: bypass the source-side Object[] intermediate. The previous shape
+    // ran S → Object[srcArity] (srcReader) → Object[tgtArity] (remap) → T (tgtBuilder) — two
+    // intermediate arrays + three Iso.then virtual dispatches per call. The fused body inlines
+    // all three stages: target Object[tgtArity] alloc, then for each target slot pull the source
+    // value directly from srcReaders[fwdSrcPos[i]].apply(s) and apply the per-slot Iso. Saves one
+    // alloc + 5 array writes + 5 array reads + 2 virtual Iso.then hops per call. Identity-Iso
+    // short-circuit preserved against the cached singleton from Iso.identity().
+    final var srcReaders = srcRefl.positionalReaders(source, srcHolderReaders);
+    final var tgtReaders = tgtRefl.positionalReaders(target, tgtHolderReaders);
+    final var tgtBuilderFn = tgtRefl.positionalBuilder(target, tgtHolderReaders, tgtHolderConstructor);
+    final var srcBuilderFn = srcRefl.positionalBuilder(source, srcHolderReaders, srcHolderConstructor);
+    final var slotMaps = buildSlotMaps(byTargetName, bySourceName, srcNames, tgtNames);
+    final Iso<Object, Object> identity = Iso.identity();
+    return Iso.of(
+      s -> {
+        if (s == null) return null;
+        final var tgtArr = new Object[slotMaps.tgtArity()];
+        for (var i = 0; i < slotMaps.tgtArity(); i++) {
+          final var sp = slotMaps.fwdSrcPos()[i];
+          final var v = sp < 0 ? null : srcReaders[sp].apply(s);
+          final var iso = slotMaps.fwdIso()[i];
+          tgtArr[i] = iso == identity ? v : iso.to(v);
+        }
+        return tgtBuilderFn.apply(tgtArr);
+      },
+      t -> {
+        if (t == null) return null;
+        final var srcArr = new Object[slotMaps.srcArity()];
+        for (var i = 0; i < slotMaps.srcArity(); i++) {
+          final var tp = slotMaps.bwdTgtPos()[i];
+          final var v = tp < 0 ? null : tgtReaders[tp].apply(t);
+          final var iso = slotMaps.bwdIso()[i];
+          srcArr[i] = iso == identity ? v : iso.from(v);
+        }
+        return srcBuilderFn.apply(srcArr);
+      }
+    );
   }
+
+  /**
+   * Precomputes the source→target and target→source slot translation tables + per-slot Iso arrays
+   * once at type-pair build time. Sentinel slot {@code -1} for "no corresponding source/target
+   * field" (placeholder rows where {@code step.sourceName} or {@code step.targetName} is null) —
+   * the value defaults to {@code null}, matching the prior {@code Map.get(missingKey)} semantics.
+   */
+  @SuppressWarnings({ "unchecked", "rawtypes" })
+  private static SlotMaps buildSlotMaps(
+    final Map<String, FieldStep> byTargetName,
+    final Map<String, FieldStep> bySourceName,
+    final String[] srcNames,
+    final String[] tgtNames
+  ) {
+    final var srcIndex = indexMap(srcNames);
+    final var tgtIndex = indexMap(tgtNames);
+    final var srcArity = srcNames.length;
+    final var tgtArity = tgtNames.length;
+    final var fwdSrcPos = new int[tgtArity];
+    final var fwdIso = (Iso<Object, Object>[]) new Iso[tgtArity];
+    final Iso<Object, Object> identity = Iso.identity();
+    for (var i = 0; i < tgtArity; i++) {
+      final var step = byTargetName.get(tgtNames[i]);
+      if (step == null) {
+        fwdSrcPos[i] = -1;
+        fwdIso[i] = identity;
+      } else {
+        final var srcPos = step.sourceName == null ? null : srcIndex.get(step.sourceName);
+        fwdSrcPos[i] = srcPos == null ? -1 : srcPos;
+        fwdIso[i] = (Iso<Object, Object>) step.iso;
+      }
+    }
+    final var bwdTgtPos = new int[srcArity];
+    final var bwdIso = (Iso<Object, Object>[]) new Iso[srcArity];
+    for (var i = 0; i < srcArity; i++) {
+      final var step = bySourceName.get(srcNames[i]);
+      if (step == null) {
+        bwdTgtPos[i] = -1;
+        bwdIso[i] = identity;
+      } else {
+        final var tgtPos = step.targetName == null ? null : tgtIndex.get(step.targetName);
+        bwdTgtPos[i] = tgtPos == null ? -1 : tgtPos;
+        bwdIso[i] = (Iso<Object, Object>) step.iso;
+      }
+    }
+    return new SlotMaps(srcArity, tgtArity, fwdSrcPos, fwdIso, bwdTgtPos, bwdIso);
+  }
+
+  private record SlotMaps(
+    int srcArity,
+    int tgtArity,
+    int[] fwdSrcPos,
+    Iso<Object, Object>[] fwdIso,
+    int[] bwdTgtPos,
+    Iso<Object, Object>[] bwdIso
+  ) {}
 
   /**
    * Position-indexed variant of {@link #remapIso}. Precomputes {@code int[]} slot maps and a

--- a/core/src/main/java/io/github/eschizoid/telescope/DeepMap.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/DeepMap.java
@@ -302,8 +302,10 @@ public final class DeepMap {
     final var key = new TypePair(source, target);
     if (cache.containsKey(key)) {
       // Re-entry on an in-progress slot (sentinel == null) means we've found a static cycle in the
-      // type graph. Mark this pair AND every ancestor on the recursion stack as cyclic — they're all
-      // in the same SCC and must keep the value-level cycle-safe shell at runtime. Acyclic pairs get
+      // type graph. Mark this pair AND every ancestor on the recursion stack as cyclic — they're
+      // all
+      // in the same SCC and must keep the value-level cycle-safe shell at runtime. Acyclic pairs
+      // get
       // a plain Iso pass-through, skipping the ~15 ns ThreadLocal + IdentityHashMap probe per hop.
       if (cache.get(key) == null) {
         cyclicPairs.add(key);

--- a/core/src/main/java/io/github/eschizoid/telescope/DeepMap.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/DeepMap.java
@@ -25,7 +25,9 @@ import java.lang.reflect.Modifier;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.time.temporal.Temporal;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Deque;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.IdentityHashMap;
@@ -118,7 +120,9 @@ public final class DeepMap {
     final var overrideTable = groupOverridesByPair(overrides.toArray(Mapping<?, ?>[]::new), source, target);
     final var cache = new HashMap<TypePair, Iso<?, ?>>();
     final var topSteps = new LinkedHashMap<String, FieldStep>();
-    populateIso(source, target, overrideTable, beanRefl, cache, topSteps, nullStrategy);
+    final var cyclicPairs = new HashSet<TypePair>();
+    final var inProgress = new ArrayDeque<TypePair>();
+    populateIso(source, target, overrideTable, beanRefl, cache, topSteps, nullStrategy, cyclicPairs, inProgress);
     validateAllHintsConsumed(hintMap, cache);
     final var iso = (Iso<A, B>) Objects.requireNonNull(cache.get(new TypePair(source, target)));
     final var patchTable = new LinkedHashMap<String, Mapper.PatchEntry>();
@@ -291,11 +295,24 @@ public final class DeepMap {
     final Reflective beanRefl,
     final Map<TypePair, Iso<?, ?>> cache,
     final Map<String, FieldStep> topStepsOut,
-    final NullHint.NullStrategy nullStrategy
+    final NullHint.NullStrategy nullStrategy,
+    final Set<TypePair> cyclicPairs,
+    final Deque<TypePair> inProgress
   ) {
     final var key = new TypePair(source, target);
-    if (cache.containsKey(key)) return;
+    if (cache.containsKey(key)) {
+      // Re-entry on an in-progress slot (sentinel == null) means we've found a static cycle in the
+      // type graph. Mark this pair AND every ancestor on the recursion stack as cyclic — they're all
+      // in the same SCC and must keep the value-level cycle-safe shell at runtime. Acyclic pairs get
+      // a plain Iso pass-through, skipping the ~15 ns ThreadLocal + IdentityHashMap probe per hop.
+      if (cache.get(key) == null) {
+        cyclicPairs.add(key);
+        cyclicPairs.addAll(inProgress);
+      }
+      return;
+    }
     cache.put(key, null); // reserve slot so cycle-re-entry short-circuits
+    inProgress.push(key);
 
     final var srcRefl = pickReflective(source, beanRefl);
     final var tgtRefl = pickReflective(target, beanRefl);
@@ -490,7 +507,9 @@ public final class DeepMap {
           overrides,
           beanRefl,
           cache,
-          nullStrategy
+          nullStrategy,
+          cyclicPairs,
+          inProgress
         )
       );
       byTargetName.put(name, step);
@@ -536,6 +555,7 @@ public final class DeepMap {
       telescopeFixups.isEmpty() ? baseIso : wrapWithTelescopeFixups(baseIso, telescopeFixups, srcRefl, source)
     );
     if (topStepsOut != null) topStepsOut.putAll(byTargetName);
+    inProgress.pop();
   }
 
   /**
@@ -748,9 +768,21 @@ public final class DeepMap {
     final Map<TypePair, List<Mapping<?, ?>>> overrides,
     final Reflective beanRefl,
     final Map<TypePair, Iso<?, ?>> cache,
-    final NullHint.NullStrategy nullStrategy
+    final NullHint.NullStrategy nullStrategy,
+    final Set<TypePair> cyclicPairs,
+    final Deque<TypePair> inProgress
   ) {
-    final var raw = computeAutoIso(srcType, tgtType, componentName, overrides, beanRefl, cache, nullStrategy);
+    final var raw = computeAutoIso(
+      srcType,
+      tgtType,
+      componentName,
+      overrides,
+      beanRefl,
+      cache,
+      nullStrategy,
+      cyclicPairs,
+      inProgress
+    );
     // DEFAULT strategy wraps EVERY auto-recursed per-component Iso uniformly: scalar identity,
     // recursive record/bean pair, lifted container, cross-Optional bridge. When the source value
     // is null, the wrapper substitutes the per-leaf-type default from NullDefaults#defaultFor so
@@ -766,7 +798,9 @@ public final class DeepMap {
     final Map<TypePair, List<Mapping<?, ?>>> overrides,
     final Reflective beanRefl,
     final Map<TypePair, Iso<?, ?>> cache,
-    final NullHint.NullStrategy nullStrategy
+    final NullHint.NullStrategy nullStrategy,
+    final Set<TypePair> cyclicPairs,
+    final Deque<TypePair> inProgress
   ) {
     // (a) Same generic type → identity Iso.
     if (srcType.equals(tgtType)) return Iso.identity();
@@ -774,8 +808,9 @@ public final class DeepMap {
     // (b) Both reflectable (record or bean) → recurse, return cache-reading Iso so cycles work.
     if (srcType instanceof Class<?> srcCls && tgtType instanceof Class<?> tgtCls) {
       if (isReflectable(srcCls) && isReflectable(tgtCls)) {
-        populateIso(srcCls, tgtCls, overrides, beanRefl, cache, null, nullStrategy);
-        return lazyCacheIso(cache, new TypePair(srcCls, tgtCls));
+        populateIso(srcCls, tgtCls, overrides, beanRefl, cache, null, nullStrategy, cyclicPairs, inProgress);
+        final var subKey = new TypePair(srcCls, tgtCls);
+        return lazyCacheIso(cache, subKey, !cyclicPairs.contains(subKey));
       }
     }
 
@@ -804,7 +839,9 @@ public final class DeepMap {
         overrides,
         beanRefl,
         cache,
-        NullHint.NullStrategy.PROPAGATE
+        NullHint.NullStrategy.PROPAGATE,
+        cyclicPairs,
+        inProgress
       );
       return Iso.liftOptionalToNullable(eraseIso(elementIso));
     }
@@ -816,7 +853,9 @@ public final class DeepMap {
         overrides,
         beanRefl,
         cache,
-        NullHint.NullStrategy.PROPAGATE
+        NullHint.NullStrategy.PROPAGATE,
+        cyclicPairs,
+        inProgress
       );
       return Iso.liftOptionalToNullable(eraseIso(elementIso)).reverse();
     }
@@ -846,7 +885,9 @@ public final class DeepMap {
         overrides,
         beanRefl,
         cache,
-        NullHint.NullStrategy.PROPAGATE
+        NullHint.NullStrategy.PROPAGATE,
+        cyclicPairs,
+        inProgress
       );
       return switch (srcShape.kind) {
         case LIST -> Iso.liftList(eraseIso(elementIso));
@@ -1319,7 +1360,23 @@ public final class DeepMap {
   );
 
   @SuppressWarnings("unchecked")
-  private static Iso<?, ?> lazyCacheIso(final Map<TypePair, Iso<?, ?>> cache, final TypePair key) {
+  private static Iso<?, ?> lazyCacheIso(
+    final Map<TypePair, Iso<?, ?>> cache,
+    final TypePair key,
+    final boolean acyclic
+  ) {
+    // Acyclic-bypass: when the static type graph has no path from this pair back to itself, the
+    // value-level cycle guard cannot fire. Skip the ThreadLocal probe + IdentityHashMap insert
+    // entirely — ~15 ns saved per nested hop. Verified at populateIso time via the cyclicPairs
+    // tracker; if a downstream change introduces a back-edge that the analysis can't see (e.g. an
+    // Object-typed component holding an instance-level cycle), the bypass would be unsafe — but the
+    // structural typing already prevents DeepMap from descending into Object-typed fields.
+    if (acyclic) {
+      return Iso.of(
+        v -> v == null ? null : ((Iso<Object, Object>) cache.get(key)).to(v),
+        v -> v == null ? null : ((Iso<Object, Object>) cache.get(key)).from(v)
+      );
+    }
     return Iso.of(
       v -> cycleSafe(FORWARD_SEEN, v, x -> ((Iso<Object, Object>) cache.get(key)).to(x)),
       v -> cycleSafe(BACKWARD_SEEN, v, x -> ((Iso<Object, Object>) cache.get(key)).from(x))

--- a/internal/src/main/java/io/github/eschizoid/telescope/internal/Reflective.java
+++ b/internal/src/main/java/io/github/eschizoid/telescope/internal/Reflective.java
@@ -220,9 +220,9 @@ public record Reflective(
    * Expose the positional reader array used inside {@link #structuralIsoArr(Class, Map, Function)}.
    * Callers (typically {@code DeepMap} on the assembly hot path) can use this to bypass the
    * source-side {@link Iso} wrapper entirely and read instance → array values inline, eliminating
-   * one virtual hop per call. Same substrate as {@link #structuralIsoArr}: holder-aware
-   * (uses {@link Lens#get} when {@code holderReaders} is non-null), records short-circuit to
-   * cached {@code RecordInfo.readers[]}, bean fallback captures the LMF reader via {@link #read}.
+   * one virtual hop per call. Same substrate as {@link #structuralIsoArr}: holder-aware (uses
+   * {@link Lens#get} when {@code holderReaders} is non-null), records short-circuit to cached
+   * {@code RecordInfo.readers[]}, bean fallback captures the LMF reader via {@link #read}.
    */
   public Function<Object, Object>[] positionalReaders(
     final Class<?> cls,
@@ -232,10 +232,11 @@ public record Reflective(
   }
 
   /**
-   * Expose the positional builder ({@code Object[arity] → T}) used inside {@link #structuralIsoArr}.
-   * Same shape as {@link #positionalReaders}: lets callers skip the Iso wrapper to invoke the
-   * canonical constructor (records — direct LMF-built {@code ctorFn}) or the named-construct path
-   * (beans — wrapped over an O(1) HashMap-indexed array lookup, no per-call name scan).
+   * Expose the positional builder ({@code Object[arity] → T}) used inside {@link
+   * #structuralIsoArr}. Same shape as {@link #positionalReaders}: lets callers skip the Iso wrapper
+   * to invoke the canonical constructor (records — direct LMF-built {@code ctorFn}) or the
+   * named-construct path (beans — wrapped over an O(1) HashMap-indexed array lookup, no per-call
+   * name scan).
    */
   @SuppressWarnings("unchecked")
   public <T> Function<Object[], T> positionalBuilder(

--- a/internal/src/main/java/io/github/eschizoid/telescope/internal/Reflective.java
+++ b/internal/src/main/java/io/github/eschizoid/telescope/internal/Reflective.java
@@ -216,6 +216,45 @@ public record Reflective(
     );
   }
 
+  /**
+   * Expose the positional reader array used inside {@link #structuralIsoArr(Class, Map, Function)}.
+   * Callers (typically {@code DeepMap} on the assembly hot path) can use this to bypass the
+   * source-side {@link Iso} wrapper entirely and read instance → array values inline, eliminating
+   * one virtual hop per call. Same substrate as {@link #structuralIsoArr}: holder-aware
+   * (uses {@link Lens#get} when {@code holderReaders} is non-null), records short-circuit to
+   * cached {@code RecordInfo.readers[]}, bean fallback captures the LMF reader via {@link #read}.
+   */
+  public Function<Object, Object>[] positionalReaders(
+    final Class<?> cls,
+    final Map<String, Lens<Object, Object>> holderReaders
+  ) {
+    return resolveReadersByPosition(cls, names(cls), holderReaders);
+  }
+
+  /**
+   * Expose the positional builder ({@code Object[arity] → T}) used inside {@link #structuralIsoArr}.
+   * Same shape as {@link #positionalReaders}: lets callers skip the Iso wrapper to invoke the
+   * canonical constructor (records — direct LMF-built {@code ctorFn}) or the named-construct path
+   * (beans — wrapped over an O(1) HashMap-indexed array lookup, no per-call name scan).
+   */
+  @SuppressWarnings("unchecked")
+  public <T> Function<Object[], T> positionalBuilder(
+    final Class<T> cls,
+    final Map<String, Lens<Object, Object>> holderReaders,
+    final Function<Function<String, Object>, Object> holderConstructor
+  ) {
+    if (cls.isRecord() && holderReaders == null && holderConstructor == null) {
+      final var ctorFn = Records.info(cls).ctorFn();
+      return arr -> (T) ctorFn.apply(arr);
+    }
+    final var componentNames = names(cls);
+    final var nameIndex = indexMap(componentNames);
+    if (holderConstructor != null) {
+      return arr -> (T) holderConstructor.apply(i -> arr[nameIndex.get(i)]);
+    }
+    return arr -> cls.cast(construct(cls, i -> arr[nameIndex.get(i)]));
+  }
+
   @SuppressWarnings("unchecked")
   private Function<Object, Object>[] resolveReadersByPosition(
     final Class<?> cls,


### PR DESCRIPTION
**Experiment 2 of overnight Tier-D autonomous run. MASSIVE WIN.**

## Hypothesis

The cycle-safe shell (`FORWARD_SEEN` / `BACKWARD_SEEN` ThreadLocal + `IdentityHashMap.put` + try/finally) wrapping every nested type-pair Iso costs ~15 ns per hop per direction. For type pairs whose static graph has no path back to themselves, the shell is pure overhead — runtime cycles are impossible without `Object`-typed escape hatches the structural walk already refuses to descend into.

Skip the probe when statically acyclic.

## Implementation

1. **Cycle detection during populateIso** — thread a `Set<TypePair> cyclicPairs` + `Deque<TypePair> inProgress` through `populateIso` / `autoIso` / `computeAutoIso`. When `cache.containsKey(key)` returns true AND `cache.get(key) == null` (in-progress sentinel), every pair currently on the recursion stack is in the cycle's SCC → add them all to `cyclicPairs`.
2. **Bypass shell at lazyCacheIso** — new `acyclic` boolean parameter. When `true`, return a plain `Iso.of(v -> v == null ? null : cache.get(key).to(v), ...)` — no ThreadLocal probe, no IHM insert, no try/finally. Cyclic pairs still get the full guard.
3. **Caller decides** — `computeAutoIso` line 794-area passes `!cyclicPairs.contains(subKey)`.

## Measured (JMH avgt, JDK 25, Apple Silicon, focused 4-row nested+deep run)

| Bench | 1.0 baseline | Exp2 | Δ ns | Δ % |
|---|---:|---:|---:|---:|
| nested fwd | 204.30 ± 3.01 | **142.60 ± 1.65** | -61.7 | **-30.2%** |
| nested bwd | 277.92 ± 3.78 | **220.04 ± 7.63** | -57.9 | **-20.8%** |
| deep fwd | 926.83 ± 25.25 | **552.03 ± 3.86** | -374.8 | **-40.4%** |
| deep bwd | 1274.30 ± 119.91 | **881.87 ± 41.21** | -392.4 | **-30.8%** |

Agent prediction: ~30 ns nested, ~75 ns deep. **Reality: 60 ns nested, 375 ns deep.** The shell fires multiple times in deep trees (one per level), compounding.

Flat tier unchanged — the top-level Iso never routes through `lazyCacheIso` (cycle handling only kicks in on nested type-pair recursion). Confirmed by spot-check on the existing Exp1 branch.

## Safety boundary

The acyclic-bypass relies on static structural typing. `Object`-typed component fields are assumed non-recursive — and `DeepMap` already refuses to descend into them at `isReflectable` (so the assumption holds). For genuine instance-level cycles in statically-typed graphs (e.g. `Hibernate @ManyToOne + @OneToMany(mappedBy=…)`), the static analysis correctly catches them and keeps the shell. Documented in the `lazyCacheIso` javadoc.

## Mantras

- ✅ Lattice-first: still routes through `Iso.of` — the bypass is just a thinner Iso instance.
- ✅ Zero new reflection.
- ✅ No FQNs (added `import java.util.ArrayDeque; import java.util.Deque;`).
- ✅ No public API change.

## Tests

Full `:internal:test :core:test` suite green. Includes the existing cycle tests (Hibernate-style `manager`/`reports` bidirectional self-association) which exercise the cyclic-pair branch — they still pass because the shell is still installed for genuinely cyclic pairs.

## Drafted because

Part of the autonomous overnight run. Combines with Exp1 (PR #123, fused src+remap) orthogonally — Exp1 saves on flat too while Exp2 saves on nested/deep. Stacking experiment next.