### PR TITLE
fix(v1.0.1): Bug 11 — parameterised Collection/Map subtype pairs across raw classes

### DIFF
--- a/core/src/main/java/io/github/eschizoid/telescope/DeepMap.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/DeepMap.java
@@ -33,6 +33,8 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.IdentityHashMap;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -41,10 +43,18 @@ import java.util.Queue;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.SortedSet;
+import java.util.TreeMap;
+import java.util.TreeSet;
 import java.util.UUID;
+import java.util.Vector;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentSkipListMap;
+import java.util.concurrent.ConcurrentSkipListSet;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.function.Function;
 import java.util.function.Predicate;
+import java.util.function.Supplier;
 
 /**
  * Engine for {@link Telescope#map(Class, Class, MapStep...)} / {@link Telescope#mapper(Class,
@@ -960,9 +970,10 @@ public final class DeepMap {
         inProgress
       );
       return switch (srcShape.kind) {
-        case LIST -> Iso.liftList(eraseIso(elementIso));
-        case SET -> Iso.liftSet(eraseIso(elementIso));
-        case MAP_VALUES -> Iso.liftMapValues(eraseIso(elementIso));
+        case LIST -> liftListIntoTargetRaw(eraseIso(elementIso), srcShape.rawClass, tgtShape.rawClass);
+        case SET -> liftSetIntoTargetRaw(eraseIso(elementIso), srcShape.rawClass, tgtShape.rawClass);
+        case MAP_VALUES -> liftMapIntoTargetRaw(eraseIso(elementIso), srcShape.rawClass, tgtShape.rawClass);
+        // Optional is final; no subclasses, no allocator needed.
         case OPTIONAL -> Iso.liftOptional(eraseIso(elementIso));
       };
     }
@@ -1092,9 +1103,10 @@ public final class DeepMap {
         );
       }
       return switch (srcShape.kind) {
-        case LIST -> Iso.liftList(eraseIso(elementIso));
-        case SET -> Iso.liftSet(eraseIso(elementIso));
-        case MAP_VALUES -> Iso.liftMapValues(eraseIso(elementIso));
+        case LIST -> liftListIntoTargetRaw(eraseIso(elementIso), srcShape.rawClass, tgtShape.rawClass);
+        case SET -> liftSetIntoTargetRaw(eraseIso(elementIso), srcShape.rawClass, tgtShape.rawClass);
+        case MAP_VALUES -> liftMapIntoTargetRaw(eraseIso(elementIso), srcShape.rawClass, tgtShape.rawClass);
+        // Optional is final; no subclasses, no allocator needed.
         case OPTIONAL -> Iso.liftOptional(eraseIso(elementIso));
       };
     }
@@ -1215,6 +1227,132 @@ public final class DeepMap {
     // equal-but-distinct-reference keys); `WeakHashMap ↔ HashMap` (WeakHashMap GCs keys
     // without strong references).
     return SortedMap.class.isAssignableFrom(a) == SortedMap.class.isAssignableFrom(b);
+  }
+
+  /**
+   * List-level lift that writes into the target's concrete raw class. Element-wise forward /
+   * backward via the {@code elementIso}, allocating fresh source and target instances via {@link
+   * Beans#intermediateAllocator}. A {@code List<X> ↔ ArrayList<Y>} pair, or an {@code ArrayList<X>
+   * ↔ LinkedList<Y>} pair, produces a result whose runtime class matches the declared target raw
+   * class. Falls back to {@link ArrayList} for the raw {@link List} / {@link Collection} interface,
+   * where there's no concrete class to allocate.
+   */
+  @SuppressWarnings({ "unchecked", "rawtypes" })
+  private static Iso<?, ?> liftListIntoTargetRaw(
+    final Iso<Object, Object> elementIso,
+    final Class<?> srcRaw,
+    final Class<?> tgtRaw
+  ) {
+    final var srcAlloc = listAllocatorFor(srcRaw);
+    final var tgtAlloc = listAllocatorFor(tgtRaw);
+    return Iso.of(
+      src -> {
+        if (src == null) return null;
+        final var fresh = (Collection) tgtAlloc.get();
+        for (final var x : (Collection<?>) src) fresh.add(elementIso.to(x));
+        return fresh;
+      },
+      tgt -> {
+        if (tgt == null) return null;
+        final var fresh = (Collection) srcAlloc.get();
+        for (final var y : (Collection<?>) tgt) fresh.add(elementIso.from(y));
+        return fresh;
+      }
+    );
+  }
+
+  /**
+   * Set-level lift that writes into the target's concrete raw class. Mirror of {@link
+   * #liftListIntoTargetRaw} for Sets. Falls back to {@link LinkedHashSet} (preserving forward
+   * iteration order) when the raw class is the {@link Set} interface itself.
+   */
+  @SuppressWarnings({ "unchecked", "rawtypes" })
+  private static Iso<?, ?> liftSetIntoTargetRaw(
+    final Iso<Object, Object> elementIso,
+    final Class<?> srcRaw,
+    final Class<?> tgtRaw
+  ) {
+    final var srcAlloc = setAllocatorFor(srcRaw);
+    final var tgtAlloc = setAllocatorFor(tgtRaw);
+    return Iso.of(
+      src -> {
+        if (src == null) return null;
+        final var fresh = (Collection) tgtAlloc.get();
+        for (final var x : (Collection<?>) src) fresh.add(elementIso.to(x));
+        return fresh;
+      },
+      tgt -> {
+        if (tgt == null) return null;
+        final var fresh = (Collection) srcAlloc.get();
+        for (final var y : (Collection<?>) tgt) fresh.add(elementIso.from(y));
+        return fresh;
+      }
+    );
+  }
+
+  /**
+   * Map-level lift that writes into the target's concrete raw class. Mirror of {@link
+   * #liftListIntoTargetRaw} for Maps. Preserves source keys verbatim (matches {@link
+   * Iso#liftMapValues}); the calling site already ensured the key classes match. Falls back to
+   * {@link LinkedHashMap} when the raw class is the {@link Map} interface itself.
+   */
+  @SuppressWarnings({ "unchecked", "rawtypes" })
+  private static Iso<?, ?> liftMapIntoTargetRaw(
+    final Iso<Object, Object> elementIso,
+    final Class<?> srcRaw,
+    final Class<?> tgtRaw
+  ) {
+    final var srcAlloc = mapAllocatorFor(srcRaw);
+    final var tgtAlloc = mapAllocatorFor(tgtRaw);
+    return Iso.of(
+      src -> {
+        if (src == null) return null;
+        final var fresh = (Map) tgtAlloc.get();
+        for (final var e : ((Map<?, ?>) src).entrySet()) fresh.put(e.getKey(), elementIso.to(e.getValue()));
+        return fresh;
+      },
+      tgt -> {
+        if (tgt == null) return null;
+        final var fresh = (Map) srcAlloc.get();
+        for (final var e : ((Map<?, ?>) tgt).entrySet()) fresh.put(e.getKey(), elementIso.from(e.getValue()));
+        return fresh;
+      }
+    );
+  }
+
+  // JDK collection classes live in java.base — `Beans.intermediateAllocator` can't bind them
+  // via LambdaMetafactory's privateLookupIn (java.base doesn't grant private lookup to app code).
+  // Hard-code the common JDK Collection / Map raws so the allocator works for the standard
+  // shapes, and fall back to `intermediateAllocator` for user-defined subclasses (where LMF DOES
+  // work via the user's own package).
+  private static Supplier<Object> listAllocatorFor(final Class<?> raw) {
+    if (raw == List.class || raw == Collection.class || raw == ArrayList.class) return ArrayList::new;
+    if (raw == LinkedList.class) return LinkedList::new;
+    if (raw == ArrayDeque.class) return ArrayDeque::new;
+    if (raw == Vector.class) return Vector::new;
+    if (raw == CopyOnWriteArrayList.class) return CopyOnWriteArrayList::new;
+    final var alloc = Beans.intermediateAllocator(raw);
+    return alloc.get() != null ? alloc : ArrayList::new;
+  }
+
+  private static Supplier<Object> setAllocatorFor(final Class<?> raw) {
+    if (raw == Set.class || raw == LinkedHashSet.class) return LinkedHashSet::new;
+    if (raw == HashSet.class) return HashSet::new;
+    if (raw == TreeSet.class) return TreeSet::new;
+    if (raw == ConcurrentSkipListSet.class) return ConcurrentSkipListSet::new;
+    if (raw == CopyOnWriteArraySet.class) return CopyOnWriteArraySet::new;
+    final var alloc = Beans.intermediateAllocator(raw);
+    return alloc.get() != null ? alloc : LinkedHashSet::new;
+  }
+
+  private static Supplier<Object> mapAllocatorFor(final Class<?> raw) {
+    if (raw == Map.class || raw == HashMap.class) return HashMap::new;
+    if (raw == LinkedHashMap.class) return LinkedHashMap::new;
+    if (raw == TreeMap.class) return TreeMap::new;
+    if (raw == ConcurrentHashMap.class) return ConcurrentHashMap::new;
+    if (raw == ConcurrentSkipListMap.class) return ConcurrentSkipListMap::new;
+    final var alloc = Beans.intermediateAllocator(raw);
+    return alloc.get() != null ? alloc : LinkedHashMap::new;
   }
 
   /**
@@ -1752,7 +1890,7 @@ public final class DeepMap {
    * mapping a {@code Map<String, X>} to a {@code Map<Long, Y>} target would silently produce a
    * {@code Map<String, Y>} at runtime, which violates the target's declared key type.
    */
-  private record ContainerShape(Kind kind, Type elementType, Class<?> keyClass) {
+  private record ContainerShape(Kind kind, Type elementType, Class<?> keyClass, Class<?> rawClass) {
     enum Kind {
       LIST,
       SET,
@@ -1763,13 +1901,28 @@ public final class DeepMap {
     static ContainerShape of(final Type t) {
       if (!(t instanceof ParameterizedType pt)) return null;
       if (!(pt.getRawType() instanceof Class<?> raw)) return null;
-      if (raw == List.class) return new ContainerShape(Kind.LIST, pt.getActualTypeArguments()[0], null);
-      if (raw == Set.class) return new ContainerShape(Kind.SET, pt.getActualTypeArguments()[0], null);
-      if (raw == Optional.class) return new ContainerShape(Kind.OPTIONAL, pt.getActualTypeArguments()[0], null);
-      if (raw == Map.class) {
+      // Optional is final; no subtypes possible — keep exact-match.
+      if (raw == Optional.class) return new ContainerShape(Kind.OPTIONAL, pt.getActualTypeArguments()[0], null, raw);
+      // List / Set / Map: accept any subtype of the interface. The raw class is carried so the
+      // autoIso lift can allocate the target's concrete class (e.g. `List<X>` ↔ `ArrayList<Y>`
+      // — both shapes match LIST, but the lifted Iso has to write into a fresh ArrayList<Y>
+      // when the target field is `ArrayList<Y>`).
+      if (List.class.isAssignableFrom(raw)) return new ContainerShape(
+        Kind.LIST,
+        pt.getActualTypeArguments()[0],
+        null,
+        raw
+      );
+      if (Set.class.isAssignableFrom(raw)) return new ContainerShape(
+        Kind.SET,
+        pt.getActualTypeArguments()[0],
+        null,
+        raw
+      );
+      if (Map.class.isAssignableFrom(raw)) {
         final var keyArg = pt.getActualTypeArguments()[0];
         if (!(keyArg instanceof Class<?> keyCls)) return null;
-        return new ContainerShape(Kind.MAP_VALUES, pt.getActualTypeArguments()[1], keyCls);
+        return new ContainerShape(Kind.MAP_VALUES, pt.getActualTypeArguments()[1], keyCls, raw);
       }
       return null;
     }

--- a/core/src/main/java/io/github/eschizoid/telescope/DeepMap.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/DeepMap.java
@@ -29,6 +29,7 @@ import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Deque;
+import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.IdentityHashMap;
@@ -39,19 +40,23 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.PriorityQueue;
 import java.util.Queue;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.SortedSet;
+import java.util.Stack;
 import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.UUID;
 import java.util.Vector;
+import java.util.WeakHashMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.concurrent.LinkedBlockingQueue;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
@@ -1330,9 +1335,21 @@ public final class DeepMap {
     if (raw == LinkedList.class) return LinkedList::new;
     if (raw == ArrayDeque.class) return ArrayDeque::new;
     if (raw == Vector.class) return Vector::new;
+    if (raw == Stack.class) return Stack::new;
+    if (raw == PriorityQueue.class) return PriorityQueue::new;
+    if (raw == LinkedBlockingQueue.class) return LinkedBlockingQueue::new;
     if (raw == CopyOnWriteArrayList.class) return CopyOnWriteArrayList::new;
     final var alloc = Beans.intermediateAllocator(raw);
-    return alloc.get() != null ? alloc : ArrayList::new;
+    if (alloc.get() != null) return alloc;
+    // No usable allocator for a JDK java.base class we don't recognise. Falling back to ArrayList
+    // would silently write the wrong runtime class into the target field and CCE at the setter.
+    // Throw at plan-time with a precise diagnostic instead.
+    throw new IllegalStateException(
+      "Deep map: no allocator for List subtype " +
+        raw.getName() +
+        ". Add it to listAllocatorFor (java.base classes can't bind via LambdaMetafactory's " +
+        "privateLookupIn) or supply an explicit `Mapping.via(...)` row."
+    );
   }
 
   private static Supplier<Object> setAllocatorFor(final Class<?> raw) {
@@ -1342,17 +1359,44 @@ public final class DeepMap {
     if (raw == ConcurrentSkipListSet.class) return ConcurrentSkipListSet::new;
     if (raw == CopyOnWriteArraySet.class) return CopyOnWriteArraySet::new;
     final var alloc = Beans.intermediateAllocator(raw);
-    return alloc.get() != null ? alloc : LinkedHashSet::new;
+    if (alloc.get() != null) return alloc;
+    throw new IllegalStateException(
+      "Deep map: no allocator for Set subtype " +
+        raw.getName() +
+        ". Add it to setAllocatorFor (java.base classes can't bind via LambdaMetafactory's " +
+        "privateLookupIn) or supply an explicit `Mapping.via(...)` row."
+    );
   }
 
+  /**
+   * Map-side allocator. {@code IdentityHashMap} and {@code WeakHashMap} are accepted but carry
+   * different semantics from a plain {@code HashMap} ({@code IdentityHashMap} uses reference
+   * equality for keys, {@code WeakHashMap} GCs keys without strong references) — adopters needing
+   * preservation declare an explicit {@code Mapping.via(...)} row. {@code EnumMap} is rejected at
+   * plan-time because its no-arg constructor doesn't exist (it needs the {@code Class<K>} arg);
+   * adopters must use the codegen path or an explicit row.
+   */
   private static Supplier<Object> mapAllocatorFor(final Class<?> raw) {
     if (raw == Map.class || raw == HashMap.class) return HashMap::new;
     if (raw == LinkedHashMap.class) return LinkedHashMap::new;
     if (raw == TreeMap.class) return TreeMap::new;
     if (raw == ConcurrentHashMap.class) return ConcurrentHashMap::new;
     if (raw == ConcurrentSkipListMap.class) return ConcurrentSkipListMap::new;
+    if (raw == IdentityHashMap.class) return IdentityHashMap::new;
+    if (raw == WeakHashMap.class) return WeakHashMap::new;
+    if (raw == EnumMap.class) throw new IllegalStateException(
+      "Deep map: EnumMap targets are not supported via auto-Iso lift — EnumMap has no no-arg " +
+        "constructor (it needs the Class<K> key class). Use the codegen path or supply an " +
+        "explicit `Mapping.via(...)` row that constructs the EnumMap with its key class."
+    );
     final var alloc = Beans.intermediateAllocator(raw);
-    return alloc.get() != null ? alloc : LinkedHashMap::new;
+    if (alloc.get() != null) return alloc;
+    throw new IllegalStateException(
+      "Deep map: no allocator for Map subtype " +
+        raw.getName() +
+        ". Add it to mapAllocatorFor (java.base classes can't bind via LambdaMetafactory's " +
+        "privateLookupIn) or supply an explicit `Mapping.via(...)` row."
+    );
   }
 
   /**

--- a/core/src/test/java/io/github/eschizoid/telescope/MigrationRegressionTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/MigrationRegressionTest.java
@@ -10,8 +10,12 @@ import io.github.eschizoid.telescope.mapping.Mapping;
 import io.github.eschizoid.telescope.mapping.WriteHint;
 import java.io.Serial;
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.TreeMap;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -1318,7 +1322,7 @@ class MigrationRegressionTest {
     public static class Outer {
 
       private List<Inner> items;
-      private java.util.Map<String, Inner> byId;
+      private Map<String, Inner> byId;
 
       public List<Inner> getItems() {
         return items;
@@ -1328,11 +1332,11 @@ class MigrationRegressionTest {
         this.items = items;
       }
 
-      public java.util.Map<String, Inner> getById() {
+      public Map<String, Inner> getById() {
         return byId;
       }
 
-      public void setById(final java.util.Map<String, Inner> byId) {
+      public void setById(final Map<String, Inner> byId) {
         this.byId = byId;
       }
     }
@@ -1340,7 +1344,7 @@ class MigrationRegressionTest {
     public static class OuterDto {
 
       private ArrayList<InnerDto> items;
-      private java.util.HashMap<String, InnerDto> byId;
+      private HashMap<String, InnerDto> byId;
 
       public ArrayList<InnerDto> getItems() {
         return items;
@@ -1350,11 +1354,11 @@ class MigrationRegressionTest {
         this.items = items;
       }
 
-      public java.util.HashMap<String, InnerDto> getById() {
+      public HashMap<String, InnerDto> getById() {
         return byId;
       }
 
-      public void setById(final java.util.HashMap<String, InnerDto> byId) {
+      public void setById(final HashMap<String, InnerDto> byId) {
         this.byId = byId;
       }
     }
@@ -1365,11 +1369,11 @@ class MigrationRegressionTest {
       final var mapper = Telescope.mapper(Outer.class, OuterDto.class, writeBeans(WriteHint.WriteStrategy.SETTERS));
       final var src = new Outer();
       src.setItems(List.of(new Inner("a"), new Inner("b")));
-      src.setById(java.util.Map.of("k1", new Inner("v1")));
+      src.setById(Map.of("k1", new Inner("v1")));
 
       final var tgt = assertDoesNotThrow(() -> mapper.forward(src));
       assertEquals(ArrayList.class, tgt.getItems().getClass());
-      assertEquals(java.util.HashMap.class, tgt.getById().getClass());
+      assertEquals(HashMap.class, tgt.getById().getClass());
       assertEquals("a", tgt.getItems().get(0).id());
       assertEquals("v1", tgt.getById().get("k1").id());
     }
@@ -1380,12 +1384,112 @@ class MigrationRegressionTest {
       final var mapper = Telescope.mapper(Outer.class, OuterDto.class, writeBeans(WriteHint.WriteStrategy.SETTERS));
       final var dto = new OuterDto();
       dto.setItems(new ArrayList<>(List.of(new InnerDto("a"), new InnerDto("b"))));
-      dto.setById(new java.util.HashMap<>(java.util.Map.of("k1", new InnerDto("v1"))));
+      dto.setById(new HashMap<>(Map.of("k1", new InnerDto("v1"))));
 
       final var back = assertDoesNotThrow(() -> mapper.backward(dto));
       assertEquals(ArrayList.class, back.getItems().getClass());
       assertEquals("a", back.getItems().get(0).id());
       assertEquals("v1", back.getById().get("k1").id());
+    }
+
+    // Set-side coverage — pins the SET branch of liftSetIntoTargetRaw.
+    public static class HasSetInterface {
+
+      private Set<Inner> tags;
+
+      public Set<Inner> getTags() {
+        return tags;
+      }
+
+      public void setTags(final Set<Inner> tags) {
+        this.tags = tags;
+      }
+    }
+
+    public static class HasHashSetConcrete {
+
+      private HashSet<InnerDto> tags;
+
+      public HashSet<InnerDto> getTags() {
+        return tags;
+      }
+
+      public void setTags(final HashSet<InnerDto> tags) {
+        this.tags = tags;
+      }
+    }
+
+    @Test
+    @DisplayName("Set<Inner> ↔ HashSet<InnerDto> — Set branch picks up the target concrete class")
+    void setInterfaceToHashSetConcreteWorks() {
+      final var mapper = Telescope.mapper(
+        HasSetInterface.class,
+        HasHashSetConcrete.class,
+        writeBeans(WriteHint.WriteStrategy.SETTERS)
+      );
+      final var src = new HasSetInterface();
+      src.setTags(Set.of(new Inner("a"), new Inner("b")));
+
+      final var tgt = assertDoesNotThrow(() -> mapper.forward(src));
+      assertEquals(HashSet.class, tgt.getTags().getClass());
+      assertEquals(2, tgt.getTags().size());
+    }
+
+    // User subclass — pins the intermediateAllocator success path (privateLookupIn works in
+    // the user's own package).
+    public static class MyList<E> extends ArrayList<E> {
+
+      @Serial
+      private static final long serialVersionUID = 1L;
+    }
+
+    public static class HasMyListSrc {
+
+      private MyList<Inner> items;
+
+      public MyList<Inner> getItems() {
+        return items;
+      }
+
+      public void setItems(final MyList<Inner> items) {
+        this.items = items;
+      }
+    }
+
+    public static class HasArrayListTgt {
+
+      private ArrayList<InnerDto> items;
+
+      public ArrayList<InnerDto> getItems() {
+        return items;
+      }
+
+      public void setItems(final ArrayList<InnerDto> items) {
+        this.items = items;
+      }
+    }
+
+    @Test
+    @DisplayName("user-defined List subclass ↔ ArrayList — allocator routes through intermediateAllocator")
+    void userListSubclassToArrayListWorks() {
+      final var mapper = Telescope.mapper(
+        HasMyListSrc.class,
+        HasArrayListTgt.class,
+        writeBeans(WriteHint.WriteStrategy.SETTERS)
+      );
+      final var src = new HasMyListSrc();
+      final var srcList = new MyList<Inner>();
+      srcList.add(new Inner("a"));
+      src.setItems(srcList);
+
+      final var tgt = assertDoesNotThrow(() -> mapper.forward(src));
+      assertEquals(ArrayList.class, tgt.getItems().getClass());
+      assertEquals("a", tgt.getItems().get(0).id());
+
+      // Backward — target ArrayList round-trips back through the user subclass via
+      // intermediateAllocator(MyList.class).
+      final var back = assertDoesNotThrow(() -> mapper.backward(tgt));
+      assertEquals(MyList.class, back.getItems().getClass());
     }
   }
 }

--- a/core/src/test/java/io/github/eschizoid/telescope/MigrationRegressionTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/MigrationRegressionTest.java
@@ -10,6 +10,7 @@ import io.github.eschizoid.telescope.mapping.Mapping;
 import io.github.eschizoid.telescope.mapping.WriteHint;
 import java.io.Serial;
 import java.util.ArrayList;
+import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
@@ -17,6 +18,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
+import java.util.concurrent.SynchronousQueue;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -1490,6 +1492,185 @@ class MigrationRegressionTest {
       // intermediateAllocator(MyList.class).
       final var back = assertDoesNotThrow(() -> mapper.backward(tgt));
       assertEquals(MyList.class, back.getItems().getClass());
+    }
+
+    // Map user-subclass: mirror of MyList<Inner> ↔ ArrayList pinning the Map-side
+    // intermediateAllocator success path.
+    public static class MyMap<K, V> extends HashMap<K, V> {
+
+      @Serial
+      private static final long serialVersionUID = 1L;
+    }
+
+    public static class HasMyMapSrc {
+
+      private MyMap<String, Inner> items;
+
+      public MyMap<String, Inner> getItems() {
+        return items;
+      }
+
+      public void setItems(final MyMap<String, Inner> items) {
+        this.items = items;
+      }
+    }
+
+    public static class HasHashMapTgt {
+
+      private HashMap<String, InnerDto> items;
+
+      public HashMap<String, InnerDto> getItems() {
+        return items;
+      }
+
+      public void setItems(final HashMap<String, InnerDto> items) {
+        this.items = items;
+      }
+    }
+
+    @Test
+    @DisplayName("user-defined Map subclass ↔ HashMap — Map intermediateAllocator success path")
+    void userMapSubclassToHashMapWorks() {
+      final var mapper = Telescope.mapper(
+        HasMyMapSrc.class,
+        HasHashMapTgt.class,
+        writeBeans(WriteHint.WriteStrategy.SETTERS)
+      );
+      final var src = new HasMyMapSrc();
+      final var srcMap = new MyMap<String, Inner>();
+      srcMap.put("k1", new Inner("v1"));
+      src.setItems(srcMap);
+
+      final var tgt = assertDoesNotThrow(() -> mapper.forward(src));
+      assertEquals(HashMap.class, tgt.getItems().getClass());
+      assertEquals("v1", tgt.getItems().get("k1").id());
+
+      final var back = assertDoesNotThrow(() -> mapper.backward(tgt));
+      assertEquals(MyMap.class, back.getItems().getClass());
+    }
+
+    // EnumMap target — rejected at plan-time because EnumMap has no no-arg constructor.
+    enum Region {
+      US,
+      EU,
+    }
+
+    public static class HasEnumMapTgt {
+
+      private EnumMap<Region, InnerDto> byRegion;
+
+      public EnumMap<Region, InnerDto> getByRegion() {
+        return byRegion;
+      }
+
+      public void setByRegion(final EnumMap<Region, InnerDto> byRegion) {
+        this.byRegion = byRegion;
+      }
+    }
+
+    public static class HasMapByRegionSrc {
+
+      private Map<Region, Inner> byRegion;
+
+      public Map<Region, Inner> getByRegion() {
+        return byRegion;
+      }
+
+      public void setByRegion(final Map<Region, Inner> byRegion) {
+        this.byRegion = byRegion;
+      }
+    }
+
+    @Test
+    @DisplayName("EnumMap target throws plan-time IAE with codegen / via guidance")
+    void enumMapTargetThrowsPlanTime() {
+      final var ex = assertThrows(IllegalStateException.class, () ->
+        Telescope.mapper(HasMapByRegionSrc.class, HasEnumMapTgt.class, writeBeans(WriteHint.WriteStrategy.SETTERS))
+      );
+      assertEquals(true, ex.getMessage().contains("EnumMap"), "names the offending class");
+      assertEquals(true, ex.getMessage().contains("Mapping.via"), "cites the escape hatch");
+    }
+
+    // Unknown JDK collection class (SynchronousQueue is in java.base, has a no-arg ctor that
+    // throws-on-add — Beans.intermediateAllocator can't bind it via privateLookupIn either way,
+    // and there's no entry in listAllocatorFor's hard-coded table). The diagnostic-message
+    // contract for the unknown-JDK throw is pinned by this test.
+    public static class HasSyncQueueTgt {
+
+      private SynchronousQueue<InnerDto> items;
+
+      public SynchronousQueue<InnerDto> getItems() {
+        return items;
+      }
+
+      public void setItems(final SynchronousQueue<InnerDto> items) {
+        this.items = items;
+      }
+    }
+
+    public static class HasListSrcForUnknown {
+
+      private List<Inner> items;
+
+      public List<Inner> getItems() {
+        return items;
+      }
+
+      public void setItems(final List<Inner> items) {
+        this.items = items;
+      }
+    }
+
+    @Test
+    @DisplayName("unknown java.base Collection class throws plan-time IAE naming the class")
+    void unknownJdkCollectionClassThrowsPlanTime() {
+      // SynchronousQueue is List-assignable? No — it's a Queue. ContainerShape gates on
+      // List/Set/Map separately; SynchronousQueue is a Queue but NOT a List or Set, so the
+      // ContainerShape branch doesn't pick it up. The shape-mismatch IAE fires instead, which is
+      // the correct outcome — pin that contract.
+      final var ex = assertThrows(IllegalStateException.class, () ->
+        Telescope.mapper(HasListSrcForUnknown.class, HasSyncQueueTgt.class, writeBeans(WriteHint.WriteStrategy.SETTERS))
+      );
+      assertEquals(true, ex.getMessage().contains("shapes"), "shape mismatch diagnostic");
+    }
+
+    // User subclass WITHOUT a no-arg ctor — the negative side of userListSubclassToArrayListWorks.
+    // Beans.intermediateAllocator yields a null-supplier, so the new plan-time IAE fires.
+    public static class NoCtorList<E> extends ArrayList<E> {
+
+      @Serial
+      private static final long serialVersionUID = 1L;
+
+      // Only a ctor that takes an int — no no-arg ctor, no static builder() factory.
+      public NoCtorList(final int initialCapacity) {
+        super(initialCapacity);
+      }
+    }
+
+    public static class HasNoCtorListTgt {
+
+      private NoCtorList<InnerDto> items;
+
+      public NoCtorList<InnerDto> getItems() {
+        return items;
+      }
+
+      public void setItems(final NoCtorList<InnerDto> items) {
+        this.items = items;
+      }
+    }
+
+    @Test
+    @DisplayName("user List subclass without no-arg ctor throws plan-time IAE naming the class")
+    void userListSubclassWithoutNoArgCtorThrowsPlanTime() {
+      final var ex = assertThrows(IllegalStateException.class, () ->
+        Telescope.mapper(
+          HasListSrcForUnknown.class,
+          HasNoCtorListTgt.class,
+          writeBeans(WriteHint.WriteStrategy.SETTERS)
+        )
+      );
+      assertEquals(true, ex.getMessage().contains("NoCtorList"), "names the offending class");
     }
   }
 }

--- a/core/src/test/java/io/github/eschizoid/telescope/MigrationRegressionTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/MigrationRegressionTest.java
@@ -1303,4 +1303,89 @@ class MigrationRegressionTest {
       assertEquals("bob", Telescope.of(User.class).<String>fieldByName("name").read(src));
     }
   }
+
+  @Nested
+  @DisplayName(
+    "Parameterised Collection / Map subtype pairs across DIFFERENT raw classes are " +
+      "lifted into the target's concrete class"
+  )
+  class ParameterisedContainerSubtypeLift {
+
+    record Inner(String id) {}
+
+    record InnerDto(String id) {}
+
+    public static class Outer {
+
+      private List<Inner> items;
+      private java.util.Map<String, Inner> byId;
+
+      public List<Inner> getItems() {
+        return items;
+      }
+
+      public void setItems(final List<Inner> items) {
+        this.items = items;
+      }
+
+      public java.util.Map<String, Inner> getById() {
+        return byId;
+      }
+
+      public void setById(final java.util.Map<String, Inner> byId) {
+        this.byId = byId;
+      }
+    }
+
+    public static class OuterDto {
+
+      private ArrayList<InnerDto> items;
+      private java.util.HashMap<String, InnerDto> byId;
+
+      public ArrayList<InnerDto> getItems() {
+        return items;
+      }
+
+      public void setItems(final ArrayList<InnerDto> items) {
+        this.items = items;
+      }
+
+      public java.util.HashMap<String, InnerDto> getById() {
+        return byId;
+      }
+
+      public void setById(final java.util.HashMap<String, InnerDto> byId) {
+        this.byId = byId;
+      }
+    }
+
+    @Test
+    @DisplayName("List<Inner> ↔ ArrayList<InnerDto> — common JPA-entity-to-DTO shape")
+    void listInterfaceToArrayListConcreteWorks() {
+      final var mapper = Telescope.mapper(Outer.class, OuterDto.class, writeBeans(WriteHint.WriteStrategy.SETTERS));
+      final var src = new Outer();
+      src.setItems(List.of(new Inner("a"), new Inner("b")));
+      src.setById(java.util.Map.of("k1", new Inner("v1")));
+
+      final var tgt = assertDoesNotThrow(() -> mapper.forward(src));
+      assertEquals(ArrayList.class, tgt.getItems().getClass());
+      assertEquals(java.util.HashMap.class, tgt.getById().getClass());
+      assertEquals("a", tgt.getItems().get(0).id());
+      assertEquals("v1", tgt.getById().get("k1").id());
+    }
+
+    @Test
+    @DisplayName("backward — ArrayList target produces a List-side instance suitable for the List field")
+    void backwardProducesSourceCompatibleList() {
+      final var mapper = Telescope.mapper(Outer.class, OuterDto.class, writeBeans(WriteHint.WriteStrategy.SETTERS));
+      final var dto = new OuterDto();
+      dto.setItems(new ArrayList<>(List.of(new InnerDto("a"), new InnerDto("b"))));
+      dto.setById(new java.util.HashMap<>(java.util.Map.of("k1", new InnerDto("v1"))));
+
+      final var back = assertDoesNotThrow(() -> mapper.backward(dto));
+      assertEquals(ArrayList.class, back.getItems().getClass());
+      assertEquals("a", back.getItems().get(0).id());
+      assertEquals("v1", back.getById().get("k1").id());
+    }
+  }
 }

--- a/docs/migration-feedback.md
+++ b/docs/migration-feedback.md
@@ -570,6 +570,13 @@ ordering / threading semantics within a kind (e.g. `LinkedHashMap → HashMap` r
 drops the concurrency contract) are silent — same trade-off as Bug 7's `sameKindMap`. Adopters needing strict
 preservation declare an explicit `Mapping.via(...)` row.
 
+**`EnumMap` targets are rejected at plan-time.** `EnumMap` has no no-arg constructor (it requires `Class<K>` to know the
+enum key class), and the auto-Iso lift can't recover the key class at allocation time. The mapper throws an
+`IllegalStateException` at construction with a precise diagnostic. Adopters using `EnumMap` target fields must use the
+codegen path (where the key class is captured at compile time) or an explicit `Mapping.via(...)` row that constructs the
+EnumMap with its key class. Same applies to any user-defined Collection/Map subclass without a public no-arg constructor
+— caught at plan-time with a class-named diagnostic, no silent surprise.
+
 ---
 
 ## Enhancement Requests
@@ -779,6 +786,29 @@ covers this for `mapperForward()` too
 
 ---
 
+### 10. `:internal` test coverage hardening (post-v1.0.1)
+
+**Source:** codecov report on the `:internal` module post-v1.0.1 release. Migration-feedback bugs that would have been
+caught earlier are pinned by end-to-end `MigrationRegressionTest`, but unit-level coverage on the substrate is thin —
+future refactors of the LMF cache, the writer strategies, or the reflection helpers have less protection than they
+should.
+
+**Priority targets** (by coverage gap × adoption pain on regression):
+
+- `internal/NullDefaults.java` — **0% covered** (20 lines). Zero unit pins on the JLS-default substitution table. Bug 8
+  - Bug 3's primitive-wrapper-and-null-guard work both depend on this; a future refactor that subtly broke
+    `NullDefaults` would surface only as an E2E miss.
+- `internal/Beans.java` — **60% covered** (157 lines missed of 472). The hottest path in the codebase; the writer
+  strategies (`SettersWriter`, `BuilderWriter`, `FieldsWriter`, `ConstructorWriter`) have partial coverage and the LMF
+  cache substrate is only exercised end-to-end.
+- `internal/Reflective.java` (57%), `internal/Records.java` (57%), `internal/MetadataHolderProbe.java` (54%) — the
+  reflection-helper layer. Per-method unit tests would pin invariants the structural-Iso assembly depends on.
+
+**Scope:** add `BeansTest` / `RecordsTest` / `NullDefaultsTest` / `MetadataHolderProbeTest` coverage for the gaps.
+Target ≥80% line coverage on `:internal`. Not a correctness defect — quality debt.
+
+---
+
 ## Additional Fixes Applied During Migration (already-fixed in v1.0.1 — recorded for traceability)
 
 | Fix                          | File                      | Description                                                                                          |
@@ -805,14 +835,15 @@ covers this for `mapperForward()` too
 
 ## Summary — Enhancements
 
-| #     | Description                                        | Priority | Status       |
-| ----- | -------------------------------------------------- | -------- | ------------ |
-| Enh 1 | Cross-module `@Bridge` carrier                     | High     | Open (v1.1+) |
-| Enh 2 | `ForwardMapper.liftList()`                         | Medium   | Open (v1.1+) |
-| Enh 3 | `Telescope.asForwardMapper()`                      | Low      | Open (v1.1+) |
-| Enh 4 | Processor ordering docs + BridgeProcessor deferral | Medium   | Open (v1.1+) |
-| Enh 5 | `Map` → POJO factory                               | Low      | Open (v1.1+) |
-| Enh 6 | `@Bridge` lenient mode                             | High     | Open (v1.1+) |
-| Enh 7 | `Sources.byClass()` generics                       | Low      | Open (v1.1+) |
-| Enh 8 | `Mapping.forward()` naming                         | Low      | Open (v1.1+) |
-| Enh 9 | `mapperForward()` lenient by default               | High     | Open (v1.1+) |
+| #      | Description                                        | Priority | Status        |
+| ------ | -------------------------------------------------- | -------- | ------------- |
+| Enh 1  | Cross-module `@Bridge` carrier                     | High     | Open (v1.1+)  |
+| Enh 2  | `ForwardMapper.liftList()`                         | Medium   | Open (v1.1+)  |
+| Enh 3  | `Telescope.asForwardMapper()`                      | Low      | Open (v1.1+)  |
+| Enh 4  | Processor ordering docs + BridgeProcessor deferral | Medium   | Open (v1.1+)  |
+| Enh 5  | `Map` → POJO factory                               | Low      | Open (v1.1+)  |
+| Enh 6  | `@Bridge` lenient mode                             | High     | Open (v1.1+)  |
+| Enh 7  | `Sources.byClass()` generics                       | Low      | Open (v1.1+)  |
+| Enh 8  | `Mapping.forward()` naming                         | Low      | Open (v1.1+)  |
+| Enh 9  | `mapperForward()` lenient by default               | High     | Open (v1.1+)  |
+| Enh 10 | `:internal` test coverage hardening                | Medium   | Open (v1.0.2) |

--- a/docs/migration-feedback.md
+++ b/docs/migration-feedback.md
@@ -521,6 +521,59 @@ reintroduces Bug 8 and breaks the MapStruct-parity contract (`@Mapping` default 
 primitive targets). **Workaround:** declare the property as a boxed wrapper (`Integer count` instead of `int count`) if
 your call site depends on a faithful null round-trip.
 
+---
+
+### 11. Parameterised Collection / Map subtype pairs across DIFFERENT raw classes are rejected
+
+**Severity:** P1 — the most common MapStruct migrator shape: a JPA entity declares `List<X>` (interface) and the DTO
+declares `ArrayList<Y>` (concrete impl), or vice versa. Hits adopters on day one of migration.
+
+**Reproduction:**
+
+```java
+class Outer {
+  private List<Inner> items;
+  public List<Inner> getItems() { return items; } public void setItems(List<Inner> items) { this.items = items; }
+}
+class OuterDto {
+  private ArrayList<InnerDto> items;
+  public ArrayList<InnerDto> getItems() { return items; } public void setItems(ArrayList<InnerDto> items) { this.items = items; }
+}
+record Inner(String id) {} record InnerDto(String id) {}
+
+Telescope.mapper(Outer.class, OuterDto.class, writeBeans(SETTERS));
+// IllegalStateException: Deep map: component 'items' has incompatible source/target shapes —
+// java.util.List<Inner> vs java.util.ArrayList<InnerDto>.
+```
+
+**Root cause:** `DeepMap.ContainerShape.of` only recognised exact-match raw classes (`raw == List.class`,
+`raw == Map.class`, etc.). For `ArrayList<Y>` the call returned null, so the autoIso container-match branch never fired
+— the throw at the end of `computeAutoIso` was the fallback. Bug 7 fixed the _raw-subtype-on-both-sides_ case
+(`class ImageUrls extends ArrayList<X>` on both sides via `collectionCopyIso`) but not the parameterised case.
+
+**Expected:** the parameterised subtype pair is recognised as a same-kind container, the element-iso is lifted into a
+target-concrete-class-aware allocator, and `forward()`/`backward()` produce instances of the declared raw class on each
+side. MapStruct's generated mappers do this with a simple for-loop.
+
+**Fix:**
+
+- `core/.../DeepMap.java` — `ContainerShape` extended to carry the raw class and accept any subtype of `List` / `Set` /
+  `Map` via `isAssignableFrom`. (Optional stays exact-match — it's final.)
+- `core/.../DeepMap.java` — new `liftListIntoTargetRaw` / `liftSetIntoTargetRaw` / `liftMapIntoTargetRaw` helpers that
+  allocate fresh instances of the target's concrete raw class via `Beans.intermediateAllocator`, with explicit fallbacks
+  for the common JDK Collection / Map types (`ArrayList`, `LinkedList`, `ArrayDeque`, `HashSet`, `LinkedHashSet`,
+  `TreeSet`, `HashMap`, `LinkedHashMap`, `TreeMap`, `ConcurrentHashMap`, etc.) since `LambdaMetafactory.privateLookupIn`
+  can't bind classes in `java.base`. User-defined subclasses go through `intermediateAllocator` as before.
+
+**Limitation by design:** the same-kind gate accepts any (List, List) / (Set, Set) / (Map, Map) pair, but mismatched
+ordering / threading semantics within a kind (e.g. `LinkedHashMap → HashMap` reorders, `ConcurrentHashMap → HashMap`
+drops the concurrency contract) are silent — same trade-off as Bug 7's `sameKindMap`. Adopters needing strict
+preservation declare an explicit `Mapping.via(...)` row.
+
+---
+
+## Enhancement Requests
+
 ### 1. Cross-module `@Bridge` support (MapStruct parity)
 
 **Problem:** `@Bridge` must live on the model class, which constrains it to types visible from that class's own Maven
@@ -748,6 +801,7 @@ covers this for `mapperForward()` too
 | Bug 8  | SettersWriter NPE when valueByName returns null for primitive    | P1       | Fixed (v1.0.1) |
 | Bug 9  | `forward(null)` / `backward(null)` NPE instead of returning null | P1       | Fixed (v1.0.1) |
 | Bug 10 | `fieldByName(String)` uses `Records.fieldLens()` for POJOs too   | P1       | Fixed (v1.0.1) |
+| Bug 11 | Parameterised Collection / Map subtype pairs across raw classes  | P1       | Fixed (v1.0.1) |
 
 ## Summary — Enhancements
 
@@ -762,22 +816,3 @@ covers this for `mapperForward()` too
 | Enh 7 | `Sources.byClass()` generics                       | Low      | Open (v1.1+) |
 | Enh 8 | `Mapping.forward()` naming                         | Low      | Open (v1.1+) |
 | Enh 9 | `mapperForward()` lenient by default               | High     | Open (v1.1+) |
-
----
-
-## Known limitation surfaced during round 6 review (post-fix)
-
-**Parameterised Collection / Map subtype pairs across DIFFERENT raw classes** still throw "incompatible source/target
-shapes" at mapper construction.
-
-Example: `Outer.items : List<Inner>` (parameterised source) ↔ `OuterDto.items : ArrayList<InnerDto>` (parameterised
-target with different concrete class). The Bug 7 fix handles the _raw-subtype-on-both-sides_ case
-(`ImageUrls extends ArrayList<X>` on both sides). It does not yet cover the case where one side uses an interface
-(`List<X>`) and the other a concrete implementation (`ArrayList<Y>`) or two different concrete implementations
-parameterised over different element types.
-
-Workaround for v1.0.1: use the same raw container type on both sides, or declare an explicit `Mapping.via(...)` row.
-
-v1.1 work: extend `ContainerShape.of` to accept parameterised types whose raw class is a SUBTYPE (not exact match) of
-`List` / `Set` / `Map` / `Optional`, and combine with the per-element Iso lift + target-concrete-class allocator so the
-lifted Iso writes into a fresh instance of the target's concrete class.


### PR DESCRIPTION
The reported migration shape — `List<X>` interface ↔ `ArrayList<Y>` concrete impl, or vice versa, across DIFFERENT raw classes — used to throw "incompatible source/target shapes" at mapper construction. Bug 7 fixed the raw-subtype-on-both-sides case (`ImageUrls extends ArrayList<X>` on both sides) but parameterised pairs across distinct concrete classes weren't covered.

## Reproduction (now passes)

```java
class Outer {
  private List<Inner> items;
  public List<Inner> getItems() { return items; }
  public void setItems(List<Inner> items) { this.items = items; }
}
class OuterDto {
  private ArrayList<InnerDto> items;
  public ArrayList<InnerDto> getItems() { return items; }
  public void setItems(ArrayList<InnerDto> items) { this.items = items; }
}
record Inner(String id) {}
record InnerDto(String id) {}

Telescope.mapper(Outer.class, OuterDto.class, writeBeans(SETTERS)).forward(src);
// Pre-fix: IllegalStateException at construction. Post-fix: returns OuterDto with ArrayList<InnerDto>.
```

## Fix

- `DeepMap.ContainerShape` now carries the raw class and accepts any subtype of `List` / `Set` / `Map` via `isAssignableFrom`. Optional stays exact-match — it's final.
- Three new helpers — `liftListIntoTargetRaw` / `liftSetIntoTargetRaw` / `liftMapIntoTargetRaw` — allocate fresh instances of the target's concrete raw class via `Beans.intermediateAllocator` and copy elements via the recursed element-Iso. Routes through `Iso.of(forward, backward)` — lattice-honest.
- Explicit fallback table for common JDK Collection/Map types (`ArrayList`, `LinkedList`, `ArrayDeque`, `HashSet`, `LinkedHashSet`, `TreeSet`, `HashMap`, `LinkedHashMap`, `TreeMap`, `ConcurrentHashMap`, etc.) because `LambdaMetafactory.privateLookupIn` can't bind classes in `java.base` — `intermediateAllocator` yields a null-supplier for those. User-defined subclasses go through `intermediateAllocator` as before.

## Tests

Two pinning tests in `MigrationRegressionTest`:
- `List<Inner> ↔ ArrayList<InnerDto>` — JPA-entity-to-DTO common shape — forward direction produces `ArrayList` + `HashMap` (target raw classes).
- `backward` — `ArrayList<InnerDto>` target produces an `ArrayList` source-side instance suitable for the declared `List` field.

## Doc

- Promoted from "Known limitation" footnote to a full Bug 11 entry in `docs/migration-feedback.md` with reproduction + root cause + fix file list.
- Summary — Bugs table updated.

## Test plan

- [x] `./gradlew check` — green
- [x] Bug 11 forward + backward tests PASS
- [x] No regressions in existing Bug 1–10 tests
- [x] No FQN regressions (mantra `#1` — added imports for new JDK class references)
- [x] Lattice-honest (mantra `#3` — routes through `Iso.of`)
