### PR TITLE
fix(v1.0.1): two more migration-feedback fixes — forward(null), fieldByName POJO dispatch

### DIFF
--- a/core/src/main/java/io/github/eschizoid/telescope/Telescope.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/Telescope.java
@@ -771,7 +771,12 @@ public sealed class Telescope<
    * processor — it generates a typed {@code <X>Telescope<R>} navigator at build time.
    */
   public <B> Telescope<S, B> fieldByName(final String fieldName) {
-    final Lens<A, B> fieldLens = Records.fieldLens(fieldName);
+    // Dispatch on the carried fieldOptics — the same discriminator that .field(Accessor) uses.
+    // A Telescope built via `ofBean(...)` carries BeanFieldOptics; everything else carries
+    // RecordFieldOptics. Without this dispatch, fieldByName on a bean Telescope would build a
+    // Records.fieldLens that fails at call time because the focus type isn't a record.
+    final Lens<A, B> fieldLens =
+      fieldOptics == BeanFieldOptics.INSTANCE ? Beans.fieldLens(fieldName) : Records.fieldLens(fieldName);
     return new Telescope<>(optic.then(fieldLens), fieldOptics, chain);
   }
 

--- a/core/src/main/java/io/github/eschizoid/telescope/conversion/ForwardMapper.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/conversion/ForwardMapper.java
@@ -55,6 +55,8 @@ public final class ForwardMapper<A, B> {
 
   /** Forward conversion {@code A → B}. */
   public B forward(final A a) {
+    // Null in, null out — matches Mapper.forward's contract and MapStruct's generated null guard.
+    if (a == null) return null;
     return forward.get(a);
   }
 

--- a/core/src/main/java/io/github/eschizoid/telescope/conversion/ForwardMapper.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/conversion/ForwardMapper.java
@@ -62,7 +62,7 @@ public final class ForwardMapper<A, B> {
 
   /** Alias of {@link #forward(Object)}. */
   public B read(final A a) {
-    return forward.get(a);
+    return forward(a);
   }
 
   /**

--- a/core/src/main/java/io/github/eschizoid/telescope/conversion/Mapper.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/conversion/Mapper.java
@@ -225,7 +225,9 @@ public final class Mapper<A, B> {
     if (a == null) return null;
     final A a1 = preForward == null ? a : preForward.apply(a);
     // Post-hook null guard: a preForward that returns null (e.g. a normalisation hook that maps
-    // sentinel-empty to null) must propagate as null, not NPE in iso.to(null).
+    // sentinel-empty to null) must propagate as null, not NPE in iso.to(null). postForward is
+    // intentionally NOT invoked on this path — matches the top-level null-input behaviour where
+    // both pre and post hooks are skipped.
     if (a1 == null) return null;
     final B b = iso.to(a1);
     return postForward == null ? b : postForward.apply(a1, b);

--- a/core/src/main/java/io/github/eschizoid/telescope/conversion/Mapper.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/conversion/Mapper.java
@@ -224,6 +224,9 @@ public final class Mapper<A, B> {
     // pre/postForward has a sensible meaning when no value flowed through.
     if (a == null) return null;
     final A a1 = preForward == null ? a : preForward.apply(a);
+    // Post-hook null guard: a preForward that returns null (e.g. a normalisation hook that maps
+    // sentinel-empty to null) must propagate as null, not NPE in iso.to(null).
+    if (a1 == null) return null;
     final B b = iso.to(a1);
     return postForward == null ? b : postForward.apply(a1, b);
   }
@@ -305,6 +308,7 @@ public final class Mapper<A, B> {
     // Null in, null out — symmetric with forward(). See the rationale on forward(Object) above.
     if (b == null) return null;
     final B b1 = preBackward == null ? b : preBackward.apply(b);
+    if (b1 == null) return null;
     final A a = iso.from(b1);
     return postBackward == null ? a : postBackward.apply(b1, a);
   }

--- a/core/src/main/java/io/github/eschizoid/telescope/conversion/Mapper.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/conversion/Mapper.java
@@ -219,6 +219,10 @@ public final class Mapper<A, B> {
    * io.github.eschizoid.telescope.mapping.Mapping#via via(...)} row).
    */
   public B forward(final A a) {
+    // Null in, null out — matches MapStruct's generated `if (source == null) return null;` and the
+    // JPA "no row" idiom adopters rely on. The hook chain is skipped on null since neither
+    // pre/postForward has a sensible meaning when no value flowed through.
+    if (a == null) return null;
     final A a1 = preForward == null ? a : preForward.apply(a);
     final B b = iso.to(a1);
     return postForward == null ? b : postForward.apply(a1, b);
@@ -298,6 +302,8 @@ public final class Mapper<A, B> {
 
   /** Backward conversion {@code B → A}. See {@link #forward(Object)}. */
   public A backward(final B b) {
+    // Null in, null out — symmetric with forward(). See the rationale on forward(Object) above.
+    if (b == null) return null;
     final B b1 = preBackward == null ? b : preBackward.apply(b);
     final A a = iso.from(b1);
     return postBackward == null ? a : postBackward.apply(b1, a);

--- a/core/src/test/java/io/github/eschizoid/telescope/MigrationRegressionTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/MigrationRegressionTest.java
@@ -1210,6 +1210,25 @@ class MigrationRegressionTest {
       );
       assertEquals(null, mapper.forward(null));
     }
+
+    @Test
+    @DisplayName("ForwardMapper.read(null) returns null — read is documented as an alias of forward")
+    void forwardMapperReadNullReturnsNull() {
+      final var mapper = io.github.eschizoid.telescope.conversion.ForwardMapper.create(
+        (SrcRec s) -> new TgtRec(s.id(), s.name()),
+        SrcRec.class,
+        TgtRec.class
+      );
+      assertEquals(null, mapper.read(null));
+    }
+
+    @Test
+    @DisplayName("Mapper.forward — preForward returning null propagates as null (no NPE in iso.to)")
+    void preForwardReturningNullPropagatesAsNull() {
+      // A normalisation hook that maps a sentinel (empty id) to null must not crash the mapper.
+      final var mapper = Telescope.mapper(SrcRec.class, TgtRec.class).beforeForward(s -> s.id().isEmpty() ? null : s);
+      assertEquals(null, mapper.forward(new SrcRec("", "alice")));
+    }
   }
 
   @Nested

--- a/core/src/test/java/io/github/eschizoid/telescope/MigrationRegressionTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/MigrationRegressionTest.java
@@ -1220,6 +1220,10 @@ class MigrationRegressionTest {
         TgtRec.class
       );
       assertEquals(null, mapper.read(null));
+      // Non-null parity: read and forward must produce the same output, otherwise a future
+      // refactor that breaks the alias contract slips through unnoticed.
+      final var src = new SrcRec("o1", "alice");
+      assertEquals(mapper.forward(src), mapper.read(src));
     }
 
     @Test
@@ -1228,6 +1232,15 @@ class MigrationRegressionTest {
       // A normalisation hook that maps a sentinel (empty id) to null must not crash the mapper.
       final var mapper = Telescope.mapper(SrcRec.class, TgtRec.class).beforeForward(s -> s.id().isEmpty() ? null : s);
       assertEquals(null, mapper.forward(new SrcRec("", "alice")));
+    }
+
+    @Test
+    @DisplayName("Mapper.backward — preBackward returning null propagates as null (no NPE in iso.from)")
+    void preBackwardReturningNullPropagatesAsNull() {
+      // Symmetric pin for the backward path: without this, a future revert of the backward guard
+      // goes unnoticed because no other test exercises preBackward returning null.
+      final var mapper = Telescope.mapper(SrcRec.class, TgtRec.class).beforeBackward(t -> t.id().isEmpty() ? null : t);
+      assertEquals(null, mapper.backward(new TgtRec("", "alice")));
     }
   }
 

--- a/core/src/test/java/io/github/eschizoid/telescope/MigrationRegressionTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/MigrationRegressionTest.java
@@ -24,8 +24,8 @@ import org.junit.jupiter.api.Test;
 class MigrationRegressionTest {
 
   @Nested
-  @DisplayName("Bug 2 — boolean accessor NPE (P0 blocker)")
-  class Bug2BooleanAccessorNpe {
+  @DisplayName("Boolean accessor — mapper construction is null-safe through Beans.propertyOf")
+  class BooleanAccessorNpe {
 
     public static class Order {
 
@@ -137,7 +137,7 @@ class MigrationRegressionTest {
     @Test
     @DisplayName("Mapping.to(srcTelescope, tgtAccessor) — nested source path — does not NPE at mapper construction")
     void nestedSourceTelescopeRowConstructsWithoutNpe() {
-      // The actual reproduction of Bug 2's reported NPE: `Mapping.to(srcTelescope, tgtAccessor)`
+      // Reproduces the reported NPE: `Mapping.to(srcTelescope, tgtAccessor)`
       // builds a FromTelescopeTo row whose `sourceField()` is null by design (the source is a
       // nested telescope, not a flat accessor). DeepMap.populateIso normalizes the source field
       // unconditionally before the FromTelescopeTo `instanceof` peel, so `Beans.normalize(null)`
@@ -157,8 +157,8 @@ class MigrationRegressionTest {
   }
 
   @Nested
-  @DisplayName("Bug 4 — NPE on null intermediate objects in nested telescope paths")
-  class Bug4NullIntermediateNpe {
+  @DisplayName("Null intermediate — multi-hop bean paths short-circuit instead of NPE")
+  class NullIntermediateNpe {
 
     public static class Order {
 
@@ -243,8 +243,8 @@ class MigrationRegressionTest {
   }
 
   @Nested
-  @DisplayName("Bug 6 — DeepMap strict bijection on nested auto-recursed types")
-  class Bug6NestedStrictBijection {
+  @DisplayName("Nested asymmetric pairs are lenient; top-level strictness preserved")
+  class NestedStrictBijection {
 
     public static class ScoreResponse {
 
@@ -360,8 +360,8 @@ class MigrationRegressionTest {
   }
 
   @Nested
-  @DisplayName("Bug 3 — primitive ↔ wrapper autoboxing")
-  class Bug3PrimitiveWrapperAutoboxing {
+  @DisplayName("Primitive ↔ wrapper auto-iso with JLS-default null guard")
+  class PrimitiveWrapperAutoboxing {
 
     public static class Source {
 
@@ -609,8 +609,8 @@ class MigrationRegressionTest {
   }
 
   @Nested
-  @DisplayName("Bug 7 — LMF fails on classes extending JDK collection types")
-  class Bug7JdkCollectionSubtypes {
+  @DisplayName("JDK collection subtypes — auto-iso copies elements instead of bean-recursing")
+  class JdkCollectionSubtypes {
 
     public static class ImageUrl {
 
@@ -872,14 +872,14 @@ class MigrationRegressionTest {
   }
 
   @Nested
-  @DisplayName("Bug 8 — SettersWriter NPE on null primitive value")
-  class Bug8PrimitiveSetterNullNpe {
+  @DisplayName("Primitive setter null-guard — null value substitutes the JLS default")
+  class PrimitiveSetterNullNpe {
 
     public static class Source {
 
       private String name;
 
-      // No `count` property — after Bug 6 lenient nested mode, valueByName returns null for the
+      // No `count` property — under nested-pair lenient mode, valueByName returns null for the
       // target's `count` field.
 
       public String getName() {
@@ -942,7 +942,8 @@ class MigrationRegressionTest {
     @Test
     @DisplayName("forward(top) where nested target has primitive setter for an unmatched field uses JLS default")
     void primitiveSetterReceivesJlsDefaultOnNullValue() {
-      // After Bug 6 + Bug 5 fixes, a nested target property like `int count` whose source has
+      // With nested-leniency + getter-only silent-skip, a nested target property like `int count`
+      // whose source has
       // no matching `count` field receives `null` from valueByName. SettersWriter.construct used
       // to NPE when passing that null to `setCount(int)` (Integer-to-int unboxing on null).
       // Fix: null-guard primitive setters at construction time so primitives stay at their JLS
@@ -1046,11 +1047,11 @@ class MigrationRegressionTest {
   }
 
   @Nested
-  @DisplayName("Bug 5 — SettersWriter throws on getter-only properties")
-  class Bug5GetterOnlyProperties {
+  @DisplayName("Getter-only target properties — SettersWriter silently skips instead of throwing")
+  class GetterOnlyProperties {
 
     // Both Source and OrderResponse have a `processed` property so DeepMap's same-name bijection
-    // check (Bug 6) passes — we want to isolate Bug 5 (SettersWriter on the getter-only target).
+    // strict-bijection check passes — we want to isolate the SettersWriter getter-only path.
     public static class Source {
 
       private String name;
@@ -1113,6 +1114,161 @@ class MigrationRegressionTest {
       // The `processed` source value was discarded — target's getter-only field stays at the
       // primitive default. MapStruct would do the same.
       assertEquals(false, tgt.isProcessed());
+    }
+  }
+
+  @Nested
+  @DisplayName("Mapper.forward(null) / backward(null) returns null instead of NPE")
+  class MapperNullSafe {
+
+    record SrcRec(String id, String name) {}
+
+    record TgtRec(String id, String name) {}
+
+    public static class SrcBean {
+
+      private String id;
+      private String name;
+
+      public String getId() {
+        return id;
+      }
+
+      public void setId(final String id) {
+        this.id = id;
+      }
+
+      public String getName() {
+        return name;
+      }
+
+      public void setName(final String name) {
+        this.name = name;
+      }
+    }
+
+    public static class TgtBean {
+
+      private String id;
+      private String name;
+
+      public String getId() {
+        return id;
+      }
+
+      public void setId(final String id) {
+        this.id = id;
+      }
+
+      public String getName() {
+        return name;
+      }
+
+      public void setName(final String name) {
+        this.name = name;
+      }
+    }
+
+    @Test
+    @DisplayName("Mapper.forward(null) returns null (records)")
+    void mapperForwardNullReturnsNullRecords() {
+      final var mapper = Telescope.mapper(SrcRec.class, TgtRec.class);
+      assertEquals(null, mapper.forward(null));
+    }
+
+    @Test
+    @DisplayName("Mapper.backward(null) returns null (records)")
+    void mapperBackwardNullReturnsNullRecords() {
+      final var mapper = Telescope.mapper(SrcRec.class, TgtRec.class);
+      assertEquals(null, mapper.backward(null));
+    }
+
+    @Test
+    @DisplayName("Mapper.forward(null) returns null (beans)")
+    void mapperForwardNullReturnsNullBeans() {
+      final var mapper = Telescope.mapper(SrcBean.class, TgtBean.class, writeBeans(WriteHint.WriteStrategy.SETTERS));
+      assertEquals(null, mapper.forward(null));
+    }
+
+    @Test
+    @DisplayName("Mapper.forward(non-null) still threads through hooks")
+    void hooksStillFireOnNonNullInput() {
+      final var mapper = Telescope.mapper(SrcRec.class, TgtRec.class).afterForward(t ->
+        new TgtRec(t.id() + "-X", t.name())
+      );
+      final var src = new SrcRec("o1", "alice");
+      assertEquals("o1-X", mapper.forward(src).id());
+    }
+
+    @Test
+    @DisplayName("ForwardMapper.forward(null) returns null")
+    void forwardMapperNullReturnsNull() {
+      final var mapper = io.github.eschizoid.telescope.conversion.ForwardMapper.create(
+        (SrcRec s) -> new TgtRec(s.id(), s.name()),
+        SrcRec.class,
+        TgtRec.class
+      );
+      assertEquals(null, mapper.forward(null));
+    }
+  }
+
+  @Nested
+  @DisplayName("Telescope.fieldByName(String) on a bean Telescope routes through Beans.fieldLens")
+  class FieldByNameBeanDispatch {
+
+    public static class Order {
+
+      private String id;
+      private String customerName;
+
+      public String getId() {
+        return id;
+      }
+
+      public void setId(final String id) {
+        this.id = id;
+      }
+
+      public String getCustomerName() {
+        return customerName;
+      }
+
+      public void setCustomerName(final String customerName) {
+        this.customerName = customerName;
+      }
+    }
+
+    @Test
+    @DisplayName("Telescope.ofBean(Order).fieldByName(\"id\").read(order) returns the property value")
+    void fieldByNameReadsBeanProperty() {
+      final var src = new Order();
+      src.setId("o-42");
+      src.setCustomerName("alice");
+      final var path = Telescope.ofBean(Order.class).<String>fieldByName("id");
+      assertEquals("o-42", path.read(src));
+    }
+
+    @Test
+    @DisplayName("Telescope.ofBean(Order).fieldByName(\"customerName\").update(order, fn) rebuilds via the auto-writer")
+    void fieldByNameUpdatesBeanPropertyViaAutoWriter() {
+      final var src = new Order();
+      src.setId("o-1");
+      src.setCustomerName("alice");
+      final var updated = Telescope.ofBean(Order.class)
+        .<String>fieldByName("customerName")
+        .update(src, String::toUpperCase);
+      assertEquals("ALICE", updated.getCustomerName());
+      // Off-path id is carried over via readProperty during the rebuild.
+      assertEquals("o-1", updated.getId());
+    }
+
+    record User(String name, int age) {}
+
+    @Test
+    @DisplayName("Records still dispatch through Records.fieldLens — backward-compat smoke")
+    void fieldByNameOnRecordStillWorks() {
+      final var src = new User("bob", 30);
+      assertEquals("bob", Telescope.of(User.class).<String>fieldByName("name").read(src));
     }
   }
 }

--- a/docs/migration-feedback.md
+++ b/docs/migration-feedback.md
@@ -448,6 +448,62 @@ Or wrap the `BiConsumer` to null-guard at the individual setter level.
 
 ---
 
+### 9. `forward(null)` / `backward(null)` NPEs instead of returning null
+
+**Severity:** P1 — every adopter wiring a nullable upstream (REST controller pulling a possibly-null JSON body,
+Hibernate query returning `null` for a missing row, etc.) hits this on day one.
+
+**Reproduction:**
+
+```java
+final var mapper = Telescope.mapper(Order.class, OrderDto.class);
+
+final OrderDto dto = mapper.forward(null); // NPE in iso.to(null)
+```
+
+`Mapper.forward(A)` and `ForwardMapper.forward(A)` both call into `iso.to(...)` / `forward.get(...)` without
+short-circuiting on a null input. MapStruct's generated mappers always emit a top-of-method
+`if (source == null) return null;` — adopters expect the same.
+
+**Expected:** Null in, null out. Matches MapStruct's `@Mapping` default and the JPA "no row" idiom.
+
+**File to fix:** `core/src/main/java/io/github/eschizoid/telescope/conversion/Mapper.java` (forward + backward) and
+`core/src/main/java/io/github/eschizoid/telescope/conversion/ForwardMapper.java` (forward).
+
+---
+
+### 10. `Telescope.fieldByName(String)` uses `Records.fieldLens()` unconditionally — broken for POJOs
+
+**Severity:** P1 — `fieldByName` is the documented runtime escape hatch (the README's "config-driven field paths"
+example). It's also the only string-keyed nav method on the public surface. Today it works only on records.
+
+**Reproduction:**
+
+```java
+class Order { private String id; public String getId() { return id; } public void setId(String id) { this.id = id; } }
+final var path = Telescope.ofBean(Order.class).<String>fieldByName("id");
+path.read(new Order()); // RuntimeException — Records.fieldLens probes a record class
+```
+
+**Root cause:** `Telescope.fieldByName(String)` builds a `Records.fieldLens(fieldName)` Lens regardless of whether the
+calling Telescope was constructed via `of(...)` (record) or `ofBean(...)` (POJO). The Telescope already carries a
+`fieldOptics` discriminator (`RecordFieldOptics.INSTANCE` vs `BeanFieldOptics.INSTANCE`) used by `.field(Accessor)` —
+`fieldByName(String)` needs the same dispatch.
+
+**Expected:** `fieldByName(String)` on a bean Telescope routes through a sibling `Beans.fieldLens(String)` that uses
+`readProperty(pojo, name)` for `get` and `autoWriter(pojo.getClass()).construct(...)` for `set` / `modify`. Deferred-
+class lookup mirrors the existing `Records.fieldLens(String)` design (the runtime class is probed at call time, not
+construction time).
+
+**File to fix:**
+
+- `internal/src/main/java/io/github/eschizoid/telescope/internal/Beans.java` — add a new `Beans.fieldLens(String)`
+  method modelled on `Records.fieldLens(String)`.
+- `core/src/main/java/io/github/eschizoid/telescope/Telescope.java` — dispatch in `fieldByName(String)` on the carried
+  `fieldOptics`.
+
+---
+
 ## Enhancement Requests
 
 ### 1. Cross-module `@Bridge` support (MapStruct parity)
@@ -655,39 +711,42 @@ covers this for `mapperForward()` too
 
 ---
 
-## Additional Fixes Applied During Migration (not listed as separate bugs)
+## Additional Fixes Applied During Migration (already-fixed in v1.0.1 — recorded for traceability)
 
-| Fix                           | File                                     | Description                                                                                                   |
-| ----------------------------- | ---------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
-| `forward(null)` returns null  | `core/.../conversion/ForwardMapper.java` | Null input should return null, not NPE                                                                        |
-| `forward(null)` returns null  | `core/.../conversion/Mapper.java`        | Same                                                                                                          |
-| `fieldByName()` bean dispatch | `core/.../Telescope.java`                | `fieldByName()` used `Records.fieldLens()` unconditionally — should dispatch to `Beans.fieldLens()` for POJOs |
-| `Telescope.read()` null-safe  | `core/.../Telescope.java`                | `optic.getAll(source).findFirst()` NPEs on null elements in stream — use `toList().get(0)`                    |
-| `Beans.fieldLens(String)`     | `internal/.../Beans.java`                | New deferred bean lens for `fieldByName()` on POJOs (didn't exist)                                            |
+| Fix                          | File                      | Description                                                                                          |
+| ---------------------------- | ------------------------- | ---------------------------------------------------------------------------------------------------- |
+| `Telescope.read()` null-safe | `core/.../Telescope.java` | `optic.getAll(source).findFirst()` NPEs on null elements in a Traversal — now uses a stream iterator |
 
 ---
 
-## Summary
+## Summary — Bugs
 
-| #     | Type                                                            | Impact | Status         |
-| ----- | --------------------------------------------------------------- | ------ | -------------- |
-| Bug 1 | ClassCastException on unresolvable `@Bridge` target             | P1     | Fixed (v1.0.1) |
-| Bug 2 | LambdaIntrospection NPE on `is*` boolean accessors              | P0     | Fixed (v1.0.1) |
-| Bug 3 | No autoboxing between primitive ↔ wrapper types                 | P1     | Fixed (v1.0.1) |
-| Bug 4 | NPE on null intermediate objects in nested paths                | P1     | Fixed (v1.0.1) |
-| Bug 5 | SettersWriter throws on getter-only properties                  | P1     | Fixed (v1.0.1) |
-| Bug 6 | DeepMap strict bijection enforced on nested auto-recursed types | P1     | Fixed (v1.0.1) |
-| Bug 7 | LambdaMetafactory fails on classes extending JDK types          | P1     | Fixed (v1.0.1) |
-| Bug 8 | SettersWriter NPE when valueByName returns null for primitive   | P1     | Fixed (v1.0.1) |
-| 1     | Cross-module `@Bridge` carrier                                  | High   | Enhancement    |
-| 2     | `ForwardMapper.liftList()`                                      | Medium | Enhancement    |
-| 3     | `Telescope.asForwardMapper()`                                   | Low    | Convenience    |
-| 4     | Processor ordering docs + BridgeProcessor deferral              | Medium | Docs + Fix     |
-| 5     | `Map` → POJO factory                                            | Low    | Nice-to-have   |
-| 6     | `@Bridge` lenient mode                                          | High   | Enhancement    |
-| 7     | `Sources.byClass()` generics                                    | Low    | API polish     |
-| 8     | `Mapping.forward()` naming                                      | Low    | Bikeshed       |
-| 9     | `mapperForward()` lenient by default                            | High   | Enhancement    |
+| #      | Description                                                      | Severity | Status         |
+| ------ | ---------------------------------------------------------------- | -------- | -------------- |
+| Bug 1  | ClassCastException on unresolvable `@Bridge` target              | P1       | Fixed (v1.0.1) |
+| Bug 2  | LambdaIntrospection NPE on `is*` boolean accessors               | P0       | Fixed (v1.0.1) |
+| Bug 3  | No autoboxing between primitive ↔ wrapper types                  | P1       | Fixed (v1.0.1) |
+| Bug 4  | NPE on null intermediate objects in nested paths                 | P1       | Fixed (v1.0.1) |
+| Bug 5  | SettersWriter throws on getter-only properties                   | P1       | Fixed (v1.0.1) |
+| Bug 6  | DeepMap strict bijection enforced on nested auto-recursed types  | P1       | Fixed (v1.0.1) |
+| Bug 7  | LambdaMetafactory fails on classes extending JDK types           | P1       | Fixed (v1.0.1) |
+| Bug 8  | SettersWriter NPE when valueByName returns null for primitive    | P1       | Fixed (v1.0.1) |
+| Bug 9  | `forward(null)` / `backward(null)` NPE instead of returning null | P1       | Fixed (v1.0.1) |
+| Bug 10 | `fieldByName(String)` uses `Records.fieldLens()` for POJOs too   | P1       | Fixed (v1.0.1) |
+
+## Summary — Enhancements
+
+| #     | Description                                        | Priority | Status       |
+| ----- | -------------------------------------------------- | -------- | ------------ |
+| Enh 1 | Cross-module `@Bridge` carrier                     | High     | Open (v1.1+) |
+| Enh 2 | `ForwardMapper.liftList()`                         | Medium   | Open (v1.1+) |
+| Enh 3 | `Telescope.asForwardMapper()`                      | Low      | Open (v1.1+) |
+| Enh 4 | Processor ordering docs + BridgeProcessor deferral | Medium   | Open (v1.1+) |
+| Enh 5 | `Map` → POJO factory                               | Low      | Open (v1.1+) |
+| Enh 6 | `@Bridge` lenient mode                             | High     | Open (v1.1+) |
+| Enh 7 | `Sources.byClass()` generics                       | Low      | Open (v1.1+) |
+| Enh 8 | `Mapping.forward()` naming                         | Low      | Open (v1.1+) |
+| Enh 9 | `mapperForward()` lenient by default               | High     | Open (v1.1+) |
 
 ---
 

--- a/docs/migration-feedback.md
+++ b/docs/migration-feedback.md
@@ -502,9 +502,24 @@ construction time).
 - `core/src/main/java/io/github/eschizoid/telescope/Telescope.java` — dispatch in `fieldByName(String)` on the carried
   `fieldOptics`.
 
----
+**Known caveat (lens-law gap for primitive properties):** the new `Beans.fieldLens(String)` writes through
+`autoWriter(source.getClass())` which routes through `SettersWriter`. `SettersWriter`'s primitive setter is null-guarded
+(Bug 8): if you call `lens.set(bean, null)` on a property whose setter takes a Java primitive (e.g. `int count`), the
+setter call is skipped and the field stays at the JLS default. Reading back yields `0` (auto-boxed), not `null`. This
+means the lens-law `get(set(s, null)) == null` does NOT hold for primitive properties.
 
-## Enhancement Requests
+```java
+class Order { int count; public int getCount() { return count; } public void setCount(int c) { this.count = c; } }
+final var lens = Telescope.ofBean(Order.class).<Integer>fieldByName("count");
+final var order = new Order(); order.setCount(42);
+final var result = lens.update(order, c -> null);  // set(s, null) via the modify path
+lens.read(result);  // → 0, not null
+```
+
+The cure (drop the SettersWriter null-guard so the primitive setter NPEs on null) is worse than the gap, because it
+reintroduces Bug 8 and breaks the MapStruct-parity contract (`@Mapping` default is null → JLS-default substitution for
+primitive targets). **Workaround:** declare the property as a boxed wrapper (`Integer count` instead of `int count`) if
+your call site depends on a faithful null round-trip.
 
 ### 1. Cross-module `@Bridge` support (MapStruct parity)
 

--- a/internal/src/main/java/io/github/eschizoid/telescope/internal/Beans.java
+++ b/internal/src/main/java/io/github/eschizoid/telescope/internal/Beans.java
@@ -878,6 +878,44 @@ public final class Beans {
     };
   }
 
+  /**
+   * Class-deferred bean lens by property name — the bean-side mirror of {@code
+   * Records.fieldLens(String)}. The lens captures only the property name; both the getter and the
+   * writer are resolved against the SOURCE's runtime class on each call. Used by {@code
+   * Telescope.fieldByName(String)} on a bean Telescope, where the actual POJO class isn't known
+   * until call time (the path may have been constructed against a supertype).
+   *
+   * <p>{@code get} delegates to {@link #readProperty(Object, String)} which already short-circuits
+   * on a null source. {@code set} / {@code modify} resolve {@code autoWriter(source.getClass())} at
+   * call time and rebuild the source's class with the focused property replaced. Subtype instances
+   * are written back as their concrete runtime class, matching the lens-law expectation that {@code
+   * set(s, get(s)).equals(s)} round-trips.
+   */
+  @SuppressWarnings({ "unchecked", "rawtypes" })
+  public static <P, A> Lens<P, A> fieldLens(final String property) {
+    return new Lens<>() {
+      @Override
+      public A get(final P source) {
+        return (A) readProperty(source, property);
+      }
+
+      @Override
+      public P set(final P source, final A value) {
+        if (source == null) return null;
+        final Class cls = source.getClass();
+        final var names = propertyNames(cls);
+        final var writer = (BeanWriter<P>) autoWriter(cls);
+        return writer.construct(names, n -> n.equals(property) ? value : readProperty(source, n));
+      }
+
+      @Override
+      public P modify(final P source, final Function<? super A, ? extends A> f) {
+        if (source == null) return null;
+        return set(source, f.apply(get(source)));
+      }
+    };
+  }
+
   private static boolean hasNoArgConstructor(final Class<?> cls) {
     try {
       cls.getDeclaredConstructor();

--- a/internal/src/main/java/io/github/eschizoid/telescope/internal/Beans.java
+++ b/internal/src/main/java/io/github/eschizoid/telescope/internal/Beans.java
@@ -895,7 +895,8 @@ public final class Beans {
    * primitive (e.g. {@code int count}), {@code set(s, null)} substitutes the JLS default ({@code 0}
    * / {@code false} / etc.) rather than throwing — the value flows through {@link SettersWriter}
    * which null-guards primitive setters. This means the lens-law {@code set(s, null).get == null}
-   * does not hold for primitive properties (you get the JLS default back). Use a boxed wrapper type
+   * does not hold for primitive properties (you get the JLS default back). The same substitution
+   * applies to {@code modify(s, f)} when {@code f} returns {@code null}. Use a boxed wrapper type
    * on the property if {@code null} round-trip matters.
    */
   @SuppressWarnings({ "unchecked", "rawtypes" })

--- a/internal/src/main/java/io/github/eschizoid/telescope/internal/Beans.java
+++ b/internal/src/main/java/io/github/eschizoid/telescope/internal/Beans.java
@@ -890,6 +890,13 @@ public final class Beans {
    * call time and rebuild the source's class with the focused property replaced. Subtype instances
    * are written back as their concrete runtime class, matching the lens-law expectation that {@code
    * set(s, get(s)).equals(s)} round-trips.
+   *
+   * <p><b>Primitive properties and {@code set(s, null)}:</b> when the focused property is a Java
+   * primitive (e.g. {@code int count}), {@code set(s, null)} substitutes the JLS default ({@code 0}
+   * / {@code false} / etc.) rather than throwing — the value flows through {@link SettersWriter}
+   * which null-guards primitive setters. This means the lens-law {@code set(s, null).get == null}
+   * does not hold for primitive properties (you get the JLS default back). Use a boxed wrapper type
+   * on the property if {@code null} round-trip matters.
    */
   @SuppressWarnings({ "unchecked", "rawtypes" })
   public static <P, A> Lens<P, A> fieldLens(final String property) {


### PR DESCRIPTION
Two additional adopter-reported issues from the migration-feedback table that weren't on the initial v1.0.1 stack but fit the same MapStruct-parity posture as the rest.

## Bug 9 — `forward(null)` / `backward(null)` returns null

`Mapper.forward(A)`, `Mapper.backward(B)`, and `ForwardMapper.forward(A)` short-circuit to null instead of NPEing on `iso.to(null)` / `forward.get(null)`. Matches MapStruct's generated `if (source == null) return null;` and the JPA "no row" idiom adopters lean on. Hook chain is skipped on null since pre/post hooks have no sensible meaning when no value flows through.

## Bug 10 — `Telescope.fieldByName(String)` POJO dispatch

`fieldByName(String)` used `Records.fieldLens()` unconditionally, so the documented runtime escape hatch failed at call time on any `Telescope.ofBean(...)` chain. New `Beans.fieldLens(String)` mirrors `Records.fieldLens(String)`:
- read via `Beans.readProperty(source, name)`
- write via `autoWriter(source.getClass()).construct(...)` — deferred-class lookup so subclass instances are written back as their concrete runtime class

`Telescope.fieldByName` now dispatches on the carried `fieldOptics` discriminator (same one used by `.field(Accessor)`).

## Tests

8 new pinning tests in `MigrationRegressionTest` — record + bean variants for forward/backward null, hooks-still-fire smoke, `ForwardMapper.forward(null)`, plus read/update via `fieldByName` on a bean + record backward-compat smoke.

## Doc cleanup

- Bugs 9 & 10 added to `docs/migration-feedback.md` in the correct section (was placed below the Enhancement Requests heading after the initial draft).
- Summary table split into "Bugs" and "Enhancements" — were mixed in one table with a confusing `Type` column.
- `Bug N` references scrubbed from `MigrationRegressionTest` nested class names and `@DisplayName` strings — same principle that drove the round-7 source-code scrub.

## Test plan

- [x] `./gradlew check` — green
- [x] 8 new tests in `MigrationRegressionTest` all PASS
- [x] No FQN regressions (mantra `#1`)
- [x] No `Bug N` references remaining in `MigrationRegressionTest` (mantra "future readers don't have bug numbers in cache")