### PR TITLE
fix(core): broken javadoc link to TelescopeMapperRegistry + CI hardening

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,6 +30,23 @@ jobs:
       - name: Build and test
         run: ./gradlew check --no-daemon --stacktrace
 
+      # Explicit cross-module javadoc verification on every PR — `check` already includes the
+      # per-module javadoc tasks, but gradle build caching can short-circuit them when sources
+      # haven't changed in a way the cache notices. `--rerun-tasks` forces a fresh javadoc compile
+      # so broken `{@link}` cross-references can't slip through to main. Catches the class of
+      # failure where a :core javadoc references a class in :quarkus / :spring-boot-starter that
+      # :core can't see (upward dep) — would have caught the v1.0.2 regression that this CI step
+      # was added in response to.
+      - name: Verify javadoc (cross-module link integrity)
+        run: |
+          ./gradlew --no-daemon --stacktrace --rerun-tasks \
+            :internal:javadoc \
+            :core:javadoc \
+            :codegen:javadoc \
+            :lombok:javadoc \
+            :quarkus:javadoc \
+            :spring-boot-starter:javadoc
+
       - name: Jacoco
         run: |
           ./gradlew :internal:jacocoTestReport \

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,13 +30,6 @@ jobs:
       - name: Build and test
         run: ./gradlew check --no-daemon --stacktrace
 
-      # Explicit cross-module javadoc verification on every PR — `check` already includes the
-      # per-module javadoc tasks, but gradle build caching can short-circuit them when sources
-      # haven't changed in a way the cache notices. `--rerun-tasks` forces a fresh javadoc compile
-      # so broken `{@link}` cross-references can't slip through to main. Catches the class of
-      # failure where a :core javadoc references a class in :quarkus / :spring-boot-starter that
-      # :core can't see (upward dep) — would have caught the v1.0.2 regression that this CI step
-      # was added in response to.
       - name: Verify javadoc (cross-module link integrity)
         run: |
           ./gradlew --no-daemon --stacktrace --rerun-tasks \

--- a/core/src/main/java/io/github/eschizoid/telescope/Telescope.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/Telescope.java
@@ -1048,8 +1048,8 @@ public sealed class Telescope<
    *
    * <p>The source / target classes are required because {@code Telescope<S, A>}'s type parameters
    * are erased at runtime. They're stored on the produced {@link ForwardMapper} so downstream
-   * machinery (e.g. {@link io.github.eschizoid.telescope.quarkus.TelescopeMapperRegistry}) can key
-   * the mapper by the {@code (source, target)} pair.
+   * machinery (e.g. {@code TelescopeMapperRegistry} in the Quarkus / Spring Boot starter modules)
+   * can key the mapper by the {@code (source, target)} pair.
    *
    * <p><b>Read semantics inherited from {@link #read}.</b> On a {@link Lens}-rooted Telescope the
    * forward returns the single focused value. On an {@link Affine}-rooted Telescope (e.g. after


### PR DESCRIPTION
## Summary

P0 fix — main CI is currently broken on a `:core:javadoc` failure introduced in PR #141:

```
Telescope.java:1051: error: reference not found
  machinery (e.g. {@link io.github.eschizoid.telescope.quarkus.TelescopeMapperRegistry}) can key
```

`TelescopeMapperRegistry` lives in `:quarkus`. `:core` doesn't depend on `:quarkus` (upward dep), so the javadoc compile can't resolve the link.

## Fix

Swap the cross-module `{@link ...}` → `{@code ...}` text reference. The destination class still gets named for adopter-facing context but doesn't try to resolve through the javadoc classpath. Verified locally: `./gradlew :core:javadoc --rerun-tasks` → BUILD SUCCESSFUL.

## CI hardening

The reason this slipped through PR #141's CI: `./gradlew check` does include per-module javadoc, but Gradle build caching can short-circuit those tasks when source changes don't invalidate them in a way the cache picks up. Added an explicit "Verify javadoc" step on every PR that runs `--rerun-tasks` against every module's javadoc, so broken `{@link}` cross-references can't slip through again.

## Test plan

- [x] `./gradlew :core:javadoc --rerun-tasks` — PASSED locally
- [ ] CI build green
- [ ] PR-level CI now runs the explicit Verify javadoc step on `--rerun-tasks`

## Auto-mergeable

This IS a bug fix on main — per the `feedback_no_auto_merge_enhancements` rule, bug fixes can auto-merge once reviews land.
