### PR TITLE
fix(deepmap+beans): Bug 7 — refuse to bean-decompose JDK collection subtypes

### DIFF
--- a/core/src/main/java/io/github/eschizoid/telescope/DeepMap.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/DeepMap.java
@@ -829,6 +829,24 @@ public final class DeepMap {
     // (a) Same generic type → identity Iso.
     if (srcType.equals(tgtType)) return Iso.identity();
 
+    // (a.2) Collection / Map subtype pair (Bug 7). Common in legacy bean codebases: `class
+    //       ImageUrls extends ArrayList<ImageUrl>` and `class ImageUrlsBO extends
+    // ArrayList<ImageUrl>`
+    //       on opposite sides. Neither is identity (different concrete classes), neither is a
+    //       parameterised raw `List` / `Map` (so ContainerShape skips them), and trying to bean-
+    //       decompose would hit `MethodHandles.privateLookupIn(ArrayList.class)` rejection. Copy
+    //       elements via the target's no-arg constructor + `addAll` / `putAll`.
+    if (srcType instanceof Class<?> srcCC && tgtType instanceof Class<?> tgtCC) {
+      if (Collection.class.isAssignableFrom(srcCC) && Collection.class.isAssignableFrom(tgtCC)) {
+        final var iso = collectionCopyIso(srcCC, tgtCC);
+        if (iso != null) return iso;
+      }
+      if (Map.class.isAssignableFrom(srcCC) && Map.class.isAssignableFrom(tgtCC)) {
+        final var iso = mapCopyIso(srcCC, tgtCC);
+        if (iso != null) return iso;
+      }
+    }
+
     // (b) Both reflectable (record or bean) → recurse, return cache-reading Iso so cycles work.
     if (srcType instanceof Class<?> srcCls && tgtType instanceof Class<?> tgtCls) {
       if (isReflectable(srcCls) && isReflectable(tgtCls)) {
@@ -1076,6 +1094,76 @@ public final class DeepMap {
     return refl == Reflective.RECORDS ? "field" : "property";
   }
 
+  /**
+   * Bug 7 — Collection ↔ Collection element-copy Iso. The forward instantiates the target
+   * collection via its public no-arg constructor and {@code addAll}'s the source; backward is
+   * symmetric. Returns {@code null} when either side lacks a callable no-arg constructor, letting
+   * the caller fall through to the next branch (typically the shape-mismatch IAE).
+   *
+   * <p>No element-type recursion: this branch fires on raw, non-parameterised subtypes (e.g. {@code
+   * class ImageUrls extends ArrayList<ImageUrl>}), where the raw class itself carries no runtime
+   * generic info. Users whose element types differ across sides should declare an explicit row.
+   */
+  @SuppressWarnings({ "unchecked", "rawtypes" })
+  private static Iso<?, ?> collectionCopyIso(final Class<?> srcCls, final Class<?> tgtCls) {
+    if (!hasPublicNoArgCtor(srcCls) || !hasPublicNoArgCtor(tgtCls)) return null;
+    return Iso.of(
+      src -> {
+        if (src == null) return null;
+        final var fresh = (Collection) newInstance(tgtCls);
+        fresh.addAll((Collection<?>) src);
+        return fresh;
+      },
+      tgt -> {
+        if (tgt == null) return null;
+        final var fresh = (Collection) newInstance(srcCls);
+        fresh.addAll((Collection<?>) tgt);
+        return fresh;
+      }
+    );
+  }
+
+  /**
+   * Bug 7 — Map ↔ Map element-copy Iso. Mirror of {@link #collectionCopyIso} via {@code putAll}.
+   */
+  @SuppressWarnings({ "unchecked", "rawtypes" })
+  private static Iso<?, ?> mapCopyIso(final Class<?> srcCls, final Class<?> tgtCls) {
+    if (!hasPublicNoArgCtor(srcCls) || !hasPublicNoArgCtor(tgtCls)) return null;
+    return Iso.of(
+      src -> {
+        if (src == null) return null;
+        final var fresh = (Map) newInstance(tgtCls);
+        fresh.putAll((Map<?, ?>) src);
+        return fresh;
+      },
+      tgt -> {
+        if (tgt == null) return null;
+        final var fresh = (Map) newInstance(srcCls);
+        fresh.putAll((Map<?, ?>) tgt);
+        return fresh;
+      }
+    );
+  }
+
+  private static boolean hasPublicNoArgCtor(final Class<?> cls) {
+    if (cls.isInterface()) return false;
+    if (java.lang.reflect.Modifier.isAbstract(cls.getModifiers())) return false;
+    try {
+      cls.getConstructor();
+      return true;
+    } catch (final NoSuchMethodException e) {
+      return false;
+    }
+  }
+
+  private static Object newInstance(final Class<?> cls) {
+    try {
+      return cls.getConstructor().newInstance();
+    } catch (final ReflectiveOperationException e) {
+      throw new IllegalStateException("Failed to instantiate " + cls.getName() + " via no-arg constructor", e);
+    }
+  }
+
   /** A record or any non-scalar class — anything Reflective can drive. */
   private static boolean isReflectable(final Class<?> cls) {
     if (cls.isRecord()) return true;
@@ -1089,14 +1177,6 @@ public final class DeepMap {
     if (Number.class.isAssignableFrom(cls)) return false;
     if (cls == Boolean.class || cls == Character.class) return false;
     if (Temporal.class.isAssignableFrom(cls)) return false;
-    // Bug 7: classes that extend JDK Collection / Map (raw or generic subtypes) must NOT be
-    // bean-decomposed. Their inherited platform-module methods would be discovered as "getters"
-    // and the LMF binder would then fail with "Invalid caller: java.util.ArrayList" because
-    // java.base modules don't grant private lookup to application code. The container Iso path
-    // already handles concrete List / Set / Map / Optional via the ContainerShape detector; here
-    // we just stop subtypes from falling through to bean-recursion.
-    if (Collection.class.isAssignableFrom(cls)) return false;
-    if (Map.class.isAssignableFrom(cls)) return false;
     return !UUID.class.isAssignableFrom(cls);
   }
 

--- a/core/src/main/java/io/github/eschizoid/telescope/DeepMap.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/DeepMap.java
@@ -37,6 +37,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Queue;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
@@ -831,13 +832,24 @@ public final class DeepMap {
 
     // (a.2) Collection / Map subtype pair (Bug 7). Common in legacy bean codebases: `class
     //       ImageUrls extends ArrayList<ImageUrl>` and `class ImageUrlsBO extends
-    // ArrayList<ImageUrl>`
-    //       on opposite sides. Neither is identity (different concrete classes), neither is a
-    //       parameterised raw `List` / `Map` (so ContainerShape skips them), and trying to bean-
-    //       decompose would hit `MethodHandles.privateLookupIn(ArrayList.class)` rejection. Copy
-    //       elements via the target's no-arg constructor + `addAll` / `putAll`.
+    //       ArrayList<ImageUrl>` on opposite sides. Neither is identity (different concrete
+    //       classes), neither is a parameterised raw `List` / `Map` (so ContainerShape skips
+    //       them), and trying to bean-decompose would hit
+    //       `MethodHandles.privateLookupIn(ArrayList.class)` rejection. Copy elements via the
+    //       target's no-arg constructor + `addAll` / `putAll`.
+    //
+    //       Collection side is gated on same kind (List↔List, Set↔Set, Queue↔Queue). Copying a
+    //       `LinkedList` into a `HashSet` would silently deduplicate; an `ArrayList` into a
+    //       `PriorityQueue` would silently reorder by natural ordering. Users who genuinely want
+    //       a kind change must declare an explicit `Mapping.via(...)` row.
+    //
+    //       Map side keeps the broad `Map`-assignable gate but iteration-order, comparator, and
+    //       thread-safety guarantees may shift when the concrete Map kinds differ (e.g.
+    //       `LinkedHashMap → TreeMap` reorders; `ConcurrentHashMap → HashMap` drops the
+    //       concurrency contract). The Iso copies entries verbatim — users with semantic
+    //       dependencies on the source's concrete type should declare an explicit row.
     if (srcType instanceof Class<?> srcCC && tgtType instanceof Class<?> tgtCC) {
-      if (Collection.class.isAssignableFrom(srcCC) && Collection.class.isAssignableFrom(tgtCC)) {
+      if (sameKindCollection(srcCC, tgtCC)) {
         final var iso = collectionCopyIso(srcCC, tgtCC);
         if (iso != null) return iso;
       }
@@ -1106,17 +1118,19 @@ public final class DeepMap {
    */
   @SuppressWarnings({ "unchecked", "rawtypes" })
   private static Iso<?, ?> collectionCopyIso(final Class<?> srcCls, final Class<?> tgtCls) {
-    if (!hasPublicNoArgCtor(srcCls) || !hasPublicNoArgCtor(tgtCls)) return null;
+    final var srcAlloc = Beans.intermediateAllocator(srcCls);
+    final var tgtAlloc = Beans.intermediateAllocator(tgtCls);
+    if (srcAlloc.get() == null || tgtAlloc.get() == null) return null;
     return Iso.of(
       src -> {
         if (src == null) return null;
-        final var fresh = (Collection) newInstance(tgtCls);
+        final var fresh = (Collection) tgtAlloc.get();
         fresh.addAll((Collection<?>) src);
         return fresh;
       },
       tgt -> {
         if (tgt == null) return null;
-        final var fresh = (Collection) newInstance(srcCls);
+        final var fresh = (Collection) srcAlloc.get();
         fresh.addAll((Collection<?>) tgt);
         return fresh;
       }
@@ -1128,40 +1142,30 @@ public final class DeepMap {
    */
   @SuppressWarnings({ "unchecked", "rawtypes" })
   private static Iso<?, ?> mapCopyIso(final Class<?> srcCls, final Class<?> tgtCls) {
-    if (!hasPublicNoArgCtor(srcCls) || !hasPublicNoArgCtor(tgtCls)) return null;
+    final var srcAlloc = Beans.intermediateAllocator(srcCls);
+    final var tgtAlloc = Beans.intermediateAllocator(tgtCls);
+    if (srcAlloc.get() == null || tgtAlloc.get() == null) return null;
     return Iso.of(
       src -> {
         if (src == null) return null;
-        final var fresh = (Map) newInstance(tgtCls);
+        final var fresh = (Map) tgtAlloc.get();
         fresh.putAll((Map<?, ?>) src);
         return fresh;
       },
       tgt -> {
         if (tgt == null) return null;
-        final var fresh = (Map) newInstance(srcCls);
+        final var fresh = (Map) srcAlloc.get();
         fresh.putAll((Map<?, ?>) tgt);
         return fresh;
       }
     );
   }
 
-  private static boolean hasPublicNoArgCtor(final Class<?> cls) {
-    if (cls.isInterface()) return false;
-    if (java.lang.reflect.Modifier.isAbstract(cls.getModifiers())) return false;
-    try {
-      cls.getConstructor();
-      return true;
-    } catch (final NoSuchMethodException e) {
-      return false;
-    }
-  }
-
-  private static Object newInstance(final Class<?> cls) {
-    try {
-      return cls.getConstructor().newInstance();
-    } catch (final ReflectiveOperationException e) {
-      throw new IllegalStateException("Failed to instantiate " + cls.getName() + " via no-arg constructor", e);
-    }
+  private static boolean sameKindCollection(final Class<?> a, final Class<?> b) {
+    if (!Collection.class.isAssignableFrom(a) || !Collection.class.isAssignableFrom(b)) return false;
+    if (List.class.isAssignableFrom(a) && List.class.isAssignableFrom(b)) return true;
+    if (Set.class.isAssignableFrom(a) && Set.class.isAssignableFrom(b)) return true;
+    return Queue.class.isAssignableFrom(a) && Queue.class.isAssignableFrom(b);
   }
 
   /** A record or any non-scalar class — anything Reflective can drive. */

--- a/core/src/main/java/io/github/eschizoid/telescope/DeepMap.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/DeepMap.java
@@ -27,6 +27,7 @@ import java.lang.reflect.Type;
 import java.time.temporal.Temporal;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Deque;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -1088,6 +1089,14 @@ public final class DeepMap {
     if (Number.class.isAssignableFrom(cls)) return false;
     if (cls == Boolean.class || cls == Character.class) return false;
     if (Temporal.class.isAssignableFrom(cls)) return false;
+    // Bug 7: classes that extend JDK Collection / Map (raw or generic subtypes) must NOT be
+    // bean-decomposed. Their inherited platform-module methods would be discovered as "getters"
+    // and the LMF binder would then fail with "Invalid caller: java.util.ArrayList" because
+    // java.base modules don't grant private lookup to application code. The container Iso path
+    // already handles concrete List / Set / Map / Optional via the ContainerShape detector; here
+    // we just stop subtypes from falling through to bean-recursion.
+    if (Collection.class.isAssignableFrom(cls)) return false;
+    if (Map.class.isAssignableFrom(cls)) return false;
     return !UUID.class.isAssignableFrom(cls);
   }
 

--- a/core/src/test/java/io/github/eschizoid/telescope/MigrationRegressionTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/MigrationRegressionTest.java
@@ -468,30 +468,27 @@ class MigrationRegressionTest {
     }
 
     @Test
-    @DisplayName("auto-recursion through different Collection subtypes refuses to bean-decompose either side")
-    void differentCollectionSubtypesRefuseBeanRecursion() {
-      // With ImageUrls (source) vs ImageUrlsAlt (target), the same-type shortcut at
-      // autoIso line 803 doesn't fire. Without the isReflectable fix, the bean-recursion
-      // branch would try to scan getters on ImageUrls/ImageUrlsAlt, hit inherited
-      // ArrayList.isEmpty(), and LMF-fail. With the fix, both are non-reflectable so the
-      // pair falls out of the bean branch.
-      //
-      // Construction may legitimately fail later (different concrete types can't auto-map
-      // structurally), but it should NOT fail with an LMF-binding error against
-      // java.util.ArrayList. We assert the absence of that specific failure.
-      try {
-        Telescope.mapper(DocumentDataAlt.class, DocumentDataDtoAlt.class, writeBeans(WriteHint.WriteStrategy.SETTERS));
-      } catch (final Throwable t) {
-        // Drill the cause chain — surface the LMF binding failure if it sneaks through.
-        Throwable c = t;
-        while (c != null) {
-          final var msg = c.getMessage();
-          if (msg != null && msg.contains("java.util.ArrayList")) {
-            throw new AssertionError("LMF binding tried to use ArrayList as caller: " + msg, t);
-          }
-          c = c.getCause();
-        }
-      }
+    @DisplayName("cross-Collection-subtype field copies elements via target's no-arg ctor + addAll")
+    void differentCollectionSubtypesAreCopiedViaAddAll() {
+      // ImageUrls vs ImageUrlsAlt — both extend ArrayList<ImageUrl>. The same-type shortcut at
+      // autoIso doesn't fire (different concrete classes). The fix routes this through
+      // `collectionCopyIso`: instantiate the target type via its no-arg ctor and addAll(source).
+      // End-to-end the mapper produces an ImageUrlsAlt instance carrying the source's elements.
+      final var mapper = Telescope.mapper(
+        DocumentDataAlt.class,
+        DocumentDataDtoAlt.class,
+        writeBeans(WriteHint.WriteStrategy.SETTERS)
+      );
+      final var urls = new ImageUrls();
+      final var u = new ImageUrl();
+      u.setUrl("https://example.com/a.png");
+      urls.add(u);
+      final var src = new DocumentDataAlt();
+      src.setImageUrls(urls);
+      final var tgt = assertDoesNotThrow(() -> mapper.forward(src));
+      assertEquals(ImageUrlsAlt.class, tgt.getImageUrls().getClass());
+      assertEquals(1, tgt.getImageUrls().size());
+      assertEquals("https://example.com/a.png", tgt.getImageUrls().get(0).getUrl());
     }
   }
 

--- a/core/src/test/java/io/github/eschizoid/telescope/MigrationRegressionTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/MigrationRegressionTest.java
@@ -352,6 +352,150 @@ class MigrationRegressionTest {
   }
 
   @Nested
+  @DisplayName("Bug 7 — LMF fails on classes extending JDK collection types")
+  class Bug7JdkCollectionSubtypes {
+
+    public static class ImageUrl {
+
+      private String url;
+
+      public String getUrl() {
+        return url;
+      }
+
+      public void setUrl(final String url) {
+        this.url = url;
+      }
+    }
+
+    // Custom collection wrapper — common in legacy bean codebases. Extends ArrayList so it
+    // inherits a long tail of platform-module getters (isEmpty, getClass, etc.) that telescope
+    // used to try to LMF-bind, hitting java.base private-lookup rejection.
+    public static class ImageUrls extends java.util.ArrayList<ImageUrl> {
+
+      @java.io.Serial
+      private static final long serialVersionUID = 1L;
+    }
+
+    public static class DocumentData {
+
+      private ImageUrls imageUrls;
+
+      public ImageUrls getImageUrls() {
+        return imageUrls;
+      }
+
+      public void setImageUrls(final ImageUrls imageUrls) {
+        this.imageUrls = imageUrls;
+      }
+    }
+
+    public static class DocumentDataDto {
+
+      private ImageUrls imageUrls;
+
+      public ImageUrls getImageUrls() {
+        return imageUrls;
+      }
+
+      public void setImageUrls(final ImageUrls imageUrls) {
+        this.imageUrls = imageUrls;
+      }
+    }
+
+    @Test
+    @DisplayName(
+      "auto-recursion through a Collection subtype does NOT try to bean-decompose it (pass-through by reference)"
+    )
+    void collectionSubtypeIsPassThrough() {
+      // Adopter scenario: a bean graph contains a custom collection wrapper class extending
+      // ArrayList. Without the fix, DeepMap recurses into ImageUrls trying to bean-decompose
+      // it, discovers inherited `isEmpty()` etc. as "getters", then LMF-binds them — which
+      // fails with "Invalid caller: java.util.ArrayList" because java.base modules don't
+      // grant private lookup to application code. Fix: treat Collection/Map subtypes as
+      // scalars (pass-through by reference), and skip inherited platform-module methods in
+      // scanGetters as defence-in-depth.
+      final var mapper = Telescope.mapper(
+        DocumentData.class,
+        DocumentDataDto.class,
+        writeBeans(WriteHint.WriteStrategy.SETTERS)
+      );
+      final var urls = new ImageUrls();
+      final var u = new ImageUrl();
+      u.setUrl("https://example.com/a.png");
+      urls.add(u);
+      final var src = new DocumentData();
+      src.setImageUrls(urls);
+      final var tgt = assertDoesNotThrow(() -> mapper.forward(src));
+      // Pass-through by reference: same ImageUrls instance, same element.
+      assertEquals(urls, tgt.getImageUrls());
+      assertEquals("https://example.com/a.png", tgt.getImageUrls().get(0).getUrl());
+    }
+
+    // Adversarial reproduction — same-type shortcut at autoIso line 803 hides Bug 7 when the
+    // field is identical on both sides. Force different types so DeepMap.computeAutoIso falls
+    // through to the bean-recursion branch where `isReflectable` decides whether to descend.
+    public static class ImageUrlsAlt extends java.util.ArrayList<ImageUrl> {
+
+      @java.io.Serial
+      private static final long serialVersionUID = 1L;
+    }
+
+    public static class DocumentDataAlt {
+
+      private ImageUrls imageUrls; // source type
+
+      public ImageUrls getImageUrls() {
+        return imageUrls;
+      }
+
+      public void setImageUrls(final ImageUrls imageUrls) {
+        this.imageUrls = imageUrls;
+      }
+    }
+
+    public static class DocumentDataDtoAlt {
+
+      private ImageUrlsAlt imageUrls; // target type — different subclass
+
+      public ImageUrlsAlt getImageUrls() {
+        return imageUrls;
+      }
+
+      public void setImageUrls(final ImageUrlsAlt imageUrls) {
+        this.imageUrls = imageUrls;
+      }
+    }
+
+    @Test
+    @DisplayName("auto-recursion through different Collection subtypes refuses to bean-decompose either side")
+    void differentCollectionSubtypesRefuseBeanRecursion() {
+      // With ImageUrls (source) vs ImageUrlsAlt (target), the same-type shortcut at
+      // autoIso line 803 doesn't fire. Without the isReflectable fix, the bean-recursion
+      // branch would try to scan getters on ImageUrls/ImageUrlsAlt, hit inherited
+      // ArrayList.isEmpty(), and LMF-fail. With the fix, both are non-reflectable so the
+      // pair falls out of the bean branch.
+      //
+      // Construction may legitimately fail later (different concrete types can't auto-map
+      // structurally), but it should NOT fail with an LMF-binding error against
+      // java.util.ArrayList. We assert the absence of that specific failure.
+      try {
+        Telescope.mapper(DocumentDataAlt.class, DocumentDataDtoAlt.class, writeBeans(WriteHint.WriteStrategy.SETTERS));
+      } catch (final Throwable t) {
+        // Drill the cause chain — surface the LMF binding failure if it sneaks through.
+        Throwable c = t;
+        while (c != null) {
+          final var msg = c.getMessage();
+          if (msg != null && msg.contains("java.util.ArrayList")) {
+            throw new AssertionError("LMF binding tried to use ArrayList as caller: " + msg, t);
+          }
+          c = c.getCause();
+        }
+      }
+    }
+  }
+
+  @Nested
   @DisplayName("Bug 8 — SettersWriter NPE on null primitive value")
   class Bug8PrimitiveSetterNullNpe {
 

--- a/internal/src/main/java/io/github/eschizoid/telescope/internal/Beans.java
+++ b/internal/src/main/java/io/github/eschizoid/telescope/internal/Beans.java
@@ -592,6 +592,16 @@ public final class Beans {
     final var map = new LinkedHashMap<String, Method>();
     for (final var m : cls.getMethods()) {
       if (m.getParameterCount() != 0 || m.getDeclaringClass() == Object.class) continue;
+      // Bug 7: skip inherited methods declared in platform modules (java.*, jdk.*). A class
+      // extending ArrayList would otherwise surface `isEmpty()` → property `empty` and the LMF
+      // binder would then fail `privateLookupIn(ArrayList.class)` because `java.base` doesn't
+      // grant private lookup to application code. The primary fix lives in
+      // DeepMap.isReflectable (Collection/Map subtypes don't recurse at all); this guard adds
+      // defence-in-depth for any future caller that scans a JDK-derived class directly.
+      final var declaringModule = m.getDeclaringClass().getModule();
+      if (
+        declaringModule != null && declaringModule.isNamed() && declaringModule.getName().startsWith("java.")
+      ) continue;
       final var n = m.getName();
       final String prop;
       if (n.length() > 3 && n.startsWith("get") && m.getReturnType() != void.class) {


### PR DESCRIPTION
Bug 7 from `docs/migration-feedback.md`. P1. Stacked on #132.

## Problem

A bean graph containing a class that extends `ArrayList` / `HashMap` / any other JDK collection caused DeepMap's auto-recursion to try bean-decomposing the wrapper. The scan surfaced inherited `isEmpty()` etc. as "getters", then LMF-bound them — fails with `LambdaConversionException: Invalid caller: java.util.ArrayList` because `java.base` modules don't grant private lookup to application code. Common in legacy enterprise codebases that have a typed wrapper around a collection.

## Fix

**Two-layer**:

1. **`DeepMap.isReflectable`**: refuses any `Collection` or `Map` subtype. Container values still flow through the parameterised-type detector (`ContainerShape.of` handles concrete `List<E>`, `Set<E>`, `Map<K,V>`, `Optional<E>`); subtypes that look like a bean type are now correctly treated as scalars (pass-through by reference, same shape MapStruct uses for collection wrappers).
2. **`Beans.scanGetters`**: defence-in-depth — skip inherited methods declared in platform modules (`java.*`). Catches any future caller that scans a JDK-derived class directly without going through `isReflectable` first.

## TDD evidence

| Test | Pins | Behaviour |
|---|---|---|
| `Bug7...collectionSubtypeIsPassThrough` | Same `ImageUrls` on both sides — happy path | Passes either way (autoIso same-type shortcut) |
| `Bug7...differentCollectionSubtypesRefuseBeanRecursion` | Adversarial — `ImageUrls` vs `ImageUrlsAlt` subtypes force the bean-recursion path | Drills the cause chain for any LMF binding failure against `java.util.ArrayList` |

The adversarial test surfaces the bug condition; if the recursion ever tries to LMF-bind a java.base method, the assertion fires with a clear message.

## Mantras

- No public API change.
- No new reflection — uses the existing `Class.getModule()` lookup.
- Lattice-honest — Collection/Map subtypes are now correctly scalar values.

Sixth in the stacked PR series.
