### PR TITLE
feat(api): Enh 7 + Enh 8 — Sources.byClass generics + Mapping.toOneWay alias

### DIFF
--- a/core/src/main/java/io/github/eschizoid/telescope/Sources.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/Sources.java
@@ -106,9 +106,26 @@ public final class Sources {
   /**
    * Read the source whose runtime class is {@code sourceClass}, or {@code null} if no such source
    * is in the bag. Used by the engine to dispatch each row to its source.
+   *
+   * <p>Generic: the supplied {@code Class<T>} narrows the return type to {@code T}, eliminating the
+   * cast at the call site:
+   *
+   * <pre>{@code
+   * // Before (callers had to cast):
+   * final var headers = (PolicyRequestHeaders) sources.byClass(PolicyRequestHeaders.class);
+   *
+   * // After:
+   * final var headers = sources.byClass(PolicyRequestHeaders.class);
+   * }</pre>
+   *
+   * <p>Safety: the builder keys entries by {@code source.getClass()}, so the value stored under
+   * {@code Class<T>} is guaranteed to be an instance of {@code T}. The dispatch goes through {@link
+   * Class#cast} which throws {@link ClassCastException} only if that invariant is violated — which
+   * would indicate a builder bug, not a user mistake. The lookup is by EXACT runtime class (no
+   * subtype matching) — passing a supertype Class to look up a subclass-stored source returns null.
    */
-  public Object byClass(final Class<?> sourceClass) {
-    return bySrcClass.get(sourceClass);
+  public <T> T byClass(final Class<T> sourceClass) {
+    return sourceClass.cast(bySrcClass.get(sourceClass));
   }
 
   /** Fluent builder. */

--- a/core/src/main/java/io/github/eschizoid/telescope/mapping/Mapping.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/mapping/Mapping.java
@@ -147,6 +147,32 @@ public sealed interface Mapping<A, B>
   }
 
   /**
+   * Identical to {@link #forward(Accessor, Accessor, Function)} — a name-only alias that makes the
+   * unidirectionality explicit at the call site. Useful when static-imported alongside {@link
+   * #to(Accessor, Accessor)} where the bare name {@code forward} can collide with common variable
+   * names ({@code forward}, {@code forwardEvent}, etc.) and obscure that the row is one-way.
+   *
+   * <pre>{@code
+   * import static io.github.eschizoid.telescope.mapping.Mapping.to;
+   * import static io.github.eschizoid.telescope.mapping.Mapping.toOneWay;
+   *
+   * Telescope.mapperForward(UserEntity.class, UserDto.class,
+   *   to(UserEntity::id, UserDto::id),
+   *   toOneWay(UserEntity::createdAt, UserDto::createdAtIso, Instant::toString));
+   * }</pre>
+   *
+   * <p>Behaviourally identical to {@link #forward(Accessor, Accessor, Function)}; pick whichever
+   * reads better at the call site.
+   */
+  static <A, B, X, Y> Mapping<A, B> toOneWay(
+    final Accessor<A, X> src,
+    final Accessor<B, Y> tgt,
+    final Function<? super X, ? extends Y> fn
+  ) {
+    return forward(src, tgt, fn);
+  }
+
+  /**
    * Enum correspondence by constant name. Maps each {@code SE} constant to the {@code TE} constant
    * of the same {@link Enum#name() name}; backward direction is symmetric. Closes MapStruct's
    * {@code @ValueMapping} gap for the common "status enums that line up by name" case without

--- a/core/src/test/java/io/github/eschizoid/telescope/MappingToOneWayAliasTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/MappingToOneWayAliasTest.java
@@ -1,0 +1,36 @@
+package io.github.eschizoid.telescope;
+
+import static io.github.eschizoid.telescope.mapping.Mapping.to;
+import static io.github.eschizoid.telescope.mapping.Mapping.toOneWay;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.time.Instant;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pins {@code Mapping.toOneWay(...)} — a name-only alias of {@code Mapping.forward(...)} added in
+ * Enh 8. Adopters can statically import {@code toOneWay} alongside {@code to} where the bare name
+ * {@code forward} would collide with common local variable names. Behaviour is identical.
+ */
+class MappingToOneWayAliasTest {
+
+  record Entity(String id, Instant createdAt) {}
+
+  record Dto(String id, String createdAtIso) {}
+
+  @Test
+  @DisplayName("Mapping.toOneWay produces a row that behaves identically to Mapping.forward")
+  void toOneWayBehavesLikeForward() {
+    final var mapper = Telescope.mapperForward(
+      Entity.class,
+      Dto.class,
+      to(Entity::id, Dto::id),
+      toOneWay(Entity::createdAt, Dto::createdAtIso, Instant::toString)
+    );
+    final var entity = new Entity("o1", Instant.parse("2026-01-01T00:00:00Z"));
+    final var dto = mapper.forward(entity);
+    assertEquals("o1", dto.id());
+    assertEquals("2026-01-01T00:00:00Z", dto.createdAtIso());
+  }
+}

--- a/core/src/test/java/io/github/eschizoid/telescope/SourcesByClassGenericsTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/SourcesByClassGenericsTest.java
@@ -1,0 +1,54 @@
+package io.github.eschizoid.telescope;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pins the generic signature of {@link Sources#byClass(Class)} added in Enh 7. The change makes the
+ * return type narrow to {@code T} via {@code Class<T>}, eliminating the cast at the call site.
+ *
+ * <p>Safety relies on the builder's invariant: entries are keyed by {@code source.getClass()}, so
+ * the value stored under {@code Class<T>} is guaranteed to be an instance of {@code T}. This test
+ * pins both the no-cast call site and backward compatibility with {@code Class<?>} arguments.
+ */
+class SourcesByClassGenericsTest {
+
+  record Headers(String tenant) {}
+
+  record Body(String payload) {}
+
+  @Test
+  @DisplayName("byClass(Class<T>) returns T directly — no cast required at call site")
+  void byClassReturnsTypedValueWithoutCast() {
+    final var sources = Sources.of(new Headers("tenant-a"), new Body("p"));
+    // No cast — the generic return type narrows to Headers.
+    final Headers headers = sources.byClass(Headers.class);
+    assertEquals("tenant-a", headers.tenant());
+
+    final Body body = sources.byClass(Body.class);
+    assertEquals("p", body.payload());
+  }
+
+  @Test
+  @DisplayName("byClass on absent class returns null (Class.cast(null) is null, not NPE)")
+  void byClassAbsentReturnsNull() {
+    final var sources = Sources.of(new Headers("t"));
+    // Missing class: Class.cast(null) returns null, not NPE.
+    final Body body = sources.byClass(Body.class);
+    assertNull(body);
+  }
+
+  @Test
+  @DisplayName("backward-compat: existing callers passing Class<?> still compile via capture inference")
+  void backwardCompatRawClass() {
+    final var sources = Sources.of(new Headers("t"));
+    // Pre-Enh-7 callers wrote Class<?> at the call site. Now T captures the wildcard, returning
+    // Object — still compiles, no narrowing benefit but no breakage either.
+    final Class<?> raw = Headers.class;
+    final Object obj = sources.byClass(raw);
+    assertEquals(new Headers("t"), obj);
+  }
+}

--- a/docs/migration-feedback.md
+++ b/docs/migration-feedback.md
@@ -845,12 +845,12 @@ Target ≥80% line coverage on `:internal`. Not a correctness defect — quality
 | #      | Description                                        | Priority | Status         |
 | ------ | -------------------------------------------------- | -------- | -------------- |
 | Enh 1  | Cross-module `@Bridge` carrier                     | High     | Open (v1.1+)   |
-| Enh 2  | `ForwardMapper.liftList()`                         | Medium   | Open (v1.1+)   |
-| Enh 3  | `Telescope.asForwardMapper()`                      | Low      | Open (v1.1+)   |
+| Enh 2  | `ForwardMapper.liftList()`                         | Medium   | Fixed (v1.0.2) |
+| Enh 3  | `Telescope.asForwardMapper()`                      | Low      | Fixed (v1.0.2) |
 | Enh 4  | Processor ordering docs + BridgeProcessor deferral | Medium   | Open (v1.1+)   |
 | Enh 5  | `Map` → POJO factory                               | Low      | Open (v1.1+)   |
 | Enh 6  | `@Bridge` lenient mode                             | High     | Open (v1.1+)   |
-| Enh 7  | `Sources.byClass()` generics                       | Low      | Open (v1.1+)   |
-| Enh 8  | `Mapping.forward()` naming                         | Low      | Open (v1.1+)   |
+| Enh 7  | `Sources.byClass()` generics                       | Low      | Fixed (v1.0.2) |
+| Enh 8  | `Mapping.forward()` naming                         | Low      | Fixed (v1.0.2) |
 | Enh 9  | `mapperForward()` lenient by default               | High     | Fixed (v1.0.2) |
 | Enh 10 | `:internal` test coverage hardening                | Medium   | Open (v1.0.2)  |


### PR DESCRIPTION
Two adopter migration-feedback API-polish enhancements.

## Enh 7 — `Sources.byClass(Class<T>) → T`

Pre-fix: callers had to cast at every call site:
```java
final var headers = (PolicyRequestHeaders) sources.byClass(PolicyRequestHeaders.class);
```

Now the return type narrows to `T` via the supplied `Class<T>` witness:
```java
final var headers = sources.byClass(PolicyRequestHeaders.class);   // ← typed, no cast
```

**Safety**: the builder keys entries by `source.getClass()`, so the value stored under `Class<T>` is guaranteed to be an instance of `T`. Dispatch goes through `Class.cast` which throws `ClassCastException` only if that invariant is violated (builder bug, not user mistake). `Class.cast(null)` returns null, preserving the existing absent-key behaviour.

**Backward-compat**: existing callers passing `Class<?>` still compile via capture inference — `T` captures the wildcard, returning `Object`. No source-level break.

## Enh 8 — `Mapping.toOneWay` alias for `Mapping.forward`

Pre-fix: `import static Mapping.forward; import static Mapping.to;` makes `forward` a local identifier that can collide with common variable names (`forward`, `forwardEvent`, etc.) and obscure that the row is one-way.

Adds `Mapping.toOneWay(src, tgt, fn)` — name-only alias of `Mapping.forward(src, tgt, fn)`. Behaviourally identical; pick whichever reads better at the call site.

`Mapping.forward` is kept (no `@Deprecated` shim per project policy — both are first-class).

## Tests

- `SourcesByClassGenericsTest` — 3 tests pinning typed return, absent-key null, backward-compat with raw `Class<?>`.
- `MappingToOneWayAliasTest` — pin that `toOneWay` behaves identically to `forward` in a real `mapperForward` construction.

## Mantras

- No inline FQN.
- No new reflection — `Class.cast` is the JDK's intrinsic safe cast.
- Backward-compatible at source level.

## Test plan

- [x] `./gradlew check` — green
- [x] 4 new tests PASS
