### PR TITLE
fix(bridgeprocessor): Bug 1 — handle unresolvable @Bridge target

### DIFF
--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
@@ -162,7 +162,22 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
       if (bridges.size() > 1) multiTargetSources.add(sourceFq);
 
       for (final var bridgeAm : bridges) {
-        final var target = targetTypeFromMirror(bridgeAm);
+        final var rawValue = rawTargetValueFromMirror(bridgeAm);
+        // When the @Bridge target class lives in a module that the annotated element's
+        // compilation unit can't see, javac's AnnotationValue.getValue() returns the target FQN
+        // as a String instead of a TypeMirror. Surface a precise diagnostic instead of letting
+        // a downstream cast crash with an unhelpful ClassCastException.
+        if (rawValue instanceof String fqn) {
+          error(
+            element,
+            "@Bridge target '" +
+              fqn +
+              "' is not resolvable from this compilation unit — annotate the other side, " +
+              "or add the dependency."
+          );
+          continue;
+        }
+        final var target = rawValue instanceof TypeMirror tm ? tm : null;
         if (target == null || target.getKind() != TypeKind.DECLARED) {
           error(element, "@Bridge value must be a class, record, or sealed-interface type");
           continue;
@@ -244,9 +259,17 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
     return bridges;
   }
 
-  private TypeMirror targetTypeFromMirror(final AnnotationMirror am) {
+  /**
+   * Read the raw {@code value} entry from a {@code @Bridge} annotation mirror. Returns a {@link
+   * TypeMirror} when the target class is resolvable from the compilation unit, a {@link String}
+   * (the target FQN) when it isn't (the fallback shape javac uses for {@code Class<?>} annotation
+   * values it can't bind), or {@code null} when the annotation has no {@code value} attribute.
+   * Callers are responsible for dispatching on the returned shape — the String fallback fires when
+   * {@code @Bridge(SomeClass.class)} references a type in an unresolvable module.
+   */
+  private Object rawTargetValueFromMirror(final AnnotationMirror am) {
     for (final var entry : am.getElementValues().entrySet()) {
-      if (entry.getKey().getSimpleName().contentEquals("value")) return (TypeMirror) entry.getValue().getValue();
+      if (entry.getKey().getSimpleName().contentEquals("value")) return entry.getValue().getValue();
     }
     return null;
   }
@@ -1460,8 +1483,8 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
       final var caseBridges = collectBridgeAnnotations(sourceCaseEl);
       TypeMirror caseTarget = null;
       for (final var bridgeAm : caseBridges) {
-        final var tm = targetTypeFromMirror(bridgeAm);
-        if (tm == null || tm.getKind() != TypeKind.DECLARED) continue;
+        final var raw = rawTargetValueFromMirror(bridgeAm);
+        if (!(raw instanceof TypeMirror tm) || tm.getKind() != TypeKind.DECLARED) continue;
         final var tEl = (TypeElement) ((DeclaredType) tm).asElement();
         if (targetPermitsFq.contains(tEl.getQualifiedName().toString())) {
           caseTarget = tm;
@@ -1480,7 +1503,7 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
           );
         } else if (caseBridges.size() == 1) {
           // Single @Bridge whose target isn't in the sealed-target permits — name it explicitly.
-          final var only = targetTypeFromMirror(caseBridges.get(0));
+          final var only = rawTargetValueFromMirror(caseBridges.get(0));
           if (!(only instanceof DeclaredType decl)) continue;
           final var onlyEl = (TypeElement) decl.asElement();
           error(

--- a/codegen/src/test/java/io/github/eschizoid/telescope/codegen/BridgeProcessorTest.java
+++ b/codegen/src/test/java/io/github/eschizoid/telescope/codegen/BridgeProcessorTest.java
@@ -672,6 +672,33 @@ class BridgeProcessorTest {
         () -> "expected no-strategy diagnostic; saw " + compilation.errorMessages()
       );
     }
+
+    @Test
+    @DisplayName("@Bridge with an unresolvable target class emits a precise diagnostic instead of a ClassCastException")
+    void unresolvableTargetEmitsPreciseDiagnostic() {
+      // When the @Bridge target lives in a module the annotated compilation unit can't see,
+      // javac's AnnotationValue.getValue() returns the target FQN as a String rather than a
+      // TypeMirror. A naive `(TypeMirror) cast` would blow up the build with an unhelpful
+      // ClassCastException; the processor recognises the String fallback shape and surfaces a
+      // guidance message that names the missing target instead.
+      final var compilation = compile(
+        source(
+          "demo.Src",
+          """
+          package demo;
+          import io.github.eschizoid.telescope.annotations.Bridge;
+          @Bridge(value = demo.does.not.Exist.class)
+          public record Src(String id) {}
+          """
+        )
+      );
+
+      assertFalse(compilation.success(), "an unresolvable @Bridge target should fail");
+      assertTrue(
+        compilation.hasError("not resolvable from this compilation unit"),
+        () -> "expected unresolvable-target diagnostic; saw " + compilation.errorMessages()
+      );
+    }
   }
 
   @Nested

--- a/core/src/main/java/io/github/eschizoid/telescope/DeepMap.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/DeepMap.java
@@ -27,6 +27,7 @@ import java.lang.reflect.Type;
 import java.time.temporal.Temporal;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Deque;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -36,7 +37,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Queue;
 import java.util.Set;
+import java.util.SortedMap;
+import java.util.SortedSet;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
@@ -315,175 +319,242 @@ public final class DeepMap {
     }
     cache.put(key, null); // reserve slot so cycle-re-entry short-circuits
     inProgress.push(key);
+    // The pop lives in finally (at the end of this method) so a thrown IllegalStateException —
+    // the strict-bijection guard at the top-level pair — doesn't corrupt the `inProgress` stack.
+    // `inProgress.size() > 1` is the lenient-nested gate; a leaked pre-pop frame would silently
+    // flip future top-level calls in the same cache into "nested" mode.
+    try {
+      final var srcRefl = pickReflective(source, beanRefl);
+      final var tgtRefl = pickReflective(target, beanRefl);
 
-    final var srcRefl = pickReflective(source, beanRefl);
-    final var tgtRefl = pickReflective(target, beanRefl);
+      final var byTargetName = new LinkedHashMap<String, FieldStep>();
+      final var bySourceName = new LinkedHashMap<String, FieldStep>();
+      // Strict claims: at most one SameTypedTo / TypedTransformTo / Via / Drop row per (src, tgt)
+      // field.
+      // Duplicates among these would be genuinely ambiguous, so they fail fast.
+      final var claimedTgt = new HashSet<String>();
+      final var claimedSrc = new HashSet<String>();
+      // Soft claims: telescope-based rows are post-fixups, not exclusive overrides — they mark a
+      // field as "consumed by a telescope read/write" so the strict source/target must-be-claimed
+      // pass below accepts it, but don't conflict with strict rows or with each other on the same
+      // field. Multiple Mapping.to(srcAcc, tgtTelescope) rows reading the same source field, or
+      // Mapping.to(srcAcc, tgtTelescope) co-existing with a Mapping.to(srcAcc, tgtAcc), are both
+      // OK.
+      final var telescopeReadsSrc = new HashSet<String>();
+      final var telescopeWritesTgt = new HashSet<String>();
+      final var telescopeFixups = new ArrayList<Mapping<?, ?>>();
 
-    final var byTargetName = new LinkedHashMap<String, FieldStep>();
-    final var bySourceName = new LinkedHashMap<String, FieldStep>();
-    // Strict claims: at most one SameTypedTo / TypedTransformTo / Via / Drop row per (src, tgt)
-    // field.
-    // Duplicates among these would be genuinely ambiguous, so they fail fast.
-    final var claimedTgt = new HashSet<String>();
-    final var claimedSrc = new HashSet<String>();
-    // Soft claims: telescope-based rows are post-fixups, not exclusive overrides — they mark a
-    // field as "consumed by a telescope read/write" so the strict source/target must-be-claimed
-    // pass below accepts it, but don't conflict with strict rows or with each other on the same
-    // field. Multiple Mapping.to(srcAcc, tgtTelescope) rows reading the same source field, or
-    // Mapping.to(srcAcc, tgtTelescope) co-existing with a Mapping.to(srcAcc, tgtAcc), are both OK.
-    final var telescopeReadsSrc = new HashSet<String>();
-    final var telescopeWritesTgt = new HashSet<String>();
-    final var telescopeFixups = new ArrayList<Mapping<?, ?>>();
-
-    for (final var rawRow : overrides.getOrDefault(key, List.of())) {
-      // Conditional<A, B>(predicate, inner) wraps a telescope-based row. For soft-claim routing,
-      // peel to the inner — Conditional delegates sourceField/targetField/sourceClass/targetClass
-      // to inner already, so the metadata is identical, but the telescope-shape checks below need
-      // the concrete inner type. The Conditional itself (rawRow) goes into telescopeFixups so
-      // applyForward can evaluate the predicate before dispatching the inner's effect.
-      final Mapping<?, ?> row = (rawRow instanceof Conditional<?, ?> c) ? c.inner() : rawRow;
-      // Normalize raw method names per side — record::name stays "name", bean::getName becomes
-      // "name". `sourceField()` returns null on rows whose source is a nested telescope rather
-      // than a flat accessor (FromTelescopeTo, TelescopeToTelescope); those branches re-read the
-      // first hop name from the telescope below and don't consume srcField, so null here is safe.
-      final var rawSrcField = row.sourceField();
-      final var srcField = rawSrcField == null ? null : srcRefl.normalize(rawSrcField);
-      // TelescopeTo: flat source accessor → nested target telescope.
-      // Soft claim on the source field (from srcAcc) AND the target telescope's first hop name.
-      // Multiple rows sharing the same source field or top-level target field all compose.
-      if (row instanceof TelescopeTo<?, ?, ?> tRow) {
-        telescopeReadsSrc.add(srcField);
-        final var firstTgtHop = tRow.targetTelescope().firstHopName();
-        if (firstTgtHop != null) telescopeWritesTgt.add(tgtRefl.normalize(firstTgtHop));
-        telescopeFixups.add(rawRow);
-        continue;
-      }
-      // FromTelescopeTo: nested source telescope → flat target accessor — soft claim mirror.
-      // Soft claim on the target field (from tgtAcc) AND the source telescope's first hop name.
-      if (row instanceof FromTelescopeTo<?, ?, ?> fRow) {
-        telescopeWritesTgt.add(tgtRefl.normalize(row.targetField()));
-        final var firstSrcHop = fRow.sourceTelescope().firstHopName();
-        if (firstSrcHop != null) telescopeReadsSrc.add(srcRefl.normalize(firstSrcHop));
-        telescopeFixups.add(rawRow);
-        continue;
-      }
-      // TelescopeToTelescope (covers both Kind.BROADCAST from Mapping.to and Kind.ZIP from
-      // Mapping.zip): both sides are nested telescopes. Recover the top-level src/tgt field names
-      // from each telescope's first hop so auto-recursion can build the top-level structure; the
-      // post-fixup then overlays the deep leaf (broadcast or positional, depending on kind).
-      if (row instanceof TelescopeToTelescope<?, ?, ?> ttRow) {
-        final var firstSrcHop = ttRow.sourceTelescope().firstHopName();
-        final var firstTgtHop = ttRow.targetTelescope().firstHopName();
-        if (firstSrcHop != null) telescopeReadsSrc.add(srcRefl.normalize(firstSrcHop));
-        if (firstTgtHop != null) telescopeWritesTgt.add(tgtRefl.normalize(firstTgtHop));
-        telescopeFixups.add(rawRow);
-        continue;
-      }
-      // Constant / Compute rows are target-injection telescope fixups: claim the target
-      // telescope's first hop as written, register the row in telescopeFixups, and let the
-      // applyForward pass stamp value (Constant) or supplier.get() (Compute) at the location the
-      // telescope navigates to. The flat factories (constant(Accessor, X) / compute(Accessor,
-      // Supplier)) wrap the accessor in a single-hop telescope at construction time so this loop
-      // sees only one shape per kind — no separate flat handler. Backward direction is a no-op:
-      // these rows don't contribute to bySourceName, so the source rebuilder ignores the slot
-      // entirely on backward (same retraction semantics as Drop on the source side).
-      if (row instanceof Constant<?, ?, ?> cRow) {
-        final var firstTgtHop = cRow.targetTelescope().firstHopName();
-        if (firstTgtHop != null) telescopeWritesTgt.add(tgtRefl.normalize(firstTgtHop));
-        telescopeFixups.add(rawRow);
-        continue;
-      }
-      if (row instanceof Compute<?, ?, ?> cpRow) {
-        final var firstTgtHop = cpRow.targetTelescope().firstHopName();
-        if (firstTgtHop != null) telescopeWritesTgt.add(tgtRefl.normalize(firstTgtHop));
-        telescopeFixups.add(rawRow);
-        continue;
-      }
-      // Drop rows claim a source field with no target counterpart — they exist to satisfy the
-      // strict source-must-be-claimed pass below when one side carries fields the other doesn't.
-      if (row instanceof Drop<?, ?, ?>) {
-        if (!claimedSrc.add(srcField)) throw new IllegalArgumentException(
+      for (final var rawRow : overrides.getOrDefault(key, List.of())) {
+        // Conditional<A, B>(predicate, inner) wraps a telescope-based row. For soft-claim routing,
+        // peel to the inner — Conditional delegates sourceField/targetField/sourceClass/targetClass
+        // to inner already, so the metadata is identical, but the telescope-shape checks below need
+        // the concrete inner type. The Conditional itself (rawRow) goes into telescopeFixups so
+        // applyForward can evaluate the predicate before dispatching the inner's effect.
+        final Mapping<?, ?> row = (rawRow instanceof Conditional<?, ?> c) ? c.inner() : rawRow;
+        // Normalize raw method names per side — record::name stays "name", bean::getName becomes
+        // "name". `sourceField()` returns null on rows whose source is a nested telescope rather
+        // than a flat accessor (FromTelescopeTo, TelescopeToTelescope); those branches re-read the
+        // first hop name from the telescope below and don't consume srcField, so null here is safe.
+        final var rawSrcField = row.sourceField();
+        final var srcField = rawSrcField == null ? null : srcRefl.normalize(rawSrcField);
+        // TelescopeTo: flat source accessor → nested target telescope.
+        // Soft claim on the source field (from srcAcc) AND the target telescope's first hop name.
+        // Multiple rows sharing the same source field or top-level target field all compose.
+        if (row instanceof TelescopeTo<?, ?, ?> tRow) {
+          telescopeReadsSrc.add(srcField);
+          final var firstTgtHop = tRow.targetTelescope().firstHopName();
+          if (firstTgtHop != null) telescopeWritesTgt.add(tgtRefl.normalize(firstTgtHop));
+          telescopeFixups.add(rawRow);
+          continue;
+        }
+        // FromTelescopeTo: nested source telescope → flat target accessor — soft claim mirror.
+        // Soft claim on the target field (from tgtAcc) AND the source telescope's first hop name.
+        if (row instanceof FromTelescopeTo<?, ?, ?> fRow) {
+          telescopeWritesTgt.add(tgtRefl.normalize(row.targetField()));
+          final var firstSrcHop = fRow.sourceTelescope().firstHopName();
+          if (firstSrcHop != null) telescopeReadsSrc.add(srcRefl.normalize(firstSrcHop));
+          telescopeFixups.add(rawRow);
+          continue;
+        }
+        // TelescopeToTelescope (covers both Kind.BROADCAST from Mapping.to and Kind.ZIP from
+        // Mapping.zip): both sides are nested telescopes. Recover the top-level src/tgt field names
+        // from each telescope's first hop so auto-recursion can build the top-level structure; the
+        // post-fixup then overlays the deep leaf (broadcast or positional, depending on kind).
+        if (row instanceof TelescopeToTelescope<?, ?, ?> ttRow) {
+          final var firstSrcHop = ttRow.sourceTelescope().firstHopName();
+          final var firstTgtHop = ttRow.targetTelescope().firstHopName();
+          if (firstSrcHop != null) telescopeReadsSrc.add(srcRefl.normalize(firstSrcHop));
+          if (firstTgtHop != null) telescopeWritesTgt.add(tgtRefl.normalize(firstTgtHop));
+          telescopeFixups.add(rawRow);
+          continue;
+        }
+        // Constant / Compute rows are target-injection telescope fixups: claim the target
+        // telescope's first hop as written, register the row in telescopeFixups, and let the
+        // applyForward pass stamp value (Constant) or supplier.get() (Compute) at the location the
+        // telescope navigates to. The flat factories (constant(Accessor, X) / compute(Accessor,
+        // Supplier)) wrap the accessor in a single-hop telescope at construction time so this loop
+        // sees only one shape per kind — no separate flat handler. Backward direction is a no-op:
+        // these rows don't contribute to bySourceName, so the source rebuilder ignores the slot
+        // entirely on backward (same retraction semantics as Drop on the source side).
+        if (row instanceof Constant<?, ?, ?> cRow) {
+          final var firstTgtHop = cRow.targetTelescope().firstHopName();
+          if (firstTgtHop != null) telescopeWritesTgt.add(tgtRefl.normalize(firstTgtHop));
+          telescopeFixups.add(rawRow);
+          continue;
+        }
+        if (row instanceof Compute<?, ?, ?> cpRow) {
+          final var firstTgtHop = cpRow.targetTelescope().firstHopName();
+          if (firstTgtHop != null) telescopeWritesTgt.add(tgtRefl.normalize(firstTgtHop));
+          telescopeFixups.add(rawRow);
+          continue;
+        }
+        // Drop rows claim a source field with no target counterpart — they exist to satisfy the
+        // strict source-must-be-claimed pass below when one side carries fields the other doesn't.
+        if (row instanceof Drop<?, ?, ?>) {
+          if (!claimedSrc.add(srcField)) throw new IllegalArgumentException(
+            "Deep map " +
+              source.getSimpleName() +
+              " → " +
+              target.getSimpleName() +
+              ": duplicate override row for source field '" +
+              srcField +
+              "'. Each (source, target) type pair may declare at most one row per source field."
+          );
+          // Register a backward-only step under the source name so the source-reconstructor
+          // (assembleIso's bySourceName loop) produces a placeholder value (null) for the dropped
+          // field. The step is NOT registered under byTargetName, so the forward direction omits
+          // the source field from the target map entirely.
+          bySourceName.put(srcField, new FieldStep(srcField, null, NULLING_ISO));
+          continue;
+        }
+        final var tgtField = tgtRefl.normalize(row.targetField());
+        // Fail fast on duplicate target — two rows targeting the same target field would silently
+        // overwrite each other in byTargetName and could produce non-bijective forward/backward
+        // (each direction using a different correspondence).
+        if (!claimedTgt.add(tgtField)) throw new IllegalArgumentException(
           "Deep map " +
             source.getSimpleName() +
             " → " +
             target.getSimpleName() +
-            ": duplicate override row for source field '" +
-            srcField +
-            "'. Each (source, target) type pair may declare at most one row per source field."
+            ": duplicate override row for target field '" +
+            tgtField +
+            "'. Each (source, target) type pair may declare at most one row per target field."
         );
-        // Register a backward-only step under the source name so the source-reconstructor
-        // (assembleIso's bySourceName loop) produces a placeholder value (null) for the dropped
-        // field. The step is NOT registered under byTargetName, so the forward direction omits
-        // the source field from the target map entirely.
-        bySourceName.put(srcField, new FieldStep(srcField, null, NULLING_ISO));
-        continue;
+        // Same-source fan-out IS permitted: one source field feeding multiple target fields is a
+        // common enterprise pattern (e.g. `businessUnit → cretnUserId AND lastUpdtdUserId` on
+        // audit-column rebuilds). Forward direction broadcasts the source value to every target row
+        // correctly. Backward direction is non-bijective for the fan-out source field — the last
+        // registered row wins the `bySourceName` slot, so backward reconstructs that source field
+        // from one target's value. Round-trip equality holds when the user keeps fan-out targets in
+        // sync (typically same-typed copies of the same column), and the test pin makes the
+        // last-row-wins behaviour explicit so silent ambiguity is impossible.
+        claimedSrc.add(srcField);
+        final var tgtType = tgtRefl.genericType(target, tgtField);
+        final var rawRowIso = fieldIsoOf(row, srcRefl.genericType(source, srcField), tgtType);
+        // SameTypedTo rows are pure identity at the leaf — wrap with default-on-null when the
+        // mapper's null strategy is DEFAULT so an unset source field lands as the type default
+        // instead of null. Other field-iso rows (TypedTransformTo, ForwardOnlyTransformTo, Via)
+        // carry user-supplied forward functions and are explicitly NOT wrapped — the user already
+        // decided how their lambda handles null. This precedence rule lets toOrElse(...) (a
+        // TypedTransformTo) and explicit transforms win over the global hint without any extra
+        // marker on the row, which is the simplest "per-row beats per-mapper" semantics.
+        final var rowIso = (nullStrategy == NullHint.NullStrategy.DEFAULT && row instanceof SameTypedTo<?, ?, ?>)
+          ? wrapDefaultOnNull(rawRowIso, tgtType)
+          : rawRowIso;
+        final var step = new FieldStep(srcField, tgtField, rowIso);
+        byTargetName.put(tgtField, step);
+        bySourceName.put(srcField, step);
       }
-      final var tgtField = tgtRefl.normalize(row.targetField());
-      // Fail fast on duplicate target — two rows targeting the same target field would silently
-      // overwrite each other in byTargetName and could produce non-bijective forward/backward
-      // (each direction using a different correspondence).
-      if (!claimedTgt.add(tgtField)) throw new IllegalArgumentException(
-        "Deep map " +
-          source.getSimpleName() +
-          " → " +
-          target.getSimpleName() +
-          ": duplicate override row for target field '" +
-          tgtField +
-          "'. Each (source, target) type pair may declare at most one row per target field."
-      );
-      // Same-source fan-out IS permitted: one source field feeding multiple target fields is a
-      // common enterprise pattern (e.g. `businessUnit → cretnUserId AND lastUpdtdUserId` on
-      // audit-column rebuilds). Forward direction broadcasts the source value to every target row
-      // correctly. Backward direction is non-bijective for the fan-out source field — the last
-      // registered row wins the `bySourceName` slot, so backward reconstructs that source field
-      // from one target's value. Round-trip equality holds when the user keeps fan-out targets in
-      // sync (typically same-typed copies of the same column), and the test pin makes the
-      // last-row-wins behaviour explicit so silent ambiguity is impossible.
-      claimedSrc.add(srcField);
-      final var tgtType = tgtRefl.genericType(target, tgtField);
-      final var rawRowIso = fieldIsoOf(row, srcRefl.genericType(source, srcField), tgtType);
-      // SameTypedTo rows are pure identity at the leaf — wrap with default-on-null when the
-      // mapper's null strategy is DEFAULT so an unset source field lands as the type default
-      // instead of null. Other field-iso rows (TypedTransformTo, ForwardOnlyTransformTo, Via)
-      // carry user-supplied forward functions and are explicitly NOT wrapped — the user already
-      // decided how their lambda handles null. This precedence rule lets toOrElse(...) (a
-      // TypedTransformTo) and explicit transforms win over the global hint without any extra
-      // marker on the row, which is the simplest "per-row beats per-mapper" semantics.
-      final var rowIso = (nullStrategy == NullHint.NullStrategy.DEFAULT && row instanceof SameTypedTo<?, ?, ?>)
-        ? wrapDefaultOnNull(rawRowIso, tgtType)
-        : rawRowIso;
-      final var step = new FieldStep(srcField, tgtField, rowIso);
-      byTargetName.put(tgtField, step);
-      bySourceName.put(srcField, step);
-    }
 
-    final var srcNames = srcRefl.names(source);
-    final var srcNameSet = new HashSet<>(List.of(srcNames));
-    for (final var name : tgtRefl.names(target)) {
-      if (claimedTgt.contains(name)) continue;
-      // Telescope-row permissive mode: when ANY telescope row is registered for this pair, target
-      // fields with no same-name source get a NULLING_ISO placeholder. The post-fixup overlays it
-      // if a TelescopeToTelescope / FromTelescopeTo writes through that field; otherwise the field
-      // stays null. Telescope rows can't recover their top-level target field name from a
-      // Telescope<B, X> at runtime (generics erased), so we permit the gap instead of failing on
-      // every nested write. Without any telescope row, the strict same-name check still fires.
-      if (!srcNameSet.contains(name)) {
-        if (!telescopeFixups.isEmpty()) {
-          // Telescope-row placeholder for a target field with no same-name source. Three cases,
-          // type-driven:
-          //   - field type is a record AND a telescope row claims it as a first hop: allocate a
-          //     recursive default-tree instance so the post-fixup overlay
-          //     (`tgtTelescope.set(t, value)`) can descend into a non-null intermediate. Records
-          //     only for v1.0; beans need a no-arg ctor or builder which isn't always present —
-          //     deferred to v1.1.
-          //   - field type is a primitive: return the JLS default (0 / false / etc.) so canonical-
-          //     ctor reflection doesn't NPE unboxing a null Object.
-          //   - everything else: NULLING_ISO (null reference, unchanged behavior).
-          final var fieldType = rawClassOf(tgtRefl.genericType(target, name));
-          byTargetName.putIfAbsent(
-            name,
-            new FieldStep(null, name, placeholderIsoFor(fieldType, telescopeWritesTgt.contains(name)))
+      final var srcNames = srcRefl.names(source);
+      final var srcNameSet = new HashSet<>(List.of(srcNames));
+      for (final var name : tgtRefl.names(target)) {
+        if (claimedTgt.contains(name)) continue;
+        // Telescope-row permissive mode: when ANY telescope row is registered for this pair, target
+        // fields with no same-name source get a NULLING_ISO placeholder. The post-fixup overlays it
+        // if a TelescopeToTelescope / FromTelescopeTo writes through that field; otherwise the
+        // field
+        // stays null. Telescope rows can't recover their top-level target field name from a
+        // Telescope<B, X> at runtime (generics erased), so we permit the gap instead of failing on
+        // every nested write. Without any telescope row, the strict same-name check still fires.
+        if (!srcNameSet.contains(name)) {
+          // Lenient on nested auto-recursed pairs: when the current call is recursed from
+          // computeAutoIso (inProgress has more than just the current pair on the stack), the
+          // user never explicitly configured this pair — it was visited because a parent field's
+          // genericType is reflectable. An unmatched target field there should stay at its JLS
+          // default rather than abort the top-level construction. Strictness is preserved at the
+          // TOP-LEVEL pair (`inProgress.size() == 1`) where the user explicitly asked for the
+          // mapper; missing fields there ARE a configuration mistake worth surfacing.
+          final var isNested = inProgress.size() > 1;
+          if (!telescopeFixups.isEmpty() || isNested) {
+            // Telescope-row placeholder for a target field with no same-name source. Three cases,
+            // type-driven:
+            //   - field type is a record AND a telescope row claims it as a first hop: allocate a
+            //     recursive default-tree instance so the post-fixup overlay
+            //     (`tgtTelescope.set(t, value)`) can descend into a non-null intermediate. Records
+            //     only for v1.0; beans need a no-arg ctor or builder which isn't always present —
+            //     deferred to v1.1.
+            //   - field type is a primitive: return the JLS default (0 / false / etc.) so
+            // canonical-
+            //     ctor reflection doesn't NPE unboxing a null Object.
+            //   - everything else: NULLING_ISO (null reference, unchanged behavior).
+            final var fieldType = rawClassOf(tgtRefl.genericType(target, name));
+            byTargetName.putIfAbsent(
+              name,
+              new FieldStep(null, name, placeholderIsoFor(fieldType, telescopeWritesTgt.contains(name)))
+            );
+            continue;
+          }
+          throw new IllegalStateException(
+            "Deep map " +
+              source.getSimpleName() +
+              " → " +
+              target.getSimpleName() +
+              ": target " +
+              slot(tgtRefl) +
+              " '" +
+              name +
+              "' has no same-name source " +
+              slot(srcRefl) +
+              ". Add a rename row to(sourceAccessor, targetAccessor) that maps to '" +
+              name +
+              "'."
           );
+        }
+        final var step = new FieldStep(
+          name,
+          name,
+          autoIso(
+            srcRefl.genericType(source, name),
+            tgtRefl.genericType(target, name),
+            name,
+            overrides,
+            beanRefl,
+            cache,
+            nullStrategy,
+            cyclicPairs,
+            inProgress
+          )
+        );
+        byTargetName.put(name, step);
+        bySourceName.put(name, step);
+        claimedSrc.add(name);
+      }
+
+      for (final var name : srcNames) {
+        if (claimedSrc.contains(name)) continue;
+        // Telescope-read source without a same-name target consumer: register a NULLING_ISO
+        // backward-only placeholder so the source rebuilder produces null for this field; the
+        // backward post-fixup will fill the real value from the target telescope.
+        if (telescopeReadsSrc.contains(name)) {
+          bySourceName.putIfAbsent(name, new FieldStep(name, null, NULLING_ISO));
+          continue;
+        }
+        // Same permissive mode as the target side: when telescope rows are present OR this is a
+        // nested auto-recursed pair, source fields with no consumer fall back to a NULLING
+        // placeholder rather than failing.
+        if (!telescopeFixups.isEmpty() || inProgress.size() > 1) {
+          bySourceName.putIfAbsent(name, new FieldStep(name, null, NULLING_ISO));
           continue;
         }
         throw new IllegalStateException(
@@ -491,76 +562,27 @@ public final class DeepMap {
             source.getSimpleName() +
             " → " +
             target.getSimpleName() +
-            ": target " +
-            slot(tgtRefl) +
+            ": source " +
+            slot(srcRefl) +
             " '" +
             name +
-            "' has no same-name source " +
-            slot(srcRefl) +
-            ". Add a rename row to(sourceAccessor, targetAccessor) that maps to '" +
+            "' has no same-name target " +
+            slot(tgtRefl) +
+            ". Add a rename row to(sourceAccessor, targetAccessor) that consumes '" +
             name +
             "'."
         );
       }
-      final var step = new FieldStep(
-        name,
-        name,
-        autoIso(
-          srcRefl.genericType(source, name),
-          tgtRefl.genericType(target, name),
-          name,
-          overrides,
-          beanRefl,
-          cache,
-          nullStrategy,
-          cyclicPairs,
-          inProgress
-        )
-      );
-      byTargetName.put(name, step);
-      bySourceName.put(name, step);
-      claimedSrc.add(name);
-    }
 
-    for (final var name : srcNames) {
-      if (claimedSrc.contains(name)) continue;
-      // Telescope-read source without a same-name target consumer: register a NULLING_ISO
-      // backward-only placeholder so the source rebuilder produces null for this field; the
-      // backward post-fixup will fill the real value from the target telescope.
-      if (telescopeReadsSrc.contains(name)) {
-        bySourceName.putIfAbsent(name, new FieldStep(name, null, NULLING_ISO));
-        continue;
-      }
-      // Same permissive mode as the target side: when telescope rows are present, source fields
-      // with no consumer fall back to a NULLING placeholder rather than failing.
-      if (!telescopeFixups.isEmpty()) {
-        bySourceName.putIfAbsent(name, new FieldStep(name, null, NULLING_ISO));
-        continue;
-      }
-      throw new IllegalStateException(
-        "Deep map " +
-          source.getSimpleName() +
-          " → " +
-          target.getSimpleName() +
-          ": source " +
-          slot(srcRefl) +
-          " '" +
-          name +
-          "' has no same-name target " +
-          slot(tgtRefl) +
-          ". Add a rename row to(sourceAccessor, targetAccessor) that consumes '" +
-          name +
-          "'."
+      final Iso<S, T> baseIso = assembleIso(source, target, srcRefl, tgtRefl, byTargetName, bySourceName);
+      cache.put(
+        key,
+        telescopeFixups.isEmpty() ? baseIso : wrapWithTelescopeFixups(baseIso, telescopeFixups, srcRefl, source)
       );
+      if (topStepsOut != null) topStepsOut.putAll(byTargetName);
+    } finally {
+      inProgress.pop();
     }
-
-    final Iso<S, T> baseIso = assembleIso(source, target, srcRefl, tgtRefl, byTargetName, bySourceName);
-    cache.put(
-      key,
-      telescopeFixups.isEmpty() ? baseIso : wrapWithTelescopeFixups(baseIso, telescopeFixups, srcRefl, source)
-    );
-    if (topStepsOut != null) topStepsOut.putAll(byTargetName);
-    inProgress.pop();
   }
 
   /**
@@ -810,6 +832,49 @@ public final class DeepMap {
     // (a) Same generic type → identity Iso.
     if (srcType.equals(tgtType)) return Iso.identity();
 
+    // (a.1) Primitive ↔ wrapper pair → autobox / unbox via JLS-default-safe Iso. Forward
+    // unboxes (null-safe — substitutes the primitive default to avoid NPE on the wrapper-to-
+    // primitive setter); backward boxes via the wrapper's static valueOf. Matches MapStruct's
+    // behaviour for these pairs (it silently autoboxes and uses 0/false/etc. for null).
+    if (
+      srcType instanceof Class<?> srcClsAB &&
+      tgtType instanceof Class<?> tgtClsAB &&
+      isPrimitiveWrapperPair(srcClsAB, tgtClsAB)
+    ) {
+      return primitiveWrapperIso(srcClsAB, tgtClsAB);
+    }
+
+    // (a.2) Collection / Map subtype pair. Common in legacy bean codebases: `class
+    //       ImageUrls extends ArrayList<ImageUrl>` and `class ImageUrlsBO extends
+    //       ArrayList<ImageUrl>` on opposite sides. Neither is identity (different concrete
+    //       classes), neither is a parameterised raw `List` / `Map` (so ContainerShape skips
+    //       them), and trying to bean-decompose would hit
+    //       `MethodHandles.privateLookupIn(ArrayList.class)` rejection. Copy elements via the
+    //       target's no-arg constructor + `addAll` / `putAll`.
+    //
+    //       Collection side is gated on same kind (List↔List, Set↔Set, Queue↔Queue). Copying a
+    //       `LinkedList` into a `HashSet` would silently deduplicate; an `ArrayList` into a
+    //       `PriorityQueue` would silently reorder by natural ordering. Users who genuinely want
+    //       a kind change must declare an explicit `Mapping.via(...)` row.
+    //
+    //       Map side uses a SortedMap-vs-non-Sorted axis (mirrors the SortedSet split): a
+    //       `HashMap ↔ TreeMap` pair over non-Comparable keys would CCE at putAll. Within each
+    //       side, iteration-order, comparator, and thread-safety guarantees may still shift
+    //       when the concrete kinds differ (e.g. `LinkedHashMap → HashMap` reorders;
+    //       `ConcurrentHashMap → HashMap` drops the concurrency contract). The Iso copies
+    //       entries verbatim — users with semantic dependencies on the source's concrete type
+    //       should declare an explicit row.
+    if (srcType instanceof Class<?> srcCC && tgtType instanceof Class<?> tgtCC) {
+      if (sameKindCollection(srcCC, tgtCC)) {
+        final var iso = collectionCopyIso(srcCC, tgtCC);
+        if (iso != null) return iso;
+      }
+      if (sameKindMap(srcCC, tgtCC)) {
+        final var iso = mapCopyIso(srcCC, tgtCC);
+        if (iso != null) return iso;
+      }
+    }
+
     // (b) Both reflectable (record or bean) → recurse, return cache-reading Iso so cycles work.
     if (srcType instanceof Class<?> srcCls && tgtType instanceof Class<?> tgtCls) {
       if (isReflectable(srcCls) && isReflectable(tgtCls)) {
@@ -1055,6 +1120,135 @@ public final class DeepMap {
    */
   private static String slot(final Reflective refl) {
     return refl == Reflective.RECORDS ? "field" : "property";
+  }
+
+  /**
+   * Collection ↔ Collection element-copy Iso. The forward instantiates the target collection via
+   * {@link Beans#intermediateAllocator(Class)} (cached LMF-bound Supplier) and {@code addAll}'s the
+   * source; backward is symmetric. Returns {@code null} when either side has no usable allocator,
+   * letting the caller fall through to the next branch (typically the shape-mismatch IAE).
+   *
+   * <p>No element-type recursion: this branch fires on raw, non-parameterised subtypes (e.g. {@code
+   * class ImageUrls extends ArrayList<ImageUrl>}), where the raw class itself carries no runtime
+   * generic info. Users whose element types differ across sides should declare an explicit row.
+   */
+  @SuppressWarnings({ "unchecked", "rawtypes" })
+  private static Iso<?, ?> collectionCopyIso(final Class<?> srcCls, final Class<?> tgtCls) {
+    final var srcAlloc = Beans.intermediateAllocator(srcCls);
+    final var tgtAlloc = Beans.intermediateAllocator(tgtCls);
+    if (srcAlloc.get() == null || tgtAlloc.get() == null) return null;
+    return Iso.of(
+      src -> {
+        if (src == null) return null;
+        final var fresh = (Collection) tgtAlloc.get();
+        fresh.addAll((Collection<?>) src);
+        return fresh;
+      },
+      tgt -> {
+        if (tgt == null) return null;
+        final var fresh = (Collection) srcAlloc.get();
+        fresh.addAll((Collection<?>) tgt);
+        return fresh;
+      }
+    );
+  }
+
+  /** Map ↔ Map element-copy Iso. Mirror of {@link #collectionCopyIso} via {@code putAll}. */
+  @SuppressWarnings({ "unchecked", "rawtypes" })
+  private static Iso<?, ?> mapCopyIso(final Class<?> srcCls, final Class<?> tgtCls) {
+    final var srcAlloc = Beans.intermediateAllocator(srcCls);
+    final var tgtAlloc = Beans.intermediateAllocator(tgtCls);
+    if (srcAlloc.get() == null || tgtAlloc.get() == null) return null;
+    return Iso.of(
+      src -> {
+        if (src == null) return null;
+        final var fresh = (Map) tgtAlloc.get();
+        fresh.putAll((Map<?, ?>) src);
+        return fresh;
+      },
+      tgt -> {
+        if (tgt == null) return null;
+        final var fresh = (Map) srcAlloc.get();
+        fresh.putAll((Map<?, ?>) tgt);
+        return fresh;
+      }
+    );
+  }
+
+  private static boolean sameKindCollection(final Class<?> a, final Class<?> b) {
+    if (!Collection.class.isAssignableFrom(a) || !Collection.class.isAssignableFrom(b)) return false;
+    // Require both sides to AGREE on every kind discriminator so the Iso doesn't silently
+    // re-interpret container semantics OR throw ClassCastException at addAll time. Without
+    // these symmetric checks:
+    //   - `LinkedList ↔ ArrayDeque` would match the Queue branch (LinkedList is both List and
+    //     Queue) and turn random-access list semantics into FIFO queue semantics.
+    //   - `PriorityQueue ↔ ArrayDeque` would match the Queue branch and turn heap-ordered
+    //     dequeue into FIFO (or vice-versa).
+    //   - `HashSet ↔ TreeSet` over a non-Comparable element type would CCE at forward() time
+    //     because the fresh TreeSet's addAll falls through to compareTo on a Comparable-less
+    //     element. The SortedSet discriminator rejects that pair before the Iso runs.
+    // If either side is a List the other must be one too; same for Set's SortedSet axis; and
+    // within the Queue residual, both must agree on whether they're also Deque.
+    final var aList = List.class.isAssignableFrom(a);
+    final var bList = List.class.isAssignableFrom(b);
+    if (aList != bList) return false;
+    if (aList) return true;
+    final var aSet = Set.class.isAssignableFrom(a);
+    final var bSet = Set.class.isAssignableFrom(b);
+    if (aSet != bSet) return false;
+    if (aSet) return SortedSet.class.isAssignableFrom(a) == SortedSet.class.isAssignableFrom(b);
+    if (!Queue.class.isAssignableFrom(a) || !Queue.class.isAssignableFrom(b)) return false;
+    return Deque.class.isAssignableFrom(a) == Deque.class.isAssignableFrom(b);
+  }
+
+  private static boolean sameKindMap(final Class<?> a, final Class<?> b) {
+    if (!Map.class.isAssignableFrom(a) || !Map.class.isAssignableFrom(b)) return false;
+    // Same SortedMap discriminator as the Set side: a `HashMap ↔ TreeMap` pair over non-
+    // Comparable keys would CCE at putAll time when the fresh TreeMap calls compareTo on the
+    // first inserted key. Reject the Sorted/non-Sorted crossing before the Iso runs. Within
+    // each side (HashMap ↔ LinkedHashMap ↔ ConcurrentHashMap on non-Sorted; TreeMap ↔
+    // ConcurrentSkipListMap on Sorted), differences are iteration-order or thread-safety
+    // attribute drops — silent, but documented at the call site.
+    //
+    // Edge cases the gate intentionally accepts (silent but recoverable via an explicit
+    // `Mapping.via(...)` row): `IdentityHashMap ↔ HashMap` (the IdentityHashMap side de-dups
+    // equal-but-distinct-reference keys); `WeakHashMap ↔ HashMap` (WeakHashMap GCs keys
+    // without strong references).
+    return SortedMap.class.isAssignableFrom(a) == SortedMap.class.isAssignableFrom(b);
+  }
+
+  /**
+   * True when {@code src} and {@code tgt} are a primitive ↔ wrapper pair (in either direction)
+   * referring to the same underlying scalar — e.g. {@code int} / {@code Integer}, {@code boolean} /
+   * {@code Boolean}. Same-scalar same-side pairs (already covered by the identity branch) are not
+   * matched here.
+   */
+  private static boolean isPrimitiveWrapperPair(final Class<?> src, final Class<?> tgt) {
+    return (src.isPrimitive() && wrap(src) == tgt) || (tgt.isPrimitive() && wrap(tgt) == src);
+  }
+
+  /** Wrap a primitive to its boxed class; non-primitives are returned unchanged. */
+  private static Class<?> wrap(final Class<?> cls) {
+    if (cls == int.class) return Integer.class;
+    if (cls == long.class) return Long.class;
+    if (cls == double.class) return Double.class;
+    if (cls == float.class) return Float.class;
+    if (cls == boolean.class) return Boolean.class;
+    if (cls == short.class) return Short.class;
+    if (cls == byte.class) return Byte.class;
+    if (cls == char.class) return Character.class;
+    return cls;
+  }
+
+  /**
+   * Build the per-field Iso for a primitive ↔ wrapper pair. The Iso's {@code to} (forward)
+   * substitutes the primitive default when the source value is null, so a wrapper-to-primitive
+   * write never NPEs at the setter. {@code from} (backward) is symmetric.
+   */
+  private static Iso<Object, Object> primitiveWrapperIso(final Class<?> src, final Class<?> tgt) {
+    final var fwdDefault = tgt.isPrimitive() ? primitiveDefault(tgt) : null;
+    final var bwdDefault = src.isPrimitive() ? primitiveDefault(src) : null;
+    return Iso.of(v -> v == null ? fwdDefault : v, v -> v == null ? bwdDefault : v);
   }
 
   /** A record or any non-scalar class — anything Reflective can drive. */

--- a/core/src/main/java/io/github/eschizoid/telescope/Telescope.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/Telescope.java
@@ -987,7 +987,14 @@ public sealed class Telescope<
     if (optic instanceof final Affine<S, A> affine) {
       return affine.getOption(source).orElseThrow(Telescope::noValue);
     }
-    return optic.getAll(source).findFirst().orElseThrow(Telescope::noValue);
+    // Stream.findFirst() routes through Optional.of(element), which NPEs on null. A Traversal
+    // can legitimately surface null elements when an intermediate hop of a multi-hop bean path
+    // is null — Beans.readProperty short-circuits to null on a null receiver, but the traversal
+    // still produces a one-element [null] stream. Use a stream iterator to grab the head in
+    // O(1) without materialising the rest, and preserve nulls explicitly.
+    final var it = optic.getAll(source).iterator();
+    if (!it.hasNext()) throw noValue();
+    return it.next();
   }
 
   private static NoSuchElementException noValue() {
@@ -1005,7 +1012,10 @@ public sealed class Telescope<
     if (optic instanceof final Affine<S, A> affine) {
       return affine.getOption(source);
     }
-    return optic.getAll(source).findFirst();
+    // Mirror of #read: Stream.findFirst() NPEs on null elements. Use the iterator to keep
+    // the lookup O(1) and preserve the null-empty distinction via Optional.ofNullable.
+    final var it = optic.getAll(source).iterator();
+    return it.hasNext() ? Optional.ofNullable(it.next()) : Optional.empty();
   }
 
   /**

--- a/core/src/test/java/io/github/eschizoid/telescope/DeepMappingTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/DeepMappingTest.java
@@ -8,7 +8,9 @@ import static io.github.eschizoid.telescope.mapping.WriteHint.WriteStrategy.CONS
 import static io.github.eschizoid.telescope.mapping.WriteHint.WriteStrategy.FIELDS;
 import static io.github.eschizoid.telescope.mapping.WriteHint.writeBean;
 import static io.github.eschizoid.telescope.mapping.WriteHint.writeBeans;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -1011,15 +1013,20 @@ class DeepMappingTest {
     }
 
     @Test
-    @DisplayName("one-arg drop on a nested-source class binds to top target — doesn't reach the nested pair")
+    @DisplayName(
+      "one-arg drop on a nested-source class binds to top target — nested pair leniently drops the unmapped field"
+    )
     void oneArgDropOnNestedSourceDoesNotReachNestedPair() {
-      // Without the explicit nested target, the top-level mapper still rejects the unmapped source
-      // because (CustomerRich, CustomerPartner) is the recursion's pair, not (CustomerRich,
-      // top-target).
-      final var ex = assertThrows(IllegalStateException.class, () ->
+      // Nested auto-recursed pairs are LENIENT — unmatched source fields are silently dropped,
+      // unmatched target fields stay at JLS defaults. The `drop(CustomerRich::tags)` row still
+      // binds to the top-level (ShipmentRich, ShipmentPartner) pair (not to the nested
+      // CustomerRich → CustomerPartner one), but the nested pair no longer throws on the
+      // unmatched `tags` source field — it just drops it silently. The top-level mapper
+      // constructs successfully.
+      final var mapper = assertDoesNotThrow(() ->
         Telescope.mapper(ShipmentRich.class, ShipmentPartner.class, drop(CustomerRich::tags))
       );
-      assertTrue(ex.getMessage().contains("tags"), ex.getMessage());
+      assertNotNull(mapper);
     }
   }
 }

--- a/core/src/test/java/io/github/eschizoid/telescope/MapperIntoTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/MapperIntoTest.java
@@ -1,5 +1,6 @@
 package io.github.eschizoid.telescope;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -228,7 +229,7 @@ class MapperIntoTest {
   }
 
   @Nested
-  @DisplayName("Missing setter — clear error names the property")
+  @DisplayName("Missing setter — silently skipped to match SettersWriter / MapStruct @MappingTarget")
   class MissingSetter {
 
     record DtoOnly(String id, String missingOnEntity) {}
@@ -254,18 +255,16 @@ class MapperIntoTest {
     }
 
     @Test
-    @DisplayName("property without a setter throws IAE at mapper-build or into() time")
-    void missingSetterThrows() {
-      // Build-or-apply might surface the missing setter at either time depending on the autoWriter
-      // discovery path. Either way the failure is unambiguous to the user.
-      final var ex = assertThrows(RuntimeException.class, () -> {
-        final var mapper = Telescope.mapper(DtoOnly.class, EntityOnlyId.class);
-        mapper.into(new EntityOnlyId(), new DtoOnly("a", "b"));
-      });
-      // The error message comes from SettersWriter or writeBeanProperty — either path names the
-      // missing setter clearly. We just verify the exception is thrown with a message; the exact
-      // wording belongs to the underlying writer's error contract, not the into() contract.
-      assertNotNull(ex.getMessage(), "exception message present");
+    @DisplayName("property without a setter is silently skipped — matches SettersWriter")
+    void missingSetterIsSilentlySkipped() {
+      // Mapper.into and Mapper.forward both reach the target through Beans setter dispatch;
+      // both paths must silently skip an absent setter to keep the contract symmetric (matches
+      // MapStruct @MappingTarget behaviour). The setId() target is still written; the
+      // missingOnEntity target stays at its JLS default.
+      final var mapper = Telescope.mapper(DtoOnly.class, EntityOnlyId.class);
+      final var target = new EntityOnlyId();
+      assertDoesNotThrow(() -> mapper.into(target, new DtoOnly("a", "b")));
+      assertEquals("a", target.getId());
     }
   }
 

--- a/core/src/test/java/io/github/eschizoid/telescope/MigrationRegressionTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/MigrationRegressionTest.java
@@ -3,8 +3,16 @@ package io.github.eschizoid.telescope;
 import static io.github.eschizoid.telescope.mapping.WriteHint.writeBeans;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import io.github.eschizoid.telescope.mapping.Mapping;
 import io.github.eschizoid.telescope.mapping.WriteHint;
+import java.io.Serial;
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.TreeMap;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -138,13 +146,973 @@ class MigrationRegressionTest {
         Telescope.mapper(
           OrderWithCustomer.class,
           FlatOrderDto.class,
-          io.github.eschizoid.telescope.mapping.Mapping.to(
+          Mapping.to(
             Telescope.ofBean(OrderWithCustomer.class).field(OrderWithCustomer::getCustomer).field(Customer::getEmail),
             FlatOrderDto::getCustomerEmail
           ),
           writeBeans(WriteHint.WriteStrategy.SETTERS)
         )
       );
+    }
+  }
+
+  @Nested
+  @DisplayName("Bug 4 — NPE on null intermediate objects in nested telescope paths")
+  class Bug4NullIntermediateNpe {
+
+    public static class Order {
+
+      private Customer customer; // may be null
+
+      public Customer getCustomer() {
+        return customer;
+      }
+
+      public void setCustomer(final Customer customer) {
+        this.customer = customer;
+      }
+    }
+
+    public static class Customer {
+
+      private String email;
+
+      public String getEmail() {
+        return email;
+      }
+
+      public void setEmail(final String email) {
+        this.email = email;
+      }
+    }
+
+    public static class OrderDto {
+
+      private String customerEmail;
+
+      public String getCustomerEmail() {
+        return customerEmail;
+      }
+
+      public void setCustomerEmail(final String customerEmail) {
+        this.customerEmail = customerEmail;
+      }
+    }
+
+    @Test
+    @DisplayName("forward(order) on a source whose nested intermediate is null short-circuits to null instead of NPE")
+    void forwardWithNullIntermediateShortCircuitsToNull() {
+      // The adopter's exact scenario: a 2-hop nested source path order → customer → email, with
+      // order.customer == null at runtime. Before the fix, the second hop calls
+      // Beans.readProperty(null, "email") which delegates to persistentClassOf(null) → null,
+      // then ClassValue.get(null) NPEs. After the fix, readProperty short-circuits to null and
+      // the optic pipeline propagates the null through the rest of the chain.
+      final var mapper = Telescope.mapper(
+        Order.class,
+        OrderDto.class,
+        Mapping.to(
+          Telescope.ofBean(Order.class).field(Order::getCustomer).field(Customer::getEmail),
+          OrderDto::getCustomerEmail
+        ),
+        writeBeans(WriteHint.WriteStrategy.SETTERS)
+      );
+      final var src = new Order(); // customer left null
+      final var tgt = assertDoesNotThrow(() -> mapper.forward(src));
+      assertEquals(null, tgt.getCustomerEmail());
+    }
+
+    @Test
+    @DisplayName("forward(order) on a populated nested intermediate still reads through the chain")
+    void forwardWithPopulatedIntermediateReadsThrough() {
+      final var mapper = Telescope.mapper(
+        Order.class,
+        OrderDto.class,
+        Mapping.to(
+          Telescope.ofBean(Order.class).field(Order::getCustomer).field(Customer::getEmail),
+          OrderDto::getCustomerEmail
+        ),
+        writeBeans(WriteHint.WriteStrategy.SETTERS)
+      );
+      final var customer = new Customer();
+      customer.setEmail("alice@example.com");
+      final var src = new Order();
+      src.setCustomer(customer);
+      final var tgt = mapper.forward(src);
+      assertEquals("alice@example.com", tgt.getCustomerEmail());
+    }
+  }
+
+  @Nested
+  @DisplayName("Bug 6 — DeepMap strict bijection on nested auto-recursed types")
+  class Bug6NestedStrictBijection {
+
+    public static class ScoreResponse {
+
+      private int firstNameScore;
+      private int lastNameScore;
+
+      public int getFirstNameScore() {
+        return firstNameScore;
+      }
+
+      public void setFirstNameScore(final int v) {
+        this.firstNameScore = v;
+      }
+
+      public int getLastNameScore() {
+        return lastNameScore;
+      }
+
+      public void setLastNameScore(final int v) {
+        this.lastNameScore = v;
+      }
+    }
+
+    public static class ScoreResponseDto {
+
+      private int firstNameScore;
+      private int lastNameScore;
+      private String matchingStatus; // extra field, not on source
+
+      public int getFirstNameScore() {
+        return firstNameScore;
+      }
+
+      public void setFirstNameScore(final int v) {
+        this.firstNameScore = v;
+      }
+
+      public int getLastNameScore() {
+        return lastNameScore;
+      }
+
+      public void setLastNameScore(final int v) {
+        this.lastNameScore = v;
+      }
+
+      public String getMatchingStatus() {
+        return matchingStatus;
+      }
+
+      public void setMatchingStatus(final String v) {
+        this.matchingStatus = v;
+      }
+    }
+
+    public static class Parent {
+
+      private ScoreResponse scores;
+
+      public ScoreResponse getScores() {
+        return scores;
+      }
+
+      public void setScores(final ScoreResponse scores) {
+        this.scores = scores;
+      }
+    }
+
+    public static class ParentDto {
+
+      private ScoreResponseDto scores;
+
+      public ScoreResponseDto getScores() {
+        return scores;
+      }
+
+      public void setScores(final ScoreResponseDto scores) {
+        this.scores = scores;
+      }
+    }
+
+    @Test
+    @DisplayName("nested auto-recursed pair with asymmetric fields is lenient — top-level construction succeeds")
+    void nestedAsymmetricPairConstructsLeniently() {
+      // The adopter's exact scenario: top-level pair (Parent, ParentDto) auto-recurses into
+      // (ScoreResponse, ScoreResponseDto). The nested target has `matchingStatus` with no
+      // same-name source. Strict bijection on every recursed pair throws at construction time.
+      // After fix, nested pairs are lenient — unmatched target fields stay at JLS defaults,
+      // unmatched source fields are silently dropped. Only the TOP-LEVEL pair (here: Parent →
+      // ParentDto) enforces strictness.
+      final var mapper = Telescope.mapper(Parent.class, ParentDto.class, writeBeans(WriteHint.WriteStrategy.SETTERS));
+      final var inner = new ScoreResponse();
+      inner.setFirstNameScore(80);
+      inner.setLastNameScore(90);
+      final var src = new Parent();
+      src.setScores(inner);
+      final var tgt = assertDoesNotThrow(() -> mapper.forward(src));
+      assertEquals(80, tgt.getScores().getFirstNameScore());
+      assertEquals(90, tgt.getScores().getLastNameScore());
+      // Nested target's unmatched field stays at the JLS default.
+      assertEquals(null, tgt.getScores().getMatchingStatus());
+    }
+
+    @Test
+    @DisplayName("top-level pair with asymmetric fields still throws — strictness preserved at the top")
+    void topLevelAsymmetricPairStillThrows() {
+      // Strictness at the top-level call (the user's explicit request) is preserved — the user
+      // asked for this pair and a missing field is a real configuration mistake. Only nested
+      // recursion auto-relaxes.
+      assertThrows(IllegalStateException.class, () ->
+        Telescope.mapper(ScoreResponse.class, ScoreResponseDto.class, writeBeans(WriteHint.WriteStrategy.SETTERS))
+      );
+    }
+  }
+
+  @Nested
+  @DisplayName("Bug 3 — primitive ↔ wrapper autoboxing")
+  class Bug3PrimitiveWrapperAutoboxing {
+
+    public static class Source {
+
+      private boolean active; // primitive
+      private Integer count; // boxed
+      private String name;
+
+      public boolean isActive() {
+        return active;
+      }
+
+      public void setActive(final boolean v) {
+        this.active = v;
+      }
+
+      public Integer getCount() {
+        return count;
+      }
+
+      public void setCount(final Integer v) {
+        this.count = v;
+      }
+
+      public String getName() {
+        return name;
+      }
+
+      public void setName(final String name) {
+        this.name = name;
+      }
+    }
+
+    public static class Target {
+
+      private Boolean active; // boxed (source is primitive)
+      private int count; // primitive (source is boxed)
+      private String name;
+
+      public Boolean getActive() {
+        return active;
+      }
+
+      public void setActive(final Boolean v) {
+        this.active = v;
+      }
+
+      public int getCount() {
+        return count;
+      }
+
+      public void setCount(final int v) {
+        this.count = v;
+      }
+
+      public String getName() {
+        return name;
+      }
+
+      public void setName(final String name) {
+        this.name = name;
+      }
+    }
+
+    @Test
+    @DisplayName("auto-mapping handles primitive↔wrapper pairs (boolean↔Boolean, Integer↔int) without throwing")
+    void primitiveWrapperPairsAreAutoBoxed() {
+      // The adopter scenario: source has boolean primitive `active` and boxed `Integer count`;
+      // target inverts them. DeepMap used to reject the pair at populateIso with
+      // "incompatible source/target shapes — boolean vs java.lang.Boolean". MapStruct silently
+      // autoboxes / unboxes; telescope should match.
+      final var mapper = Telescope.mapper(Source.class, Target.class, writeBeans(WriteHint.WriteStrategy.SETTERS));
+      final var src = new Source();
+      src.setActive(true);
+      src.setCount(42);
+      src.setName("alice");
+      final var tgt = assertDoesNotThrow(() -> mapper.forward(src));
+      assertEquals(Boolean.TRUE, tgt.getActive());
+      assertEquals(42, tgt.getCount());
+      assertEquals("alice", tgt.getName());
+    }
+
+    @Test
+    @DisplayName("null boxed source mapping to primitive target uses JLS default (no unboxing NPE)")
+    void nullBoxedToPrimitiveUsesJlsDefault() {
+      // Source.count is Integer null; target.count is int. The auto-iso must null-guard at the
+      // boxing leaf, otherwise we get NullPointerException on intValue().
+      final var mapper = Telescope.mapper(Source.class, Target.class, writeBeans(WriteHint.WriteStrategy.SETTERS));
+      final var src = new Source();
+      src.setActive(false);
+      // count left null
+      final var tgt = assertDoesNotThrow(() -> mapper.forward(src));
+      assertEquals(0, tgt.getCount()); // JLS default for int
+    }
+
+    // Broader primitive coverage (long, double, char, short, byte, float) so a future refactor
+    // of the wrap()/primitiveDefault tables doesn't silently drop a primitive variant.
+
+    public static class WideSrc {
+
+      private long l;
+      private Double d;
+      private char c;
+      private Short sh;
+      private byte by;
+      private Float f;
+
+      public long getL() {
+        return l;
+      }
+
+      public void setL(final long l) {
+        this.l = l;
+      }
+
+      public Double getD() {
+        return d;
+      }
+
+      public void setD(final Double d) {
+        this.d = d;
+      }
+
+      public char getC() {
+        return c;
+      }
+
+      public void setC(final char c) {
+        this.c = c;
+      }
+
+      public Short getSh() {
+        return sh;
+      }
+
+      public void setSh(final Short sh) {
+        this.sh = sh;
+      }
+
+      public byte getBy() {
+        return by;
+      }
+
+      public void setBy(final byte by) {
+        this.by = by;
+      }
+
+      public Float getF() {
+        return f;
+      }
+
+      public void setF(final Float f) {
+        this.f = f;
+      }
+    }
+
+    public static class WideTgt {
+
+      private Long l; // primitive → boxed
+      private double d; // boxed → primitive
+      private Character c; // primitive → boxed
+      private short sh; // boxed → primitive
+      private Byte by; // primitive → boxed
+      private float f; // boxed → primitive
+
+      public Long getL() {
+        return l;
+      }
+
+      public void setL(final Long l) {
+        this.l = l;
+      }
+
+      public double getD() {
+        return d;
+      }
+
+      public void setD(final double d) {
+        this.d = d;
+      }
+
+      public Character getC() {
+        return c;
+      }
+
+      public void setC(final Character c) {
+        this.c = c;
+      }
+
+      public short getSh() {
+        return sh;
+      }
+
+      public void setSh(final short sh) {
+        this.sh = sh;
+      }
+
+      public Byte getBy() {
+        return by;
+      }
+
+      public void setBy(final Byte by) {
+        this.by = by;
+      }
+
+      public float getF() {
+        return f;
+      }
+
+      public void setF(final float f) {
+        this.f = f;
+      }
+    }
+
+    @Test
+    @DisplayName("all 6 remaining primitive ↔ wrapper pairs (long, double, char, short, byte, float) autobox")
+    void allPrimitiveVariantsAutoBox() {
+      final var mapper = Telescope.mapper(WideSrc.class, WideTgt.class, writeBeans(WriteHint.WriteStrategy.SETTERS));
+      final var src = new WideSrc();
+      src.setL(99L);
+      src.setD(2.5);
+      src.setC('z');
+      src.setSh((short) 7);
+      src.setBy((byte) 3);
+      src.setF(1.5f);
+      final var tgt = assertDoesNotThrow(() -> mapper.forward(src));
+      assertEquals(Long.valueOf(99L), tgt.getL());
+      assertEquals(2.5, tgt.getD());
+      assertEquals(Character.valueOf('z'), tgt.getC());
+      assertEquals((short) 7, tgt.getSh());
+      assertEquals(Byte.valueOf((byte) 3), tgt.getBy());
+      assertEquals(1.5f, tgt.getF());
+    }
+
+    @Test
+    @DisplayName("null boxed source values to primitive targets use JLS defaults for every primitive variant")
+    void nullBoxedToPrimitiveDefaultsForEveryPrimitive() {
+      final var mapper = Telescope.mapper(WideSrc.class, WideTgt.class, writeBeans(WriteHint.WriteStrategy.SETTERS));
+      final var src = new WideSrc();
+      // src.d, src.sh, src.f left null
+      final var tgt = assertDoesNotThrow(() -> mapper.forward(src));
+      assertEquals(0.0, tgt.getD());
+      assertEquals((short) 0, tgt.getSh());
+      assertEquals(0.0f, tgt.getF());
+    }
+  }
+
+  @Nested
+  @DisplayName("Bug 7 — LMF fails on classes extending JDK collection types")
+  class Bug7JdkCollectionSubtypes {
+
+    public static class ImageUrl {
+
+      private String url;
+
+      public String getUrl() {
+        return url;
+      }
+
+      public void setUrl(final String url) {
+        this.url = url;
+      }
+    }
+
+    // Custom collection wrapper — common in legacy bean codebases. Extends ArrayList so it
+    // inherits a long tail of platform-module getters (isEmpty, getClass, etc.) that telescope
+    // used to try to LMF-bind, hitting java.base private-lookup rejection.
+    public static class ImageUrls extends ArrayList<ImageUrl> {
+
+      @Serial
+      private static final long serialVersionUID = 1L;
+    }
+
+    public static class DocumentData {
+
+      private ImageUrls imageUrls;
+
+      public ImageUrls getImageUrls() {
+        return imageUrls;
+      }
+
+      public void setImageUrls(final ImageUrls imageUrls) {
+        this.imageUrls = imageUrls;
+      }
+    }
+
+    public static class DocumentDataDto {
+
+      private ImageUrls imageUrls;
+
+      public ImageUrls getImageUrls() {
+        return imageUrls;
+      }
+
+      public void setImageUrls(final ImageUrls imageUrls) {
+        this.imageUrls = imageUrls;
+      }
+    }
+
+    @Test
+    @DisplayName(
+      "auto-recursion through a Collection subtype does NOT try to bean-decompose it (pass-through by reference)"
+    )
+    void collectionSubtypeIsPassThrough() {
+      // Adopter scenario: a bean graph contains a custom collection wrapper class extending
+      // ArrayList. Without the fix, DeepMap recurses into ImageUrls trying to bean-decompose
+      // it, discovers inherited `isEmpty()` etc. as "getters", then LMF-binds them — which
+      // fails with "Invalid caller: java.util.ArrayList" because java.base modules don't
+      // grant private lookup to application code. Fix: treat Collection/Map subtypes as
+      // scalars (pass-through by reference), and skip inherited platform-module methods in
+      // scanGetters as defence-in-depth.
+      final var mapper = Telescope.mapper(
+        DocumentData.class,
+        DocumentDataDto.class,
+        writeBeans(WriteHint.WriteStrategy.SETTERS)
+      );
+      final var urls = new ImageUrls();
+      final var u = new ImageUrl();
+      u.setUrl("https://example.com/a.png");
+      urls.add(u);
+      final var src = new DocumentData();
+      src.setImageUrls(urls);
+      final var tgt = assertDoesNotThrow(() -> mapper.forward(src));
+      // Pass-through by reference: same ImageUrls instance, same element. assertSame pins
+      // identity — assertEquals would pass on any List with the same contents.
+      assertSame(urls, tgt.getImageUrls());
+      assertEquals("https://example.com/a.png", tgt.getImageUrls().get(0).getUrl());
+    }
+
+    // Adversarial reproduction — the same-generic-type identity shortcut at the top of
+    // DeepMap.computeAutoIso hides this bug when the field is identical on both sides. Force
+    // different concrete types so computeAutoIso falls through to the same-kind Collection
+    // branch where collectionCopyIso decides whether to copy elements via addAll.
+    public static class ImageUrlsAlt extends ArrayList<ImageUrl> {
+
+      @Serial
+      private static final long serialVersionUID = 1L;
+    }
+
+    public static class DocumentDataAlt {
+
+      private ImageUrls imageUrls; // source type
+
+      public ImageUrls getImageUrls() {
+        return imageUrls;
+      }
+
+      public void setImageUrls(final ImageUrls imageUrls) {
+        this.imageUrls = imageUrls;
+      }
+    }
+
+    public static class DocumentDataDtoAlt {
+
+      private ImageUrlsAlt imageUrls; // target type — different subclass
+
+      public ImageUrlsAlt getImageUrls() {
+        return imageUrls;
+      }
+
+      public void setImageUrls(final ImageUrlsAlt imageUrls) {
+        this.imageUrls = imageUrls;
+      }
+    }
+
+    @Test
+    @DisplayName("cross-Collection-subtype field copies elements via target's no-arg ctor + addAll")
+    void differentCollectionSubtypesAreCopiedViaAddAll() {
+      // ImageUrls vs ImageUrlsAlt — both extend ArrayList<ImageUrl>. The same-type shortcut at
+      // autoIso doesn't fire (different concrete classes). The fix routes this through
+      // `collectionCopyIso`: instantiate the target type via its no-arg ctor and addAll(source).
+      // End-to-end the mapper produces an ImageUrlsAlt instance carrying the source's elements.
+      final var mapper = Telescope.mapper(
+        DocumentDataAlt.class,
+        DocumentDataDtoAlt.class,
+        writeBeans(WriteHint.WriteStrategy.SETTERS)
+      );
+      final var urls = new ImageUrls();
+      final var u = new ImageUrl();
+      u.setUrl("https://example.com/a.png");
+      urls.add(u);
+      final var src = new DocumentDataAlt();
+      src.setImageUrls(urls);
+      final var tgt = assertDoesNotThrow(() -> mapper.forward(src));
+      assertEquals(ImageUrlsAlt.class, tgt.getImageUrls().getClass());
+      assertEquals(1, tgt.getImageUrls().size());
+      assertEquals("https://example.com/a.png", tgt.getImageUrls().get(0).getUrl());
+    }
+
+    // Fixture pair for the positive same-kind-List acceptance test: both StringList and
+    // StringLinkedList implement List, so sameKindCollection accepts the pair and the element-
+    // copy Iso runs via the target's no-arg ctor + addAll.
+    public static class StringList extends ArrayList<String> {
+
+      @Serial
+      private static final long serialVersionUID = 1L;
+    }
+
+    public static class StringLinkedList extends LinkedList<String> {
+
+      @Serial
+      private static final long serialVersionUID = 1L;
+    }
+
+    public static class HolderList {
+
+      private StringList items;
+
+      public StringList getItems() {
+        return items;
+      }
+
+      public void setItems(final StringList items) {
+        this.items = items;
+      }
+    }
+
+    public static class HolderLinkedList {
+
+      private StringLinkedList items;
+
+      public StringLinkedList getItems() {
+        return items;
+      }
+
+      public void setItems(final StringLinkedList items) {
+        this.items = items;
+      }
+    }
+
+    @Test
+    @DisplayName("List subtype ↔ List subtype is copied via addAll (positive case for same-kind gate)")
+    void listSubtypeVsListSubtypeAccepted() {
+      // Both StringList and StringLinkedList implement List — the same-kind gate accepts them.
+      // Element order survives via List's contract.
+      final var mapper = Telescope.mapper(
+        HolderList.class,
+        HolderLinkedList.class,
+        writeBeans(WriteHint.WriteStrategy.SETTERS)
+      );
+      final var src = new HolderList();
+      src.setItems(new StringList());
+      src.getItems().add("a");
+      src.getItems().add("b");
+      final var tgt = assertDoesNotThrow(() -> mapper.forward(src));
+      assertEquals(StringLinkedList.class, tgt.getItems().getClass());
+      assertEquals(List.of("a", "b"), tgt.getItems());
+    }
+
+    // Fixture pair for the SortedMap positive case — both sides extend TreeMap so the new
+    // sameKindMap discriminator's Sorted-vs-Sorted axis fires the copy Iso.
+    public static class StringTreeMap extends TreeMap<String, String> {
+
+      @Serial
+      private static final long serialVersionUID = 1L;
+    }
+
+    public static class StringTreeMapAlt extends TreeMap<String, String> {
+
+      @Serial
+      private static final long serialVersionUID = 1L;
+    }
+
+    public static class HolderTreeMap {
+
+      private StringTreeMap items;
+
+      public StringTreeMap getItems() {
+        return items;
+      }
+
+      public void setItems(final StringTreeMap items) {
+        this.items = items;
+      }
+    }
+
+    public static class HolderTreeMapAlt {
+
+      private StringTreeMapAlt items;
+
+      public StringTreeMapAlt getItems() {
+        return items;
+      }
+
+      public void setItems(final StringTreeMapAlt items) {
+        this.items = items;
+      }
+    }
+
+    @Test
+    @DisplayName("SortedMap subtype ↔ SortedMap subtype is copied via putAll (positive case for sameKindMap gate)")
+    void sortedMapSubtypeVsSortedMapSubtypeAccepted() {
+      // Both extend TreeMap → both are SortedMap → the gate accepts. Forward copies entries
+      // verbatim into a fresh instance of the target's concrete class.
+      final var mapper = Telescope.mapper(
+        HolderTreeMap.class,
+        HolderTreeMapAlt.class,
+        writeBeans(WriteHint.WriteStrategy.SETTERS)
+      );
+      final var src = new HolderTreeMap();
+      src.setItems(new StringTreeMap());
+      src.getItems().put("a", "alpha");
+      src.getItems().put("b", "beta");
+      final var tgt = assertDoesNotThrow(() -> mapper.forward(src));
+      assertEquals(StringTreeMapAlt.class, tgt.getItems().getClass());
+      assertEquals("alpha", tgt.getItems().get("a"));
+      assertEquals("beta", tgt.getItems().get("b"));
+    }
+  }
+
+  @Nested
+  @DisplayName("Bug 8 — SettersWriter NPE on null primitive value")
+  class Bug8PrimitiveSetterNullNpe {
+
+    public static class Source {
+
+      private String name;
+
+      // No `count` property — after Bug 6 lenient nested mode, valueByName returns null for the
+      // target's `count` field.
+
+      public String getName() {
+        return name;
+      }
+
+      public void setName(final String name) {
+        this.name = name;
+      }
+    }
+
+    public static class Target {
+
+      private String name;
+      private int count; // primitive, will receive null from valueByName
+
+      public String getName() {
+        return name;
+      }
+
+      public void setName(final String name) {
+        this.name = name;
+      }
+
+      public int getCount() {
+        return count;
+      }
+
+      public void setCount(final int count) {
+        this.count = count;
+      }
+    }
+
+    public static class TopSource {
+
+      private Source nested;
+
+      public Source getNested() {
+        return nested;
+      }
+
+      public void setNested(final Source nested) {
+        this.nested = nested;
+      }
+    }
+
+    public static class TopTarget {
+
+      private Target nested;
+
+      public Target getNested() {
+        return nested;
+      }
+
+      public void setNested(final Target nested) {
+        this.nested = nested;
+      }
+    }
+
+    @Test
+    @DisplayName("forward(top) where nested target has primitive setter for an unmatched field uses JLS default")
+    void primitiveSetterReceivesJlsDefaultOnNullValue() {
+      // After Bug 6 + Bug 5 fixes, a nested target property like `int count` whose source has
+      // no matching `count` field receives `null` from valueByName. SettersWriter.construct used
+      // to NPE when passing that null to `setCount(int)` (Integer-to-int unboxing on null).
+      // Fix: null-guard primitive setters at construction time so primitives stay at their JLS
+      // default (0 for int, false for boolean, etc.).
+      final var mapper = Telescope.mapper(
+        TopSource.class,
+        TopTarget.class,
+        writeBeans(WriteHint.WriteStrategy.SETTERS)
+      );
+      final var src = new TopSource();
+      final var inner = new Source();
+      inner.setName("alice");
+      src.setNested(inner);
+      final var tgt = assertDoesNotThrow(() -> mapper.forward(src));
+      assertEquals("alice", tgt.getNested().getName());
+      // Target's primitive int stays at JLS default 0 (source had no `count`).
+      assertEquals(0, tgt.getNested().getCount());
+    }
+
+    public static class FlatSource {
+
+      private String name;
+      private Integer count; // boxed; will hold null at runtime
+      private Boolean active; // boxed; will hold null at runtime
+
+      public String getName() {
+        return name;
+      }
+
+      public void setName(final String name) {
+        this.name = name;
+      }
+
+      public Integer getCount() {
+        return count;
+      }
+
+      public void setCount(final Integer count) {
+        this.count = count;
+      }
+
+      public Boolean getActive() {
+        return active;
+      }
+
+      public void setActive(final Boolean active) {
+        this.active = active;
+      }
+    }
+
+    public static class FlatTarget {
+
+      private String name;
+      private Integer count; // matching: boxed → boxed (no autoboxing needed)
+      private Boolean active; // matching: boxed → boxed
+
+      public String getName() {
+        return name;
+      }
+
+      public void setName(final String name) {
+        this.name = name;
+      }
+
+      public Integer getCount() {
+        return count;
+      }
+
+      public void setCount(final Integer count) {
+        this.count = count;
+      }
+
+      public Boolean getActive() {
+        return active;
+      }
+
+      public void setActive(final Boolean active) {
+        this.active = active;
+      }
+    }
+
+    @Test
+    @DisplayName("forward(src) with null boxed source values reaching matching boxed setters does not NPE")
+    void nullBoxedSourceReachesBoxedSetterWithoutNpe() {
+      // Even on matched-name boxed→boxed paths, the source value can legitimately be null and
+      // the target setter must accept null gracefully. Pins the contract that the construct
+      // loop doesn't choke on legitimately-null boxed values.
+      final var mapper = Telescope.mapper(
+        FlatSource.class,
+        FlatTarget.class,
+        writeBeans(WriteHint.WriteStrategy.SETTERS)
+      );
+      final var src = new FlatSource();
+      src.setName("alice");
+      // count and active left null
+      final var tgt = assertDoesNotThrow(() -> mapper.forward(src));
+      assertEquals("alice", tgt.getName());
+      assertEquals(null, tgt.getCount());
+      assertEquals(null, tgt.getActive());
+    }
+  }
+
+  @Nested
+  @DisplayName("Bug 5 — SettersWriter throws on getter-only properties")
+  class Bug5GetterOnlyProperties {
+
+    // Both Source and OrderResponse have a `processed` property so DeepMap's same-name bijection
+    // check (Bug 6) passes — we want to isolate Bug 5 (SettersWriter on the getter-only target).
+    public static class Source {
+
+      private String name;
+      private boolean processed;
+
+      public String getName() {
+        return name;
+      }
+
+      public void setName(final String name) {
+        this.name = name;
+      }
+
+      public boolean isProcessed() {
+        return processed;
+      }
+
+      public void setProcessed(final boolean processed) {
+        this.processed = processed;
+      }
+    }
+
+    public static class OrderResponse {
+
+      private String name;
+      private boolean processed;
+
+      public String getName() {
+        return name;
+      }
+
+      public void setName(final String name) {
+        this.name = name;
+      }
+
+      // Getter-only — no setProcessed() exists. Common shape for computed / derived properties
+      // (the field is populated by an internal hook, not by external callers).
+      public boolean isProcessed() {
+        return processed;
+      }
+    }
+
+    @Test
+    @DisplayName("forward(source) silently skips getter-only target properties — no throw")
+    void getterOnlyTargetPropertiesAreSilentlySkipped() {
+      // MapStruct silently ignores target fields whose setter is missing. Telescope used to throw
+      // IllegalArgumentException("no setter setX") at first forward() call. This pins the new
+      // no-op contract: forward() succeeds; the getter-only target property stays at its JLS
+      // default (false for boolean primitive).
+      final var mapper = Telescope.mapper(
+        Source.class,
+        OrderResponse.class,
+        writeBeans(WriteHint.WriteStrategy.SETTERS)
+      );
+      final var src = new Source();
+      src.setName("alice");
+      src.setProcessed(true);
+      final var tgt = assertDoesNotThrow(() -> mapper.forward(src));
+      assertEquals("alice", tgt.getName());
+      // The `processed` source value was discarded — target's getter-only field stays at the
+      // primitive default. MapStruct would do the same.
+      assertEquals(false, tgt.isProcessed());
     }
   }
 }

--- a/docs/migration-feedback.md
+++ b/docs/migration-feedback.md
@@ -85,7 +85,6 @@ public static String propertyOf(final String getterName) {
 This allows the null to propagate gracefully (the null property is skipped by DeepMap).
 
 **File to fix:** `internal/src/main/java/io/github/eschizoid/telescope/internal/Beans.java` — `propertyOf()` method
-(line ~622)
 
 For explicit `to()` rows targeting boolean fields, use `fieldByName()`:
 
@@ -670,22 +669,41 @@ covers this for `mapperForward()` too
 
 ## Summary
 
-| #     | Type                                                            | Impact | Status       |
-| ----- | --------------------------------------------------------------- | ------ | ------------ |
-| Bug 1 | ClassCastException on unresolvable `@Bridge` target             | P1     | Needs fix    |
-| Bug 2 | LambdaIntrospection NPE on `is*` boolean accessors              | P0     | Needs fix    |
-| Bug 3 | No autoboxing between primitive ↔ wrapper types                 | P1     | Needs fix    |
-| Bug 4 | NPE on null intermediate objects in nested paths                | P1     | Needs fix    |
-| Bug 5 | SettersWriter throws on getter-only properties                  | P1     | Needs fix    |
-| Bug 6 | DeepMap strict bijection enforced on nested auto-recursed types | P1     | Needs fix    |
-| Bug 7 | LambdaMetafactory fails on classes extending JDK types          | P1     | Needs fix    |
-| Bug 8 | SettersWriter NPE when valueByName returns null for primitive   | P1     | Needs fix    |
-| 1     | Cross-module `@Bridge` carrier                                  | High   | Enhancement  |
-| 2     | `ForwardMapper.liftList()`                                      | Medium | Enhancement  |
-| 3     | `Telescope.asForwardMapper()`                                   | Low    | Convenience  |
-| 4     | Processor ordering docs + BridgeProcessor deferral              | Medium | Docs + Fix   |
-| 5     | `Map` → POJO factory                                            | Low    | Nice-to-have |
-| 6     | `@Bridge` lenient mode                                          | High   | Enhancement  |
-| 7     | `Sources.byClass()` generics                                    | Low    | API polish   |
-| 8     | `Mapping.forward()` naming                                      | Low    | Bikeshed     |
-| 9     | `mapperForward()` lenient by default                            | High   | Enhancement  |
+| #     | Type                                                            | Impact | Status         |
+| ----- | --------------------------------------------------------------- | ------ | -------------- |
+| Bug 1 | ClassCastException on unresolvable `@Bridge` target             | P1     | Fixed (v1.0.1) |
+| Bug 2 | LambdaIntrospection NPE on `is*` boolean accessors              | P0     | Fixed (v1.0.1) |
+| Bug 3 | No autoboxing between primitive ↔ wrapper types                 | P1     | Fixed (v1.0.1) |
+| Bug 4 | NPE on null intermediate objects in nested paths                | P1     | Fixed (v1.0.1) |
+| Bug 5 | SettersWriter throws on getter-only properties                  | P1     | Fixed (v1.0.1) |
+| Bug 6 | DeepMap strict bijection enforced on nested auto-recursed types | P1     | Fixed (v1.0.1) |
+| Bug 7 | LambdaMetafactory fails on classes extending JDK types          | P1     | Fixed (v1.0.1) |
+| Bug 8 | SettersWriter NPE when valueByName returns null for primitive   | P1     | Fixed (v1.0.1) |
+| 1     | Cross-module `@Bridge` carrier                                  | High   | Enhancement    |
+| 2     | `ForwardMapper.liftList()`                                      | Medium | Enhancement    |
+| 3     | `Telescope.asForwardMapper()`                                   | Low    | Convenience    |
+| 4     | Processor ordering docs + BridgeProcessor deferral              | Medium | Docs + Fix     |
+| 5     | `Map` → POJO factory                                            | Low    | Nice-to-have   |
+| 6     | `@Bridge` lenient mode                                          | High   | Enhancement    |
+| 7     | `Sources.byClass()` generics                                    | Low    | API polish     |
+| 8     | `Mapping.forward()` naming                                      | Low    | Bikeshed       |
+| 9     | `mapperForward()` lenient by default                            | High   | Enhancement    |
+
+---
+
+## Known limitation surfaced during round 6 review (post-fix)
+
+**Parameterised Collection / Map subtype pairs across DIFFERENT raw classes** still throw "incompatible source/target
+shapes" at mapper construction.
+
+Example: `Outer.items : List<Inner>` (parameterised source) ↔ `OuterDto.items : ArrayList<InnerDto>` (parameterised
+target with different concrete class). The Bug 7 fix handles the _raw-subtype-on-both-sides_ case
+(`ImageUrls extends ArrayList<X>` on both sides). It does not yet cover the case where one side uses an interface
+(`List<X>`) and the other a concrete implementation (`ArrayList<Y>`) or two different concrete implementations
+parameterised over different element types.
+
+Workaround for v1.0.1: use the same raw container type on both sides, or declare an explicit `Mapping.via(...)` row.
+
+v1.1 work: extend `ContainerShape.of` to accept parameterised types whose raw class is a SUBTYPE (not exact match) of
+`List` / `Set` / `Map` / `Optional`, and combine with the per-element Iso lift + target-concrete-class allocator so the
+lifted Iso writes into a fresh instance of the target's concrete class.

--- a/internal/src/main/java/io/github/eschizoid/telescope/internal/Beans.java
+++ b/internal/src/main/java/io/github/eschizoid/telescope/internal/Beans.java
@@ -369,6 +369,15 @@ public final class Beans {
    * }</pre>
    */
   public static Object readProperty(final Object pojo, final String name) {
+    // Null-source short-circuit: multi-hop telescope paths (e.g.
+    // `Telescope.ofBean(Order.class).field(Order::getCustomer).field(Customer::getEmail)`) read
+    // each hop through this method. When an intermediate object is null at runtime
+    // (`order.getCustomer() == null`), the next hop arrives here with `pojo == null` and the
+    // pipeline needs the null to propagate gracefully — same shape as MapStruct's generated
+    // `if (source.getCustomer() != null) target.setEmail(source.getCustomer().getEmail())`
+    // null-guard. Without this short-circuit, `persistentClassOf(null)` returns null and
+    // `ClassValue.get(null)` NPEs.
+    if (pojo == null) return null;
     // Unwrap HibernateProxy (when present) so a LAZY-fetched entity routes through the
     // persistent class's cache entry, not a per-proxy-subclass one. See persistentClassOf.
     final var beanClass = persistentClassOf(pojo);
@@ -390,8 +399,11 @@ public final class Beans {
    * helper does NOT require a no-arg constructor on the target's class: the user supplies the
    * already-constructed target. Only the setters need to be public.
    *
-   * @throws IllegalArgumentException when {@code pojo.getClass()} exposes no public setter named
-   *     {@code "set<Capitalized name>"} taking exactly one argument
+   * <p>Properties without a public {@code setX} setter are silently skipped — matches both {@link
+   * SettersWriter} (used by {@code Mapper.forward}) and MapStruct's {@code @MappingTarget}
+   * semantics so a getter-only / computed / immutable target property never breaks an otherwise
+   * valid mapping.
+   *
    * @throws IllegalStateException via {@link MethodHandles#privateLookupIn} when the setter's
    *     declaring class lives in a closed-package module without an {@code opens} directive
    */
@@ -411,9 +423,11 @@ public final class Beans {
         break;
       }
     }
-    if (setter == null) throw new IllegalArgumentException(
-      "writeBeanProperty(" + cls.getName() + ", '" + name + "'): no setter '" + set + "'"
-    );
+    // Getter-only / computed / immutable properties are silently skipped — without this,
+    // Mapper.into(target, source) would throw on the same property pair that Mapper.forward
+    // (via SettersWriter) silently skipped, producing an asymmetric same-mapper contract.
+    // MapStruct's @MappingTarget ignores unwritable target fields too; match.
+    if (setter == null) return (pojo, value) -> {};
     final var declaringClass = setter.getDeclaringClass();
     final var lookup = privateLookupOrThrow(declaringClass, cls, "setter");
     final var paramType = setter.getParameterTypes()[0];
@@ -577,6 +591,17 @@ public final class Beans {
     final var map = new LinkedHashMap<String, Method>();
     for (final var m : cls.getMethods()) {
       if (m.getParameterCount() != 0 || m.getDeclaringClass() == Object.class) continue;
+      // Skip inherited methods declared in platform modules (java.*, jdk.*). A class extending
+      // ArrayList would otherwise surface `isEmpty()` → property `empty` and the LMF binder
+      // would then fail `privateLookupIn(ArrayList.class)` because `java.base` doesn't grant
+      // private lookup to application code. The primary gate lives in DeepMap (Collection/Map
+      // subtypes don't recurse at all); this scan-time skip is defence-in-depth for any future
+      // caller that touches a JDK-derived class directly.
+      final var declaringModule = m.getDeclaringClass().getModule();
+      if (declaringModule != null && declaringModule.isNamed()) {
+        final var moduleName = declaringModule.getName();
+        if (moduleName.startsWith("java.") || moduleName.startsWith("jdk.")) continue;
+      }
       final var n = m.getName();
       final String prop;
       if (n.length() > 3 && n.startsWith("get") && m.getReturnType() != void.class) {
@@ -951,9 +976,12 @@ public final class Beans {
       }
       for (final var name : names) {
         final var setter = setters.get(name);
-        if (setter == null) throw new IllegalArgumentException(
-          "writeBean(" + cls.getName() + ", FIELDS): no field '" + name + "'"
-        );
+        // Align with SettersWriter and BuilderWriter: silently skip a name that has no matching
+        // field. Without this the FIELDS strategy throws on the same input the other two writer
+        // strategies tolerate — two POJOs differing only by the presence of setters or a static
+        // builder() factory would have opposite mapping contracts on the same source/target
+        // pair. MapStruct's @MappingTarget ignores unwritable target fields too; match.
+        if (setter == null) continue;
         setter.accept(pojo, valueByName.apply(name));
       }
       return pojo;
@@ -997,7 +1025,16 @@ public final class Beans {
           .unreflectSetter(field)
           .asType(MethodType.methodType(void.class, Object.class, Object.class));
       } catch (final IllegalAccessException e) {
-        throw new RuntimeException("Failed to set field '" + field.getName() + "' on " + cls.getName(), e);
+        // Lookup.unreflectSetter rejects final fields with IAE regardless of setAccessible(true).
+        // Diagnose the most likely root cause so the adopter doesn't have to read the JDK source
+        // to figure out which of [final, JPMS-closed, missing opens] applies.
+        final var finalHint = Modifier.isFinal(field.getModifiers())
+          ? " — field is final; switch the writeBean hint to SETTERS or BUILDER, or remove final"
+          : "";
+        throw new RuntimeException(
+          "Failed to bind setter for field '" + field.getName() + "' on " + cls.getName() + finalHint,
+          e
+        );
       }
       return (pojo, value) -> {
         try {
@@ -1205,8 +1242,15 @@ public final class Beans {
         // builder pattern works either way (build() doesn't depend on setter return type).
         if (inv instanceof BiConsumer<?, ?>) {
           ((BiConsumer<Object, Object>) inv).accept(builder, value);
-        } else {
+        } else if (inv instanceof BiFunction<?, ?, ?>) {
           ((BiFunction<Object, Object, Object>) inv).apply(builder, value);
+        } else {
+          // buildSetterInvoker today returns one of {BiConsumer no-op, BiConsumer void setter,
+          // BiFunction fluent setter}. A future SAM shape would silently CCE on the BiFunction
+          // cast above — surface the contract violation explicitly so the regression is loud.
+          throw new IllegalStateException(
+            "BuilderWriter: unknown setter invoker SAM shape " + inv.getClass().getName() + " for '" + name + "'"
+          );
         }
       }
       return (P) buildFn.apply(builder);
@@ -1245,14 +1289,15 @@ public final class Beans {
           break;
         }
       }
-      if (setter == null) throw new IllegalArgumentException(
-        "writeBean(" +
-          cls.getName() +
-          ", BUILDER): no single-argument builder method for '" +
-          name +
-          "' on " +
-          builderType.getName()
-      );
+      // Align with SettersWriter and the static {@code writeBeanProperty} path — when a target
+      // property has no matching builder setter (getter-only on the target POJO, computed-only
+      // value, etc.), silently skip rather than throw. The names array passed to
+      // {@code construct(...)} is derived from the target's getter set, not from a user-
+      // authored builder name list, so an asymmetric writer contract here would diverge from
+      // {@code Mapper.forward} (via SettersWriter) on POJOs that happen to expose a static
+      // {@code builder()} factory. A BiConsumer no-op matches the dispatch path in
+      // {@code construct(...)}.
+      if (setter == null) return (BiConsumer<Object, Object>) (builder, value) -> {};
       // Inherited-accessor correctness: a builder type may extend another builder type whose
       // setters live in a different package / module. Pin the lookup, error message, and
       // instantiatedMethodType receiver to the setter's declaring class so a closed inheritor
@@ -1446,9 +1491,12 @@ public final class Beans {
           break;
         }
       }
-      if (setter == null) throw new IllegalArgumentException(
-        "writeBean(" + cls.getName() + ", SETTERS): no setter '" + set + "'"
-      );
+      // Getter-only properties (computed fields, immutable accessors, etc.) have no matching
+      // setX. Throwing here would make writeBean(SETTERS) unusable on any class with a read-
+      // only property. MapStruct silently ignores unwritable target fields; match that by
+      // returning a no-op BiConsumer so the construct loop skips the property at write time.
+      // The property's underlying field stays at its JLS default (null/0/false).
+      if (setter == null) return (pojo, value) -> {};
       // Use the SETTER's declaring class — inherited setters live on a superclass / interface
       // whose package may be in a different module than `cls`. Pinning the lookup, the
       // instantiated receiver type, and the opens-error message to the declaring class keeps all
@@ -1467,7 +1515,22 @@ public final class Beans {
           handle,
           MethodType.methodType(void.class, declaringClass, instantiatedParamType)
         );
-        return (BiConsumer<Object, Object>) callSite.getTarget().invoke();
+        final var lmfSetter = (BiConsumer<Object, Object>) callSite.getTarget().invoke();
+        // Defence-in-depth on the primitive-setter null guard. The LMF-built setter for a
+        // primitive parameter (e.g. setCount(int)) NPEs when invoked with null
+        // (Object → Integer → int unbox). DeepMap's placeholderIsoFor short-circuits unmatched
+        // primitive target fields to their JLS default before the value ever reaches here, so
+        // this guard is unreachable on the happy path — it's kept to lock the contract against
+        // future code paths that may legitimately deliver null to a primitive setter (e.g.
+        // autoboxing-relaxation work). When the parameter type is a primitive, skip on null so
+        // the field stays at its JLS default rather than crashing the construct call.
+        if (paramType.isPrimitive()) {
+          return (pojo, value) -> {
+            if (value == null) return;
+            lmfSetter.accept(pojo, value);
+          };
+        }
+        return lmfSetter;
       } catch (final Throwable t) {
         throw new RuntimeException("Failed to set '" + name + "' on " + cls.getName(), t);
       }

--- a/internal/src/test/java/io/github/eschizoid/telescope/internal/BeansTest.java
+++ b/internal/src/test/java/io/github/eschizoid/telescope/internal/BeansTest.java
@@ -548,12 +548,22 @@ class BeansTest {
     }
 
     @Test
+    @DisplayName("readProperty(null, name) returns null instead of NPEing on persistentClassOf")
+    void readPropertyNullPojoIsNullSafe() {
+      // When a multi-hop telescope path reads through a null intermediate, the next lens hop
+      // calls Beans.readProperty(null, "..."). persistentClassOf(null) returns null, then
+      // ClassValue.get(null) would NPE. Short-circuit at the readProperty entry so the optic
+      // pipeline propagates the null gracefully through intermediate hops.
+      assertNull(Beans.readProperty(null, "anything"));
+    }
+
+    @Test
     @DisplayName("propertyOf(null) returns null instead of throwing NPE")
     void propertyOfNullIsNullSafe() {
-      // Belt-and-suspenders guard. The structural fix for Bug 2 lives in DeepMap.populateIso —
-      // the row-loop now peels nested-telescope sub-shapes (FromTelescopeTo / TelescopeToTelescope
-      // whose sourceField() returns null by design) before normalising. This guard ensures the
-      // public Beans surface stays null-safe in case any future caller forgets to peel.
+      // Defensive null-safety on the public Beans surface — nested-telescope sub-shapes
+      // (FromTelescopeTo / TelescopeToTelescope whose sourceField() returns null by design)
+      // are peeled in DeepMap.populateIso before normalising, but propertyOf is part of the
+      // public API and should not NPE when handed a null lambda probe.
       assertNull(Beans.propertyOf(null));
     }
 
@@ -631,10 +641,16 @@ class BeansTest {
     }
 
     @Test
-    @DisplayName("construct throws when a name has no matching declared field")
-    void fieldsUnknownNameThrows() {
+    @DisplayName("construct silently skips a name without a matching declared field (no-op)")
+    void fieldsMissingFieldIsSilentlySkipped() {
+      // Mirrors SettersWriter and BuilderWriter — the FIELDS strategy must not throw on a
+      // name without a matching field, otherwise three writer strategies on the same engine
+      // would carry three different contracts. The named slot stays at the JLS default; the
+      // value flowing through valueByName is dropped.
       final var writer = Beans.fieldsWriter(NoArgFields.class);
-      assertThrows(IllegalArgumentException.class, () -> writer.construct(new String[] { "ghost" }, n -> "x"));
+      final var pojo = writer.construct(new String[] { "ghost", "name" }, n -> n.equals("name") ? "alice" : "x");
+      assertNotNull(pojo);
+      assertEquals("alice", pojo.name);
     }
 
     @Test
@@ -685,10 +701,18 @@ class BeansTest {
     }
 
     @Test
-    @DisplayName("construct throws IllegalArgumentException for a name without a matching setter")
-    void settersMissingSetterThrows() {
+    @DisplayName("construct silently skips a name without a matching setter (no-op consumer)")
+    void settersMissingSetterIsSilentlySkipped() {
+      // Getter-only / computed / immutable target properties would otherwise throw
+      // IllegalArgumentException("no setter setX") at write time. MapStruct silently ignores
+      // unwritable target fields; we match by installing a no-op BiConsumer for missing
+      // setters. The property's underlying field stays at its JLS default (here:
+      // NoArgFields.name stays null, the source value "x" is dropped).
       final var writer = Beans.settersWriter(NoArgFields.class); // has fields but no setters
-      assertThrows(IllegalArgumentException.class, () -> writer.construct(new String[] { "name" }, n -> "x"));
+      final var pojo = writer.construct(new String[] { "name" }, n -> "x");
+      assertNotNull(pojo);
+      // The constructed instance has the JLS-default null for `name` (no setter fired).
+      assertNull(pojo.name);
     }
 
     @Test
@@ -758,10 +782,19 @@ class BeansTest {
     }
 
     @Test
-    @DisplayName("construct throws if no setter on the builder matches a given name")
-    void builderUnknownSetterThrows() {
+    @DisplayName("construct silently skips a name without a matching builder setter (no-op consumer)")
+    void builderMissingSetterIsSilentlySkipped() {
+      // Mirrors SettersWriter's silent-skip contract on the builder path. The `names` array
+      // fed to construct(...) is derived from the target's getter set (Beans.propertyNames),
+      // so a computed/read-only getter on the target POJO would surface here as a builder
+      // method that doesn't exist. Without alignment, two POJOs differing only by the presence
+      // of a `builder()` factory would have opposite mapping semantics on the same
+      // source/target pair. Silently skip the unmatched name, leaving the builder slot at its
+      // default.
       final var writer = Beans.builderWriter(WithBuilder.class);
-      assertThrows(IllegalArgumentException.class, () -> writer.construct(new String[] { "ghost" }, n -> "x"));
+      final var pojo = writer.construct(new String[] { "ghost", "name" }, n -> n.equals("name") ? "alice" : "x");
+      assertNotNull(pojo);
+      assertEquals("alice", pojo.getName());
     }
 
     @Test


### PR DESCRIPTION
Bug 1 from `docs/migration-feedback.md`. P1. Stacked on #134.

**Last in the migration-feedback PR stack — all 8 bugs fixed.**

## Problem

When `@Bridge(value = SomeClass.class)` referenced a class that the annotated compilation unit couldn't see (different Maven module with no dependency edge), javac's `AnnotationValue.getValue()` returned the target FQN as a `String` instead of a `TypeMirror`. The processor cast unconditionally to `TypeMirror`, which crashed the build with:

```
ClassCastException: class java.lang.String cannot be cast to class javax.lang.model.type.TypeMirror
```

No file, no line, no hint at what was wrong.

## Fix

Rename `targetTypeFromMirror` → `rawTargetValueFromMirror` and have it return `Object` (the documented union of `TypeMirror` / `String` / `null`). Callers dispatch on `instanceof`. The primary caller surfaces a precise diagnostic:

```
@Bridge target 'some.x.Foo' is not resolvable from this compilation unit — annotate the other side, or add the dependency.
```

The sealed-roots caller (which iterates per-case bridges) silently skips non-`TypeMirror` values — matches the prior "continue on non-DECLARED" semantics; subsequent code emits a more specific diagnostic for that case anyway.

## TDD evidence

`BridgeProcessorTest.unresolvableTargetEmitsPreciseDiagnostic` — new test in the existing `Rejections` nest. Compiles a `@Bridge` with an unresolvable target FQN. Without the fix the processor throws `ClassCastException`; with the fix the compilation reports the precise diagnostic.

## Mantras

- No public API change.
- No new reflection.
- Diagnostic message names the missing FQN so the user knows exactly what to add to their module dependencies.

## Stack summary

| # | PR | Bug | Severity |
|---|---|---|---|
| 1 | [#128](https://github.com/eschizoid/telescope/pull/128) | Bug 2: boolean accessor NPE (real root cause: nested-telescope row `sourceField()` null) | **P0** |
| 2 | [#129](https://github.com/eschizoid/telescope/pull/129) | Bug 4: null intermediate NPE + `Telescope.read` toList swap | P1 |
| 3 | [#130](https://github.com/eschizoid/telescope/pull/130) | Bug 5: SettersWriter no-op for missing setters | P1 |
| 4 | [#131](https://github.com/eschizoid/telescope/pull/131) | Bug 6: lenient nested auto-recursed pairs | P1 |
| 5 | [#132](https://github.com/eschizoid/telescope/pull/132) | Bug 8: primitive setter null-guard (defence-in-depth) | P1 |
| 6 | [#133](https://github.com/eschizoid/telescope/pull/133) | Bug 7: refuse to bean-decompose JDK collection subtypes | P1 |
| 7 | [#134](https://github.com/eschizoid/telescope/pull/134) | Bug 3: primitive ↔ wrapper auto-iso | P1 |
| 8 | **THIS** | Bug 1: BridgeProcessor unresolvable target | P1 |

Eighth and final PR in the migration-feedback stack.
