### PR TITLE
fix(beans): Bug 8 — null-guard primitive setters (defence-in-depth)

### DIFF
--- a/core/src/test/java/io/github/eschizoid/telescope/MigrationRegressionTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/MigrationRegressionTest.java
@@ -352,6 +352,180 @@ class MigrationRegressionTest {
   }
 
   @Nested
+  @DisplayName("Bug 8 — SettersWriter NPE on null primitive value")
+  class Bug8PrimitiveSetterNullNpe {
+
+    public static class Source {
+
+      private String name;
+
+      // No `count` property — after Bug 6 lenient nested mode, valueByName returns null for the
+      // target's `count` field.
+
+      public String getName() {
+        return name;
+      }
+
+      public void setName(final String name) {
+        this.name = name;
+      }
+    }
+
+    public static class Target {
+
+      private String name;
+      private int count; // primitive, will receive null from valueByName
+
+      public String getName() {
+        return name;
+      }
+
+      public void setName(final String name) {
+        this.name = name;
+      }
+
+      public int getCount() {
+        return count;
+      }
+
+      public void setCount(final int count) {
+        this.count = count;
+      }
+    }
+
+    public static class TopSource {
+
+      private Source nested;
+
+      public Source getNested() {
+        return nested;
+      }
+
+      public void setNested(final Source nested) {
+        this.nested = nested;
+      }
+    }
+
+    public static class TopTarget {
+
+      private Target nested;
+
+      public Target getNested() {
+        return nested;
+      }
+
+      public void setNested(final Target nested) {
+        this.nested = nested;
+      }
+    }
+
+    @Test
+    @DisplayName("forward(top) where nested target has primitive setter for an unmatched field uses JLS default")
+    void primitiveSetterReceivesJlsDefaultOnNullValue() {
+      // After Bug 6 + Bug 5 fixes, a nested target property like `int count` whose source has
+      // no matching `count` field receives `null` from valueByName. SettersWriter.construct used
+      // to NPE when passing that null to `setCount(int)` (Integer-to-int unboxing on null).
+      // Fix: null-guard primitive setters at construction time so primitives stay at their JLS
+      // default (0 for int, false for boolean, etc.).
+      final var mapper = Telescope.mapper(
+        TopSource.class,
+        TopTarget.class,
+        writeBeans(WriteHint.WriteStrategy.SETTERS)
+      );
+      final var src = new TopSource();
+      final var inner = new Source();
+      inner.setName("alice");
+      src.setNested(inner);
+      final var tgt = assertDoesNotThrow(() -> mapper.forward(src));
+      assertEquals("alice", tgt.getNested().getName());
+      // Target's primitive int stays at JLS default 0 (source had no `count`).
+      assertEquals(0, tgt.getNested().getCount());
+    }
+
+    public static class FlatSource {
+
+      private String name;
+      private Integer count; // boxed; will hold null at runtime
+      private Boolean active; // boxed; will hold null at runtime
+
+      public String getName() {
+        return name;
+      }
+
+      public void setName(final String name) {
+        this.name = name;
+      }
+
+      public Integer getCount() {
+        return count;
+      }
+
+      public void setCount(final Integer count) {
+        this.count = count;
+      }
+
+      public Boolean getActive() {
+        return active;
+      }
+
+      public void setActive(final Boolean active) {
+        this.active = active;
+      }
+    }
+
+    public static class FlatTarget {
+
+      private String name;
+      private Integer count; // matching: boxed → boxed (no autoboxing needed)
+      private Boolean active; // matching: boxed → boxed
+
+      public String getName() {
+        return name;
+      }
+
+      public void setName(final String name) {
+        this.name = name;
+      }
+
+      public Integer getCount() {
+        return count;
+      }
+
+      public void setCount(final Integer count) {
+        this.count = count;
+      }
+
+      public Boolean getActive() {
+        return active;
+      }
+
+      public void setActive(final Boolean active) {
+        this.active = active;
+      }
+    }
+
+    @Test
+    @DisplayName("forward(src) with null boxed source values reaching matching boxed setters does not NPE")
+    void nullBoxedSourceReachesBoxedSetterWithoutNpe() {
+      // Even on matched-name boxed→boxed paths, the source value can legitimately be null and
+      // the target setter must accept null gracefully. Pins the contract that the construct
+      // loop doesn't choke on legitimately-null boxed values.
+      final var mapper = Telescope.mapper(
+        FlatSource.class,
+        FlatTarget.class,
+        writeBeans(WriteHint.WriteStrategy.SETTERS)
+      );
+      final var src = new FlatSource();
+      src.setName("alice");
+      // count and active left null
+      final var tgt = assertDoesNotThrow(() -> mapper.forward(src));
+      assertEquals("alice", tgt.getName());
+      assertEquals(null, tgt.getCount());
+      assertEquals(null, tgt.getActive());
+    }
+  }
+
+  @Nested
   @DisplayName("Bug 5 — SettersWriter throws on getter-only properties")
   class Bug5GetterOnlyProperties {
 

--- a/internal/src/main/java/io/github/eschizoid/telescope/internal/Beans.java
+++ b/internal/src/main/java/io/github/eschizoid/telescope/internal/Beans.java
@@ -1486,7 +1486,23 @@ public final class Beans {
           handle,
           MethodType.methodType(void.class, declaringClass, instantiatedParamType)
         );
-        return (BiConsumer<Object, Object>) callSite.getTarget().invoke();
+        final var lmfSetter = (BiConsumer<Object, Object>) callSite.getTarget().invoke();
+        // Bug 8: defence-in-depth. The LMF-built setter for a primitive parameter (e.g.
+        // setCount(int)) NPEs when invoked with `null` (Object → Integer → int unbox). In the
+        // current architecture, Bug 6's placeholderIsoFor short-circuits unmatched primitive
+        // target fields to their JLS default before the value ever reaches here — so this guard
+        // is unreachable on the happy path. It's kept to lock the contract against future code
+        // paths that may legitimately deliver null to a primitive setter (e.g. a forthcoming
+        // autoboxing relaxation in Bug 3 work). When the wrapped parameter type is a primitive
+        // wrapper, the underlying setter takes a primitive — skip on null so the field stays
+        // at its JLS default rather than crashing the construct call.
+        if (paramType.isPrimitive()) {
+          return (pojo, value) -> {
+            if (value == null) return;
+            lmfSetter.accept(pojo, value);
+          };
+        }
+        return lmfSetter;
       } catch (final Throwable t) {
         throw new RuntimeException("Failed to set '" + name + "' on " + cls.getName(), t);
       }


### PR DESCRIPTION
Bug 8 from `docs/migration-feedback.md`. P1. Stacked on #131.

## Status: preempted in practice, locked as contract

Bug 6's `placeholderIsoFor` short-circuits unmatched primitive target fields to their JLS default before any value reaches the SettersWriter — so the LMF-built primitive setter never sees a null on the current forward path. This PR lands defence-in-depth at the setter level to lock the contract for future code paths that may legitimately deliver null to a primitive setter (e.g. the forthcoming autoboxing relaxation in Bug 3).

## Fix

When `buildSetterInvoker` resolves a setter whose declared parameter is a primitive, wrap the LMF-built `BiConsumer` to skip on null. The field stays at its JLS default — same semantics as MapStruct's generated null-guard on primitive assignments. Non-primitive setters return the raw LMF dispatcher unchanged (no per-call cost).

## TDD evidence

Both regression tests pass with the current architecture even WITHOUT this guard (Bug 6 preempts). They stay as forward-compatible contract pins:

- `Bug8...primitiveSetterReceivesJlsDefaultOnNullValue` — nested target with `int count`; source doesn't have `count`.
- `Bug8...nullBoxedSourceReachesBoxedSetterWithoutNpe` — matched boxed→boxed pair carrying null.

The defence-in-depth wrap doesn't change observable behaviour on these tests — it just locks the contract.

## Mantras

- No public API change.
- No new reflection.
- Behaviour now matches MapStruct's null-guard on primitive assignments.

Fifth in the stacked PR series.
