### PR TITLE
feat(deepmap): Enh 9 — Telescope.mapperForward is lenient by default

### DIFF
--- a/core/src/main/java/io/github/eschizoid/telescope/DeepMap.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/DeepMap.java
@@ -99,14 +99,27 @@ public final class DeepMap {
   // ---------- Package-private entries (called from Telescope.map / Telescope.mapper) ----------
 
   static <A, B> Iso<A, B> resolve(final Class<A> source, final Class<B> target, final MapStep[] steps) {
-    return resolution(source, target, steps).iso;
+    return resolution(source, target, steps, false).iso;
   }
 
   static <A, B> Mapper<A, B> resolveMapper(final Class<A> source, final Class<B> target, final MapStep[] steps) {
-    final var r = resolution(source, target, steps);
+    // Bidirectional: strict bijection — unmatched fields on EITHER side throw at construction.
+    // Round-trip safety depends on every field having a same-name counterpart or an explicit row.
+    final var r = resolution(source, target, steps, false);
     // Go through Mapper.create (public, Function-typed) — same call works regardless of whether
     // Mapper sits in this package or moves to conversion/.
     return Mapper.create(r.iso::to, r.iso::from, source, target, r.patchTable);
+  }
+
+  /**
+   * Forward-only resolution: lenient by default. There's no {@code backward()} call to satisfy, so
+   * the bijection invariant doesn't apply — unmatched target fields silently receive JLS defaults,
+   * unmatched source fields are silently ignored. Matches MapStruct's default behaviour for every
+   * mapper and removes the "13 drops + 2 constants for a 3-field rename" friction adopters hit on a
+   * small-DTO ↔ large-entity migration shape.
+   */
+  static <A, B> Iso<A, B> resolveForward(final Class<A> source, final Class<B> target, final MapStep[] steps) {
+    return resolution(source, target, steps, true).iso;
   }
 
   // ---------- Resolution (shared by both public entries) ----------
@@ -115,7 +128,8 @@ public final class DeepMap {
   private static <A, B> Resolution<A, B> resolution(
     final Class<A> source,
     final Class<B> target,
-    final MapStep[] steps
+    final MapStep[] steps,
+    final boolean lenient
   ) {
     final var overrides = new ArrayList<Mapping<?, ?>>();
     final var hints = new ArrayList<WriteHint<?>>();
@@ -141,7 +155,18 @@ public final class DeepMap {
     final var topSteps = new LinkedHashMap<String, FieldStep>();
     final var cyclicPairs = new HashSet<TypePair>();
     final var inProgress = new ArrayDeque<TypePair>();
-    populateIso(source, target, overrideTable, beanRefl, cache, topSteps, nullStrategy, cyclicPairs, inProgress);
+    populateIso(
+      source,
+      target,
+      overrideTable,
+      beanRefl,
+      cache,
+      topSteps,
+      nullStrategy,
+      cyclicPairs,
+      inProgress,
+      lenient
+    );
     validateAllHintsConsumed(hintMap, cache);
     final var iso = (Iso<A, B>) Objects.requireNonNull(cache.get(new TypePair(source, target)));
     final var patchTable = new LinkedHashMap<String, Mapper.PatchEntry>();
@@ -316,7 +341,8 @@ public final class DeepMap {
     final Map<String, FieldStep> topStepsOut,
     final NullHint.NullStrategy nullStrategy,
     final Set<TypePair> cyclicPairs,
-    final Deque<TypePair> inProgress
+    final Deque<TypePair> inProgress,
+    final boolean lenient
   ) {
     final var key = new TypePair(source, target);
     if (cache.containsKey(key)) {
@@ -501,7 +527,12 @@ public final class DeepMap {
           // TOP-LEVEL pair (`inProgress.size() == 1`) where the user explicitly asked for the
           // mapper; missing fields there ARE a configuration mistake worth surfacing.
           final var isNested = inProgress.size() > 1;
-          if (!telescopeFixups.isEmpty() || isNested) {
+          // `lenient` is set by `resolveForward` — forward-only mappers don't run `backward()`,
+          // so the bijection invariant doesn't apply and unmatched target fields silently take
+          // the JLS default rather than abort construction. Matches MapStruct's default behaviour
+          // and removes "13 drops + 2 constants for a 3-field rename" friction on small-DTO →
+          // large-entity migration shapes.
+          if (!telescopeFixups.isEmpty() || isNested || lenient) {
             // Telescope-row placeholder for a target field with no same-name source. Three cases,
             // type-driven:
             //   - field type is a record AND a telescope row claims it as a first hop: allocate a
@@ -565,10 +596,10 @@ public final class DeepMap {
           bySourceName.putIfAbsent(name, new FieldStep(name, null, NULLING_ISO));
           continue;
         }
-        // Same permissive mode as the target side: when telescope rows are present OR this is a
-        // nested auto-recursed pair, source fields with no consumer fall back to a NULLING
-        // placeholder rather than failing.
-        if (!telescopeFixups.isEmpty() || inProgress.size() > 1) {
+        // Same permissive mode as the target side: when telescope rows are present, this is a
+        // nested auto-recursed pair, OR the resolution is forward-only (lenient), source fields
+        // with no consumer fall back to a NULLING placeholder rather than failing.
+        if (!telescopeFixups.isEmpty() || inProgress.size() > 1 || lenient) {
           bySourceName.putIfAbsent(name, new FieldStep(name, null, NULLING_ISO));
           continue;
         }
@@ -893,7 +924,10 @@ public final class DeepMap {
     // (b) Both reflectable (record or bean) → recurse, return cache-reading Iso so cycles work.
     if (srcType instanceof Class<?> srcCls && tgtType instanceof Class<?> tgtCls) {
       if (isReflectable(srcCls) && isReflectable(tgtCls)) {
-        populateIso(srcCls, tgtCls, overrides, beanRefl, cache, null, nullStrategy, cyclicPairs, inProgress);
+        // Nested recursion — `isNested` (inProgress.size() > 1) already triggers the lenient gate
+        // for unmatched fields regardless of the outer call's strictness. Pass `false` here so the
+        // lenient flag's meaning stays anchored to the user-facing top-level call (mapperForward).
+        populateIso(srcCls, tgtCls, overrides, beanRefl, cache, null, nullStrategy, cyclicPairs, inProgress, false);
         final var subKey = new TypePair(srcCls, tgtCls);
         return lazyCacheIso(cache, subKey, !cyclicPairs.contains(subKey));
       }

--- a/core/src/main/java/io/github/eschizoid/telescope/Telescope.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/Telescope.java
@@ -597,6 +597,14 @@ public sealed class Telescope<
    *
    * UserDto dto = projector.forward(entity);
    * }</pre>
+   *
+   * <p><b>Lenient by default.</b> Unmatched target properties take their JLS default ({@code null}
+   * for reference, {@code 0} for primitives, {@code false} for {@code boolean}); unmatched source
+   * properties are silently ignored. This matches MapStruct's generated-mapper default for every
+   * mapper and removes the "many drops + constants for a small rename" friction on the small-DTO →
+   * large-entity migration shape. Use the bidirectional {@link #mapper(Class, Class, MapStep...)}
+   * instead if you need the strict bijection check (which guards {@code backward()} against
+   * silently losing data).
    */
   public static <A, B> ForwardMapper<A, B> mapperForward(
     final Class<A> source,

--- a/core/src/main/java/io/github/eschizoid/telescope/Telescope.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/Telescope.java
@@ -603,8 +603,12 @@ public sealed class Telescope<
     final Class<B> target,
     final MapStep... steps
   ) {
-    final var bidi = DeepMap.resolveMapper(source, target, steps);
-    return ForwardMapper.create(bidi::forward, source, target);
+    // Forward-only: lenient by default. Unmatched target fields silently take JLS defaults,
+    // unmatched source fields are silently ignored — no `drop()` / `constant()` rows required
+    // for the common "small DTO → large entity" migration shape. Matches MapStruct's default.
+    // Bidirectional `mapper(...)` keeps the strict bijection check.
+    final var iso = DeepMap.resolveForward(source, target, steps);
+    return ForwardMapper.create(iso::to, source, target);
   }
 
   /**

--- a/core/src/test/java/io/github/eschizoid/telescope/MigrationRegressionTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/MigrationRegressionTest.java
@@ -1840,5 +1840,103 @@ class MigrationRegressionTest {
       assertEquals("alice", tgt.getName());
       assertEquals(null, tgt.getCreatedBy());
     }
+
+    @Test
+    @DisplayName(
+      "hook chain (afterForward) composes with lenient construction — stamped fields land on the leniently-built target"
+    )
+    void hookChainComposesWithLeniency() {
+      // Pins that the lenient-construction change doesn't break afterForward composition. The
+      // mapper is built leniently (unmatched fields default), then the hook stamps a derived
+      // field post-mapping. Both behaviours fire correctly together.
+      final var mapper = Telescope.mapperForward(
+        SmallDto.class,
+        LargeEntity.class,
+        writeBeans(WriteHint.WriteStrategy.SETTERS)
+      ).afterForward(e -> {
+        e.setCreatedBy("system");
+        return e;
+      });
+      final var tgt = mapper.forward(new SmallDto("o1", "alice", 42));
+      assertEquals("system", tgt.getCreatedBy(), "afterForward hook fired");
+      assertEquals(null, tgt.getUpdatedBy(), "other unmatched fields still at JLS default");
+      assertEquals("alice", tgt.getName(), "matched field carried through");
+    }
+
+    public static class HolderWithCustomer {
+
+      private InnerCustomer customer;
+
+      public InnerCustomer getCustomer() {
+        return customer;
+      }
+
+      public void setCustomer(final InnerCustomer customer) {
+        this.customer = customer;
+      }
+    }
+
+    public static class InnerCustomer {
+
+      private String email;
+
+      public String getEmail() {
+        return email;
+      }
+
+      public void setEmail(final String email) {
+        this.email = email;
+      }
+    }
+
+    public static class FlatTgt {
+
+      private String customerEmail;
+      private String otherField;
+
+      public String getCustomerEmail() {
+        return customerEmail;
+      }
+
+      public void setCustomerEmail(final String customerEmail) {
+        this.customerEmail = customerEmail;
+      }
+
+      public String getOtherField() {
+        return otherField;
+      }
+
+      public void setOtherField(final String otherField) {
+        this.otherField = otherField;
+      }
+    }
+
+    @Test
+    @DisplayName(
+      "Mapping.to(srcTelescope, tgtAccessor) composes with lenient — nested source row + unmatched target field"
+    )
+    void telescopeRowComposesWithLeniency() {
+      // A nested-source telescope row alongside an UNMATCHED target field. Pre-fix this needed a
+      // constant() for `otherField`. Under lenient default, `otherField` takes its JLS default
+      // while the explicit telescope-row binding still fires for `customerEmail`.
+      final var mapper = Telescope.mapperForward(
+        HolderWithCustomer.class,
+        FlatTgt.class,
+        Mapping.to(
+          Telescope.ofBean(HolderWithCustomer.class)
+            .field(HolderWithCustomer::getCustomer)
+            .field(InnerCustomer::getEmail),
+          FlatTgt::getCustomerEmail
+        ),
+        writeBeans(WriteHint.WriteStrategy.SETTERS)
+      );
+      final var src = new HolderWithCustomer();
+      final var c = new InnerCustomer();
+      c.setEmail("alice@example.com");
+      src.setCustomer(c);
+      final var tgt = mapper.forward(src);
+      assertEquals("alice@example.com", tgt.getCustomerEmail(), "telescope row fired");
+      assertEquals(null, tgt.getOtherField(), "unmatched target field at JLS default");
+    }
   }
 }

--- a/core/src/test/java/io/github/eschizoid/telescope/MigrationRegressionTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/MigrationRegressionTest.java
@@ -1673,4 +1673,172 @@ class MigrationRegressionTest {
       assertEquals(true, ex.getMessage().contains("NoCtorList"), "names the offending class");
     }
   }
+
+  @Nested
+  @DisplayName("mapperForward is lenient by default — unmatched target → JLS default, unmatched source → ignored")
+  class MapperForwardLenientByDefault {
+
+    // Reproduces the adopter-reported "small DTO → large entity" friction shape: a 3-field source
+    // record mapping into a many-field bean target. Before Enh 9 this required N drops + M
+    // constants just to satisfy the strict bijection check; under the lenient default it just
+    // works.
+    record SmallDto(String id, String name, int quantity) {}
+
+    public static class LargeEntity {
+
+      // Same-name fields with the source.
+      private String id;
+      private String name;
+      private int quantity;
+      // Unmatched target fields — these should stay at JLS defaults under lenient mode.
+      private String createdBy;
+      private String updatedBy;
+      private boolean archived;
+      private int version;
+      private String tenant;
+
+      public String getId() {
+        return id;
+      }
+
+      public void setId(final String id) {
+        this.id = id;
+      }
+
+      public String getName() {
+        return name;
+      }
+
+      public void setName(final String name) {
+        this.name = name;
+      }
+
+      public int getQuantity() {
+        return quantity;
+      }
+
+      public void setQuantity(final int quantity) {
+        this.quantity = quantity;
+      }
+
+      public String getCreatedBy() {
+        return createdBy;
+      }
+
+      public void setCreatedBy(final String createdBy) {
+        this.createdBy = createdBy;
+      }
+
+      public String getUpdatedBy() {
+        return updatedBy;
+      }
+
+      public void setUpdatedBy(final String updatedBy) {
+        this.updatedBy = updatedBy;
+      }
+
+      public boolean isArchived() {
+        return archived;
+      }
+
+      public void setArchived(final boolean archived) {
+        this.archived = archived;
+      }
+
+      public int getVersion() {
+        return version;
+      }
+
+      public void setVersion(final int version) {
+        this.version = version;
+      }
+
+      public String getTenant() {
+        return tenant;
+      }
+
+      public void setTenant(final String tenant) {
+        this.tenant = tenant;
+      }
+    }
+
+    @Test
+    @DisplayName("forward-only mapper construction with unmatched target fields succeeds (no drops/constants)")
+    void mapperForwardConstructsWithoutDropsOrConstants() {
+      // Adopter pain reproduction: pre-fix this required 5 constant() rows for the unmatched
+      // target fields. Lenient default: it just works.
+      assertDoesNotThrow(() ->
+        Telescope.mapperForward(SmallDto.class, LargeEntity.class, writeBeans(WriteHint.WriteStrategy.SETTERS))
+      );
+    }
+
+    @Test
+    @DisplayName("forward(small) populates same-name fields; unmatched fields take JLS defaults")
+    void forwardPopulatesSameNameFieldsAndJlsDefaultsTheRest() {
+      final var mapper = Telescope.mapperForward(
+        SmallDto.class,
+        LargeEntity.class,
+        writeBeans(WriteHint.WriteStrategy.SETTERS)
+      );
+      final var tgt = mapper.forward(new SmallDto("o1", "alice", 42));
+      // Matched fields carry through.
+      assertEquals("o1", tgt.getId());
+      assertEquals("alice", tgt.getName());
+      assertEquals(42, tgt.getQuantity());
+      // Unmatched target fields take JLS defaults (null for reference, 0 for int, false for bool).
+      assertEquals(null, tgt.getCreatedBy());
+      assertEquals(null, tgt.getUpdatedBy());
+      assertEquals(false, tgt.isArchived());
+      assertEquals(0, tgt.getVersion());
+      assertEquals(null, tgt.getTenant());
+    }
+
+    record SourceWithExtras(String id, String name, String extraNote, String anotherExtra) {}
+
+    record TargetSmall(String id, String name) {}
+
+    @Test
+    @DisplayName("forward-only — unmatched source fields are silently ignored (no drop required)")
+    void unmatchedSourceFieldsAreIgnoredUnderLenient() {
+      // Pre-fix: this required drop(SourceWithExtras::extraNote) +
+      // drop(SourceWithExtras::anotherExtra).
+      final var mapper = Telescope.mapperForward(SourceWithExtras.class, TargetSmall.class);
+      final var tgt = mapper.forward(new SourceWithExtras("o1", "alice", "ignored", "also ignored"));
+      assertEquals("o1", tgt.id());
+      assertEquals("alice", tgt.name());
+    }
+
+    @Test
+    @DisplayName("bidirectional mapper() STILL enforces strict bijection — unmatched target throws")
+    void bidirectionalMapperStillStrict() {
+      // Round-trip safety: Telescope.mapper (bidirectional) must keep throwing on unmatched
+      // fields so callers know backward() won't silently lose data.
+      assertThrows(IllegalStateException.class, () ->
+        Telescope.mapper(SmallDto.class, LargeEntity.class, writeBeans(WriteHint.WriteStrategy.SETTERS))
+      );
+    }
+
+    @Test
+    @DisplayName("bidirectional mapper() STILL enforces strict bijection — unmatched source throws")
+    void bidirectionalMapperStrictOnUnmatchedSource() {
+      assertThrows(IllegalStateException.class, () -> Telescope.mapper(SourceWithExtras.class, TargetSmall.class));
+    }
+
+    @Test
+    @DisplayName("explicit rename rows still work — only unmatched fields are leniently defaulted")
+    void explicitRenameRowsStillFire() {
+      // Same-name id + an explicit rename `name → fullName`-equivalent via Mapping.to with
+      // different accessors. The unmatched (createdBy etc.) fields stay at default; the explicit
+      // rename fires normally.
+      final var mapper = Telescope.mapperForward(
+        SmallDto.class,
+        LargeEntity.class,
+        Mapping.to(SmallDto::name, LargeEntity::getName),
+        writeBeans(WriteHint.WriteStrategy.SETTERS)
+      );
+      final var tgt = mapper.forward(new SmallDto("o1", "alice", 42));
+      assertEquals("alice", tgt.getName());
+      assertEquals(null, tgt.getCreatedBy());
+    }
+  }
 }

--- a/docs/migration-feedback.md
+++ b/docs/migration-feedback.md
@@ -751,10 +751,17 @@ the call site without requiring readers to check the import.
 
 ---
 
-### 9. `mapperForward()` should be lenient by default
+### 9. `mapperForward()` should be lenient by default — Fixed (v1.0.2)
 
-**Problem:** `Telescope.mapperForward()` runs the same strict bijection check as `Telescope.mapper()` — it throws at
-construction time if the target has properties with no same-name source property:
+**Resolution:** `DeepMap.resolveForward(...)` threads a `lenient=true` flag through `populateIso`. Both unmatched-field
+gates now fire under `lenient || isNested || telescope-fixups`. `Telescope.mapperForward(...)` routes through the new
+lenient path; `Telescope.mapper(...)` keeps the strict bijection check for round-trip safety. Pinned by the
+`MapperForwardLenientByDefault` nested test in `MigrationRegressionTest`. PR #138.
+
+---
+
+**Problem:** `Telescope.mapperForward()` ran the same strict bijection check as `Telescope.mapper()` — it threw at
+construction time if the target had properties with no same-name source property:
 
 ```
 IllegalState: Deep map DocumentT → IdentificationResponse: target property 'documentStatus'
@@ -835,15 +842,15 @@ Target ≥80% line coverage on `:internal`. Not a correctness defect — quality
 
 ## Summary — Enhancements
 
-| #      | Description                                        | Priority | Status        |
-| ------ | -------------------------------------------------- | -------- | ------------- |
-| Enh 1  | Cross-module `@Bridge` carrier                     | High     | Open (v1.1+)  |
-| Enh 2  | `ForwardMapper.liftList()`                         | Medium   | Open (v1.1+)  |
-| Enh 3  | `Telescope.asForwardMapper()`                      | Low      | Open (v1.1+)  |
-| Enh 4  | Processor ordering docs + BridgeProcessor deferral | Medium   | Open (v1.1+)  |
-| Enh 5  | `Map` → POJO factory                               | Low      | Open (v1.1+)  |
-| Enh 6  | `@Bridge` lenient mode                             | High     | Open (v1.1+)  |
-| Enh 7  | `Sources.byClass()` generics                       | Low      | Open (v1.1+)  |
-| Enh 8  | `Mapping.forward()` naming                         | Low      | Open (v1.1+)  |
-| Enh 9  | `mapperForward()` lenient by default               | High     | Open (v1.1+)  |
-| Enh 10 | `:internal` test coverage hardening                | Medium   | Open (v1.0.2) |
+| #      | Description                                        | Priority | Status         |
+| ------ | -------------------------------------------------- | -------- | -------------- |
+| Enh 1  | Cross-module `@Bridge` carrier                     | High     | Open (v1.1+)   |
+| Enh 2  | `ForwardMapper.liftList()`                         | Medium   | Open (v1.1+)   |
+| Enh 3  | `Telescope.asForwardMapper()`                      | Low      | Open (v1.1+)   |
+| Enh 4  | Processor ordering docs + BridgeProcessor deferral | Medium   | Open (v1.1+)   |
+| Enh 5  | `Map` → POJO factory                               | Low      | Open (v1.1+)   |
+| Enh 6  | `@Bridge` lenient mode                             | High     | Open (v1.1+)   |
+| Enh 7  | `Sources.byClass()` generics                       | Low      | Open (v1.1+)   |
+| Enh 8  | `Mapping.forward()` naming                         | Low      | Open (v1.1+)   |
+| Enh 9  | `mapperForward()` lenient by default               | High     | Fixed (v1.0.2) |
+| Enh 10 | `:internal` test coverage hardening                | Medium   | Open (v1.0.2)  |


### PR DESCRIPTION
Adopter migration-feedback Enh 9. Removes the "13 drops + 2 constants for a 3-field rename" friction on the small-DTO → large-entity migration shape.

## Problem

`Telescope.mapperForward(Source, Target, steps)` ran the same strict-bijection check as `Telescope.mapper(...)` — it threw at construction time if the target had properties with no same-name source property. But the bijection invariant only matters for round-trip safety (`backward()`), which `ForwardMapper<A, B>` doesn't have.

Real-world impact: a 3-field rename between `DocumentT` (39 fields) → `IdentificationResponse` (29 fields) required 13 `drop()` + 2 `constant()` rows just to satisfy the strict check — turning a 3-line mapper into a 20-line mapper.

## Fix

- `DeepMap.resolution(...)` now accepts a `boolean lenient` flag, threaded through to `populateIso(...)`.
- The two unmatched-field gates (target → JLS default, source → silently dropped) now fire under `lenient || isNested || telescope-fixups`. The leniency Bug 6 already had for nested auto-recursed pairs is now also available for the top-level call.
- New `DeepMap.resolveForward(...)` package-private entry passes `lenient=true`.
- `Telescope.mapperForward(...)` routes through `resolveForward` instead of `resolveMapper`. Bidirectional `Telescope.mapper(...)` is unchanged — strict bijection preserved for round-trip safety.

## Tests

6 pinning tests in `MigrationRegressionTest.MapperForwardLenientByDefault`:
- Small-DTO → 8-field-bean: constructs without drops/constants; same-name fields carry through; unmatched target fields take JLS defaults.
- Unmatched source fields are silently ignored under forward-only.
- Bidirectional `mapper()` STILL throws on both unmatched-target AND unmatched-source cases.
- Explicit `Mapping.to(...)` rows still fire normally alongside leniency.

## Mantras

- No public API change to `Telescope.mapperForward`'s signature; behavioural improvement only.
- Lattice-honest — routes through `Iso` as before.
- No new reflection.
- North star: dethrone MapStruct — closes a major MapStruct-parity gap.

## Test plan

- [x] `./gradlew check` — green
- [x] Bidirectional `mapper()` still throws on unmatched fields (round-trip safety preserved)
- [x] All existing tests pass (no regression in the bijection-strict path)
