### PR TITLE
chore(quarkus): switch to strict source-level module-info.java (drops PR #145's Automatic-Module-Name)

### DIFF
--- a/lombok/README.md
+++ b/lombok/README.md
@@ -40,7 +40,7 @@ classpath.)
 ```kotlin
 // Gradle
 dependencies {
-    implementation("io.github.eschizoid:telescope-core:0.13.0")
+    implementation("io.github.eschizoid:telescope-core:1.0.1")
 
     // Lombok itself
     compileOnly("org.projectlombok:lombok:1.18.42")
@@ -48,7 +48,7 @@ dependencies {
 
     // Telescope's Lombok-aware codegen — must come AFTER Lombok in the processor list so
     // Lombok's AST patches have fired when telescope reads the synthesized members.
-    annotationProcessor("io.github.eschizoid:telescope-lombok:0.13.0")
+    annotationProcessor("io.github.eschizoid:telescope-lombok:1.0.1")
 }
 ```
 
@@ -67,7 +67,7 @@ dependencies {
       <path>
         <groupId>io.github.eschizoid</groupId>
         <artifactId>telescope-lombok</artifactId>
-        <version>0.13.0</version>
+        <version>1.0.1</version>
       </path>
     </annotationProcessorPaths>
   </configuration>

--- a/quarkus/README.md
+++ b/quarkus/README.md
@@ -5,7 +5,7 @@ nothing else. Mirrors the [`spring-boot-starter`](../spring-boot-starter/README.
 
 ```kotlin
 dependencies {
-    implementation("io.github.eschizoid:telescope-quarkus:0.13.0")
+    implementation("io.github.eschizoid:telescope-quarkus:1.0.1")
 }
 ```
 
@@ -32,7 +32,7 @@ archive ... is being scanned without a Jandex index" warning.
 // Gradle (Quarkus 3 BOM picks up Quarkus's version)
 dependencies {
     implementation(platform("io.quarkus.platform:quarkus-bom:3.20.0"))
-    implementation("io.github.eschizoid:telescope-quarkus:0.13.0")
+    implementation("io.github.eschizoid:telescope-quarkus:1.0.1")
 }
 ```
 
@@ -41,7 +41,7 @@ dependencies {
 <dependency>
   <groupId>io.github.eschizoid</groupId>
   <artifactId>telescope-quarkus</artifactId>
-  <version>0.13.0</version>
+  <version>1.0.1</version>
 </dependency>
 ```
 

--- a/quarkus/build.gradle.kts
+++ b/quarkus/build.gradle.kts
@@ -46,6 +46,20 @@ tasks.withType<JavaCompile>().configureEach {
     options.compilerArgs.addAll(listOf("-Xlint:all,-processing", "-parameters"))
 }
 
+// Telescope-quarkus is consumable as a JPMS module via Automatic-Module-Name: downstream modules
+// can `requires io.github.eschizoid.telescope.quarkus;` in their own module-info.java without
+// telescope-quarkus carrying a strict module-info.java itself. The strict form is impractical here
+// because two transitive deps (quarkus-arc, smallrye-config) ship neither module-info.class nor
+// Automatic-Module-Name — the strict compile would either need the `extra-java-module-info`
+// plugin's `module()` declaration to synthesize a module-info for each one (build infra cost),
+// or invasive `--patch-module` flags. The manifest hint is the standard library-side answer for
+// "I sit on a non-modular transitive graph but still need to be JPMS-consumer-friendly."
+tasks.jar {
+    manifest {
+        attributes(mapOf("Automatic-Module-Name" to "io.github.eschizoid.telescope.quarkus"))
+    }
+}
+
 tasks.withType<Test>().configureEach {
     useJUnitPlatform()
     testLogging {

--- a/quarkus/build.gradle.kts
+++ b/quarkus/build.gradle.kts
@@ -43,21 +43,25 @@ java {
 tasks.withType<JavaCompile>().configureEach {
     options.release = 17
     options.encoding = "UTF-8"
-    options.compilerArgs.addAll(listOf("-Xlint:all,-processing", "-parameters"))
+    // --add-reads lets the strict module-info.java import from quarkus-arc + smallrye-config —
+    // both ship neither module-info.class nor Automatic-Module-Name, so without this the strict
+    // compile fails with `package io.quarkus.arc is not visible`. Compile-time only; consumers
+    // see a clean `requires io.github.eschizoid.telescope.quarkus;` surface.
+    options.compilerArgs.addAll(
+        listOf(
+            "-Xlint:all,-processing",
+            "-parameters",
+            "--add-reads",
+            "io.github.eschizoid.telescope.quarkus=ALL-UNNAMED",
+        ),
+    )
 }
 
-// Telescope-quarkus is consumable as a JPMS module via Automatic-Module-Name: downstream modules
-// can `requires io.github.eschizoid.telescope.quarkus;` in their own module-info.java without
-// telescope-quarkus carrying a strict module-info.java itself. The strict form is impractical here
-// because two transitive deps (quarkus-arc, smallrye-config) ship neither module-info.class nor
-// Automatic-Module-Name — the strict compile would either need the `extra-java-module-info`
-// plugin's `module()` declaration to synthesize a module-info for each one (build infra cost),
-// or invasive `--patch-module` flags. The manifest hint is the standard library-side answer for
-// "I sit on a non-modular transitive graph but still need to be JPMS-consumer-friendly."
-tasks.jar {
-    manifest {
-        attributes(mapOf("Automatic-Module-Name" to "io.github.eschizoid.telescope.quarkus"))
-    }
+tasks.javadoc {
+    (options as StandardJavadocDocletOptions).addStringOption(
+        "-add-reads",
+        "io.github.eschizoid.telescope.quarkus=ALL-UNNAMED",
+    )
 }
 
 tasks.withType<Test>().configureEach {

--- a/quarkus/src/main/java/module-info.java
+++ b/quarkus/src/main/java/module-info.java
@@ -1,0 +1,20 @@
+/**
+ * Quarkus 3 CDI extension module for telescope. Provides {@link
+ * io.github.eschizoid.telescope.quarkus.TelescopeProducer} and the {@link
+ * io.github.eschizoid.telescope.quarkus.TelescopeMapperRegistry} bean — a typed registry indexing
+ * every {@link io.github.eschizoid.telescope.conversion.Mapper} bean visible to ArC by {@code
+ * (sourceClass, targetClass)} pair.
+ *
+ * <p>Two transitive deps ({@code quarkus-arc}, {@code smallrye-config}) ship neither {@code
+ * module-info.class} nor {@code Automatic-Module-Name} in their manifests. Rather than patching
+ * them via the {@code org.gradlex.extra-java-module-info} plugin, this module reads them via {@code
+ * --add-reads io.github.eschizoid.telescope.quarkus=ALL-UNNAMED} (see {@code build.gradle.kts}).
+ * Strict downstream JPMS consumers still get a real {@code requires
+ * io.github.eschizoid.telescope.quarkus;} surface; the unnamed-module read is compile-time only.
+ */
+module io.github.eschizoid.telescope.quarkus {
+  requires transitive io.github.eschizoid.telescope;
+  requires transitive jakarta.cdi;
+
+  exports io.github.eschizoid.telescope.quarkus;
+}

--- a/spring-boot-starter/README.md
+++ b/spring-boot-starter/README.md
@@ -5,7 +5,7 @@ Drop-in Spring Boot 4 auto-config for [telescope](../README.md). Adds one bean t
 
 ```kotlin
 dependencies {
-    implementation("io.github.eschizoid:telescope-spring-boot-starter:0.13.0")
+    implementation("io.github.eschizoid:telescope-spring-boot-starter:1.0.1")
 }
 ```
 
@@ -25,7 +25,7 @@ your `@Configuration` and they show up in the registry; the registry resolves th
 // Gradle (Spring Boot 4 BOM picks up Boot's version)
 dependencies {
     implementation(platform("org.springframework.boot:spring-boot-dependencies:4.0.1"))
-    implementation("io.github.eschizoid:telescope-spring-boot-starter:0.13.0")
+    implementation("io.github.eschizoid:telescope-spring-boot-starter:1.0.1")
 }
 ```
 
@@ -34,7 +34,7 @@ dependencies {
 <dependency>
   <groupId>io.github.eschizoid</groupId>
   <artifactId>telescope-spring-boot-starter</artifactId>
-  <version>0.13.0</version>
+  <version>1.0.1</version>
 </dependency>
 ```
 


### PR DESCRIPTION
## Summary

Per your direction — replace PR #145's `Automatic-Module-Name`-in-manifest shortcut with a proper source-level `module-info.java` for `:quarkus`.

PR #145 went out with the manifest-only approach because two transitive runtime deps (`io.quarkus:quarkus-arc`, `io.smallrye.config:smallrye-config`) ship neither `module-info.class` nor `Automatic-Module-Name` — strict `requires` failed with "package not visible".

## The strict-form fix

Bridge the two unmodular deps via `--add-reads io.github.eschizoid.telescope.quarkus=ALL-UNNAMED` (compile-time + javadoc only). Strict downstream JPMS consumers still get a real `requires io.github.eschizoid.telescope.quarkus;` surface. No new build plugin.

`module-info.java`:

```java
module io.github.eschizoid.telescope.quarkus {
  requires transitive io.github.eschizoid.telescope;
  requires transitive jakarta.cdi;

  exports io.github.eschizoid.telescope.quarkus;
}
```

`build.gradle.kts` changes:
- `compileJava` and `javadoc` both get `--add-reads io.github.eschizoid.telescope.quarkus=ALL-UNNAMED`.
- Dropped the `Automatic-Module-Name` manifest entry — replaced by the real `module-info.class` Gradle compiles into the jar.

## Test plan

- [x] `./gradlew :quarkus:check` — PASSED
- [x] `./gradlew :quarkus:javadoc` — PASSED
- [x] Jar verified to contain `module-info.class`
- [ ] CI green

## NOT auto-merged

Per `feedback_no_auto_merge_enhancements`. Awaiting review.
