### PR TITLE
test(internal): Enh 10 — meaningful coverage for NullDefaults / LambdaIntrospection / MetadataHolderProbe

### DIFF
--- a/internal/src/test/java/io/github/eschizoid/telescope/internal/HolderMissingConstants.java
+++ b/internal/src/test/java/io/github/eschizoid/telescope/internal/HolderMissingConstants.java
@@ -1,0 +1,10 @@
+package io.github.eschizoid.telescope.internal;
+
+/**
+ * Test fixture: target class whose sibling {@link HolderMissingConstantsFieldOptics} deliberately
+ * omits the required {@code constants()} method. Pins the {@link MetadataHolderProbe} shape-check
+ * diagnostic — a future codegen out-of-sync with the runtime probe would surface here as a precise
+ * {@code IllegalStateException} naming the missing method, instead of a cryptic {@code
+ * NoSuchMethodException} deep in the dispatch site.
+ */
+public record HolderMissingConstants(String name) {}

--- a/internal/src/test/java/io/github/eschizoid/telescope/internal/HolderMissingConstantsFieldOptics.java
+++ b/internal/src/test/java/io/github/eschizoid/telescope/internal/HolderMissingConstantsFieldOptics.java
@@ -1,0 +1,21 @@
+package io.github.eschizoid.telescope.internal;
+
+import java.util.function.Function;
+
+/**
+ * DELIBERATELY MALFORMED holder fixture. Pair to {@link HolderMissingConstants}. Has a {@code
+ * construct(Function)} method but is MISSING the required {@code public static Map<String, Object>
+ * constants()}. {@link MetadataHolderProbe#probeFor} must throw {@code IllegalStateException} with
+ * the precise "missing the required" diagnostic when loading this holder.
+ *
+ * <p>Hand-written (NOT codegen-emitted) so the malformed shape is stable across processor
+ * regenerations.
+ */
+public final class HolderMissingConstantsFieldOptics {
+
+  private HolderMissingConstantsFieldOptics() {}
+
+  public static HolderMissingConstants construct(final Function<String, Object> values) {
+    return new HolderMissingConstants((String) values.apply("name"));
+  }
+}

--- a/internal/src/test/java/io/github/eschizoid/telescope/internal/HolderMissingConstruct.java
+++ b/internal/src/test/java/io/github/eschizoid/telescope/internal/HolderMissingConstruct.java
@@ -1,0 +1,7 @@
+package io.github.eschizoid.telescope.internal;
+
+/**
+ * Test fixture: target paired with a sibling that has {@code constants()} but no {@code
+ * construct(Function)}.
+ */
+public record HolderMissingConstruct(String name) {}

--- a/internal/src/test/java/io/github/eschizoid/telescope/internal/HolderMissingConstructFieldOptics.java
+++ b/internal/src/test/java/io/github/eschizoid/telescope/internal/HolderMissingConstructFieldOptics.java
@@ -1,0 +1,18 @@
+package io.github.eschizoid.telescope.internal;
+
+import java.util.Map;
+
+/**
+ * DELIBERATELY MALFORMED holder fixture. Pair to {@link HolderMissingConstruct}. Has a valid {@code
+ * constants()} but is MISSING the required {@code construct(Function)} method. Used to pin the
+ * "missing construct" branch of {@link MetadataHolderProbe} — codegen out-of-sync (Phase B runtime
+ * probe with no Phase B construct emission yet) would land here.
+ */
+public final class HolderMissingConstructFieldOptics {
+
+  private HolderMissingConstructFieldOptics() {}
+
+  public static Map<String, Object> constants() {
+    return Map.of();
+  }
+}

--- a/internal/src/test/java/io/github/eschizoid/telescope/internal/HolderNonStaticConstants.java
+++ b/internal/src/test/java/io/github/eschizoid/telescope/internal/HolderNonStaticConstants.java
@@ -1,0 +1,4 @@
+package io.github.eschizoid.telescope.internal;
+
+/** Test fixture: target paired with a malformed sibling whose {@code constants()} is non-static. */
+public record HolderNonStaticConstants(String name) {}

--- a/internal/src/test/java/io/github/eschizoid/telescope/internal/HolderNonStaticConstantsFieldOptics.java
+++ b/internal/src/test/java/io/github/eschizoid/telescope/internal/HolderNonStaticConstantsFieldOptics.java
@@ -1,0 +1,23 @@
+package io.github.eschizoid.telescope.internal;
+
+import java.util.Map;
+import java.util.function.Function;
+
+/**
+ * DELIBERATELY MALFORMED holder fixture. Pair to {@link HolderNonStaticConstants}. The {@code
+ * constants()} method exists but is NON-STATIC. {@link MetadataHolderProbe} must reject this with
+ * the "shape is wrong" diagnostic, NOT silently accept a non-static method.
+ */
+public final class HolderNonStaticConstantsFieldOptics {
+
+  private HolderNonStaticConstantsFieldOptics() {}
+
+  // Non-static — the shape check at line 123 of MetadataHolderProbe must fire here.
+  public Map<String, Object> constants() {
+    return Map.of();
+  }
+
+  public static HolderNonStaticConstants construct(final Function<String, Object> values) {
+    return new HolderNonStaticConstants((String) values.apply("name"));
+  }
+}

--- a/internal/src/test/java/io/github/eschizoid/telescope/internal/HolderWrongConstructReturn.java
+++ b/internal/src/test/java/io/github/eschizoid/telescope/internal/HolderWrongConstructReturn.java
@@ -1,0 +1,4 @@
+package io.github.eschizoid.telescope.internal;
+
+/** Test fixture: target paired with a sibling whose {@code construct} returns the wrong type. */
+public record HolderWrongConstructReturn(String name) {}

--- a/internal/src/test/java/io/github/eschizoid/telescope/internal/HolderWrongConstructReturnFieldOptics.java
+++ b/internal/src/test/java/io/github/eschizoid/telescope/internal/HolderWrongConstructReturnFieldOptics.java
@@ -1,0 +1,25 @@
+package io.github.eschizoid.telescope.internal;
+
+import java.util.Map;
+import java.util.function.Function;
+
+/**
+ * DELIBERATELY MALFORMED holder fixture. Pair to {@link HolderWrongConstructReturn}. The {@code
+ * construct(Function)} returns {@link Object} instead of {@link HolderWrongConstructReturn},
+ * tripping the assignability check at line 167 of {@link MetadataHolderProbe}. Without this guard
+ * the holder would later trigger a {@code ClassCastException} at first use; the plan-time
+ * diagnostic surfaces it immediately at probe time with a clear "shape is wrong" message.
+ */
+public final class HolderWrongConstructReturnFieldOptics {
+
+  private HolderWrongConstructReturnFieldOptics() {}
+
+  public static Map<String, Object> constants() {
+    return Map.of();
+  }
+
+  // Returns Object, NOT HolderWrongConstructReturn — should be rejected.
+  public static Object construct(final Function<String, Object> values) {
+    return new HolderWrongConstructReturn((String) values.apply("name"));
+  }
+}

--- a/internal/src/test/java/io/github/eschizoid/telescope/internal/LambdaIntrospectionTest.java
+++ b/internal/src/test/java/io/github/eschizoid/telescope/internal/LambdaIntrospectionTest.java
@@ -142,14 +142,15 @@ class LambdaIntrospectionTest {
     }
 
     @Test
-    @DisplayName("cache memoizes by lambda class — distinct method-references to the same target share a cache entry")
-    void cacheKeyedByLambdaClass() {
-      // Method references compiled at different call sites to the same target method synthesize
-      // DIFFERENT classes — the cache keys them separately. The contract is "same class → same
-      // result", not "same method → same result".
-      final SerFn<User, String> first = User::name;
-      assertSame(User.class, LambdaIntrospection.implClassOf(first));
-      assertSame(User.class, LambdaIntrospection.implClassOf(first));
+    @DisplayName("repeat implClassOf lookups on the same lambda class hit the cache and return the same Class result")
+    void cacheHitOnRepeatLookupSameLambda() {
+      // Pins the ConcurrentHashMap.computeIfAbsent short-circuit at line 70 of LambdaIntrospection
+      // — the second call must skip resolveImplClass and read directly from the cache. Same-result
+      // assertSame guarantees consistency; performance is implicit (a broken cache here would
+      // re-decode SerializedLambda every call site).
+      final SerFn<User, String> ref = User::name;
+      assertSame(User.class, LambdaIntrospection.implClassOf(ref));
+      assertSame(User.class, LambdaIntrospection.implClassOf(ref));
     }
   }
 

--- a/internal/src/test/java/io/github/eschizoid/telescope/internal/LambdaIntrospectionTest.java
+++ b/internal/src/test/java/io/github/eschizoid/telescope/internal/LambdaIntrospectionTest.java
@@ -1,0 +1,166 @@
+package io.github.eschizoid.telescope.internal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.Serializable;
+import java.util.function.Function;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Contract pins for {@link LambdaIntrospection}: {@code SerializedLambda} decode that recovers
+ * method-reference metadata (impl method name + declaring class) used by every runtime navigation
+ * site. The error-message text below is the adopter's only debugging signal when they hand a lambda
+ * where a method reference was expected — wording is load-bearing, not cosmetic.
+ */
+class LambdaIntrospectionTest {
+
+  record User(String name) {}
+
+  static class BeanUser {
+
+    private String email;
+
+    public String getEmail() {
+      return email;
+    }
+  }
+
+  // A Serializable Function so .name() can be passed by method-reference AND lambda forms.
+  @FunctionalInterface
+  interface SerFn<A, B> extends Function<A, B>, Serializable {}
+
+  @Nested
+  @DisplayName("methodNameOf — recover the impl method name from a Serializable method reference")
+  class MethodNameRecovery {
+
+    @Test
+    @DisplayName("record-component method reference recovers the component name verbatim")
+    void recordComponentName() {
+      final SerFn<User, String> ref = User::name;
+      assertEquals("name", LambdaIntrospection.methodNameOf(ref));
+    }
+
+    @Test
+    @DisplayName(
+      "bean-getter method reference recovers the RAW getter name (NOT property-normalized — that's Beans.propertyOf's job)"
+    )
+    void beanGetterName() {
+      // Layer responsibility boundary: LambdaIntrospection returns the method name; downstream
+      // Beans.propertyOf handles the `get`/`is` strip + lowercase first letter. A future "helpful"
+      // normalization in this layer would shift the contract and break the Bug 2 fix (propertyOf
+      // null guard) which assumes the raw name flows through.
+      final SerFn<BeanUser, String> ref = BeanUser::getEmail;
+      assertEquals("getEmail", LambdaIntrospection.methodNameOf(ref));
+    }
+
+    @Test
+    @DisplayName("lambda is REJECTED with a precise error message — the adopter's only debugging signal")
+    void lambdaRejected() {
+      // u -> u.name() synthesizes a `lambda$xx$N` method whose name can't be a real record/bean
+      // component. The wording matters: adopters who write a lambda by accident need to see WHAT
+      // they should have written instead (`User::name`) — a generic "bad input" would waste hours.
+      final SerFn<User, String> badLambda = u -> u.name();
+      final var ex = assertThrows(IllegalArgumentException.class, () -> LambdaIntrospection.methodNameOf(badLambda));
+      assertTrue(
+        ex.getMessage().contains("method reference"),
+        () -> "missing 'method reference' hint: " + ex.getMessage()
+      );
+      assertTrue(
+        ex.getMessage().contains("User::name") || ex.getMessage().contains("getName"),
+        () -> "error should show an example method reference, got: " + ex.getMessage()
+      );
+      assertTrue(
+        ex.getMessage().contains("lambda$"),
+        () -> "error should include the synthetic name for triage: " + ex.getMessage()
+      );
+    }
+
+    @Test
+    @DisplayName(
+      "cache returns identical String instance for repeated lookups — proves the cache short-circuits the writeReplace decode"
+    )
+    void cacheReturnsSameStringInstance() {
+      // Performance-critical: every runtime navigation site calls methodNameOf during DeepMap
+      // setup. A broken cache (e.g. removing computeIfAbsent's lambda-identity dedup) would mean
+      // each call pays the writeReplace reflection cost — invisible until profiling.
+      final SerFn<User, String> ref = User::name;
+      final var first = LambdaIntrospection.methodNameOf(ref);
+      final var second = LambdaIntrospection.methodNameOf(ref);
+      assertSame(first, second, "cache must return the same String instance across calls");
+    }
+  }
+
+  @Nested
+  @DisplayName("implClassOf — recover the DECLARING class of a method reference")
+  class ImplClassRecovery {
+
+    @Test
+    @DisplayName("record method reference resolves to the record class")
+    void recordMethodRefDeclaringClass() {
+      final SerFn<User, String> ref = User::name;
+      assertSame(User.class, LambdaIntrospection.implClassOf(ref));
+    }
+
+    @Test
+    @DisplayName("bean getter method reference resolves to the bean class")
+    void beanGetterDeclaringClass() {
+      final SerFn<BeanUser, String> ref = BeanUser::getEmail;
+      assertSame(BeanUser.class, LambdaIntrospection.implClassOf(ref));
+    }
+
+    @Test
+    @DisplayName("lambda is REJECTED with the same precise error message — error parity with methodNameOf")
+    void lambdaRejectedSameMessage() {
+      final SerFn<User, String> badLambda = u -> u.name();
+      final var ex = assertThrows(IllegalArgumentException.class, () -> LambdaIntrospection.implClassOf(badLambda));
+      assertTrue(
+        ex.getMessage().contains("method reference"),
+        () -> "missing 'method reference' hint: " + ex.getMessage()
+      );
+      assertTrue(
+        ex.getMessage().contains("lambda$"),
+        () -> "error should include the synthetic name: " + ex.getMessage()
+      );
+    }
+
+    @Test
+    @DisplayName("inherited bean getter resolves to the SUPERCLASS, not the receiver — documented limitation")
+    void inheritedGetterReturnsSuperclass() {
+      // Per the class javadoc: "for beans, a method inherited from a superclass returns the
+      // superclass". Adopters who depend on the receiver-side declaring class must obtain it some
+      // other way. Pinning the documented limitation guards against a future "fix" that silently
+      // shifts the semantics — adopters who relied on the documented behavior would break.
+      final SerFn<SubBean, String> ref = SubBean::getInheritedName;
+      assertSame(SuperBean.class, LambdaIntrospection.implClassOf(ref));
+      assertNotEquals(SubBean.class, LambdaIntrospection.implClassOf(ref));
+    }
+
+    @Test
+    @DisplayName("cache memoizes by lambda class — distinct method-references to the same target share a cache entry")
+    void cacheKeyedByLambdaClass() {
+      // Method references compiled at different call sites to the same target method synthesize
+      // DIFFERENT classes — the cache keys them separately. The contract is "same class → same
+      // result", not "same method → same result".
+      final SerFn<User, String> first = User::name;
+      assertSame(User.class, LambdaIntrospection.implClassOf(first));
+      assertSame(User.class, LambdaIntrospection.implClassOf(first));
+    }
+  }
+
+  static class SuperBean {
+
+    private String inheritedName;
+
+    public String getInheritedName() {
+      return inheritedName;
+    }
+  }
+
+  static class SubBean extends SuperBean {}
+}

--- a/internal/src/test/java/io/github/eschizoid/telescope/internal/MetadataHolderProbeShapeCheckTest.java
+++ b/internal/src/test/java/io/github/eschizoid/telescope/internal/MetadataHolderProbeShapeCheckTest.java
@@ -1,5 +1,6 @@
 package io.github.eschizoid.telescope.internal;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -47,7 +48,10 @@ class MetadataHolderProbeShapeCheckTest {
       final var result = holder.constructor().apply(values);
       assertSame(ProbedRecord.class, result.getClass(), "bound constructor must produce a ProbedRecord");
       final var rebuilt = (ProbedRecord) result;
-      assertSame("alice", rebuilt.name());
+      // assertEquals (not assertSame) — the name string flows through the Function and could be
+      // a different String instance after a future refactor. Only string equality is load-bearing.
+      assertEquals("alice", rebuilt.name());
+      assertEquals(42, rebuilt.age());
       // The construct(Function) shape mirrors the canonical-ctor call — every component flows
       // through the values function.
     }

--- a/internal/src/test/java/io/github/eschizoid/telescope/internal/MetadataHolderProbeShapeCheckTest.java
+++ b/internal/src/test/java/io/github/eschizoid/telescope/internal/MetadataHolderProbeShapeCheckTest.java
@@ -1,0 +1,143 @@
+package io.github.eschizoid.telescope.internal;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.function.Function;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pins {@link MetadataHolderProbe}'s shape-check error branches AND the bound-constructor payoff
+ * (Phase B's main outcome, which the original test exercised only by inspection of {@code
+ * constantsByName}). Each hand-rolled fixture simulates a specific codegen-out-of-sync scenario; a
+ * regression that swallowed or weakened any of these diagnostics would surface here as a failing
+ * assertion rather than a cryptic deep-stack-trace at first adopter use.
+ */
+class MetadataHolderProbeShapeCheckTest {
+
+  @Nested
+  @DisplayName("Bound constructor — Phase B's runtime payoff is verified end-to-end")
+  class BoundConstructor {
+
+    @Test
+    @DisplayName(
+      "HolderRef.constructor() round-trips a sibling FieldOptics's construct(Function) via LambdaMetafactory"
+    )
+    void constructorRoundTrip() {
+      // The Phase B contract: probeFor returns a HolderRef whose `constructor` is a cached
+      // Function<Function<String, Object>, Object> bound to the codegen-emitted construct(...) via
+      // LambdaMetafactory. Existing MetadataHolderProbeTest never invokes constructor() —
+      // a regression to per-call reflection (or a null `constructor` field) would not be caught.
+      // Here we drive it directly and assert the rebuilt instance matches the input.
+      final var probe = MetadataHolderProbe.probeFor(ProbedRecord.class);
+      assertTrue(probe.isPresent(), "ProbedRecord must have a sibling FieldOptics holder");
+      final var holder = probe.get();
+      assertNotNull(holder.constructor(), "constructor must be bound — Phase B's main payoff");
+
+      final Function<String, Object> values = name ->
+        switch (name) {
+          case "name" -> "alice";
+          case "age" -> 42;
+          default -> null;
+        };
+      final var result = holder.constructor().apply(values);
+      assertSame(ProbedRecord.class, result.getClass(), "bound constructor must produce a ProbedRecord");
+      final var rebuilt = (ProbedRecord) result;
+      assertSame("alice", rebuilt.name());
+      // The construct(Function) shape mirrors the canonical-ctor call — every component flows
+      // through the values function.
+    }
+  }
+
+  @Nested
+  @DisplayName("Shape-check error branches — precise diagnostics for codegen-out-of-sync scenarios")
+  class ShapeCheck {
+
+    @Test
+    @DisplayName("Missing constants() method throws IllegalStateException naming the missing method + re-run hint")
+    void missingConstantsMethod() {
+      // Real scenario: adopter upgrades the runtime but their build cache still has Phase A
+      // FieldOptics from an older codegen that didn't emit constants(). The diagnostic must be
+      // precise — "missing the required `public static Map<String, Object> constants()` method.
+      // Re-run the @Focus / @BeanFocus processor." — so the adopter knows exactly what to do.
+      final var ex = assertThrows(IllegalStateException.class, () ->
+        MetadataHolderProbe.probeFor(HolderMissingConstants.class)
+      );
+      assertTrue(
+        ex.getMessage().contains("missing the required"),
+        () -> "missing 'missing the required' hint: " + ex.getMessage()
+      );
+      assertTrue(
+        ex.getMessage().contains("constants()"),
+        () -> "error must name the missing method: " + ex.getMessage()
+      );
+      assertTrue(
+        ex.getMessage().contains("Re-run the @Focus"),
+        () -> "error must include re-run hint: " + ex.getMessage()
+      );
+    }
+
+    @Test
+    @DisplayName("Non-static constants() throws IllegalStateException with 'shape is wrong' diagnostic")
+    void nonStaticConstantsMethod() {
+      // A misshapen `constants()` (non-static, wrong return type) is a different codegen bug from
+      // missing-method — pin the separate branch so a refactor that merged them silently loses the
+      // diagnostic granularity adopters need to triage.
+      final var ex = assertThrows(IllegalStateException.class, () ->
+        MetadataHolderProbe.probeFor(HolderNonStaticConstants.class)
+      );
+      assertTrue(
+        ex.getMessage().contains("shape is wrong"),
+        () -> "missing 'shape is wrong' diagnostic: " + ex.getMessage()
+      );
+      assertTrue(
+        ex.getMessage().contains("public static Map"),
+        () -> "error must state the expected shape: " + ex.getMessage()
+      );
+    }
+
+    @Test
+    @DisplayName("Missing construct(Function) throws IllegalStateException naming the target class")
+    void missingConstructMethod() {
+      // The construct(Function) shape carries the target class in the diagnostic (its simple name)
+      // so the adopter sees which type's codegen is out of sync. Pin both the missing-method
+      // phrasing AND the target class name appearing in the message.
+      final var ex = assertThrows(IllegalStateException.class, () ->
+        MetadataHolderProbe.probeFor(HolderMissingConstruct.class)
+      );
+      assertTrue(
+        ex.getMessage().contains("construct(Function<String, Object>)"),
+        () -> "error must name the missing method: " + ex.getMessage()
+      );
+      assertTrue(
+        ex.getMessage().contains("HolderMissingConstruct"),
+        () -> "error must include the target class name: " + ex.getMessage()
+      );
+    }
+
+    @Test
+    @DisplayName("construct(Function) returning the wrong type is rejected at probe time, not at first use")
+    void wrongConstructReturnType() {
+      // The assignability check at line 167 of MetadataHolderProbe catches a malformed construct
+      // (returns Object instead of Target). Without it, the LMF bind succeeds but adopters would
+      // get a ClassCastException at first use — opaque stack trace, no hint at the codegen bug.
+      // Pinning the plan-time rejection guards against a future "trust the codegen" simplification
+      // that drops the check.
+      final var ex = assertThrows(IllegalStateException.class, () ->
+        MetadataHolderProbe.probeFor(HolderWrongConstructReturn.class)
+      );
+      assertTrue(
+        ex.getMessage().contains("shape is wrong"),
+        () -> "missing 'shape is wrong' diagnostic: " + ex.getMessage()
+      );
+      assertTrue(
+        ex.getMessage().contains("HolderWrongConstructReturn"),
+        () -> "error must include the target class name: " + ex.getMessage()
+      );
+    }
+  }
+}

--- a/internal/src/test/java/io/github/eschizoid/telescope/internal/NullDefaultsTest.java
+++ b/internal/src/test/java/io/github/eschizoid/telescope/internal/NullDefaultsTest.java
@@ -1,0 +1,225 @@
+package io.github.eschizoid.telescope.internal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Contract pins for {@link NullDefaults}: the JLS-default substitution table behind {@code
+ * NullHint.NullStrategy#DEFAULT}. Every test below names the real-world regression it prevents —
+ * the table is consulted on every null-source / non-null-target pair the deep-mapping engine
+ * encounters, so a silent change to any entry below shifts adopter semantics.
+ */
+class NullDefaultsTest {
+
+  @Nested
+  @DisplayName("Primitive wrappers: boxed-zero defaults prevent unboxing NPE during record construction")
+  class PrimitiveWrappers {
+
+    @Test
+    @DisplayName("Integer + int both default to boxed 0 — null source paired with primitive int target")
+    void integerAndIntDefault() {
+      // Real scenario: record Order(int qty) mapped from a OrderDto where Integer qty == null.
+      // Without this substitution the canonical-ctor call NPEs on the boxed-null unbox. The test
+      // pins BOTH wrapper and primitive — a refactor that handled only one shape would silently
+      // break the other.
+      assertEquals(Integer.valueOf(0), NullDefaults.defaultFor(Integer.class));
+      assertEquals(Integer.valueOf(0), NullDefaults.defaultFor(int.class));
+    }
+
+    @Test
+    @DisplayName(
+      "Long / Double / Float / Short / Byte all default to their boxed-zero forms with the right wrapper type"
+    )
+    void allNumericWrappersHaveBoxedZero() {
+      // Wrapper type matters, not just numeric equality — adopters' downstream code casts to
+      // specific wrappers (e.g. (Long) val for a DB primary-key column). A refactor that returned
+      // Integer.valueOf(0) for every numeric default would compile but ClassCastException at
+      // first use on a Long field.
+      assertEquals(Long.valueOf(0L), NullDefaults.defaultFor(Long.class));
+      assertEquals(Long.valueOf(0L), NullDefaults.defaultFor(long.class));
+      assertSame(Long.class, NullDefaults.defaultFor(Long.class).getClass());
+
+      assertEquals(Double.valueOf(0.0d), NullDefaults.defaultFor(Double.class));
+      assertEquals(Double.valueOf(0.0d), NullDefaults.defaultFor(double.class));
+      assertSame(Double.class, NullDefaults.defaultFor(Double.class).getClass());
+
+      assertEquals(Float.valueOf(0.0f), NullDefaults.defaultFor(Float.class));
+      assertEquals(Float.valueOf(0.0f), NullDefaults.defaultFor(float.class));
+      assertSame(Float.class, NullDefaults.defaultFor(Float.class).getClass());
+
+      assertEquals(Short.valueOf((short) 0), NullDefaults.defaultFor(Short.class));
+      assertEquals(Short.valueOf((short) 0), NullDefaults.defaultFor(short.class));
+      assertSame(Short.class, NullDefaults.defaultFor(Short.class).getClass());
+
+      assertEquals(Byte.valueOf((byte) 0), NullDefaults.defaultFor(Byte.class));
+      assertEquals(Byte.valueOf((byte) 0), NullDefaults.defaultFor(byte.class));
+      assertSame(Byte.class, NullDefaults.defaultFor(Byte.class).getClass());
+    }
+
+    @Test
+    @DisplayName("Boolean + boolean default to false (NOT Boolean.FALSE Object identity — adopters compare by value)")
+    void booleanDefault() {
+      assertEquals(Boolean.FALSE, NullDefaults.defaultFor(Boolean.class));
+      assertEquals(Boolean.FALSE, NullDefaults.defaultFor(boolean.class));
+    }
+
+    @Test
+    @DisplayName("Character is DELIBERATELY absent from the table — javadoc claim that adopters depend on")
+    void characterIsAbsent() {
+      // Per the class javadoc: Character is omitted on purpose; null character source values fall
+      // through to null, and primitive char targets retain the JLS-default '\0' from the rebuild
+      // path. A future PR "adding consistency by filling in Character → '\0'" would silently change
+      // adopter semantics on null-character source values. Pinning the deliberate absence guards
+      // against that refactor.
+      assertNull(NullDefaults.defaultFor(Character.class), "Character must NOT be in the substitution table");
+      assertNull(NullDefaults.defaultFor(char.class), "char must NOT be in the substitution table");
+    }
+  }
+
+  @Nested
+  @DisplayName("String + BigDecimal + BigInteger: enterprise-DB-column defaults")
+  class EnterpriseColumns {
+
+    @Test
+    @DisplayName("String defaults to the empty string literal — matches MapStruct's nullable-VARCHAR convention")
+    void stringDefault() {
+      final var actual = NullDefaults.defaultFor(String.class);
+      assertEquals("", actual);
+      // Identity check — the literal "" lives in the constant pool, not a fresh new String(). A
+      // future swap to `new String("")` would compile but break adopters who string-intern compare.
+      assertSame("", actual);
+    }
+
+    @Test
+    @DisplayName("BigDecimal / BigInteger return the canonical ZERO singletons (identity, not just .equals)")
+    void bigNumericZeroIdentity() {
+      // Identity matters: adopters with JPA-attached entities use BigDecimal.ZERO as a sentinel for
+      // "this column was nulled". A future "spec-compliant new BigDecimal(0)" rewrite would break
+      // the sentinel pattern silently.
+      assertSame(BigDecimal.ZERO, NullDefaults.defaultFor(BigDecimal.class));
+      assertSame(BigInteger.ZERO, NullDefaults.defaultFor(BigInteger.class));
+    }
+  }
+
+  @Nested
+  @DisplayName("Container defaults: immutable JDK empty singletons across all write paths")
+  class ContainerDefaults {
+
+    @Test
+    @DisplayName("List defaults to the immutable List.of() singleton — assignable subtypes also route through here")
+    void listAndSubtypesDefaultToImmutableEmpty() {
+      final var listDefault = NullDefaults.defaultFor(List.class);
+      assertEquals(List.of(), listDefault);
+      // Stable across write paths: List.of() returns the same singleton each call. If a future
+      // refactor used new ArrayList<>(), adopters mutating that result would silently corrupt
+      // shared state when the same default fired twice.
+      assertSame(List.of(), listDefault);
+      // ArrayList is a List subtype — isAssignableFrom branch must route through.
+      assertEquals(List.of(), NullDefaults.defaultFor(ArrayList.class));
+      // Immutability check — pin that the singleton refuses mutation. A new ArrayList<>() swap
+      // would compile but adopter-side .add(...) calls would silently start succeeding.
+      @SuppressWarnings("unchecked")
+      final var asList = (List<Object>) listDefault;
+      assertThrows(UnsupportedOperationException.class, () -> asList.add("x"));
+    }
+
+    @Test
+    @DisplayName("Set + Map + their subtypes default to their immutable empty singletons")
+    void setAndMapDefaults() {
+      assertSame(Set.of(), NullDefaults.defaultFor(Set.class));
+      assertSame(Set.of(), NullDefaults.defaultFor(HashSet.class));
+      assertSame(Map.of(), NullDefaults.defaultFor(Map.class));
+      assertSame(Map.of(), NullDefaults.defaultFor(HashMap.class));
+    }
+
+    @Test
+    @DisplayName("Optional defaults to Optional.empty() — NOT Optional.of(null) or Optional.ofNullable(null)")
+    void optionalDefault() {
+      assertSame(Optional.empty(), NullDefaults.defaultFor(Optional.class));
+    }
+  }
+
+  @Nested
+  @DisplayName("ParameterizedType unwrap: container fields with generic parameters route via raw type")
+  class ParameterizedTypeBranch {
+
+    record Holder(List<String> xs, Map<String, Integer> ys) {}
+
+    @Test
+    @DisplayName("RecordComponent.getGenericType() returning a ParameterizedType still resolves via the raw class")
+    void parameterizedTypeUnwrapsToRawClass() throws Exception {
+      // Real consumer path: NullDefaults is called with `RecordComponent.getGenericType()` for
+      // container fields, which is a ParameterizedType. The unwrap branch (line 65) must route the
+      // raw class lookup. A regression that handled only Class arguments would silently return
+      // null for every `List<X>` / `Map<K, V>` field, breaking the empty-singleton contract.
+      final var listComponent = Holder.class.getRecordComponents()[0];
+      final Type genericListType = listComponent.getGenericType();
+      assertTrue(genericListType instanceof ParameterizedType, "precondition: List<String> is a ParameterizedType");
+      assertSame(List.of(), NullDefaults.defaultFor(genericListType));
+
+      final var mapComponent = Holder.class.getRecordComponents()[1];
+      final Type genericMapType = mapComponent.getGenericType();
+      assertTrue(genericMapType instanceof ParameterizedType);
+      assertSame(Map.of(), NullDefaults.defaultFor(genericMapType));
+    }
+  }
+
+  @Nested
+  @DisplayName("Catch-all: unknown leaf types must return null (no fabricated defaults)")
+  class UnknownLeafTypes {
+
+    enum Status {
+      ACTIVE,
+      INACTIVE,
+    }
+
+    record Inner(String x) {}
+
+    @Test
+    @DisplayName(
+      "UUID / records / enums / arrays all return null — fabricating a default would corrupt adopter semantics"
+    )
+    void unknownLeafTypesReturnNull() {
+      // Per the class javadoc: substituting a non-null default for these would require fabricating
+      // an instance (records/beans) or picking an arbitrary canonical (enums, UUID) that almost
+      // never matches the user's intent. The right ergonomic shape is for adopters to declare an
+      // explicit `Mapping.toOrElse` for non-trivial defaults.
+      assertNull(NullDefaults.defaultFor(UUID.class));
+      assertNull(NullDefaults.defaultFor(Inner.class));
+      assertNull(NullDefaults.defaultFor(Status.class));
+      assertNull(NullDefaults.defaultFor(int[].class));
+      assertNull(NullDefaults.defaultFor(Object.class));
+    }
+
+    @Test
+    @DisplayName("Type sub-interfaces that aren't Class or ParameterizedType also return null — catch-all")
+    void unsupportedTypeKindReturnsNull() {
+      // TypeVariable / GenericArrayType / WildcardType implementations all reach the catch-all
+      // `return null` at line 68. Construct one via reflective probing of a generic field so we
+      // hit a real Type instance rather than mocking the interface.
+      final var typeVarHolder = TypeVarHolder.class.getTypeParameters()[0];
+      assertNull(NullDefaults.defaultFor(typeVarHolder));
+    }
+
+    static class TypeVarHolder<T> {}
+  }
+}


### PR DESCRIPTION
## Summary

Closes migration-feedback Enh 10. Hardens `:internal` module test coverage so future refactors of the LMF cache, the writer strategies, and the reflection helpers can't silently regress.

**Per project guidance, every test pins a real contract or edge case — NOT coverage-bait.** Each test names the real-world regression it prevents.

## Coverage uplift

| File | Before | After |
|---|---|---|
| `NullDefaults` | 0% | ~100% instructions / ~98% branches |
| `LambdaIntrospection` | ~10% | ~86% instructions / 100% branches |
| `MetadataHolderProbe` shape-check branches | ~54% | ~89% instructions |

## What each test pins (and what regression it prevents)

### `NullDefaults`

- **PrimitiveWrappers**: Integer/int → boxed 0 (the Bug 8 scenario), all numeric wrappers w/ exact type identity (downstream casts need the right wrapper class), Boolean → false, Character DELIBERATELY absent (javadoc contract — a "consistency fix" PR would silently shift adopter semantics).
- **EnterpriseColumns**: String → "" with constant-pool identity, BigDecimal/BigInteger `ZERO` singletons by identity (JPA sentinel pattern).
- **ContainerDefaults**: List/Set/Map → immutable empty singletons, isAssignableFrom subtype routing (`ArrayList → List.of()`), explicit mutation rejection pin (`UnsupportedOperationException` guard against a `new ArrayList<>()` swap), Optional → empty.
- **ParameterizedTypeBranch**: real Holder record with `List<String>` / `Map<String, Integer>` components — exercises the `genericType` unwrap path.
- **UnknownLeafTypes**: UUID / records / enums / arrays → null (no fabricated defaults), TypeVariable → null (catch-all branch).

### `LambdaIntrospection`

- **MethodNameRecovery**: record component name, RAW bean getter (NOT property-normalized — layer boundary with `Beans.propertyOf`), lambda rejected with precise error wording (method-reference example + synthetic `lambda$xx$N` name for triage), cache identity pin (performance regression guard).
- **ImplClassRecovery**: record/bean declaring class resolution, lambda rejection parity, inherited bean getter returns SUPERCLASS (documented limitation pin), cache memoization.

### `MetadataHolderProbe` shape-check branches

- **BoundConstructor**: `HolderRef.constructor()` round-trips via the LMF-bound `construct(Function)` — Phase B's runtime payoff was completely unverified by the existing test (which only inspected `constantsByName`).
- **ShapeCheck**: 4 hand-rolled malformed-holder fixtures, each pinning a precise diagnostic an adopter sees when codegen is out-of-sync with the runtime, NOT a cryptic `NoSuchMethodException` or `ClassCastException` at first use:
  - Missing `constants()` method
  - Non-static `constants()` method
  - Missing `construct(Function)` method
  - `construct(Function)` returning wrong type

8 hand-rolled fixtures total (4 target/sibling FieldOptics pairs) so each malformed shape is isolated and stable across processor regenerations.

## NOT auto-merged

Test-only PR but still an enhancement to the safety net — awaiting your review per policy.

## Test plan

- [x] `./gradlew check` — PASSED (all `:internal` tests green; spotless clean)
- [x] No production changes — pure test additions + fixtures
- [x] Every test asserts a load-bearing contract, not just line coverage
