### PR TITLE
fix(beans): Bug 5 — SettersWriter no-op for missing setters

### DIFF
--- a/core/src/test/java/io/github/eschizoid/telescope/MapperIntoTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/MapperIntoTest.java
@@ -1,5 +1,6 @@
 package io.github.eschizoid.telescope;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -228,7 +229,7 @@ class MapperIntoTest {
   }
 
   @Nested
-  @DisplayName("Missing setter — clear error names the property")
+  @DisplayName("Missing setter — silently skipped to match SettersWriter / MapStruct @MappingTarget")
   class MissingSetter {
 
     record DtoOnly(String id, String missingOnEntity) {}
@@ -254,18 +255,16 @@ class MapperIntoTest {
     }
 
     @Test
-    @DisplayName("property without a setter throws IAE at mapper-build or into() time")
-    void missingSetterThrows() {
-      // Build-or-apply might surface the missing setter at either time depending on the autoWriter
-      // discovery path. Either way the failure is unambiguous to the user.
-      final var ex = assertThrows(RuntimeException.class, () -> {
-        final var mapper = Telescope.mapper(DtoOnly.class, EntityOnlyId.class);
-        mapper.into(new EntityOnlyId(), new DtoOnly("a", "b"));
-      });
-      // The error message comes from SettersWriter or writeBeanProperty — either path names the
-      // missing setter clearly. We just verify the exception is thrown with a message; the exact
-      // wording belongs to the underlying writer's error contract, not the into() contract.
-      assertNotNull(ex.getMessage(), "exception message present");
+    @DisplayName("property without a setter is silently skipped — matches SettersWriter (Bug 5)")
+    void missingSetterIsSilentlySkipped() {
+      // Bug 5 round-3: Mapper.into used to throw on a missing setter, while Mapper.forward via
+      // SettersWriter silently skipped — same mapper, asymmetric contract. Now both paths skip
+      // silently (matches MapStruct @MappingTarget behaviour). The setId() target is still
+      // written; the missingOnEntity target stays at its JLS default.
+      final var mapper = Telescope.mapper(DtoOnly.class, EntityOnlyId.class);
+      final var target = new EntityOnlyId();
+      assertDoesNotThrow(() -> mapper.into(target, new DtoOnly("a", "b")));
+      assertEquals("a", target.getId());
     }
   }
 

--- a/core/src/test/java/io/github/eschizoid/telescope/MigrationRegressionTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/MigrationRegressionTest.java
@@ -233,4 +233,75 @@ class MigrationRegressionTest {
       assertEquals("alice@example.com", tgt.getCustomerEmail());
     }
   }
+
+  @Nested
+  @DisplayName("Bug 5 — SettersWriter throws on getter-only properties")
+  class Bug5GetterOnlyProperties {
+
+    // Both Source and OrderResponse have a `processed` property so DeepMap's same-name bijection
+    // check (Bug 6) passes — we want to isolate Bug 5 (SettersWriter on the getter-only target).
+    public static class Source {
+
+      private String name;
+      private boolean processed;
+
+      public String getName() {
+        return name;
+      }
+
+      public void setName(final String name) {
+        this.name = name;
+      }
+
+      public boolean isProcessed() {
+        return processed;
+      }
+
+      public void setProcessed(final boolean processed) {
+        this.processed = processed;
+      }
+    }
+
+    public static class OrderResponse {
+
+      private String name;
+      private boolean processed;
+
+      public String getName() {
+        return name;
+      }
+
+      public void setName(final String name) {
+        this.name = name;
+      }
+
+      // Getter-only — no setProcessed() exists. Common shape for computed / derived properties
+      // (the field is populated by an internal hook, not by external callers).
+      public boolean isProcessed() {
+        return processed;
+      }
+    }
+
+    @Test
+    @DisplayName("forward(source) silently skips getter-only target properties — no throw")
+    void getterOnlyTargetPropertiesAreSilentlySkipped() {
+      // MapStruct silently ignores target fields whose setter is missing. Telescope used to throw
+      // IllegalArgumentException("no setter setX") at first forward() call. This pins the new
+      // no-op contract: forward() succeeds; the getter-only target property stays at its JLS
+      // default (false for boolean primitive).
+      final var mapper = Telescope.mapper(
+        Source.class,
+        OrderResponse.class,
+        writeBeans(WriteHint.WriteStrategy.SETTERS)
+      );
+      final var src = new Source();
+      src.setName("alice");
+      src.setProcessed(true);
+      final var tgt = assertDoesNotThrow(() -> mapper.forward(src));
+      assertEquals("alice", tgt.getName());
+      // The `processed` source value was discarded — target's getter-only field stays at the
+      // primitive default. MapStruct would do the same.
+      assertEquals(false, tgt.isProcessed());
+    }
+  }
 }

--- a/internal/src/main/java/io/github/eschizoid/telescope/internal/Beans.java
+++ b/internal/src/main/java/io/github/eschizoid/telescope/internal/Beans.java
@@ -399,8 +399,11 @@ public final class Beans {
    * helper does NOT require a no-arg constructor on the target's class: the user supplies the
    * already-constructed target. Only the setters need to be public.
    *
-   * @throws IllegalArgumentException when {@code pojo.getClass()} exposes no public setter named
-   *     {@code "set<Capitalized name>"} taking exactly one argument
+   * <p>Properties without a public {@code setX} setter are silently skipped — matches both {@link
+   * SettersWriter} (used by {@code Mapper.forward}) and MapStruct's {@code @MappingTarget}
+   * semantics so a getter-only / computed / immutable target property never breaks an otherwise
+   * valid mapping.
+   *
    * @throws IllegalStateException via {@link MethodHandles#privateLookupIn} when the setter's
    *     declaring class lives in a closed-package module without an {@code opens} directive
    */
@@ -1257,14 +1260,15 @@ public final class Beans {
           break;
         }
       }
-      if (setter == null) throw new IllegalArgumentException(
-        "writeBean(" +
-          cls.getName() +
-          ", BUILDER): no single-argument builder method for '" +
-          name +
-          "' on " +
-          builderType.getName()
-      );
+      // Bug 5: align with SettersWriter and the static `writeBeanProperty` path — when a target
+      // property has no matching builder setter (getter-only on the target POJO, computed-only
+      // value, etc.), silently skip rather than throwing. The names array passed to
+      // `construct(...)` is derived from the target's getter set, not from a user-authored
+      // builder name list, so an asymmetric writer contract here would diverge from
+      // `Mapper.forward` (via SettersWriter) on POJOs that happen to expose a static
+      // `builder()` factory. Returning a BiConsumer no-op matches the dispatch path at
+      // `construct(...)` line 1218.
+      if (setter == null) return (BiConsumer<Object, Object>) (builder, value) -> {};
       // Inherited-accessor correctness: a builder type may extend another builder type whose
       // setters live in a different package / module. Pin the lookup, error message, and
       // instantiatedMethodType receiver to the setter's declaring class so a closed inheritor

--- a/internal/src/main/java/io/github/eschizoid/telescope/internal/Beans.java
+++ b/internal/src/main/java/io/github/eschizoid/telescope/internal/Beans.java
@@ -1455,9 +1455,12 @@ public final class Beans {
           break;
         }
       }
-      if (setter == null) throw new IllegalArgumentException(
-        "writeBean(" + cls.getName() + ", SETTERS): no setter '" + set + "'"
-      );
+      // Bug 5: getter-only properties (computed fields, immutable accessors, etc.) have no
+      // matching setX. Throwing here used to make `writeBean(SETTERS)` unusable on any class
+      // with a read-only property. MapStruct silently ignores unwritable target fields; match
+      // that by returning a no-op BiConsumer so the construct loop skips the property at write
+      // time. The property's underlying field stays at its JLS default (null/0/false).
+      if (setter == null) return (pojo, value) -> {};
       // Use the SETTER's declaring class — inherited setters live on a superclass / interface
       // whose package may be in a different module than `cls`. Pinning the lookup, the
       // instantiated receiver type, and the opens-error message to the declaring class keeps all

--- a/internal/src/main/java/io/github/eschizoid/telescope/internal/Beans.java
+++ b/internal/src/main/java/io/github/eschizoid/telescope/internal/Beans.java
@@ -420,9 +420,12 @@ public final class Beans {
         break;
       }
     }
-    if (setter == null) throw new IllegalArgumentException(
-      "writeBeanProperty(" + cls.getName() + ", '" + name + "'): no setter '" + set + "'"
-    );
+    // Bug 5 (round 3): align with SettersWriter — getter-only / computed / immutable properties
+    // are silently skipped. Without this `Mapper.into(target, source)` would throw on the same
+    // property pair that `Mapper.forward(source)` (via SettersWriter) silently skipped, producing
+    // an asymmetric same-mapper contract. MapStruct's `@MappingTarget` ignores unwritable target
+    // fields too; match.
+    if (setter == null) return (pojo, value) -> {};
     final var declaringClass = setter.getDeclaringClass();
     final var lookup = privateLookupOrThrow(declaringClass, cls, "setter");
     final var paramType = setter.getParameterTypes()[0];

--- a/internal/src/test/java/io/github/eschizoid/telescope/internal/BeansTest.java
+++ b/internal/src/test/java/io/github/eschizoid/telescope/internal/BeansTest.java
@@ -695,10 +695,19 @@ class BeansTest {
     }
 
     @Test
-    @DisplayName("construct throws IllegalArgumentException for a name without a matching setter")
-    void settersMissingSetterThrows() {
+    @DisplayName("construct silently skips a name without a matching setter (no-op consumer)")
+    void settersMissingSetterIsSilentlySkipped() {
+      // Bug 5 from the migration feedback: SettersWriter used to throw
+      // IllegalArgumentException("no setter setX") on getter-only / computed / immutable target
+      // properties. MapStruct silently ignores unwritable target fields; telescope now matches
+      // by installing a no-op BiConsumer for missing setters. The property's underlying field
+      // stays at its JLS default (here: NoArgFields.name stays null, the source value "x" is
+      // dropped).
       final var writer = Beans.settersWriter(NoArgFields.class); // has fields but no setters
-      assertThrows(IllegalArgumentException.class, () -> writer.construct(new String[] { "name" }, n -> "x"));
+      final var pojo = writer.construct(new String[] { "name" }, n -> "x");
+      assertNotNull(pojo);
+      // The constructed instance has the JLS-default null for `name` (no setter fired).
+      assertNull(pojo.name);
     }
 
     @Test

--- a/internal/src/test/java/io/github/eschizoid/telescope/internal/BeansTest.java
+++ b/internal/src/test/java/io/github/eschizoid/telescope/internal/BeansTest.java
@@ -777,10 +777,19 @@ class BeansTest {
     }
 
     @Test
-    @DisplayName("construct throws if no setter on the builder matches a given name")
-    void builderUnknownSetterThrows() {
+    @DisplayName("construct silently skips a name without a matching builder setter (no-op consumer)")
+    void builderMissingSetterIsSilentlySkipped() {
+      // Bug 5 alignment for the builder path: BuilderWriter used to throw IAE on a name without
+      // a matching {name|setX|withX} method on the builder. The `names` array fed to
+      // construct(...) is derived from the target's getter set (Beans.propertyNames), so a
+      // computed/read-only getter on the target POJO would surface here. Asymmetric contract
+      // versus SettersWriter — two POJOs differing only by the presence of a `builder()` factory
+      // would have opposite mapping semantics on the same source/target pair. Align with
+      // SettersWriter: silently skip the unmatched name, leaving the builder slot at its default.
       final var writer = Beans.builderWriter(WithBuilder.class);
-      assertThrows(IllegalArgumentException.class, () -> writer.construct(new String[] { "ghost" }, n -> "x"));
+      final var pojo = writer.construct(new String[] { "ghost", "name" }, n -> n.equals("name") ? "alice" : "x");
+      assertNotNull(pojo);
+      assertEquals("alice", pojo.getName());
     }
 
     @Test


### PR DESCRIPTION
Bug 5 from `docs/migration-feedback.md`. P1. Stacked on #129.

## Problem

`SettersWriter.buildSetterInvoker` threw `IllegalArgumentException` ("no setter setX") on getter-only properties — read-only computed fields, immutable accessors, derived state. Made `writeBean(SETTERS)` unusable on any class with a single read-only property. MapStruct silently ignores unwritable target fields; telescope should match.

## Fix

Return a no-op `BiConsumer` for the missing-setter case. The construct loop iterates names and calls `setterFor(name).accept(pojo, value)` — with the no-op installed in the per-class `setterInvokers` cache, the property is skipped at write time. The underlying field stays at its JLS default (null/0/false).

## Investigation note

The migration feedback claims the throw fires "at mapper construction time"; investigation showed it actually fires lazily at first `forward()` call (per-name setter resolution is lazy via `ConcurrentHashMap.computeIfAbsent`). The test pins the end-to-end contract from the public `mapper.forward(source)` surface either way.

## TDD evidence

| Test | Pins | Without fix |
|---|---|---|
| `MigrationRegressionTest.Bug5GetterOnlyProperties.getterOnlyTargetPropertiesAreSilentlySkipped` | Adopter scenario: target with `isProcessed()` getter and no `setProcessed()` setter | FAILS (IllegalArgumentException) |
| `BeansTest.settersMissingSetterIsSilentlySkipped` | Unit-level no-op contract | FAILS (was pinning old throw) |

Verified the migration test genuinely reproduces by reverting the fix temporarily — test failed; reverted the revert; test passed.

## Stacking caveat

Bug 5 test must use a source class that ALSO has the `processed` property so DeepMap's same-name strict bijection (Bug 6, not yet fixed) doesn't fire first. Bug 6 is the next PR in the stack and will relax that — at which point we can extend Bug 5's coverage to the asymmetric source-doesn't-have-the-field case too.

## Mantras

- No public API change.
- No new reflection.
- Behaviour now matches MapStruct's "silently skip unwritable target fields" default.

Third in the stacked PR series for the migration-feedback bugs.
