### PR TITLE
fix(beans+telescope): Bug 4 — null intermediate short-circuit

### DIFF
--- a/core/src/main/java/io/github/eschizoid/telescope/Telescope.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/Telescope.java
@@ -987,7 +987,14 @@ public sealed class Telescope<
     if (optic instanceof final Affine<S, A> affine) {
       return affine.getOption(source).orElseThrow(Telescope::noValue);
     }
-    return optic.getAll(source).findFirst().orElseThrow(Telescope::noValue);
+    // Stream.findFirst() routes through Optional.of(element), which NPEs on null. A Traversal
+    // can legitimately surface null elements when an intermediate hop of a multi-hop bean path
+    // is null (see Bug 4: Beans.readProperty short-circuits to null, the traversal still
+    // produces a one-element [null] stream). Materialise to a List to preserve nulls and decide
+    // emptiness explicitly.
+    final var values = optic.getAll(source).toList();
+    if (values.isEmpty()) throw noValue();
+    return values.get(0);
   }
 
   private static NoSuchElementException noValue() {

--- a/core/src/main/java/io/github/eschizoid/telescope/Telescope.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/Telescope.java
@@ -1012,7 +1012,11 @@ public sealed class Telescope<
     if (optic instanceof final Affine<S, A> affine) {
       return affine.getOption(source);
     }
-    return optic.getAll(source).findFirst();
+    // Mirror of #read: Stream.findFirst() routes through Optional.of(element) and NPEs on null.
+    // A Traversal can surface null elements after Bug 4's readProperty short-circuit; materialise
+    // the values explicitly and use Optional.ofNullable to preserve the null-empty distinction.
+    final var values = optic.getAll(source).toList();
+    return values.isEmpty() ? Optional.empty() : Optional.ofNullable(values.get(0));
   }
 
   /**

--- a/core/src/test/java/io/github/eschizoid/telescope/MigrationRegressionTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/MigrationRegressionTest.java
@@ -147,4 +147,90 @@ class MigrationRegressionTest {
       );
     }
   }
+
+  @Nested
+  @DisplayName("Bug 4 — NPE on null intermediate objects in nested telescope paths")
+  class Bug4NullIntermediateNpe {
+
+    public static class Order {
+
+      private Customer customer; // may be null
+
+      public Customer getCustomer() {
+        return customer;
+      }
+
+      public void setCustomer(final Customer customer) {
+        this.customer = customer;
+      }
+    }
+
+    public static class Customer {
+
+      private String email;
+
+      public String getEmail() {
+        return email;
+      }
+
+      public void setEmail(final String email) {
+        this.email = email;
+      }
+    }
+
+    public static class OrderDto {
+
+      private String customerEmail;
+
+      public String getCustomerEmail() {
+        return customerEmail;
+      }
+
+      public void setCustomerEmail(final String customerEmail) {
+        this.customerEmail = customerEmail;
+      }
+    }
+
+    @Test
+    @DisplayName("forward(order) on a source whose nested intermediate is null short-circuits to null instead of NPE")
+    void forwardWithNullIntermediateShortCircuitsToNull() {
+      // The adopter's exact scenario: a 2-hop nested source path order → customer → email, with
+      // order.customer == null at runtime. Before the fix, the second hop calls
+      // Beans.readProperty(null, "email") which delegates to persistentClassOf(null) → null,
+      // then ClassValue.get(null) NPEs. After the fix, readProperty short-circuits to null and
+      // the optic pipeline propagates the null through the rest of the chain.
+      final var mapper = Telescope.mapper(
+        Order.class,
+        OrderDto.class,
+        io.github.eschizoid.telescope.mapping.Mapping.to(
+          Telescope.ofBean(Order.class).field(Order::getCustomer).field(Customer::getEmail),
+          OrderDto::getCustomerEmail
+        ),
+        writeBeans(WriteHint.WriteStrategy.SETTERS)
+      );
+      final var src = new Order(); // customer left null
+      final var tgt = assertDoesNotThrow(() -> mapper.forward(src));
+      assertEquals(null, tgt.getCustomerEmail());
+    }
+
+    @Test
+    @DisplayName("forward(order) on a populated nested intermediate still reads through the chain")
+    void forwardWithPopulatedIntermediateReadsThrough() {
+      final var mapper = Telescope.mapper(
+        Order.class,
+        OrderDto.class,
+        io.github.eschizoid.telescope.mapping.Mapping.to(
+          Telescope.ofBean(Order.class).field(Order::getCustomer).field(Customer::getEmail),
+          OrderDto::getCustomerEmail
+        ),
+        writeBeans(WriteHint.WriteStrategy.SETTERS)
+      );
+      final var customer = new Customer();
+      customer.setEmail("alice@example.com");
+      final var src = new Order();
+      src.setCustomer(customer);
+      final var tgt = mapper.forward(src);
+      assertEquals("alice@example.com", tgt.getCustomerEmail());
+    }
+  }
 }

--- a/internal/src/main/java/io/github/eschizoid/telescope/internal/Beans.java
+++ b/internal/src/main/java/io/github/eschizoid/telescope/internal/Beans.java
@@ -369,6 +369,15 @@ public final class Beans {
    * }</pre>
    */
   public static Object readProperty(final Object pojo, final String name) {
+    // Null-source short-circuit: multi-hop telescope paths (e.g.
+    // `Telescope.ofBean(Order.class).field(Order::getCustomer).field(Customer::getEmail)`) read
+    // each hop through this method. When an intermediate object is null at runtime
+    // (`order.getCustomer() == null`), the next hop arrives here with `pojo == null` and the
+    // pipeline needs the null to propagate gracefully — same shape as MapStruct's generated
+    // `if (source.getCustomer() != null) target.setEmail(source.getCustomer().getEmail())`
+    // null-guard. Without this short-circuit, `persistentClassOf(null)` returns null and
+    // `ClassValue.get(null)` NPEs.
+    if (pojo == null) return null;
     // Unwrap HibernateProxy (when present) so a LAZY-fetched entity routes through the
     // persistent class's cache entry, not a per-proxy-subclass one. See persistentClassOf.
     final var beanClass = persistentClassOf(pojo);

--- a/internal/src/test/java/io/github/eschizoid/telescope/internal/BeansTest.java
+++ b/internal/src/test/java/io/github/eschizoid/telescope/internal/BeansTest.java
@@ -548,6 +548,16 @@ class BeansTest {
     }
 
     @Test
+    @DisplayName("readProperty(null, name) returns null instead of NPEing on persistentClassOf")
+    void readPropertyNullPojoIsNullSafe() {
+      // Bug 4: when a multi-hop telescope path reads through a null intermediate, the next lens
+      // hop calls Beans.readProperty(null, "..."). persistentClassOf(null) returns null, then
+      // ClassValue.get(null) NPEs. Short-circuit at the readProperty entry so the optic pipeline
+      // propagates the null gracefully through intermediate hops.
+      assertNull(Beans.readProperty(null, "anything"));
+    }
+
+    @Test
     @DisplayName("propertyOf(null) returns null instead of throwing NPE")
     void propertyOfNullIsNullSafe() {
       // Belt-and-suspenders guard. The structural fix for Bug 2 lives in DeepMap.populateIso —


### PR DESCRIPTION
Bug 4 from `docs/migration-feedback.md`. P1. Stacked on #128.

## The bug

Multi-hop nested bean paths like `Telescope.ofBean(Order).field(::getCustomer).field(::getEmail)` NPE at runtime when `order.getCustomer()` returns null. The migration feedback reported one NPE at `Beans.readProperty` — investigation showed there's actually a second one at `Telescope.read` (the `findFirst()` route).

## Fix

**Two complementary changes, both required**:

1. **`Beans.readProperty(null, name)` returns null** instead of NPEing on `ClassValue.get(null)`. Lets the optic pipeline propagate a null intermediate gracefully — same shape as MapStruct's generated null guard.

2. **`Telescope.read` materialises `getAll` via `.toList()`** instead of `findFirst()`. `Stream.findFirst()` routes through `Optional.of(element)` which NPEs on null. The Traversal can now legitimately surface a null element once the readProperty short-circuit above lands. Materialise the list and decide emptiness explicitly.

## TDD evidence

| Test | Pins | Without fix |
|---|---|---|
| `BeansTest.readPropertyNullPojoIsNullSafe` | Unit-level short-circuit | FAILS (NPE in ClassValue.get) |
| `MigrationRegressionTest.forwardWithNullIntermediateShortCircuitsToNull` | Adopter's exact 2-hop scenario with null intermediate | FAILS (NPE in Optional.of) |
| `MigrationRegressionTest.forwardWithPopulatedIntermediateReadsThrough` | Happy-path regression — short-circuit doesn't suppress non-null values | passes (regression guard) |

Round 1 of review on Bug 2 caught that my initial commit was symptom relief without root cause. Applied the same discipline here — wrote the end-to-end test FIRST, watched it fail in two places, fixed both, watched it pass.

## Mantras

- No public API change.
- Lattice-honest — `Telescope.read` swap is materialise-then-index, semantically identical to the prior `findFirst().orElseThrow()` for non-null elements.

Second in the stacked PR series for the migration-feedback bugs.
