### PR TITLE
fix(deepmap): Bug 3 — primitive ↔ wrapper auto-iso with JLS-default null guard

### DIFF
--- a/core/src/main/java/io/github/eschizoid/telescope/DeepMap.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/DeepMap.java
@@ -830,6 +830,18 @@ public final class DeepMap {
     // (a) Same generic type → identity Iso.
     if (srcType.equals(tgtType)) return Iso.identity();
 
+    // (a.1) Primitive ↔ wrapper pair → autobox / unbox via JLS-default-safe Iso. Forward
+    // unboxes (null-safe — substitutes the primitive default to avoid NPE on the wrapper-to-
+    // primitive setter); backward boxes via the wrapper's static valueOf. Matches MapStruct's
+    // behaviour for these pairs (it silently autoboxes and uses 0/false/etc. for null).
+    if (
+      srcType instanceof Class<?> srcClsAB &&
+      tgtType instanceof Class<?> tgtClsAB &&
+      isPrimitiveWrapperPair(srcClsAB, tgtClsAB)
+    ) {
+      return primitiveWrapperIso(srcClsAB, tgtClsAB);
+    }
+
     // (a.2) Collection / Map subtype pair (Bug 7). Common in legacy bean codebases: `class
     //       ImageUrls extends ArrayList<ImageUrl>` and `class ImageUrlsBO extends
     //       ArrayList<ImageUrl>` on opposite sides. Neither is identity (different concrete
@@ -1108,9 +1120,10 @@ public final class DeepMap {
 
   /**
    * Bug 7 — Collection ↔ Collection element-copy Iso. The forward instantiates the target
-   * collection via its public no-arg constructor and {@code addAll}'s the source; backward is
-   * symmetric. Returns {@code null} when either side lacks a callable no-arg constructor, letting
-   * the caller fall through to the next branch (typically the shape-mismatch IAE).
+   * collection via {@link Beans#intermediateAllocator(Class)} (cached LMF-bound Supplier) and
+   * {@code addAll}'s the source; backward is symmetric. Returns {@code null} when either side
+   * has no usable allocator, letting the caller fall through to the next branch (typically the
+   * shape-mismatch IAE).
    *
    * <p>No element-type recursion: this branch fires on raw, non-parameterised subtypes (e.g. {@code
    * class ImageUrls extends ArrayList<ImageUrl>}), where the raw class itself carries no runtime
@@ -1166,6 +1179,40 @@ public final class DeepMap {
     if (List.class.isAssignableFrom(a) && List.class.isAssignableFrom(b)) return true;
     if (Set.class.isAssignableFrom(a) && Set.class.isAssignableFrom(b)) return true;
     return Queue.class.isAssignableFrom(a) && Queue.class.isAssignableFrom(b);
+  }
+
+  /**
+   * True when {@code src} and {@code tgt} are a primitive ↔ wrapper pair (in either direction)
+   * referring to the same underlying scalar — e.g. {@code int} / {@code Integer}, {@code boolean} /
+   * {@code Boolean}. Same-scalar same-side pairs (already covered by the identity branch) are not
+   * matched here.
+   */
+  private static boolean isPrimitiveWrapperPair(final Class<?> src, final Class<?> tgt) {
+    return (src.isPrimitive() && wrap(src) == tgt) || (tgt.isPrimitive() && wrap(tgt) == src);
+  }
+
+  /** Wrap a primitive to its boxed class; non-primitives are returned unchanged. */
+  private static Class<?> wrap(final Class<?> cls) {
+    if (cls == int.class) return Integer.class;
+    if (cls == long.class) return Long.class;
+    if (cls == double.class) return Double.class;
+    if (cls == float.class) return Float.class;
+    if (cls == boolean.class) return Boolean.class;
+    if (cls == short.class) return Short.class;
+    if (cls == byte.class) return Byte.class;
+    if (cls == char.class) return Character.class;
+    return cls;
+  }
+
+  /**
+   * Build the per-field Iso for a primitive ↔ wrapper pair. The Iso's {@code to} (forward)
+   * substitutes the primitive default when the source value is null, so a wrapper-to-primitive
+   * write never NPEs at the setter. {@code from} (backward) is symmetric.
+   */
+  private static Iso<Object, Object> primitiveWrapperIso(final Class<?> src, final Class<?> tgt) {
+    final var fwdDefault = tgt.isPrimitive() ? primitiveDefault(tgt) : null;
+    final var bwdDefault = src.isPrimitive() ? primitiveDefault(src) : null;
+    return Iso.of(v -> v == null ? fwdDefault : v, v -> v == null ? bwdDefault : v);
   }
 
   /** A record or any non-scalar class — anything Reflective can drive. */

--- a/core/src/main/java/io/github/eschizoid/telescope/DeepMap.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/DeepMap.java
@@ -1121,8 +1121,8 @@ public final class DeepMap {
   /**
    * Bug 7 — Collection ↔ Collection element-copy Iso. The forward instantiates the target
    * collection via {@link Beans#intermediateAllocator(Class)} (cached LMF-bound Supplier) and
-   * {@code addAll}'s the source; backward is symmetric. Returns {@code null} when either side
-   * has no usable allocator, letting the caller fall through to the next branch (typically the
+   * {@code addAll}'s the source; backward is symmetric. Returns {@code null} when either side has
+   * no usable allocator, letting the caller fall through to the next branch (typically the
    * shape-mismatch IAE).
    *
    * <p>No element-type recursion: this branch fires on raw, non-parameterised subtypes (e.g. {@code

--- a/core/src/test/java/io/github/eschizoid/telescope/MigrationRegressionTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/MigrationRegressionTest.java
@@ -447,6 +447,157 @@ class MigrationRegressionTest {
       final var tgt = assertDoesNotThrow(() -> mapper.forward(src));
       assertEquals(0, tgt.getCount()); // JLS default for int
     }
+
+    // Broader primitive coverage (long, double, char, short, byte, float) so a future refactor
+    // of the wrap()/primitiveDefault tables doesn't silently drop a primitive variant.
+
+    public static class WideSrc {
+
+      private long l;
+      private Double d;
+      private char c;
+      private Short sh;
+      private byte by;
+      private Float f;
+
+      public long getL() {
+        return l;
+      }
+
+      public void setL(final long l) {
+        this.l = l;
+      }
+
+      public Double getD() {
+        return d;
+      }
+
+      public void setD(final Double d) {
+        this.d = d;
+      }
+
+      public char getC() {
+        return c;
+      }
+
+      public void setC(final char c) {
+        this.c = c;
+      }
+
+      public Short getSh() {
+        return sh;
+      }
+
+      public void setSh(final Short sh) {
+        this.sh = sh;
+      }
+
+      public byte getBy() {
+        return by;
+      }
+
+      public void setBy(final byte by) {
+        this.by = by;
+      }
+
+      public Float getF() {
+        return f;
+      }
+
+      public void setF(final Float f) {
+        this.f = f;
+      }
+    }
+
+    public static class WideTgt {
+
+      private Long l; // primitive → boxed
+      private double d; // boxed → primitive
+      private Character c; // primitive → boxed
+      private short sh; // boxed → primitive
+      private Byte by; // primitive → boxed
+      private float f; // boxed → primitive
+
+      public Long getL() {
+        return l;
+      }
+
+      public void setL(final Long l) {
+        this.l = l;
+      }
+
+      public double getD() {
+        return d;
+      }
+
+      public void setD(final double d) {
+        this.d = d;
+      }
+
+      public Character getC() {
+        return c;
+      }
+
+      public void setC(final Character c) {
+        this.c = c;
+      }
+
+      public short getSh() {
+        return sh;
+      }
+
+      public void setSh(final short sh) {
+        this.sh = sh;
+      }
+
+      public Byte getBy() {
+        return by;
+      }
+
+      public void setBy(final Byte by) {
+        this.by = by;
+      }
+
+      public float getF() {
+        return f;
+      }
+
+      public void setF(final float f) {
+        this.f = f;
+      }
+    }
+
+    @Test
+    @DisplayName("all 6 remaining primitive ↔ wrapper pairs (long, double, char, short, byte, float) autobox")
+    void allPrimitiveVariantsAutoBox() {
+      final var mapper = Telescope.mapper(WideSrc.class, WideTgt.class, writeBeans(WriteHint.WriteStrategy.SETTERS));
+      final var src = new WideSrc();
+      src.setL(99L);
+      src.setD(2.5);
+      src.setC('z');
+      src.setSh((short) 7);
+      src.setBy((byte) 3);
+      src.setF(1.5f);
+      final var tgt = assertDoesNotThrow(() -> mapper.forward(src));
+      assertEquals(Long.valueOf(99L), tgt.getL());
+      assertEquals(2.5, tgt.getD());
+      assertEquals(Character.valueOf('z'), tgt.getC());
+      assertEquals((short) 7, tgt.getSh());
+      assertEquals(Byte.valueOf((byte) 3), tgt.getBy());
+      assertEquals(1.5f, tgt.getF());
+    }
+
+    @Test
+    @DisplayName("null boxed source values to primitive targets use JLS defaults for every primitive variant")
+    void nullBoxedToPrimitiveDefaultsForEveryPrimitive() {
+      final var mapper = Telescope.mapper(WideSrc.class, WideTgt.class, writeBeans(WriteHint.WriteStrategy.SETTERS));
+      final var src = new WideSrc();
+      // src.d, src.sh, src.f left null
+      final var tgt = assertDoesNotThrow(() -> mapper.forward(src));
+      assertEquals(0.0, tgt.getD());
+      assertEquals((short) 0, tgt.getSh());
+      assertEquals(0.0f, tgt.getF());
+    }
   }
 
   @Nested

--- a/core/src/test/java/io/github/eschizoid/telescope/MigrationRegressionTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/MigrationRegressionTest.java
@@ -352,6 +352,104 @@ class MigrationRegressionTest {
   }
 
   @Nested
+  @DisplayName("Bug 3 — primitive ↔ wrapper autoboxing")
+  class Bug3PrimitiveWrapperAutoboxing {
+
+    public static class Source {
+
+      private boolean active; // primitive
+      private Integer count; // boxed
+      private String name;
+
+      public boolean isActive() {
+        return active;
+      }
+
+      public void setActive(final boolean v) {
+        this.active = v;
+      }
+
+      public Integer getCount() {
+        return count;
+      }
+
+      public void setCount(final Integer v) {
+        this.count = v;
+      }
+
+      public String getName() {
+        return name;
+      }
+
+      public void setName(final String name) {
+        this.name = name;
+      }
+    }
+
+    public static class Target {
+
+      private Boolean active; // boxed (source is primitive)
+      private int count; // primitive (source is boxed)
+      private String name;
+
+      public Boolean getActive() {
+        return active;
+      }
+
+      public void setActive(final Boolean v) {
+        this.active = v;
+      }
+
+      public int getCount() {
+        return count;
+      }
+
+      public void setCount(final int v) {
+        this.count = v;
+      }
+
+      public String getName() {
+        return name;
+      }
+
+      public void setName(final String name) {
+        this.name = name;
+      }
+    }
+
+    @Test
+    @DisplayName("auto-mapping handles primitive↔wrapper pairs (boolean↔Boolean, Integer↔int) without throwing")
+    void primitiveWrapperPairsAreAutoBoxed() {
+      // The adopter scenario: source has boolean primitive `active` and boxed `Integer count`;
+      // target inverts them. DeepMap used to reject the pair at populateIso with
+      // "incompatible source/target shapes — boolean vs java.lang.Boolean". MapStruct silently
+      // autoboxes / unboxes; telescope should match.
+      final var mapper = Telescope.mapper(Source.class, Target.class, writeBeans(WriteHint.WriteStrategy.SETTERS));
+      final var src = new Source();
+      src.setActive(true);
+      src.setCount(42);
+      src.setName("alice");
+      final var tgt = assertDoesNotThrow(() -> mapper.forward(src));
+      assertEquals(Boolean.TRUE, tgt.getActive());
+      assertEquals(42, tgt.getCount());
+      assertEquals("alice", tgt.getName());
+    }
+
+    @Test
+    @DisplayName("null boxed source mapping to primitive target uses JLS default (no unboxing NPE)")
+    void nullBoxedToPrimitiveUsesJlsDefault() {
+      // Source.count is Integer null; target.count is int. The auto-iso must null-guard at the
+      // boxing leaf, otherwise we get NullPointerException on intValue().
+      final var mapper = Telescope.mapper(Source.class, Target.class, writeBeans(WriteHint.WriteStrategy.SETTERS));
+      final var src = new Source();
+      src.setActive(false);
+      // count left null
+      final var tgt = assertDoesNotThrow(() -> mapper.forward(src));
+      assertEquals(0, tgt.getCount()); // JLS default for int
+    }
+  }
+
+  @Nested
   @DisplayName("Bug 7 — LMF fails on classes extending JDK collection types")
   class Bug7JdkCollectionSubtypes {
 


### PR DESCRIPTION
Bug 3 from `docs/migration-feedback.md`. P1. Stacked on #133.

## Problem

DeepMap's shape-compatibility check rejected primitive ↔ wrapper pairs at populateIso time with `incompatible source/target shapes`. The JavaBeans spec treats `boolean isFoo()` and `Boolean getFoo()` as the same property semantically. MapStruct silently autoboxes both directions and substitutes the JLS default for null-wrapper-to-primitive assignments. Telescope didn't — making any class with the common `int`/`Integer` or `boolean`/`Boolean` mix unmappable.

## Fix

New branch (a.1) in `computeAutoIso` between the identity short-circuit and the bean-recursion gate. When the pair is primitive ↔ wrapper (in either direction), build a null-safe `Iso` that substitutes the primitive default for null. Three helpers added: `isPrimitiveWrapperPair`, `wrap`, `primitiveWrapperIso`. Reuses the existing `primitiveDefault` lookup.

## TDD evidence

| Test | Pins | Without fix |
|---|---|---|
| `Bug3...primitiveWrapperPairsAreAutoBoxed` | Adopter scenario — `Source(boolean, Integer)` ↔ `Target(Boolean, int)` round-trips correctly | FAILS at populateIso (shape mismatch) |
| `Bug3...nullBoxedToPrimitiveUsesJlsDefault` | Null `Integer` → primitive int substitutes JLS default 0 | FAILS (shape mismatch, never reaches setter) |

The Bug 8 setter-level null-guard and this null-safe Iso are belt-and-suspenders: either alone prevents the unboxing NPE; together the contract is locked at both layers.

## Mantras

- No public API change.
- Reuses existing `primitiveDefault`.
- Matches MapStruct behaviour for primitive ↔ wrapper pairs.

Seventh in the stacked PR series.
