### PR TITLE
docs(adr): ADR-0007/0008/0009 for v1.1+ enhancement candidates (Enh 1/5/6)

### DIFF
--- a/docs/adr/0007-cross-module-bridge-carrier.md
+++ b/docs/adr/0007-cross-module-bridge-carrier.md
@@ -1,0 +1,80 @@
+# ADR-0007: Cross-module `@Bridge` via a declarative carrier class
+
+**Status:** Proposed (v1.1+ candidate) · **Date:** 2026-06-16
+
+## Context
+
+`@Bridge(Target.class)` lives on the source model class. That places a hard constraint: the source class's Maven module
+must see the target type at compile time. Adopters with split-module domain models (`a-entity`, `a-dto`, `b-entity`,
+`b-dto`, each in its own Maven module) typically can't satisfy this — neither side has a dependency path to the other,
+and adding one would create a cycle or pollute the entity module with DTO references it has no business knowing.
+
+MapStruct sidesteps this by lifting the mapping declaration out of the model. The `@Mapper` interface is a standalone
+file in a third "wiring" module that depends on both the source and target modules. The model classes stay
+annotation-free.
+
+Today, telescope adopters facing the constraint fall back to the runtime `Telescope.mapper(Source.class, Target.class,
+...)` factory — they lose the codegen path, accept the ~94× runtime-vs-codegen perf gap, and write the type-pair
+inline at every call site. The migration-feedback report from a 12-mapper MapStruct → telescope adopter flagged this as
+a P1 blocker for any non-trivial multi-module codebase.
+
+## Decision
+
+Allow `@Bridge` on a third **carrier** class that declares the source and target explicitly via the annotation's
+attributes:
+
+```java
+@Bridge(
+  source = IdentityDocumentDBDetails.class,
+  target = IdentityDocumentDetailsBO.class,
+  renames = { @Rename(source = "icVerificationExt", target = "vendorExtendedResult") }
+)
+public class IdentificationBridgeDef {}
+```
+
+The carrier class lives in a module that sees both `source` and `target`. The `BridgeProcessor` emits the
+`Iso<Source, Target>` constant as a sibling class in the **carrier's** package — `IdentificationBridgeDefBridge.BRIDGE`
+— not in the source's package as it would for the model-anchored form. The model classes stay annotation-free.
+
+The model-anchored form (`@Bridge(Target.class)` on the source class) is **retained as-is** for the single-module case;
+it remains the recommended posture when adopters control both sides. The carrier form is the opt-in escape hatch for
+cross-module setups.
+
+## Consequences
+
+- **MapStruct parity unlocked for split-module codebases.** The carrier shape mirrors `@Mapper`'s placement
+  philosophy — declaration sits in a module that sees both sides, not on the model itself. Adopters porting from
+  MapStruct don't need to restructure their module graph.
+- **Codegen path stays the hot path even for cross-module pairs.** Today's fallback (runtime `Telescope.mapper(...)`)
+  drops the ~94× perf advantage on the floor. The carrier form keeps codegen — same emitted `Iso<X, Y>` body, same
+  `BRIDGE` constant, same JIT-inlinable dispatch.
+- **`@Rename` (and any future per-field directives) accept their own annotation array.** The migration-feedback proposal
+  uses `renames = { @Rename(source="...", target="...") }`. The existing inline-on-source attribute set (`renames`,
+  `valueTransforms`, etc.) carries over verbatim — no new vocabulary to learn, same parser code.
+- **`BridgeProcessor` gains a small dispatch fork.** `process(...)` needs one extra branch: if the annotated class
+  carries a `source = ...` attribute → carrier path (read source + target from the annotation, emit
+  `<Carrier>Bridge.BRIDGE` in the carrier's package); else → existing model-anchored path. The downstream emit pipeline
+  is otherwise unchanged.
+- **`as<Target>()` Path hop is only generated for the model-anchored form.** Carrier-anchored bridges don't have a
+  source-class `<Source>Path<R>` to hang the hop off of, by design — the source class is annotation-free in the
+  cross-module case. Adopters use the carrier's `<Carrier>Bridge.BRIDGE` constant directly via `Telescope.from(...)
+  .to(...).using(BRIDGE)` or `Telescope.of(Source.class).then(BRIDGE)`. Documented limitation; symmetric with the reality
+  that the source module can't see the carrier class either.
+
+## Alternatives considered
+
+- **Restructure adopter modules to share a common compile-time visibility.** Rejected. The constraint is structural
+  ("entity modules must not depend on DTO modules") and is the right architectural call for the adopter's codebase. The
+  library should not require its consumers to compromise their module graph.
+- **External `@Mapper`-style standalone interface, with abstract methods telescope implements.** Rejected as too
+  MapStruct-shaped. Telescope's compile-checked DSL is already the right ergonomic shape; this would re-introduce the
+  "write the inverse method signature by hand" friction that bidirectional `Mapper<A, B>` already eliminated.
+- **Two `@Bridge` annotations — `@Bridge.OnModel` and `@Bridge.External`.** Rejected. Two annotations doubles the
+  surface and forces adopters to pick. The single `@Bridge` with attribute-based dispatch (presence of `source =` →
+  carrier form, absence → model-anchored form) gives one mental model with two valid call shapes.
+- **Generate the `<Source>Bridge` constant in the source's package even for the carrier form.** Rejected. The carrier's
+  module can't write source files into the source's package without `javac --add-modules` gymnastics. Emitting in the
+  carrier's package is the only sound choice — JSR-269 processors emit into the same module that triggered them.
+- **Do nothing — adopters can keep using the runtime path.** Rejected. The migration-feedback adopter flagged this as
+  P1; the runtime path drops codegen's perf advantage; cross-module is a real shape MapStruct users routinely use, not
+  an edge case.

--- a/docs/adr/0007-cross-module-bridge-carrier.md
+++ b/docs/adr/0007-cross-module-bridge-carrier.md
@@ -50,7 +50,7 @@ cross-module setups.
   `BRIDGE` constant, same JIT-inlinable dispatch.
 - **`@Rename` (and any future per-field directives) accept their own annotation array.** The migration-feedback proposal
   uses `renames = { @Rename(source="...", target="...") }`. The existing inline-on-source attribute set (`renames`,
-  `valueTransforms`, etc.) carries over verbatim — no new vocabulary to learn, same parser code.
+  `transforms`, etc.) carries over verbatim — no new vocabulary to learn, same parser code.
 - **`BridgeProcessor` gains a small dispatch fork.** `process(...)` needs one extra branch: if the annotated class
   carries a `source = ...` attribute → carrier path (read source + target from the annotation, emit
   `<Carrier>Bridge.BRIDGE` in the carrier's package); else → existing model-anchored path. The downstream emit pipeline

--- a/docs/adr/0007-cross-module-bridge-carrier.md
+++ b/docs/adr/0007-cross-module-bridge-carrier.md
@@ -13,10 +13,10 @@ MapStruct sidesteps this by lifting the mapping declaration out of the model. Th
 file in a third "wiring" module that depends on both the source and target modules. The model classes stay
 annotation-free.
 
-Today, telescope adopters facing the constraint fall back to the runtime `Telescope.mapper(Source.class, Target.class,
-...)` factory — they lose the codegen path, accept the ~94× runtime-vs-codegen perf gap, and write the type-pair
-inline at every call site. The migration-feedback report from a 12-mapper MapStruct → telescope adopter flagged this as
-a P1 blocker for any non-trivial multi-module codebase.
+Today, telescope adopters facing the constraint fall back to the runtime
+`Telescope.mapper(Source.class, Target.class, ...)` factory — they lose the codegen path, accept the ~94×
+runtime-vs-codegen perf gap, and write the type-pair inline at every call site. The migration-feedback report from a
+12-mapper MapStruct → telescope adopter flagged this as a P1 blocker for any non-trivial multi-module codebase.
 
 ## Decision
 
@@ -42,9 +42,9 @@ cross-module setups.
 
 ## Consequences
 
-- **MapStruct parity unlocked for split-module codebases.** The carrier shape mirrors `@Mapper`'s placement
-  philosophy — declaration sits in a module that sees both sides, not on the model itself. Adopters porting from
-  MapStruct don't need to restructure their module graph.
+- **MapStruct parity unlocked for split-module codebases.** The carrier shape mirrors `@Mapper`'s placement philosophy —
+  declaration sits in a module that sees both sides, not on the model itself. Adopters porting from MapStruct don't need
+  to restructure their module graph.
 - **Codegen path stays the hot path even for cross-module pairs.** Today's fallback (runtime `Telescope.mapper(...)`)
   drops the ~94× perf advantage on the floor. The carrier form keeps codegen — same emitted `Iso<X, Y>` body, same
   `BRIDGE` constant, same JIT-inlinable dispatch.
@@ -57,9 +57,9 @@ cross-module setups.
   is otherwise unchanged.
 - **`as<Target>()` Path hop is only generated for the model-anchored form.** Carrier-anchored bridges don't have a
   source-class `<Source>Path<R>` to hang the hop off of, by design — the source class is annotation-free in the
-  cross-module case. Adopters use the carrier's `<Carrier>Bridge.BRIDGE` constant directly via `Telescope.from(...)
-  .to(...).using(BRIDGE)` or `Telescope.of(Source.class).then(BRIDGE)`. Documented limitation; symmetric with the reality
-  that the source module can't see the carrier class either.
+  cross-module case. Adopters use the carrier's `<Carrier>Bridge.BRIDGE` constant directly via
+  `Telescope.from(...) .to(...).using(BRIDGE)` or `Telescope.of(Source.class).then(BRIDGE)`. Documented limitation;
+  symmetric with the reality that the source module can't see the carrier class either.
 
 ## Alternatives considered
 

--- a/docs/adr/0007-cross-module-bridge-carrier.md
+++ b/docs/adr/0007-cross-module-bridge-carrier.md
@@ -58,7 +58,7 @@ cross-module setups.
 - **`as<Target>()` Path hop is only generated for the model-anchored form.** Carrier-anchored bridges don't have a
   source-class `<Source>Path<R>` to hang the hop off of, by design — the source class is annotation-free in the
   cross-module case. Adopters use the carrier's `<Carrier>Bridge.BRIDGE` constant directly via
-  `Telescope.from(...) .to(...).using(BRIDGE)` or `Telescope.of(Source.class).then(BRIDGE)`. Documented limitation;
+  `Telescope.from(...).to(...).using(BRIDGE)` or `Telescope.of(Source.class).then(BRIDGE)`. Documented limitation;
   symmetric with the reality that the source module can't see the carrier class either.
 
 ## Alternatives considered
@@ -78,3 +78,9 @@ cross-module setups.
 - **Do nothing — adopters can keep using the runtime path.** Rejected. The migration-feedback adopter flagged this as
   P1; the runtime path drops codegen's perf advantage; cross-module is a real shape MapStruct users routinely use, not
   an edge case.
+
+## See also
+
+- [ADR-0008](0008-fromMap-untyped-source-factory.md) — sibling v1.1+ enhancement, untyped-source factory
+- [ADR-0009](0009-bridge-lenient-mode.md) — sibling v1.1+ enhancement, codegen lenient mode for `@Bridge`
+- [ADR-0004](0004-runtime-and-codegen-strategy-separate.md) — strategy separation motivating the carrier form

--- a/docs/adr/0008-fromMap-untyped-source-factory.md
+++ b/docs/adr/0008-fromMap-untyped-source-factory.md
@@ -1,0 +1,85 @@
+# ADR-0008: `Telescope.fromMap(Class<T>, MapExtractStep...)` for untyped sources
+
+**Status:** Proposed (v1.1+ candidate) · **Date:** 2026-06-16
+
+## Context
+
+A meaningful slice of real codebases interacts with untyped sources: `Map<String, Object>` returned by JDBC `ResultSet`
+unwrappers, raw JSON nodes from a framework's request body parser, message bus payloads decoded as a flat map. Today,
+telescope has no first-class shape for these — the closest workaround is `Telescope.all(Edit.over(...))` on a
+pre-allocated target, which is imperative on the extraction side and loses every type guarantee telescope normally
+provides.
+
+MapStruct hits the same wall and punts: its `@Mapper` interface can declare a method whose source is `Map<String,
+Object>`, but the user must write a `@AfterMapping` callback that does the typed extraction by hand. There's no
+contractual middle ground.
+
+The migration-feedback report from a 12-mapper MapStruct → telescope adopter flagged this as a Low-priority enhancement
+because the workaround works — but every adopter who hits it loses the static-type story for the affected mapper. The
+asymmetry is bad marketing more than it is bad code.
+
+## Decision
+
+Add a forward-only factory:
+
+```java
+ForwardMapper<Map<String, Object>, CaseListRequest> m = Telescope.fromMap(
+    CaseListRequest.class,
+    extract("bookingType", CaseListRequest::getBookingType, Extractors::firstStringOrValue),
+    extract("caseId",      CaseListRequest::getCaseId,      Object::toString),
+    extract("priority",    CaseListRequest::getPriority,    v -> Integer.parseInt(v.toString())));
+```
+
+`extract(...)` is a new static factory on a new sealed `MapExtractStep` interface (sibling of `MapStep`). Each row
+carries:
+
+- The map key (as a `String`).
+- The target accessor (`Function<T, X>` method reference) — recovered via `SerializedLambda` so the field name + type
+  flow into the rebuild step exactly like today's `Mapping.to(...)`.
+- A `Function<Object, X>` value-converter that consumes the raw map value and produces the typed target value.
+
+The factory returns a `ForwardMapper<Map<String, Object>, T>` — not a bidirectional `Mapper`, because the backward
+direction (`T → Map<String, Object>`) loses information by design and adopters who genuinely need it should write it
+explicitly. Lenient by default: missing map keys → JLS-default target value via `NullDefaults`; unmatched map keys →
+silently ignored.
+
+## Consequences
+
+- **Untyped-source codebases keep telescope's compile-checked story for everything downstream.** The map is the boundary
+  layer; once you're past `fromMap(...)`, you have a `ForwardMapper<Map<String, Object>, T>` you can `.then(...)`-chain,
+  lift into a list with `liftList()`, and inject as a CDI/Spring bean exactly like any other ForwardMapper.
+- **No new internal substrate.** The factory routes through `DeepMap` with a synthetic source-side reader: the
+  per-component "read this field's value" Function returned by `Reflective` becomes `map -> converter.apply(map.get(key))`.
+  The target-side construct path is unchanged. The lattice still holds.
+- **Lenient-by-default is symmetric with `mapperForward(...)`.** Telescope's forward-only family (`mapperForward`,
+  `asForwardMapper`, `fromMap`) all share the same JLS-default-on-miss + silent-ignore-on-extra semantics, matching
+  MapStruct's default for every generated mapper.
+- **`MapExtractStep` is sealed.** Today's permits: `Extract`. Future expansion (nested extracts, conditional gates,
+  required-key validation) extends the sealed surface — same pattern as `MapStep` already follows.
+- **Static-import friendly.** `extract(...)` is intended to be static-imported alongside `Mapping.to` / `Mapping.via`:
+  the call site reads as a list-of-rows with no `Telescope.` qualifier noise on each line.
+- **Performance is intentionally below the typed path.** Map lookups are O(1) HashMap probes, not JIT-inlined
+  field reads; the converter `Function<Object, X>` is a virtual call, not a method-reference. Adopters hit this for
+  legacy code; the documented expectation is "this is the cost of unstructured input, run it at request-boundary not
+  in a hot inner loop."
+
+## Alternatives considered
+
+- **Inverse direction `Telescope.toMap(...)`.** Rejected for v1.x. The `T → Map<String, Object>` direction is what
+  `MapperBuilder.into(Map.class, target)` already does loosely via reflection-walked components; making it first-class
+  requires picking a key-shape policy (verbatim field names? camelCase → snake_case? configurable?) that's a separate
+  ADR-worthy decision and out of scope here.
+- **Polymorphic source — `JsonNode`, `org.json.JSONObject`, `bson.Document`, etc.** Rejected for v1.x. Each library has
+  its own per-type read shape, and pulling them into telescope as compile dependencies is the wrong direction. Adopters
+  needing those wrap them: `JsonNode → Map<String, Object>` first (their framework already does this), then
+  `Telescope.fromMap(...)`.
+- **Reuse `Mapping.to(...)` with a `Map.Entry`-like source accessor.** Rejected. The source side has no compile-time
+  type, so `SerializedLambda`-based field-name recovery doesn't work, and the row would have to invent a different
+  shape for its source identifier. A separate `MapExtractStep` interface keeps the typed-row infrastructure (`Mapping`)
+  unburdened by the untyped corner case.
+- **Annotation-driven — `@MapSource` on a target field with a `key` attribute.** Rejected for the runtime path. Could
+  surface in codegen as a sibling enhancement, but the runtime factory needs to land first; codegen always trails
+  runtime by at least one release cycle (per [ADR-0004](0004-runtime-and-codegen-strategy-separate.md)).
+- **Do nothing — workaround works.** Rejected for the same reason as Enh 1 (cross-module `@Bridge`): the workaround
+  works mechanically but throws away the compile-checked story for any mapper that touches an untyped boundary, and
+  every adopter hitting this experiences the same loss in isolation.

--- a/docs/adr/0008-fromMap-untyped-source-factory.md
+++ b/docs/adr/0008-fromMap-untyped-source-factory.md
@@ -74,6 +74,11 @@ silently ignored.
   its own per-type read shape, and pulling them into telescope as compile dependencies is the wrong direction. Adopters
   needing those wrap them: `JsonNode → Map<String, Object>` first (their framework already does this), then
   `Telescope.fromMap(...)`.
+- **Typed `Symbol<X>` marker keys (`extract(KEYS.bookingType, ...)` with a `Symbol<X>` table declared once).** Rejected.
+  The actual shape on the wire is string-keyed — JDBC `ResultSet#getColumns`, framework request-body parsers, and
+  message-bus payload decoders all produce `String → Object` maps. Forcing adopters to declare a typed `Symbol<X>` table
+  just to call the factory adds boilerplate without removing the underlying string-lookup step (the framework still
+  emits string keys). The runtime converter `Function<Object, X>` is the right type-recovery point.
 - **Reuse `Mapping.to(...)` with a `Map.Entry`-like source accessor.** Rejected. The source side has no compile-time
   type, so `SerializedLambda`-based field-name recovery doesn't work, and the row would have to invent a different shape
   for its source identifier. A separate `MapExtractStep` interface keeps the typed-row infrastructure (`Mapping`)
@@ -84,3 +89,10 @@ silently ignored.
 - **Do nothing — workaround works.** Rejected for the same reason as Enh 1 (cross-module `@Bridge`): the workaround
   works mechanically but throws away the compile-checked story for any mapper that touches an untyped boundary, and
   every adopter hitting this experiences the same loss in isolation.
+
+## See also
+
+- [ADR-0007](0007-cross-module-bridge-carrier.md) — sibling v1.1+ enhancement, cross-module `@Bridge` carrier
+- [ADR-0009](0009-bridge-lenient-mode.md) — sibling v1.1+ enhancement, codegen `@Bridge(lenient = true)`
+- [ADR-0004](0004-runtime-and-codegen-strategy-separate.md) — runtime-vs-codegen separation that pushes `fromMap` into
+  the runtime path first

--- a/docs/adr/0008-fromMap-untyped-source-factory.md
+++ b/docs/adr/0008-fromMap-untyped-source-factory.md
@@ -10,9 +10,9 @@ telescope has no first-class shape for these — the closest workaround is `Tele
 pre-allocated target, which is imperative on the extraction side and loses every type guarantee telescope normally
 provides.
 
-MapStruct hits the same wall and punts: its `@Mapper` interface can declare a method whose source is `Map<String,
-Object>`, but the user must write a `@AfterMapping` callback that does the typed extraction by hand. There's no
-contractual middle ground.
+MapStruct hits the same wall and punts: its `@Mapper` interface can declare a method whose source is
+`Map<String, Object>`, but the user must write a `@AfterMapping` callback that does the typed extraction by hand.
+There's no contractual middle ground.
 
 The migration-feedback report from a 12-mapper MapStruct → telescope adopter flagged this as a Low-priority enhancement
 because the workaround works — but every adopter who hits it loses the static-type story for the affected mapper. The
@@ -24,10 +24,11 @@ Add a forward-only factory:
 
 ```java
 ForwardMapper<Map<String, Object>, CaseListRequest> m = Telescope.fromMap(
-    CaseListRequest.class,
-    extract("bookingType", CaseListRequest::getBookingType, Extractors::firstStringOrValue),
-    extract("caseId",      CaseListRequest::getCaseId,      Object::toString),
-    extract("priority",    CaseListRequest::getPriority,    v -> Integer.parseInt(v.toString())));
+  CaseListRequest.class,
+  extract("bookingType", CaseListRequest::getBookingType, Extractors::firstStringOrValue),
+  extract("caseId", CaseListRequest::getCaseId, Object::toString),
+  extract("priority", CaseListRequest::getPriority, (v) -> Integer.parseInt(v.toString()))
+);
 ```
 
 `extract(...)` is a new static factory on a new sealed `MapExtractStep` interface (sibling of `MapStep`). Each row
@@ -49,8 +50,8 @@ silently ignored.
   layer; once you're past `fromMap(...)`, you have a `ForwardMapper<Map<String, Object>, T>` you can `.then(...)`-chain,
   lift into a list with `liftList()`, and inject as a CDI/Spring bean exactly like any other ForwardMapper.
 - **No new internal substrate.** The factory routes through `DeepMap` with a synthetic source-side reader: the
-  per-component "read this field's value" Function returned by `Reflective` becomes `map -> converter.apply(map.get(key))`.
-  The target-side construct path is unchanged. The lattice still holds.
+  per-component "read this field's value" Function returned by `Reflective` becomes
+  `map -> converter.apply(map.get(key))`. The target-side construct path is unchanged. The lattice still holds.
 - **Lenient-by-default is symmetric with `mapperForward(...)`.** Telescope's forward-only family (`mapperForward`,
   `asForwardMapper`, `fromMap`) all share the same JLS-default-on-miss + silent-ignore-on-extra semantics, matching
   MapStruct's default for every generated mapper.
@@ -58,10 +59,10 @@ silently ignored.
   required-key validation) extends the sealed surface — same pattern as `MapStep` already follows.
 - **Static-import friendly.** `extract(...)` is intended to be static-imported alongside `Mapping.to` / `Mapping.via`:
   the call site reads as a list-of-rows with no `Telescope.` qualifier noise on each line.
-- **Performance is intentionally below the typed path.** Map lookups are O(1) HashMap probes, not JIT-inlined
-  field reads; the converter `Function<Object, X>` is a virtual call, not a method-reference. Adopters hit this for
-  legacy code; the documented expectation is "this is the cost of unstructured input, run it at request-boundary not
-  in a hot inner loop."
+- **Performance is intentionally below the typed path.** Map lookups are O(1) HashMap probes, not JIT-inlined field
+  reads; the converter `Function<Object, X>` is a virtual call, not a method-reference. Adopters hit this for legacy
+  code; the documented expectation is "this is the cost of unstructured input, run it at request-boundary not in a hot
+  inner loop."
 
 ## Alternatives considered
 
@@ -74,8 +75,8 @@ silently ignored.
   needing those wrap them: `JsonNode → Map<String, Object>` first (their framework already does this), then
   `Telescope.fromMap(...)`.
 - **Reuse `Mapping.to(...)` with a `Map.Entry`-like source accessor.** Rejected. The source side has no compile-time
-  type, so `SerializedLambda`-based field-name recovery doesn't work, and the row would have to invent a different
-  shape for its source identifier. A separate `MapExtractStep` interface keeps the typed-row infrastructure (`Mapping`)
+  type, so `SerializedLambda`-based field-name recovery doesn't work, and the row would have to invent a different shape
+  for its source identifier. A separate `MapExtractStep` interface keeps the typed-row infrastructure (`Mapping`)
   unburdened by the untyped corner case.
 - **Annotation-driven — `@MapSource` on a target field with a `key` attribute.** Rejected for the runtime path. Could
   surface in codegen as a sibling enhancement, but the runtime factory needs to land first; codegen always trails

--- a/docs/adr/0009-bridge-lenient-mode.md
+++ b/docs/adr/0009-bridge-lenient-mode.md
@@ -1,0 +1,87 @@
+# ADR-0009: `@Bridge(lenient = true)` for the small-DTO → large-entity pattern
+
+**Status:** Proposed (v1.1+ candidate) · **Date:** 2026-06-16
+
+## Context
+
+`@Bridge` enforces strict bijection at codegen time: every component on the source must have a same-name
+component on the target, and vice versa. The check is the same one `Telescope.mapper(...)` enforces at runtime, and
+the rationale is the same — a `Mapper<A, B>` is bidirectional, so unmatched fields would silently lose data on the
+backward direction.
+
+This produces an unworkable shape for one common adopter case: small DTO → large entity. The migration-feedback
+report names a concrete example — `CustomerCaseRequest` (7 fields) → `GovtIdDBData` (135 fields). Only 6 fields
+actually map. The other 129 target fields stay at JLS defaults by design. Today, that requires 129 `@Constant(field =
+"x", value = "null")` entries on the `@Bridge` annotation. Completely impractical.
+
+The runtime sibling of this gap was Enh 9 / PR #138: `Telescope.mapperForward(...)` made lenient by default, threading
+a `lenient=true` flag through `DeepMap.populateIso`. The codegen path needs the symmetric move.
+
+## Decision
+
+Add a `lenient` attribute to `@Bridge` (default `false` to preserve today's strict semantics):
+
+```java
+@Bridge(
+  value = GovtIdDBData.class,
+  lenient = true,
+  renames = { @Rename(source = "referenceID", target = "entRefncId"),
+              @Rename(source = "policyNo",    target = "policyNumber") })
+public class CustomerCaseRequestBridge {}
+```
+
+When `lenient = true`, `BridgeProcessor`:
+
+- Skips the "every target component has a same-name source component" check.
+- Emits writes only for the components named in `renames`, `valueTransforms`, plus same-name auto-matches that
+  exist on both sides.
+- Leaves unmatched target components at their JLS default — the canonical-ctor call (records) or builder/setter chain
+  (POJOs) for those positions takes the `NullDefaults.defaultFor(componentType)` value, exactly as the runtime lenient
+  path does.
+- Unmatched source components are silently ignored — same semantic as `mapperForward(...)` lenient default.
+
+The generated `Iso<Source, Target>` is **forward-only-in-semantics-but-bidirectional-in-type** when `lenient = true`:
+the backward direction still type-checks, but the rebuilt source has the same unmatched-on-source fields populated
+with `NullDefaults` values. That's the same "partial round-trip" shape `mapperForward(...)` already exposes
+deliberately. Document it loudly in the `@Bridge` javadoc: `lenient = true` opts out of the round-trip law; users who
+want round-trip safety must keep `lenient = false`.
+
+## Consequences
+
+- **The small-DTO → large-entity pattern becomes one-line viable.** The `CustomerCaseRequest → GovtIdDBData` example
+  drops from 130 annotation entries to 1 attribute + the actual rename rows. Adopter pain disappears.
+- **Codegen symmetry with `mapperForward(...)` lenient default.** Both the runtime forward-only path and the codegen
+  `@Bridge` path now expose the same lenient semantics, gated by a flag that defaults to the safe-bijection direction.
+- **`BridgeProcessor` change is small.** One new annotation attribute parse, one branch in the bijection-validation
+  step (`if (!lenient) { ... }`), and the existing same-name auto-matching loop just runs against a smaller match set.
+  The emitted `Iso<S, T>` body itself is unchanged at the structural level.
+- **`@Rename` and `@ValueTransform` continue to express ALL non-default mappings explicitly.** Lenient mode doesn't add
+  any heuristic — it only removes the bijection requirement. Adopters still get a static compile-time guarantee that
+  every declared rename or value-transform refers to real components on both sides.
+- **No silent corruption surface.** Unlike a fuzzy-match heuristic (which [ADR-0002](0002-no-fuzzy-auto-mapping.md)
+  explicitly rejected), lenient mode only opts out of the "complete the match" check — same-name auto-matches and
+  declared renames still go through their normal type-safety pipeline. A field that was matched correctly before
+  `lenient = true` still matches correctly; the only change is that the absence of a match no longer fails compilation.
+- **Documentation must call out the round-trip-loss explicitly.** `lenient = true` users get a partial-Iso. Their
+  generated `BRIDGE.from(...)` will produce a source instance with the `Source`-side fields that have no `Target`
+  counterpart populated at `NullDefaults`. Adopters who rely on backward round-trip safety must NOT set `lenient`. The
+  `@Bridge` javadoc must spell this out next to the attribute declaration, and the BridgeProcessor must emit a
+  matching warning in the `<X>Bridge` class javadoc for any class compiled with `lenient = true`.
+
+## Alternatives considered
+
+- **Always lenient — flip the default.** Rejected. `@Bridge` has historical strict-bijection semantics; flipping the
+  default silently changes behavior for every existing adopter and removes the safety net for codebases that genuinely
+  want the round-trip law. Opt-in is the right posture.
+- **Lenient-only via a separate annotation — `@BridgeForward`.** Rejected. Duplicates the `@Bridge` surface
+  (annotation parser, processor dispatch, generated class shape) for what is really a one-flag variant. The
+  attribute-flag form keeps a single annotation with one optional knob.
+- **Auto-generate the missing `@Constant(field, null)` entries via a code-quick-fix.** Rejected. IDE-level annotation
+  scaffolding is fragile (different IDEs implement quick-fixes differently, only the user's primary IDE benefits) and
+  doesn't help build-time correctness. The flag approach fixes the build itself.
+- **Per-field lenient — `@Lenient(field = "x")`.** Rejected as over-engineered. The real-world pattern is "almost
+  everything is unmatched and that's fine" — not "some specific subset is unmatched." Granular per-field control adds
+  surface area for no clear adopter win.
+- **Symmetric runtime API — add a `lenient = true` knob to `Telescope.mapper(Class, Class, ...)`.** Out of scope here
+  (separate ADR moment); the runtime bidirectional `mapper(...)` keeping strict-by-default for round-trip safety is
+  load-bearing semantics. `mapperForward(...)` already covers the lenient runtime case.

--- a/docs/adr/0009-bridge-lenient-mode.md
+++ b/docs/adr/0009-bridge-lenient-mode.md
@@ -4,18 +4,17 @@
 
 ## Context
 
-`@Bridge` enforces strict bijection at codegen time: every component on the source must have a same-name
-component on the target, and vice versa. The check is the same one `Telescope.mapper(...)` enforces at runtime, and
-the rationale is the same — a `Mapper<A, B>` is bidirectional, so unmatched fields would silently lose data on the
-backward direction.
+`@Bridge` enforces strict bijection at codegen time: every component on the source must have a same-name component on
+the target, and vice versa. The check is the same one `Telescope.mapper(...)` enforces at runtime, and the rationale is
+the same — a `Mapper<A, B>` is bidirectional, so unmatched fields would silently lose data on the backward direction.
 
-This produces an unworkable shape for one common adopter case: small DTO → large entity. The migration-feedback
-report names a concrete example — `CustomerCaseRequest` (7 fields) → `GovtIdDBData` (135 fields). Only 6 fields
-actually map. The other 129 target fields stay at JLS defaults by design. Today, that requires 129 `@Constant(field =
-"x", value = "null")` entries on the `@Bridge` annotation. Completely impractical.
+This produces an unworkable shape for one common adopter case: small DTO → large entity. The migration-feedback report
+names a concrete example — `CustomerCaseRequest` (7 fields) → `GovtIdDBData` (135 fields). Only 6 fields actually map.
+The other 129 target fields stay at JLS defaults by design. Today, that requires 129
+`@Constant(field = "x", value = "null")` entries on the `@Bridge` annotation. Completely impractical.
 
-The runtime sibling of this gap was Enh 9 / PR #138: `Telescope.mapperForward(...)` made lenient by default, threading
-a `lenient=true` flag through `DeepMap.populateIso`. The codegen path needs the symmetric move.
+The runtime sibling of this gap was Enh 9 / PR #138: `Telescope.mapperForward(...)` made lenient by default, threading a
+`lenient=true` flag through `DeepMap.populateIso`. The codegen path needs the symmetric move.
 
 ## Decision
 
@@ -25,26 +24,28 @@ Add a `lenient` attribute to `@Bridge` (default `false` to preserve today's stri
 @Bridge(
   value = GovtIdDBData.class,
   lenient = true,
-  renames = { @Rename(source = "referenceID", target = "entRefncId"),
-              @Rename(source = "policyNo",    target = "policyNumber") })
+  renames = {
+    @Rename(source = "referenceID", target = "entRefncId"), @Rename(source = "policyNo", target = "policyNumber"),
+  }
+)
 public class CustomerCaseRequestBridge {}
 ```
 
 When `lenient = true`, `BridgeProcessor`:
 
 - Skips the "every target component has a same-name source component" check.
-- Emits writes only for the components named in `renames`, `valueTransforms`, plus same-name auto-matches that
-  exist on both sides.
+- Emits writes only for the components named in `renames`, `valueTransforms`, plus same-name auto-matches that exist on
+  both sides.
 - Leaves unmatched target components at their JLS default — the canonical-ctor call (records) or builder/setter chain
   (POJOs) for those positions takes the `NullDefaults.defaultFor(componentType)` value, exactly as the runtime lenient
   path does.
 - Unmatched source components are silently ignored — same semantic as `mapperForward(...)` lenient default.
 
 The generated `Iso<Source, Target>` is **forward-only-in-semantics-but-bidirectional-in-type** when `lenient = true`:
-the backward direction still type-checks, but the rebuilt source has the same unmatched-on-source fields populated
-with `NullDefaults` values. That's the same "partial round-trip" shape `mapperForward(...)` already exposes
-deliberately. Document it loudly in the `@Bridge` javadoc: `lenient = true` opts out of the round-trip law; users who
-want round-trip safety must keep `lenient = false`.
+the backward direction still type-checks, but the rebuilt source has the same unmatched-on-source fields populated with
+`NullDefaults` values. That's the same "partial round-trip" shape `mapperForward(...)` already exposes deliberately.
+Document it loudly in the `@Bridge` javadoc: `lenient = true` opts out of the round-trip law; users who want round-trip
+safety must keep `lenient = false`.
 
 ## Consequences
 
@@ -52,9 +53,9 @@ want round-trip safety must keep `lenient = false`.
   drops from 130 annotation entries to 1 attribute + the actual rename rows. Adopter pain disappears.
 - **Codegen symmetry with `mapperForward(...)` lenient default.** Both the runtime forward-only path and the codegen
   `@Bridge` path now expose the same lenient semantics, gated by a flag that defaults to the safe-bijection direction.
-- **`BridgeProcessor` change is small.** One new annotation attribute parse, one branch in the bijection-validation
-  step (`if (!lenient) { ... }`), and the existing same-name auto-matching loop just runs against a smaller match set.
-  The emitted `Iso<S, T>` body itself is unchanged at the structural level.
+- **`BridgeProcessor` change is small.** One new annotation attribute parse, one branch in the bijection-validation step
+  (`if (!lenient) { ... }`), and the existing same-name auto-matching loop just runs against a smaller match set. The
+  emitted `Iso<S, T>` body itself is unchanged at the structural level.
 - **`@Rename` and `@ValueTransform` continue to express ALL non-default mappings explicitly.** Lenient mode doesn't add
   any heuristic — it only removes the bijection requirement. Adopters still get a static compile-time guarantee that
   every declared rename or value-transform refers to real components on both sides.
@@ -65,17 +66,17 @@ want round-trip safety must keep `lenient = false`.
 - **Documentation must call out the round-trip-loss explicitly.** `lenient = true` users get a partial-Iso. Their
   generated `BRIDGE.from(...)` will produce a source instance with the `Source`-side fields that have no `Target`
   counterpart populated at `NullDefaults`. Adopters who rely on backward round-trip safety must NOT set `lenient`. The
-  `@Bridge` javadoc must spell this out next to the attribute declaration, and the BridgeProcessor must emit a
-  matching warning in the `<X>Bridge` class javadoc for any class compiled with `lenient = true`.
+  `@Bridge` javadoc must spell this out next to the attribute declaration, and the BridgeProcessor must emit a matching
+  warning in the `<X>Bridge` class javadoc for any class compiled with `lenient = true`.
 
 ## Alternatives considered
 
 - **Always lenient — flip the default.** Rejected. `@Bridge` has historical strict-bijection semantics; flipping the
   default silently changes behavior for every existing adopter and removes the safety net for codebases that genuinely
   want the round-trip law. Opt-in is the right posture.
-- **Lenient-only via a separate annotation — `@BridgeForward`.** Rejected. Duplicates the `@Bridge` surface
-  (annotation parser, processor dispatch, generated class shape) for what is really a one-flag variant. The
-  attribute-flag form keeps a single annotation with one optional knob.
+- **Lenient-only via a separate annotation — `@BridgeForward`.** Rejected. Duplicates the `@Bridge` surface (annotation
+  parser, processor dispatch, generated class shape) for what is really a one-flag variant. The attribute-flag form
+  keeps a single annotation with one optional knob.
 - **Auto-generate the missing `@Constant(field, null)` entries via a code-quick-fix.** Rejected. IDE-level annotation
   scaffolding is fragile (different IDEs implement quick-fixes differently, only the user's primary IDE benefits) and
   doesn't help build-time correctness. The flag approach fixes the build itself.

--- a/docs/adr/0009-bridge-lenient-mode.md
+++ b/docs/adr/0009-bridge-lenient-mode.md
@@ -63,11 +63,15 @@ safety must keep `lenient = false`.
   explicitly rejected), lenient mode only opts out of the "complete the match" check — same-name auto-matches and
   declared renames still go through their normal type-safety pipeline. A field that was matched correctly before
   `lenient = true` still matches correctly; the only change is that the absence of a match no longer fails compilation.
-- **Documentation must call out the round-trip-loss explicitly.** `lenient = true` users get a partial-Iso. Their
-  generated `BRIDGE.from(...)` will produce a source instance with the `Source`-side fields that have no `Target`
-  counterpart populated at `NullDefaults`. Adopters who rely on backward round-trip safety must NOT set `lenient`. The
-  `@Bridge` javadoc must spell this out next to the attribute declaration, and the BridgeProcessor must emit a matching
-  warning in the `<X>Bridge` class javadoc for any class compiled with `lenient = true`.
+- **Documentation must call out the round-trip-loss explicitly, by direction name.** `lenient = true` users get a
+  partial-Iso whose **`BRIDGE.from(target)` direction is the lossy one** — every `Source`-side field with no `Target`
+  counterpart comes back populated at `NullDefaults` (zero / empty-string / null), regardless of what the original
+  Source held. The forward direction (`BRIDGE.to(source)`) remains lossy-by-design in the well-understood small-DTO →
+  large-entity shape (unmatched Target fields take JLS defaults, which is the whole point). Adopters who rely on
+  backward round-trip safety must NOT set `lenient`. The `@Bridge` javadoc must spell this out next to the attribute
+  declaration AND name `BRIDGE.from(target)` as the partial direction; the BridgeProcessor must emit a matching warning
+  in the `<X>Bridge` class javadoc for any class compiled with `lenient = true`, again naming `BRIDGE.from(target)` as
+  the asymmetric side so the IDE warning is unambiguous.
 
 ## Alternatives considered
 
@@ -86,3 +90,11 @@ safety must keep `lenient = false`.
 - **Symmetric runtime API — add a `lenient = true` knob to `Telescope.mapper(Class, Class, ...)`.** Out of scope here
   (separate ADR moment); the runtime bidirectional `mapper(...)` keeping strict-by-default for round-trip safety is
   load-bearing semantics. `mapperForward(...)` already covers the lenient runtime case.
+
+## See also
+
+- [ADR-0007](0007-cross-module-bridge-carrier.md) — sibling v1.1+ enhancement, cross-module `@Bridge` carrier (companion
+  `@Bridge` surface)
+- [ADR-0008](0008-fromMap-untyped-source-factory.md) — sibling v1.1+ enhancement, untyped-source factory
+- [ADR-0002](0002-no-fuzzy-auto-mapping.md) — the no-fuzzy-matching guardrail that lenient mode
+  opts-out-of-but-doesn't-violate

--- a/docs/adr/0009-bridge-lenient-mode.md
+++ b/docs/adr/0009-bridge-lenient-mode.md
@@ -34,8 +34,8 @@ public class CustomerCaseRequestBridge {}
 When `lenient = true`, `BridgeProcessor`:
 
 - Skips the "every target component has a same-name source component" check.
-- Emits writes only for the components named in `renames`, `valueTransforms`, plus same-name auto-matches that exist on
-  both sides.
+- Emits writes only for the components named in `renames`, `transforms`, plus same-name auto-matches that exist on both
+  sides.
 - Leaves unmatched target components at their JLS default — the canonical-ctor call (records) or builder/setter chain
   (POJOs) for those positions takes the `NullDefaults.defaultFor(componentType)` value, exactly as the runtime lenient
   path does.
@@ -56,22 +56,22 @@ safety must keep `lenient = false`.
 - **`BridgeProcessor` change is small.** One new annotation attribute parse, one branch in the bijection-validation step
   (`if (!lenient) { ... }`), and the existing same-name auto-matching loop just runs against a smaller match set. The
   emitted `Iso<S, T>` body itself is unchanged at the structural level.
-- **`@Rename` and `@ValueTransform` continue to express ALL non-default mappings explicitly.** Lenient mode doesn't add
-  any heuristic — it only removes the bijection requirement. Adopters still get a static compile-time guarantee that
-  every declared rename or value-transform refers to real components on both sides.
+- **`@Rename` and `@Transform` continue to express ALL non-default mappings explicitly.** Lenient mode doesn't add any
+  heuristic — it only removes the bijection requirement. Adopters still get a static compile-time guarantee that every
+  declared rename or value-transform refers to real components on both sides.
 - **No silent corruption surface.** Unlike a fuzzy-match heuristic (which [ADR-0002](0002-no-fuzzy-auto-mapping.md)
   explicitly rejected), lenient mode only opts out of the "complete the match" check — same-name auto-matches and
   declared renames still go through their normal type-safety pipeline. A field that was matched correctly before
   `lenient = true` still matches correctly; the only change is that the absence of a match no longer fails compilation.
 - **Documentation must call out the round-trip-loss explicitly, by direction name.** `lenient = true` users get a
-  partial-Iso whose **`BRIDGE.from(target)` direction is the lossy one** — every `Source`-side field with no `Target`
-  counterpart comes back populated at `NullDefaults` (zero / empty-string / null), regardless of what the original
-  Source held. The forward direction (`BRIDGE.to(source)`) remains lossy-by-design in the well-understood small-DTO →
-  large-entity shape (unmatched Target fields take JLS defaults, which is the whole point). Adopters who rely on
-  backward round-trip safety must NOT set `lenient`. The `@Bridge` javadoc must spell this out next to the attribute
-  declaration AND name `BRIDGE.from(target)` as the partial direction; the BridgeProcessor must emit a matching warning
-  in the `<X>Bridge` class javadoc for any class compiled with `lenient = true`, again naming `BRIDGE.from(target)` as
-  the asymmetric side so the IDE warning is unambiguous.
+  partial-Iso whose **`BRIDGE.set(source, target)` direction is the lossy one** — every `Source`-side field with no
+  `Target` counterpart comes back populated at `NullDefaults` (zero / empty-string / null), regardless of what the
+  original Source held. The forward direction (`BRIDGE.read(source)`) remains lossy-by-design in the well-understood
+  small-DTO → large-entity shape (unmatched Target fields take JLS defaults, which is the whole point). Adopters who
+  rely on backward round-trip safety must NOT set `lenient`. The `@Bridge` javadoc must spell this out next to the
+  attribute declaration AND name `BRIDGE.set(source, target)` as the partial direction; the BridgeProcessor must emit a
+  matching warning in the `<X>Bridge` class javadoc for any class compiled with `lenient = true`, again naming
+  `BRIDGE.set(source, target)` as the asymmetric side so the IDE warning is unambiguous.
 
 ## Alternatives considered
 


### PR DESCRIPTION
## Summary

Captures the design rationale for the three remaining migration-feedback enhancements that are NOT being pulled into v1.0.2 — so the v1.1 implementation work has the decisions recorded rather than re-litigating them.

- **ADR-0007 — Cross-module `@Bridge` via a declarative carrier class** (Enh 1). Allows `@Bridge` on a third "carrier" class declaring `source = X.class, target = Y.class` explicitly. Carrier lives in a module that sees both sides; `BridgeProcessor` emits `<Carrier>Bridge.BRIDGE` in the carrier's package. Closes the MapStruct-parity gap for split-module domain models.
- **ADR-0008 — `Telescope.fromMap(Class<T>, MapExtractStep...)` for untyped sources** (Enh 5). New forward-only factory for `Map<String, Object> → T` mappings; `extract(key, accessor, converter)` rows. Lenient by default. Symmetric with `Telescope.mapperForward(...)`.
- **ADR-0009 — `@Bridge(lenient = true)` for small-DTO → large-entity** (Enh 6). Codegen sibling of Enh 9's `mapperForward` lenient default. Opt-in flag (default `false` preserves bijection); when `true`, `BridgeProcessor` skips the bijection check and unmatched target components take `NullDefaults` values.

Each ADR follows the project's existing ADR shape: Status + Date, Context, Decision, Consequences, Alternatives considered.

## Why now (docs-only, no code)

All three are **Proposed** — no implementation in this PR. Pulling them in early gives reviewers a chance to push back on the design BEFORE implementation work starts, instead of after a v1.1 PR has already coded against a half-baked decision.

## Test plan

- [x] No code changes — all three files are markdown
- [x] CLAUDE.md ADR index updated locally (file is gitignored per existing pattern; each clone maintains its own copy)
- [ ] User confirms each ADR's Decision section reads as the right design — reject / refine before implementation work starts
