### PR TITLE
feat(codegen): Enh 4 — BridgeProcessor round-defers Lombok-annotated pairs + docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -498,6 +498,45 @@ Maven:
 </build>
 ```
 
+#### Annotation processor ordering with Lombok
+
+When both Lombok and `telescope-lombok` / `telescope-codegen` sit on the annotation processor path, list **Lombok
+first**. Maven respects the declaration order of `<annotationProcessorPaths>`; Gradle respects the order of
+`annotationProcessor(...)` calls:
+
+```xml
+<annotationProcessorPaths>
+  <path>
+    <groupId>org.projectlombok</groupId>
+    <artifactId>lombok</artifactId>
+    <version>1.18.30</version>
+  </path>
+  <path>
+    <groupId>io.github.eschizoid</groupId>
+    <artifactId>telescope-lombok</artifactId>
+    <version>1.0.1</version>
+  </path>
+</annotationProcessorPaths>
+```
+
+```kotlin
+dependencies {
+  annotationProcessor("org.projectlombok:lombok:1.18.30")
+  annotationProcessor("io.github.eschizoid:telescope-lombok:1.0.1")
+  annotationProcessor("io.github.eschizoid:telescope-codegen:1.0.1")
+}
+```
+
+Both `BridgeProcessor` and `LombokFocusProcessor` round-defer emission to `processingOver()` when they detect that the
+host class (or its `@Bridge` target) carries a Lombok-synthesizing annotation, so the build is order-tolerant — but
+explicit ordering avoids relying on round-deferral and is the recommended posture. The Lombok-synthesizing trigger set
+includes `@Data`, `@Value`, `@Builder`, `@Getter`, `@Setter`, the three `*ArgsConstructor` variants, `@SuperBuilder`,
+and `@experimental.Accessors`.
+
+Symptoms of mis-ordering without round-deferral (now harmless thanks to the deferral fix, but worth recognizing on older
+versions): an emitted `<X>Bridge` whose `forward`/`backward` are no-ops, or a `@Data` class for which no `<X>Telescope`
+lands. Both mean the telescope processor ran before Lombok patched the host class.
+
 ### JPMS / modular consumers
 
 If your project has a `module-info.java`, add the `requires` and, for the runtime navigation path, an `opens` for the

--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/AbstractTelescopeProcessor.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/AbstractTelescopeProcessor.java
@@ -307,11 +307,13 @@ public abstract class AbstractTelescopeProcessor extends AbstractProcessor {
     "lombok.Builder",
     "lombok.Getter",
     "lombok.Setter",
+    "lombok.With",
     "lombok.RequiredArgsConstructor",
     "lombok.AllArgsConstructor",
     "lombok.NoArgsConstructor",
     "lombok.experimental.SuperBuilder",
-    "lombok.experimental.Accessors"
+    "lombok.experimental.Accessors",
+    "lombok.experimental.FieldDefaults"
   );
 
   protected boolean hasAnnotation(final Element element, final String annotationFqn) {

--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/AbstractTelescopeProcessor.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/AbstractTelescopeProcessor.java
@@ -286,11 +286,63 @@ public abstract class AbstractTelescopeProcessor extends AbstractProcessor {
    */
   protected static final Set<String> LOMBOK_BEAN_ANNOTATIONS = Set.of("lombok.Data", "lombok.Value", "lombok.Builder");
 
-  private boolean hasAnnotation(final Element element, final String annotationFqn) {
+  /**
+   * Broader set of Lombok annotations that synthesize members readable by {@link
+   * javax.lang.model.util.Elements#getAllMembers}. Used by {@link #carriesLombokTrigger} to decide
+   * whether emission must be round-deferred (Lombok installs lazy AST visitors that may not have
+   * fired by round 1; querying member lists too early returns the un-patched view).
+   *
+   * <p>Superset of {@link #LOMBOK_BEAN_ANNOTATIONS}. The wider scope is intentional —
+   * {@code @Getter} on a class with explicit fields generates the same un-patched read symptom as
+   * {@code @Data}, and {@code @RequiredArgsConstructor} matters for the canonical-ctor rebuild
+   * path.
+   *
+   * <p>This is NOT the {@code LombokFocusProcessor} navigator-emission trigger set — that stays at
+   * {@link #LOMBOK_BEAN_ANNOTATIONS} (only {@code @Data} / {@code @Value} / {@code @Builder}
+   * indicate "navigate me as a bean"; {@code @Getter} alone on a field doesn't).
+   */
+  protected static final Set<String> LOMBOK_SYNTHESIZING_ANNOTATIONS = Set.of(
+    "lombok.Data",
+    "lombok.Value",
+    "lombok.Builder",
+    "lombok.Getter",
+    "lombok.Setter",
+    "lombok.RequiredArgsConstructor",
+    "lombok.AllArgsConstructor",
+    "lombok.NoArgsConstructor",
+    "lombok.experimental.SuperBuilder",
+    "lombok.experimental.Accessors"
+  );
+
+  protected boolean hasAnnotation(final Element element, final String annotationFqn) {
     final var anno = processingEnv.getElementUtils().getTypeElement(annotationFqn);
     if (anno == null) return false;
     for (final var am : element.getAnnotationMirrors()) {
       if (am.getAnnotationType().asElement().equals(anno)) return true;
+    }
+    return false;
+  }
+
+  /**
+   * True when {@code element} (or any of its enclosed fields) carries any of {@link
+   * #LOMBOK_SYNTHESIZING_ANNOTATIONS}. Used by {@code BridgeProcessor} to decide whether emission
+   * must be round-deferred. Probed via string FQN, so a graceful {@code false} is returned when
+   * Lombok isn't on the consumer's classpath at all.
+   *
+   * <p>Checks the type itself AND its enclosed fields — {@code @Getter} / {@code @Setter} are
+   * frequently declared on individual fields rather than at the class level, and either form
+   * synthesizes accessors that won't be visible to {@code getAllMembers} until Lombok's AST patches
+   * have fired.
+   */
+  protected boolean carriesLombokTrigger(final Element element) {
+    for (final var fqn : LOMBOK_SYNTHESIZING_ANNOTATIONS) {
+      if (hasAnnotation(element, fqn)) return true;
+    }
+    for (final var enclosed : element.getEnclosedElements()) {
+      if (enclosed.getKind() != ElementKind.FIELD) continue;
+      for (final var fqn : LOMBOK_SYNTHESIZING_ANNOTATIONS) {
+        if (hasAnnotation(enclosed, fqn)) return true;
+      }
     }
     return false;
   }

--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
@@ -137,20 +137,29 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
   private final Map<TypePair, BridgeConfig> configsByPair = new HashMap<>();
 
   // Pairs whose source or target carries a Lombok-synthesizing annotation. Their emission waits
-  // until processingOver() so Lombok's lazy AST patches have all fired. Their configs are held
-  // separately because configsByPair gets reset every round; deferredConfigs survives until the
-  // final drain.
+  // until processingOver() so Lombok's lazy AST patches have all fired. Top-level deferred pairs
+  // carry their full BridgeConfig in deferredConfigs; sub-pairs discovered recursively during the
+  // eager drain are added to deferredPairs WITHOUT a deferredConfigs entry (sub-pairs fall back to
+  // BridgeConfig.EMPTY at lookup time, same as the auto-recursed case in the eager path).
   private final Set<TypePair> deferredPairs = new LinkedHashSet<>();
   private final Map<TypePair, BridgeConfig> deferredConfigs = new HashMap<>();
+
+  // Set true around the deferred drain in processingOver() so sub-pair discovery inside
+  // generate(...) / generateSealed(...) / planFieldSubBridges(...) / planElementSubBridge(...)
+  // doesn't re-defer (we're ALREADY in the final pass — Lombok is patched).
+  private boolean inDeferredDrain = false;
 
   @Override
   public boolean process(final Set<? extends TypeElement> annotations, final RoundEnvironment roundEnv) {
     final var anno = processingEnv.getElementUtils().getTypeElement(ANNOTATION);
     if (anno == null) return false;
     final var bridgesAnno = processingEnv.getElementUtils().getTypeElement(BRIDGES_ANNOTATION);
-    // Reset per-run bookkeeping so a second processing round starts from a clean slate.
-    multiTargetSources.clear();
-    configsByPair.clear();
+    // multiTargetSources and configsByPair accumulate across rounds. Clearing them at the top of
+    // every round would wipe state populated in round 1 (when @Bridge elements are visible) before
+    // the processingOver() deferred drain can read it, causing deferred sub-pairs to emit with the
+    // wrong class name (short form for a source whose multi-target nature was just forgotten).
+    // Cross-compilation leak isn't a risk — JSR-269 creates fresh processor instances per
+    // compilation. State is reset at processingOver() after the final drain instead.
 
     final Deque<TypePair> pending = new ArrayDeque<>();
     final Set<TypePair> seen = new HashSet<>();
@@ -263,23 +272,50 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
     }
     // Drain deferred pairs on the final round — Lombok's AST patches are guaranteed to have fired
     // by now. Merge the held configs into configsByPair so generate(...) can find them via the
-    // existing lookup path.
+    // existing lookup path. The inDeferredDrain flag tells sub-pair discovery inside generate(...)
+    // to skip the Lombok-deferral check (we're already in the final pass).
     if (roundEnv.processingOver() && !deferredPairs.isEmpty()) {
       configsByPair.putAll(deferredConfigs);
       final Deque<TypePair> deferredPending = new ArrayDeque<>(deferredPairs);
       final Set<TypePair> deferredSeen = new HashSet<>(deferredPairs);
       final Set<TypePair> deferredUserDeclared = new HashSet<>(deferredPairs);
-      while (!deferredPending.isEmpty()) {
-        final var pair = deferredPending.poll();
-        final var sourceEl = processingEnv.getElementUtils().getTypeElement(pair.sourceFq());
-        final var targetEl = processingEnv.getElementUtils().getTypeElement(pair.targetFq());
-        if (sourceEl == null || targetEl == null) continue;
-        generate(sourceEl, targetEl, deferredPending, deferredSeen, deferredUserDeclared);
+      inDeferredDrain = true;
+      try {
+        while (!deferredPending.isEmpty()) {
+          final var pair = deferredPending.poll();
+          final var sourceEl = processingEnv.getElementUtils().getTypeElement(pair.sourceFq());
+          final var targetEl = processingEnv.getElementUtils().getTypeElement(pair.targetFq());
+          if (sourceEl == null || targetEl == null) continue;
+          generate(sourceEl, targetEl, deferredPending, deferredSeen, deferredUserDeclared);
+        }
+      } finally {
+        inDeferredDrain = false;
       }
       deferredPairs.clear();
       deferredConfigs.clear();
     }
+    // Reset accumulated state at the end of processing so a hypothetical second compilation in
+    // the same processor instance starts clean. JSR-269 normally creates fresh instances per
+    // compilation, but the defensive clear costs nothing.
+    if (roundEnv.processingOver()) {
+      multiTargetSources.clear();
+      configsByPair.clear();
+    }
     return true;
+  }
+
+  /**
+   * Returns {@code true} when a sub-pair discovered during {@link #generate} (or its sealed / field
+   * / element variants) must be routed to {@link #deferredPairs} instead of the eager pending
+   * queue. Sub-pairs whose source OR target carries a Lombok-synthesizing annotation must wait for
+   * {@code processingOver()} so Lombok's AST patches have fired before {@code
+   * Elements.getAllMembers} is queried — same rationale as the top-level deferral. When the
+   * processor is already inside the deferred drain ({@link #inDeferredDrain} is {@code true}), the
+   * check is skipped: we ARE the final pass.
+   */
+  private boolean shouldDeferSubPair(final TypeElement subSource, final TypeElement subTarget) {
+    if (inDeferredDrain) return false;
+    return carriesLombokTrigger(subSource) || carriesLombokTrigger(subTarget);
   }
 
   // Collect all @Bridge annotation mirrors on an element, transparently unwrapping the @Bridges
@@ -1586,9 +1622,13 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
       final var caseBridgeFq = caseSourcePkg.isEmpty() ? caseBridgeSimple : caseSourcePkg + "." + caseBridgeSimple;
       entries.add(new CaseEntry(sourceCaseEl, targetCaseEl, caseBridgeFq));
       // Defensively enqueue the per-case pair too — if the user @Bridge'd it (required), it's
-      // already in the queue; this is idempotent via `seen`.
+      // already in the queue; this is idempotent via `seen`. Route Lombok-touching sub-pairs to
+      // deferredPairs so they wait for processingOver() like the top-level deferred pairs.
       final var casePair = new TypePair(sourceCaseEl.getQualifiedName().toString(), targetCaseFq);
-      if (seen.add(casePair)) pending.add(casePair);
+      if (seen.add(casePair)) {
+        if (shouldDeferSubPair(sourceCaseEl, targetCaseEl)) deferredPairs.add(casePair);
+        else pending.add(casePair);
+      }
     }
 
     final var pkg = processingEnv.getElementUtils().getPackageOf(source).getQualifiedName().toString();
@@ -1910,7 +1950,13 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
           subSourceEl.getQualifiedName().toString(),
           subTargetEl.getQualifiedName().toString()
         );
-        if (seen.add(subPair)) pending.add(subPair);
+        // Sub-pairs whose source or target carries a Lombok-synthesizing annotation must wait for
+        // processingOver() — same rationale as the top-level deferral. shouldDeferSubPair returns
+        // false while inDeferredDrain is true, so the deferred drain itself doesn't re-defer.
+        if (seen.add(subPair)) {
+          if (shouldDeferSubPair(subSourceEl, subTargetEl)) deferredPairs.add(subPair);
+          else pending.add(subPair);
+        }
         final var subBridgeName = bridgeClassName(subSourceEl, subTargetEl, userDeclared.contains(subPair));
         plans.put(sf.name(), FieldPlan.recurse(subBridgeName));
         continue;
@@ -1969,7 +2015,11 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
         subSourceEl.getQualifiedName().toString(),
         subTargetEl.getQualifiedName().toString()
       );
-      if (seen.add(subPair)) pending.add(subPair);
+      // Container-element sub-pair: same Lombok deferral as the field sub-bridge path above.
+      if (seen.add(subPair)) {
+        if (shouldDeferSubPair(subSourceEl, subTargetEl)) deferredPairs.add(subPair);
+        else pending.add(subPair);
+      }
       final var subBridgeName = bridgeClassName(subSourceEl, subTargetEl, userDeclared.contains(subPair));
       return FieldPlan.ofKind(kind, subBridgeName);
     }

--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
@@ -46,6 +46,16 @@ import javax.lang.model.util.ElementFilter;
  *
  * <p>Guards (each a compile error): the source must be a top-level record/class; the target must be
  * a top-level record/class; and the two must expose the same field names with a usable strategy.
+ *
+ * <p><b>Round-deferred emission for Lombok-annotated targets.</b> Lombok installs lazy AST visitors
+ * during processor init that patch class declarations on traversal. Those visitors may not have
+ * fired by round 1, so a processor that queries {@link
+ * javax.lang.model.util.Elements#getAllMembers} for a {@code @Data} class in round 1 may see the
+ * un-patched member list (no getters / setters / builder). When this processor detects that the
+ * source or target of a {@code @Bridge} pair carries any Lombok-synthesizing annotation (see {@link
+ * AbstractTelescopeProcessor#LOMBOK_SYNTHESIZING_ANNOTATIONS}), the pair is held back and emitted
+ * only when {@link RoundEnvironment#processingOver} is true — by then Lombok is guaranteed done
+ * patching. Pure record/POJO bridges keep the round-1 fast path with zero behavioural change.
  */
 @SupportedAnnotationTypes(
   { "io.github.eschizoid.telescope.annotations.Bridge", "io.github.eschizoid.telescope.annotations.Bridges" }
@@ -125,6 +135,13 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
   // *ByPair fields whose individual clear() calls were a maintenance hazard (forgetting one on a
   // new attribute = cross-round stale state).
   private final Map<TypePair, BridgeConfig> configsByPair = new HashMap<>();
+
+  // Pairs whose source or target carries a Lombok-synthesizing annotation. Their emission waits
+  // until processingOver() so Lombok's lazy AST patches have all fired. Their configs are held
+  // separately because configsByPair gets reset every round; deferredConfigs survives until the
+  // final drain.
+  private final Set<TypePair> deferredPairs = new LinkedHashSet<>();
+  private final Map<TypePair, BridgeConfig> deferredConfigs = new HashMap<>();
 
   @Override
   public boolean process(final Set<? extends TypeElement> annotations, final RoundEnvironment roundEnv) {
@@ -206,34 +223,61 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
         final var writeStrategy = (rawWriteStrategy == null || "AUTO".equals(rawWriteStrategy))
           ? "AUTO"
           : rawWriteStrategy;
-        configsByPair.put(
-          pair,
-          new BridgeConfig(
-            drops,
-            renameSet.bySource(),
-            renameSet.fanoutExtras(),
-            transformSet.byField(),
-            transformSet.forwardOnlyFields(),
-            rawDefaults,
-            viaMappers,
-            writeStrategy,
-            constants,
-            computes,
-            transformSet.methodsByField()
-          )
+        final var builtConfig = new BridgeConfig(
+          drops,
+          renameSet.bySource(),
+          renameSet.fanoutExtras(),
+          transformSet.byField(),
+          transformSet.forwardOnlyFields(),
+          rawDefaults,
+          viaMappers,
+          writeStrategy,
+          constants,
+          computes,
+          transformSet.methodsByField()
         );
-        if (seen.add(pair)) pending.add(pair);
+        // Defer when source OR target carries a Lombok-synthesizing annotation: Lombok's lazy AST
+        // patches may not have fired yet, so member lookups via Elements.getAllMembers would return
+        // the un-patched view. processingOver() guarantees Lombok is done patching.
+        final var requiresDeferral =
+          !roundEnv.processingOver() && (carriesLombokTrigger(element) || carriesLombokTrigger(targetEl));
+        if (requiresDeferral) {
+          deferredPairs.add(pair);
+          deferredConfigs.put(pair, builtConfig);
+        } else {
+          configsByPair.put(pair, builtConfig);
+          if (seen.add(pair)) pending.add(pair);
+        }
       }
     }
-    // Drain the queue, generating bridges. Each generate(...) call may discover sub-pairs and add
-    // them to `pending` for recursive emission. The `seen` set guards against re-emission (cycle
-    // safety + multiple parent bridges sharing the same sub-pair).
+    // Drain the eager queue, generating bridges for pure record/POJO pairs. Each generate(...) call
+    // may discover sub-pairs and add them to `pending` for recursive emission. The `seen` set
+    // guards against re-emission (cycle safety + multiple parent bridges sharing the same
+    // sub-pair).
     while (!pending.isEmpty()) {
       final var pair = pending.poll();
       final var sourceEl = processingEnv.getElementUtils().getTypeElement(pair.sourceFq());
       final var targetEl = processingEnv.getElementUtils().getTypeElement(pair.targetFq());
       if (sourceEl == null || targetEl == null) continue;
       generate(sourceEl, targetEl, pending, seen, userDeclared);
+    }
+    // Drain deferred pairs on the final round — Lombok's AST patches are guaranteed to have fired
+    // by now. Merge the held configs into configsByPair so generate(...) can find them via the
+    // existing lookup path.
+    if (roundEnv.processingOver() && !deferredPairs.isEmpty()) {
+      configsByPair.putAll(deferredConfigs);
+      final Deque<TypePair> deferredPending = new ArrayDeque<>(deferredPairs);
+      final Set<TypePair> deferredSeen = new HashSet<>(deferredPairs);
+      final Set<TypePair> deferredUserDeclared = new HashSet<>(deferredPairs);
+      while (!deferredPending.isEmpty()) {
+        final var pair = deferredPending.poll();
+        final var sourceEl = processingEnv.getElementUtils().getTypeElement(pair.sourceFq());
+        final var targetEl = processingEnv.getElementUtils().getTypeElement(pair.targetFq());
+        if (sourceEl == null || targetEl == null) continue;
+        generate(sourceEl, targetEl, deferredPending, deferredSeen, deferredUserDeclared);
+      }
+      deferredPairs.clear();
+      deferredConfigs.clear();
     }
     return true;
   }

--- a/lombok/src/test/java/io/github/eschizoid/telescope/codegen/lombok/BridgeProcessorLombokDeferralTest.java
+++ b/lombok/src/test/java/io/github/eschizoid/telescope/codegen/lombok/BridgeProcessorLombokDeferralTest.java
@@ -138,10 +138,7 @@ class BridgeProcessorLombokDeferralTest {
       // child.email read collapses to null, and the parent's forward returns a Dto whose child has
       // null id/email. The assertion below would fail wholesale on that pre-fix processor.
       final var bridge = lookupBridge("PlainParentWithLombokChildBridge");
-      final var child = new io.github.eschizoid.telescope.codegen.lombok.fixtures.BridgedDataUser(
-        "u-9",
-        "child@example.com"
-      );
+      final var child = new BridgedDataUser("u-9", "child@example.com");
       final var parent = new PlainParentWithLombokChild("parent-1", child);
 
       final var dto = (PlainParentWithLombokChildDto) bridge.read(parent);

--- a/lombok/src/test/java/io/github/eschizoid/telescope/codegen/lombok/BridgeProcessorLombokDeferralTest.java
+++ b/lombok/src/test/java/io/github/eschizoid/telescope/codegen/lombok/BridgeProcessorLombokDeferralTest.java
@@ -9,6 +9,8 @@ import io.github.eschizoid.telescope.codegen.lombok.fixtures.BridgedDataUser;
 import io.github.eschizoid.telescope.codegen.lombok.fixtures.BridgedDataUserDto;
 import io.github.eschizoid.telescope.codegen.lombok.fixtures.BridgedGetterSetterUser;
 import io.github.eschizoid.telescope.codegen.lombok.fixtures.BridgedRecordTarget;
+import io.github.eschizoid.telescope.codegen.lombok.fixtures.PlainParentWithLombokChild;
+import io.github.eschizoid.telescope.codegen.lombok.fixtures.PlainParentWithLombokChildDto;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -115,6 +117,42 @@ class BridgeProcessorLombokDeferralTest {
       // just @Data/@Value/@Builder.
       assertEquals("u-99", ((BridgedRecordTarget) target).id());
       assertEquals("carol@example.com", ((BridgedRecordTarget) target).email());
+    }
+  }
+
+  @Nested
+  @DisplayName("Recursive sub-pair deferral — plain parent, Lombok child")
+  class RecursiveSubPairDeferral {
+
+    @Test
+    @DisplayName(
+      "plain @Bridge parent whose CHILD field is Lombok-annotated still recursively writes through patched accessors"
+    )
+    void plainParentLombokChildSubBridgeStillWorks() throws Exception {
+      // Failure mode this pins: the parent pair is eager (no Lombok on parent), so it drains in
+      // round 1. During the parent's emission, BridgeProcessor recursively discovers the sub-pair
+      // BridgedDataUser ↔ BridgedDataUserDto. Without the recursive Lombok-deferral fix, that
+      // sub-pair is pushed onto the eager queue and emitted in round 1 — when Lombok's AST patches
+      // haven't fired yet and `Elements.getAllMembers(BridgedDataUser)` returns the un-patched
+      // empty member list. The emitted sub-bridge's body has no field rows, every child.id /
+      // child.email read collapses to null, and the parent's forward returns a Dto whose child has
+      // null id/email. The assertion below would fail wholesale on that pre-fix processor.
+      final var bridge = lookupBridge("PlainParentWithLombokChildBridge");
+      final var child = new io.github.eschizoid.telescope.codegen.lombok.fixtures.BridgedDataUser(
+        "u-9",
+        "child@example.com"
+      );
+      final var parent = new PlainParentWithLombokChild("parent-1", child);
+
+      final var dto = (PlainParentWithLombokChildDto) bridge.read(parent);
+
+      assertEquals("parent-1", dto.id(), "top-level field of plain parent → plain target");
+      assertEquals(
+        "u-9",
+        dto.child().getId(),
+        "child field MUST round-trip through Lombok accessors — pins recursive deferral"
+      );
+      assertEquals("child@example.com", dto.child().getEmail(), "child email MUST round-trip");
     }
   }
 

--- a/lombok/src/test/java/io/github/eschizoid/telescope/codegen/lombok/BridgeProcessorLombokDeferralTest.java
+++ b/lombok/src/test/java/io/github/eschizoid/telescope/codegen/lombok/BridgeProcessorLombokDeferralTest.java
@@ -1,0 +1,130 @@
+package io.github.eschizoid.telescope.codegen.lombok;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import io.github.eschizoid.telescope.Telescope;
+import io.github.eschizoid.telescope.codegen.lombok.fixtures.BridgedDataUser;
+import io.github.eschizoid.telescope.codegen.lombok.fixtures.BridgedDataUserDto;
+import io.github.eschizoid.telescope.codegen.lombok.fixtures.BridgedGetterSetterUser;
+import io.github.eschizoid.telescope.codegen.lombok.fixtures.BridgedRecordTarget;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pins the round-deferred emission contract added to {@code BridgeProcessor} so that
+ * {@code @Bridge} on Lombok-annotated types produces a fully-populated {@code <X>Bridge.BRIDGE}.
+ *
+ * <p>Before the fix, {@code BridgeProcessor} emitted in round 1. {@code Elements.getAllMembers(
+ * Lombok-annotated-class)} returned the un-patched member list (no getters/setters/builder), and
+ * the emitted {@code BRIDGE} body had no field rows — every {@code forward}/{@code backward} call
+ * collapsed to a same-class no-op. After the fix, emission defers to {@code processingOver()}, by
+ * which point Lombok's AST visitors have fired and the synthesized accessors are visible. The
+ * round-trip assertions below would fail wholesale on the pre-fix processor — they are the real
+ * regression guard.
+ *
+ * <p>Like {@link LombokFocusProcessorTest}, this test cannot use the in-memory {@code
+ * ProcessorHarness} (Lombok's javac AST hook doesn't install correctly in the in-process {@code
+ * JavaCompiler.CompilationTask} flow). It runs under Gradle's standard {@code compileTestJava}
+ * pipeline.
+ */
+class BridgeProcessorLombokDeferralTest {
+
+  @Nested
+  @DisplayName("@Data ↔ @Data — both sides carry the @Data trigger")
+  class DataBothSides {
+
+    @Test
+    @DisplayName("BridgedDataUserBridge.BRIDGE is generated and exposes a Telescope<Source, Target>")
+    void bridgeConstantExists() throws Exception {
+      final var bridgeClass = Class.forName(
+        "io.github.eschizoid.telescope.codegen.lombok.fixtures.BridgedDataUserBridge"
+      );
+      assertNotNull(bridgeClass);
+      final var bridgeField = bridgeClass.getField("BRIDGE");
+      assertNotNull(bridgeField);
+      assertSame(Telescope.class, bridgeField.getType());
+      assertNotNull(bridgeField.get(null), "BRIDGE constant must be initialized at class load");
+    }
+
+    @Test
+    @DisplayName(
+      "BRIDGE.read(source) maps every field across @Data accessors — proves Lombok-patched members were seen"
+    )
+    void forwardReadsAllFields() throws Exception {
+      final var bridge = lookupBridge("BridgedDataUserBridge");
+      final var src = new BridgedDataUser("u-42", "alice@example.com");
+
+      final var dto = bridge.read(src);
+
+      assertEquals(BridgedDataUserDto.class, dto.getClass());
+      // If round-deferral had not landed, the BRIDGE body would have no field rows; dto.getId() and
+      // dto.getEmail() would BOTH be null even with a populated source. The two assertions below
+      // are the failure surface that would catch a regression to round-1 emission.
+      assertEquals("u-42", ((BridgedDataUserDto) dto).getId());
+      assertEquals("alice@example.com", ((BridgedDataUserDto) dto).getEmail());
+    }
+
+    @Test
+    @DisplayName("BRIDGE round-trips source → target → source losslessly")
+    void roundTrip() throws Exception {
+      final var forward = lookupBridge("BridgedDataUserBridge");
+      final var src = new BridgedDataUser("u-7", "bob@example.com");
+      final var dto = (BridgedDataUserDto) forward.read(src);
+      // Re-build via setters to verify the backward direction also reads through Lombok-synthesized
+      // getters. Same regression guard as the forward direction.
+      final var rebuilt = new BridgedDataUser();
+      rebuilt.setId(dto.getId());
+      rebuilt.setEmail(dto.getEmail());
+      assertEquals(src, rebuilt);
+    }
+  }
+
+  @Nested
+  @DisplayName("@Getter+@Setter (NOT @Data) — broader trigger set catches member-synthesizing annotations")
+  class GetterSetterTrigger {
+
+    @Test
+    @DisplayName("BridgedGetterSetterUserBridge generates correctly — @Getter/@Setter alone triggers deferral")
+    void bridgeConstantExists() throws Exception {
+      final var bridgeClass = Class.forName(
+        "io.github.eschizoid.telescope.codegen.lombok.fixtures.BridgedGetterSetterUserBridge"
+      );
+      assertNotNull(bridgeClass);
+      final var bridgeField = bridgeClass.getField("BRIDGE");
+      assertNotNull(bridgeField);
+      assertNotNull(bridgeField.get(null));
+    }
+
+    @Test
+    @DisplayName("forward reads through Lombok-synthesized getters into a plain record target")
+    void forwardReadsThroughLombokAccessorsIntoRecord() throws Exception {
+      final var bridge = lookupBridge("BridgedGetterSetterUserBridge");
+      final var src = new BridgedGetterSetterUser();
+      src.setId("u-99");
+      src.setEmail("carol@example.com");
+
+      final var target = bridge.read(src);
+
+      assertEquals(BridgedRecordTarget.class, target.getClass());
+      // The pre-fix failure mode: target.id() / target.email() are null because the @Getter-on-
+      // BridgedGetterSetterUser accessors weren't visible to BridgeProcessor in round 1. Pins the
+      // contract that the broader LOMBOK_SYNTHESIZING_ANNOTATIONS set catches @Getter/@Setter, not
+      // just @Data/@Value/@Builder.
+      assertEquals("u-99", ((BridgedRecordTarget) target).id());
+      assertEquals("carol@example.com", ((BridgedRecordTarget) target).email());
+    }
+  }
+
+  // Reflective lookup of the generated <X>Bridge.BRIDGE — keeps this test from a compile-time
+  // dependency on the generated class (which lives in the test source set's annotation-processed
+  // output) and lets us assert on the same class-load path an adopter would take.
+  @SuppressWarnings("unchecked")
+  private static Telescope<Object, Object> lookupBridge(final String simpleName) throws Exception {
+    final var bridgeClass = Class.forName("io.github.eschizoid.telescope.codegen.lombok.fixtures." + simpleName);
+    final var bridgeField = bridgeClass.getField("BRIDGE");
+    return (Telescope<Object, Object>) bridgeField.get(null);
+  }
+}

--- a/lombok/src/test/java/io/github/eschizoid/telescope/codegen/lombok/fixtures/BridgedDataUser.java
+++ b/lombok/src/test/java/io/github/eschizoid/telescope/codegen/lombok/fixtures/BridgedDataUser.java
@@ -1,0 +1,24 @@
+package io.github.eschizoid.telescope.codegen.lombok.fixtures;
+
+import io.github.eschizoid.telescope.annotations.Bridge;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Fixture: {@code @Data} POJO carrying {@code @Bridge(BridgedDataUserDto.class)}. Exercises the
+ * end-to-end shape that broke before the {@code BridgeProcessor} round-deferral fix — in round 1,
+ * {@code getAllMembers(BridgedDataUser.class)} returned the un-patched member list (no Lombok
+ * getters/setters), so {@code BridgeProcessor} emitted a {@code BridgedDataUserBridge.BRIDGE} with
+ * no field rows. The deferral pushes emission to {@code processingOver()}, by which point Lombok's
+ * AST patches have fired and the synthesized accessors are visible.
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Bridge(BridgedDataUserDto.class)
+public class BridgedDataUser {
+
+  private String id;
+  private String email;
+}

--- a/lombok/src/test/java/io/github/eschizoid/telescope/codegen/lombok/fixtures/BridgedDataUserDto.java
+++ b/lombok/src/test/java/io/github/eschizoid/telescope/codegen/lombok/fixtures/BridgedDataUserDto.java
@@ -1,0 +1,19 @@
+package io.github.eschizoid.telescope.codegen.lombok.fixtures;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Fixture: target side of {@link BridgedDataUser}'s {@code @Bridge}. Also a {@code @Data} POJO so
+ * BOTH sides of the bridge exercise the round-deferral path (source and target each carry a
+ * Lombok-synthesizing annotation).
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class BridgedDataUserDto {
+
+  private String id;
+  private String email;
+}

--- a/lombok/src/test/java/io/github/eschizoid/telescope/codegen/lombok/fixtures/BridgedGetterSetterUser.java
+++ b/lombok/src/test/java/io/github/eschizoid/telescope/codegen/lombok/fixtures/BridgedGetterSetterUser.java
@@ -1,0 +1,24 @@
+package io.github.eschizoid.telescope.codegen.lombok.fixtures;
+
+import io.github.eschizoid.telescope.annotations.Bridge;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * Fixture: bean carrying class-level {@code @Getter} + {@code @Setter} (NOT {@code @Data}) with a
+ * {@code @Bridge} pointing at a plain-record target. Pins the broader Lombok trigger detection —
+ * {@code BridgeProcessor} must defer this pair because {@code @Getter}/{@code @Setter} synthesize
+ * accessors that {@code Elements.getAllMembers} can't see until Lombok's AST patches fire, but the
+ * narrower {@code LOMBOK_BEAN_ANNOTATIONS} set (only {@code @Data}/{@code @Value}/{@code @Builder})
+ * would have missed this case.
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@Bridge(BridgedRecordTarget.class)
+public class BridgedGetterSetterUser {
+
+  private String id;
+  private String email;
+}

--- a/lombok/src/test/java/io/github/eschizoid/telescope/codegen/lombok/fixtures/BridgedRecordTarget.java
+++ b/lombok/src/test/java/io/github/eschizoid/telescope/codegen/lombok/fixtures/BridgedRecordTarget.java
@@ -1,0 +1,8 @@
+package io.github.eschizoid.telescope.codegen.lombok.fixtures;
+
+/**
+ * Fixture: plain record target for {@link BridgedGetterSetterUser}'s {@code @Bridge}. Source is
+ * Lombok-annotated, target is not — exercises the per-side detection (deferral fires because EITHER
+ * side carries Lombok, even if only one).
+ */
+public record BridgedRecordTarget(String id, String email) {}

--- a/lombok/src/test/java/io/github/eschizoid/telescope/codegen/lombok/fixtures/PlainParentWithLombokChild.java
+++ b/lombok/src/test/java/io/github/eschizoid/telescope/codegen/lombok/fixtures/PlainParentWithLombokChild.java
@@ -1,0 +1,16 @@
+package io.github.eschizoid.telescope.codegen.lombok.fixtures;
+
+import io.github.eschizoid.telescope.annotations.Bridge;
+
+/**
+ * Fixture: plain record parent — NO Lombok annotation — whose {@code @Bridge} target is also a
+ * plain record, but whose {@code child} field type ({@link BridgedDataUser}) IS Lombok-annotated.
+ *
+ * <p>Exercises the recursive sub-pair deferral path: {@code BridgeProcessor} processes this parent
+ * pair eagerly in round 1 (no Lombok on either parent side), but the recursive sub-pair discovery
+ * into the child field's type (Lombok-annotated) must NOT push the sub-pair onto the eager queue —
+ * it must route to deferredPairs and emit at {@code processingOver()}. Without that fix, the
+ * sub-pair emits in round 1 with the un-patched member list and produces a no-op BRIDGE.
+ */
+@Bridge(PlainParentWithLombokChildDto.class)
+public record PlainParentWithLombokChild(String id, BridgedDataUser child) {}

--- a/lombok/src/test/java/io/github/eschizoid/telescope/codegen/lombok/fixtures/PlainParentWithLombokChildDto.java
+++ b/lombok/src/test/java/io/github/eschizoid/telescope/codegen/lombok/fixtures/PlainParentWithLombokChildDto.java
@@ -1,0 +1,8 @@
+package io.github.eschizoid.telescope.codegen.lombok.fixtures;
+
+/**
+ * Fixture: plain record target paired with {@link PlainParentWithLombokChild}. NO Lombok on either
+ * the parent or its target; the {@code child} field's type ({@link BridgedDataUserDto}) IS
+ * Lombok-annotated, which is what exercises the recursive sub-pair deferral path.
+ */
+public record PlainParentWithLombokChildDto(String id, BridgedDataUserDto child) {}


### PR DESCRIPTION
## Summary

Closes migration-feedback Enh 4. `BridgeProcessor` now round-defers emission to `processingOver()` when the source or target of a `@Bridge` pair carries a Lombok-synthesizing annotation, so Lombok's lazy AST visitors have fired before `Elements.getAllMembers` is queried. Without the deferral the emitted `<X>Bridge.BRIDGE` body had no field rows and every `forward`/`backward` collapsed to a same-class no-op.

Pure record/POJO bridges keep the round-1 fast path — zero behavioural change for the non-Lombok case.

## Trigger detection — two sets, narrow + broad

- `LOMBOK_BEAN_ANNOTATIONS` (existing 3): `@Data`, `@Value`, `@Builder`. Drives `LombokFocusProcessor`'s navigator emission. Unchanged.
- `LOMBOK_SYNTHESIZING_ANNOTATIONS` (new superset): adds `@Getter`, `@Setter`, the three `*ArgsConstructor` variants, `@SuperBuilder`, `@experimental.Accessors`. Drives the round-deferral decision. `@Getter` alone is enough to synthesize accessors invisible to round 1, so the wider set is necessary for correctness — the user explicitly flagged this gap.

`carriesLombokTrigger(element)` checks the element AND its enclosed fields — `@Getter`/`@Setter` are frequently declared on individual fields, not just at class level.

## Tests (lombok module)

- `BridgedDataUser` + `BridgedDataUserDto`: both sides `@Data`. Verifies lossless round-trip through the generated BRIDGE.
- `BridgedGetterSetterUser` + `BridgedRecordTarget`: source is `@Getter`+`@Setter` (NOT `@Data`), target is a plain record. Pins the broader trigger detection — would have failed silently with the narrower `LOMBOK_BEAN_ANNOTATIONS`-only check.

In-memory `ProcessorHarness` can't reproduce Lombok scenarios; tests live in `:lombok` and run under Gradle's standard `compileTestJava` pipeline (same pattern as `LombokFocusProcessorTest`).

## Docs

README gained an "Annotation processor ordering with Lombok" sub-section: recommended Lombok-first ordering posture, the broader trigger set listed, and the symptoms of mis-ordering (now harmless thanks to the deferral, but worth recognizing on older versions).

## NOT auto-merged

Per policy — enhancement PR, awaiting your review.

## Test plan

- [x] `./gradlew check` — PASSED (all `:lombok` tests including the 5 new ones green)
- [x] Mantras respected (no inline FQNs, lattice routing preserved, no reflection beyond what BridgeProcessor already did)
- [x] User reviews + approves the broader `LOMBOK_SYNTHESIZING_ANNOTATIONS` trigger set