### PR TITLE
feat(forwardmapper): Enh 2 + Enh 3 — container lifts + cross-tier conversions

### DIFF
--- a/core/src/main/java/io/github/eschizoid/telescope/Telescope.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/Telescope.java
@@ -1024,6 +1024,27 @@ public sealed class Telescope<
   }
 
   /**
+   * Project this Telescope as a {@link ForwardMapper} from the root type {@code S} to the focused
+   * type {@code A}, exposing the read direction. Useful when a {@code @Bridge}-generated Telescope
+   * constant needs to surface as a forward-only mapper bean (CDI, Spring controller, audit
+   * projection) without manually wrapping with {@link ForwardMapper#create}.
+   *
+   * <pre>{@code
+   * // @Bridge emits a Telescope<UserEntity, UserDto> constant
+   * Telescope<UserEntity, UserDto> bridge = UserEntityBridge.BRIDGE;
+   * ForwardMapper<UserEntity, UserDto> mapper = bridge.asForwardMapper(UserEntity.class, UserDto.class);
+   * }</pre>
+   *
+   * <p>The source / target classes are required because {@code Telescope<S, A>}'s type parameters
+   * are erased at runtime. They're stored on the produced {@link ForwardMapper} so downstream
+   * machinery (e.g. {@link io.github.eschizoid.telescope.quarkus.TelescopeMapperRegistry}) can key
+   * the mapper by the {@code (source, target)} pair.
+   */
+  public ForwardMapper<S, A> asForwardMapper(final Class<S> sourceClass, final Class<A> targetClass) {
+    return ForwardMapper.create(this::read, sourceClass, targetClass);
+  }
+
+  /**
    * All focused values, in traversal order.
    *
    * <pre>{@code

--- a/core/src/main/java/io/github/eschizoid/telescope/conversion/ForwardMapper.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/conversion/ForwardMapper.java
@@ -2,6 +2,10 @@ package io.github.eschizoid.telescope.conversion;
 
 import io.github.eschizoid.telescope.Telescope;
 import io.github.eschizoid.telescope.internal.optics.Getter;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
@@ -124,6 +128,42 @@ public final class ForwardMapper<A, B> {
     final Getter<A, B> prior = forward;
     final Getter<A, B> wrapped = a -> hook.apply(a, prior.get(a));
     return new ForwardMapper<>(wrapped, sourceClass, targetClass);
+  }
+
+  /**
+   * Lift this element-level forward mapper to a {@code ForwardMapper<List<A>, List<B>>}. Element-
+   * wise forward via the lattice's {@link Getter#liftList(Getter)} primitive. {@code null} lists
+   * round-trip to {@code null}. Forward-only counterpart of {@link Mapper#liftList()}.
+   *
+   * <pre>{@code
+   * ForwardMapper<Entity, Dto> elementToDto = Telescope.mapperForward(Entity.class, Dto.class, ...);
+   * ForwardMapper<List<Entity>, List<Dto>> listToList = elementToDto.liftList();
+   * }</pre>
+   */
+  @SuppressWarnings({ "unchecked", "rawtypes" })
+  public ForwardMapper<List<A>, List<B>> liftList() {
+    return new ForwardMapper<>(Getter.liftList(forward), (Class) List.class, (Class) List.class);
+  }
+
+  /** Same as {@link #liftList()} but produces a {@code ForwardMapper<Set<A>, Set<B>>}. */
+  @SuppressWarnings({ "unchecked", "rawtypes" })
+  public ForwardMapper<Set<A>, Set<B>> liftSet() {
+    return new ForwardMapper<>(Getter.liftSet(forward), (Class) Set.class, (Class) Set.class);
+  }
+
+  /** Same as {@link #liftList()} but produces a {@code ForwardMapper<Optional<A>, Optional<B>>}. */
+  @SuppressWarnings({ "unchecked", "rawtypes" })
+  public ForwardMapper<Optional<A>, Optional<B>> liftOptional() {
+    return new ForwardMapper<>(Getter.liftOptional(forward), (Class) Optional.class, (Class) Optional.class);
+  }
+
+  /**
+   * Same as {@link #liftList()} but produces a {@code ForwardMapper<Map<K, A>, Map<K, B>>}. Keys
+   * are preserved; only the values flow through {@link #forward}.
+   */
+  @SuppressWarnings({ "unchecked", "rawtypes" })
+  public <K> ForwardMapper<Map<K, A>, Map<K, B>> liftMapValues() {
+    return new ForwardMapper<>(Getter.liftMapValues(forward), (Class) Map.class, (Class) Map.class);
   }
 
   /** The mapper's source class. */

--- a/core/src/main/java/io/github/eschizoid/telescope/conversion/Mapper.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/conversion/Mapper.java
@@ -182,13 +182,18 @@ public final class Mapper<A, B> {
    * Project this bidirectional mapper to a {@link ForwardMapper} that exposes only the forward
    * direction. Useful when threading a bidirectional `Mapper` into a forward-only API surface (CDI
    * bean wiring, Spring controllers, audit projections) without the call site needing the
-   * `backward()` half. Hooks installed via {@link #beforeForward}/{@link #afterForward} on this
-   * mapper are NOT carried over — the resulting `ForwardMapper` is a clean projection of the
-   * structural forward direction.
+   * `backward()` half.
+   *
+   * <p><b>Hooks are carried over.</b> The projection routes through {@code this::forward}, which
+   * runs the configured {@link #beforeForward}/{@link #afterForward} chain just like the
+   * bidirectional surface does. Mirrors {@link #asTelescope()} — a configured mapper would silently
+   * drop its hooks if the projection bypassed the chain.
    *
    * <pre>{@code
-   * Mapper<UserEntity, UserDto> bidi = Telescope.mapper(UserEntity.class, UserDto.class, ...);
+   * Mapper<UserEntity, UserDto> bidi = Telescope.mapper(UserEntity.class, UserDto.class, ...)
+   *     .afterForward(dto -> { dto.setStamp("audited"); return dto; });
    * ForwardMapper<UserEntity, UserDto> projector = bidi.toForwardMapper();
+   * // projector.forward(entity) runs the afterForward stamp, same as bidi.forward(entity).
    * }</pre>
    */
   public ForwardMapper<A, B> toForwardMapper() {

--- a/core/src/main/java/io/github/eschizoid/telescope/conversion/Mapper.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/conversion/Mapper.java
@@ -179,6 +179,23 @@ public final class Mapper<A, B> {
   }
 
   /**
+   * Project this bidirectional mapper to a {@link ForwardMapper} that exposes only the forward
+   * direction. Useful when threading a bidirectional `Mapper` into a forward-only API surface (CDI
+   * bean wiring, Spring controllers, audit projections) without the call site needing the
+   * `backward()` half. Hooks installed via {@link #beforeForward}/{@link #afterForward} on this
+   * mapper are NOT carried over — the resulting `ForwardMapper` is a clean projection of the
+   * structural forward direction.
+   *
+   * <pre>{@code
+   * Mapper<UserEntity, UserDto> bidi = Telescope.mapper(UserEntity.class, UserDto.class, ...);
+   * ForwardMapper<UserEntity, UserDto> projector = bidi.toForwardMapper();
+   * }</pre>
+   */
+  public ForwardMapper<A, B> toForwardMapper() {
+    return ForwardMapper.create(this::forward, sourceClass, targetClass);
+  }
+
+  /**
    * Sparse update: overlay the non-null fields of {@code partial} (a partially-populated target)
    * onto {@code base}, leaving the rest of {@code base} untouched. Each present target field is run
    * back through its component {@link Iso}'s backward direction and used to override the matching

--- a/core/src/test/java/io/github/eschizoid/telescope/ForwardMapperLiftsAndConversionsTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/ForwardMapperLiftsAndConversionsTest.java
@@ -1,0 +1,131 @@
+package io.github.eschizoid.telescope;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import io.github.eschizoid.telescope.conversion.ForwardMapper;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pins the new container-lifts on {@link ForwardMapper} ({@code liftList}, {@code liftSet}, {@code
+ * liftOptional}, {@code liftMapValues}) plus the {@code Mapper.toForwardMapper()} and {@code
+ * Telescope.asForwardMapper(...)} cross-tier conversions. Forward-only mirror of {@code
+ * Mapper.liftList/Set/Optional/MapValues} plus the {@code @Bridge → ForwardMapper} bean-wiring
+ * ergonomic.
+ */
+class ForwardMapperLiftsAndConversionsTest {
+
+  record Entity(String id, String email) {}
+
+  record Dto(String id, String email) {}
+
+  @Nested
+  @DisplayName("ForwardMapper.liftList / liftSet / liftOptional / liftMapValues")
+  class ContainerLifts {
+
+    @Test
+    @DisplayName("liftList — element-wise forward over a List; null list round-trips to null")
+    void liftList() {
+      final var elem = Telescope.mapperForward(Entity.class, Dto.class);
+      final var lifted = elem.liftList();
+      final var out = lifted.forward(List.of(new Entity("a", "alice@example.com"), new Entity("b", "bob@example.com")));
+      assertEquals(2, out.size());
+      assertEquals("a", out.get(0).id());
+      assertEquals("bob@example.com", out.get(1).email());
+      // Concrete output class is ArrayList (mirrors Iso.liftList).
+      assertEquals(ArrayList.class, out.getClass());
+
+      // Null pass-through.
+      assertNull(lifted.forward(null));
+    }
+
+    @Test
+    @DisplayName("liftSet — element-wise forward over a Set; output is LinkedHashSet preserving forward-pass order")
+    void liftSet() {
+      final var lifted = Telescope.mapperForward(Entity.class, Dto.class).liftSet();
+      final var input = new java.util.LinkedHashSet<Entity>();
+      input.add(new Entity("a", "alice@example.com"));
+      input.add(new Entity("b", "bob@example.com"));
+
+      final var out = lifted.forward(input);
+      assertEquals(2, out.size());
+      assertEquals(LinkedHashSet.class, out.getClass());
+
+      assertNull(lifted.forward(null));
+    }
+
+    @Test
+    @DisplayName("liftOptional — Optional.empty round-trips to Optional.empty; null reference to null")
+    void liftOptional() {
+      final var lifted = Telescope.mapperForward(Entity.class, Dto.class).liftOptional();
+      final var out = lifted.forward(Optional.of(new Entity("a", "alice@example.com")));
+      assertEquals("a", out.orElseThrow().id());
+
+      final var empty = lifted.forward(Optional.empty());
+      assertEquals(Optional.empty(), empty);
+
+      // Null reference pass-through (records may legally hold a null Optional).
+      assertNull(lifted.forward(null));
+    }
+
+    @Test
+    @DisplayName("liftMapValues — keys preserved verbatim; values flow through forward; null map to null")
+    void liftMapValues() {
+      final ForwardMapper<Map<String, Entity>, Map<String, Dto>> lifted = Telescope.mapperForward(
+        Entity.class,
+        Dto.class
+      ).liftMapValues();
+      final var input = new LinkedHashMap<String, Entity>();
+      input.put("k1", new Entity("v1", "alice@example.com"));
+      final var out = lifted.forward(input);
+      assertEquals(1, out.size());
+      assertEquals("v1", out.get("k1").id());
+      // Keys are preserved verbatim.
+      assertEquals(Set.of("k1"), out.keySet());
+
+      assertNull(lifted.forward(null));
+    }
+  }
+
+  @Nested
+  @DisplayName("Cross-tier conversions: Mapper.toForwardMapper + Telescope.asForwardMapper")
+  class CrossTierConversions {
+
+    record A(String id) {}
+
+    record B(String id) {}
+
+    @Test
+    @DisplayName("Mapper.toForwardMapper() projects a bidirectional Mapper to a forward-only ForwardMapper")
+    void mapperToForwardMapper() {
+      final var bidi = Telescope.mapper(A.class, B.class);
+      final var fm = bidi.toForwardMapper();
+      assertEquals(A.class, fm.sourceClass());
+      assertEquals(B.class, fm.targetClass());
+      final var out = fm.forward(new A("o1"));
+      assertEquals("o1", out.id());
+    }
+
+    @Test
+    @DisplayName("Telescope.asForwardMapper(srcClass, tgtClass) wraps a Telescope path as a forward-only mapper")
+    void telescopeAsForwardMapper() {
+      // Telescope<A, A> identity — the asForwardMapper test cares about the wrapping shape, not
+      // the path complexity.
+      final var path = Telescope.of(A.class);
+      final var fm = path.asForwardMapper(A.class, A.class);
+      assertEquals(A.class, fm.sourceClass());
+      assertEquals(A.class, fm.targetClass());
+      final var out = fm.forward(new A("o1"));
+      assertEquals("o1", out.id());
+    }
+  }
+}

--- a/core/src/test/java/io/github/eschizoid/telescope/ForwardMapperLiftsAndConversionsTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/ForwardMapperLiftsAndConversionsTest.java
@@ -52,7 +52,7 @@ class ForwardMapperLiftsAndConversionsTest {
     @DisplayName("liftSet — element-wise forward over a Set; output is LinkedHashSet preserving forward-pass order")
     void liftSet() {
       final var lifted = Telescope.mapperForward(Entity.class, Dto.class).liftSet();
-      final var input = new java.util.LinkedHashSet<Entity>();
+      final var input = new LinkedHashSet<Entity>();
       input.add(new Entity("a", "alice@example.com"));
       input.add(new Entity("b", "bob@example.com"));
 
@@ -61,6 +61,16 @@ class ForwardMapperLiftsAndConversionsTest {
       assertEquals(LinkedHashSet.class, out.getClass());
 
       assertNull(lifted.forward(null));
+    }
+
+    @Test
+    @DisplayName("empty-container forward — empty List/Set/Map/Optional pass through correctly")
+    void emptyContainersForward() {
+      final var elem = Telescope.mapperForward(Entity.class, Dto.class);
+      assertEquals(0, elem.liftList().forward(List.of()).size());
+      assertEquals(0, elem.liftSet().forward(Set.of()).size());
+      assertEquals(Optional.empty(), elem.liftOptional().forward(Optional.empty()));
+      assertEquals(0, elem.<String>liftMapValues().forward(Map.of()).size());
     }
 
     @Test
@@ -113,6 +123,19 @@ class ForwardMapperLiftsAndConversionsTest {
       assertEquals(B.class, fm.targetClass());
       final var out = fm.forward(new A("o1"));
       assertEquals("o1", out.id());
+    }
+
+    @Test
+    @DisplayName(
+      "Mapper.toForwardMapper() carries over afterForward hooks (the projection routes through this::forward)"
+    )
+    void mapperToForwardMapperCarriesHooks() {
+      // Pin the javadoc contract: the projection delegates to Mapper.forward(A), which runs the
+      // configured hook chain. A future refactor that bypassed the chain (e.g. via iso::to) would
+      // silently drop the hooks — this test catches that.
+      final var bidi = Telescope.mapper(A.class, B.class).afterForward(b -> new B(b.id() + "-STAMPED"));
+      final var fm = bidi.toForwardMapper();
+      assertEquals("o1-STAMPED", fm.forward(new A("o1")).id(), "afterForward hook fired through the projection");
     }
 
     @Test

--- a/internal/src/main/java/io/github/eschizoid/telescope/internal/optics/Getter.java
+++ b/internal/src/main/java/io/github/eschizoid/telescope/internal/optics/Getter.java
@@ -1,5 +1,12 @@
 package io.github.eschizoid.telescope.internal.optics;
 
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Stream;
 
 /**
@@ -37,5 +44,58 @@ public interface Getter<S, A> extends Fold<S, A> {
    */
   default <B> Getter<S, B> then(final Getter<A, B> next) {
     return s -> next.get(get(s));
+  }
+
+  /**
+   * Lift an element-level {@code Getter<X, Y>} into a {@code List}-level {@code Getter<List<X>,
+   * List<Y>>}. Element-wise read via the element Getter. {@code null} lists round-trip to {@code
+   * null} (mirrors the convention of {@link Iso#liftList}). Forward-only counterpart of {@link
+   * Iso#liftList} — used by {@code ForwardMapper#liftList} in the {@code conversion} package.
+   */
+  static <X, Y> Getter<List<X>, List<Y>> liftList(final Getter<X, Y> element) {
+    return xs -> {
+      if (xs == null) return null;
+      final var out = new ArrayList<Y>(xs.size());
+      for (final var x : xs) out.add(element.get(x));
+      return out;
+    };
+  }
+
+  /**
+   * Lift an element-level {@code Getter<X, Y>} into a {@code Set}-level {@code Getter<Set<X>,
+   * Set<Y>>}. Element-wise read into a fresh {@link LinkedHashSet} (preserves forward-pass
+   * iteration order). {@code null} sets round-trip to {@code null}.
+   */
+  static <X, Y> Getter<Set<X>, Set<Y>> liftSet(final Getter<X, Y> element) {
+    return xs -> {
+      if (xs == null) return null;
+      final var out = new LinkedHashSet<Y>(xs.size());
+      for (final var x : xs) out.add(element.get(x));
+      return out;
+    };
+  }
+
+  /**
+   * Lift an element-level {@code Getter<X, Y>} into an {@code Optional}-level {@code
+   * Getter<Optional<X>, Optional<Y>>}. {@code Optional.empty()} maps to {@code Optional.empty()}; a
+   * {@code null} reference (records/beans may legally hold null Optionals) maps to {@code null}.
+   */
+  @SuppressWarnings("OptionalAssignedToNull")
+  static <X, Y> Getter<Optional<X>, Optional<Y>> liftOptional(final Getter<X, Y> element) {
+    return ox -> ox == null ? null : ox.map(element::get);
+  }
+
+  /**
+   * Lift an element-level {@code Getter<X, Y>} into a {@code Map}-values-level {@code Getter<Map<K,
+   * X>, Map<K, Y>>}. Keys are preserved verbatim; only values flow through the element Getter.
+   * {@code null} maps round-trip to {@code null}.
+   */
+  static <K, X, Y> Getter<Map<K, X>, Map<K, Y>> liftMapValues(final Getter<X, Y> element) {
+    return xs -> {
+      if (xs == null) return null;
+      final var out = new LinkedHashMap<K, Y>(xs.size());
+      for (final var e : xs.entrySet()) out.put(e.getKey(), element.get(e.getValue()));
+      return out;
+    };
   }
 }


### PR DESCRIPTION
Closes adopter migration-feedback Enh 2 (ForwardMapper container lifts) + Enh 3 (Telescope/Mapper → ForwardMapper conversions).

## Enh 2 — ForwardMapper container lifts

Closes the asymmetry where `Mapper<A,B>` had `liftList()`/`liftSet()`/`liftOptional()`/`liftMapValues()` but `ForwardMapper<A,B>` didn't. Adopters with forward-only mappers had to wrap as `Mapper` just to get list/set/optional/map projection, which they then immediately threw away.

Implementation:
- New lattice primitives: `Getter.liftList`/`liftSet`/`liftOptional`/`liftMapValues` in `:internal/optics/Getter.java`. Forward-only counterparts of the existing `Iso.liftXxx`. Share the null-pass-through and concrete-output-class conventions.
- New public methods: `ForwardMapper.liftList()`/`liftSet()`/`liftOptional()`/`liftMapValues()` routing through the new `Getter.liftXxx`. Lattice-honest — substrate stays `Getter<A,B>`, not raw `Function`.

## Enh 3 — Cross-tier conversions

`@Bridge` generates a `Telescope<A,B>` constant; exposing it as a `ForwardMapper<A,B>` bean (CDI/Spring) required `ForwardMapper.create(SomeBridge.BRIDGE::read, A.class, B.class)` — verbose and required repeating the type classes.

- `Mapper.toForwardMapper()` — instance method projecting a bidirectional `Mapper` to a forward-only `ForwardMapper`. Hook chain IS carried over — the projection routes through `this::forward`, mirroring `asTelescope`.
- `Telescope.asForwardMapper(srcClass, tgtClass)` — instance method wrapping a `Telescope` path as a forward-only mapper. The classes are required because `Telescope<S,A>`'s type parameters are erased at runtime.

## Tests

`ForwardMapperLiftsAndConversionsTest` — 6 tests:
- `liftList` / `liftSet` / `liftOptional` / `liftMapValues` — element-wise forward; null pass-through; concrete output class (ArrayList / LinkedHashSet / LinkedHashMap).
- `mapperToForwardMapper` — bidirectional → forward-only projection.
- `telescopeAsForwardMapper` — Telescope wrap with explicit class anchors.

## Mantras

- ✅ No inline FQN — all new types imported.
- ✅ Lattice-honest — new `Getter.liftXxx` are lattice primitives; `ForwardMapper.liftXxx` route through them; cross-tier conversions go through the public substrate.
- ✅ Zero reflection.
- ✅ North star: dethrone MapStruct — closes the `ForwardMapper` ergonomic gap.

## Test plan

- [x] `./gradlew check` — green
- [x] All 6 new tests PASS
- [x] No regression in `Iso.liftXxx` (Mapper side) or existing `ForwardMapperTest`

