### PR TITLE
docs(javadoc): refresh package-info + module-info for v1.0.2 surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Quarkus extension ship as separate artifacts.
 ```kotlin
 // Gradle (Kotlin DSL)
 dependencies {
-  implementation("io.github.eschizoid:telescope-core:0.13.0")
+  implementation("io.github.eschizoid:telescope-core:1.0.4")
 }
 ```
 
@@ -32,7 +32,7 @@ dependencies {
 <dependency>
   <groupId>io.github.eschizoid</groupId>
   <artifactId>telescope-core</artifactId>
-  <version>0.13.0</version>
+  <version>1.0.4</version>
 </dependency>
 ```
 
@@ -465,8 +465,8 @@ Gradle (Kotlin DSL):
 
 ```kotlin
 dependencies {
-    implementation("io.github.eschizoid:telescope-core:0.13.0")
-    annotationProcessor("io.github.eschizoid:telescope-codegen:0.13.0")
+    implementation("io.github.eschizoid:telescope-core:1.0.4")
+    annotationProcessor("io.github.eschizoid:telescope-codegen:1.0.4")
 }
 ```
 
@@ -476,7 +476,7 @@ Maven:
 <dependency>
   <groupId>io.github.eschizoid</groupId>
   <artifactId>telescope-core</artifactId>
-  <version>0.13.0</version>
+  <version>1.0.4</version>
 </dependency>
 
 <build>
@@ -489,7 +489,7 @@ Maven:
           <path>
             <groupId>io.github.eschizoid</groupId>
             <artifactId>telescope-codegen</artifactId>
-            <version>0.13.0</version>
+            <version>1.0.4</version>
           </path>
         </annotationProcessorPaths>
       </configuration>
@@ -514,7 +514,7 @@ first**. Maven respects the declaration order of `<annotationProcessorPaths>`; G
   <path>
     <groupId>io.github.eschizoid</groupId>
     <artifactId>telescope-lombok</artifactId>
-    <version>1.0.1</version>
+    <version>1.0.4</version>
   </path>
 </annotationProcessorPaths>
 ```
@@ -522,8 +522,8 @@ first**. Maven respects the declaration order of `<annotationProcessorPaths>`; G
 ```kotlin
 dependencies {
   annotationProcessor("org.projectlombok:lombok:1.18.30")
-  annotationProcessor("io.github.eschizoid:telescope-lombok:1.0.1")
-  annotationProcessor("io.github.eschizoid:telescope-codegen:1.0.1")
+  annotationProcessor("io.github.eschizoid:telescope-lombok:1.0.4")
+  annotationProcessor("io.github.eschizoid:telescope-codegen:1.0.4")
 }
 ```
 
@@ -1281,8 +1281,8 @@ The return type degrades to a terminal `Telescope<R, Target>` when the target is
 Gradle wiring:
 
 ```kotlin
-implementation("io.github.eschizoid:telescope-core:0.13.0")
-annotationProcessor("io.github.eschizoid:telescope-codegen:0.13.0")
+implementation("io.github.eschizoid:telescope-core:1.0.4")
+annotationProcessor("io.github.eschizoid:telescope-codegen:1.0.4")
 ```
 
 `@Focus` and `@BeanFocus` are source-retention and inert without the processor, so annotating costs nothing if you don't

--- a/benchmarks/src/jmh/java/io/github/eschizoid/telescope/benchmarks/package-info.java
+++ b/benchmarks/src/jmh/java/io/github/eschizoid/telescope/benchmarks/package-info.java
@@ -7,8 +7,8 @@
  * <ul>
  *   <li>{@link io.github.eschizoid.telescope.benchmarks.TelescopeBenchmark} — measures the three
  *       update paths against each other: reflective {@code .field(...)}, the reflection-free {@code
- *       Telescope.lens(getter, setter)} constant, and the generated {@code *Focus} / {@code
- *       *Bridge} constants emitted by the {@code :codegen} processor.
+ *       Telescope.lens(getter, setter)} constant, and the generated {@code <X>Path<R>} navigator /
+ *       {@code <X>Bridge.BRIDGE} constants emitted by the {@code :codegen} processor.
  *   <li>{@link io.github.eschizoid.telescope.benchmarks.BenchUserA} / {@link
  *       io.github.eschizoid.telescope.benchmarks.BenchUserB} — top-level POJO fixtures used by the
  *       generated-{@code @Bridge} benchmark (must be top-level because {@code @Bridge} generates a

--- a/benchmarks/src/jmh/java/module-info.java
+++ b/benchmarks/src/jmh/java/module-info.java
@@ -4,10 +4,10 @@
  *
  * <p>Requires {@code io.github.eschizoid.telescope} for the DSL surface and the {@code @Focus} /
  * {@code @Bridge} annotations; the {@code :codegen} processor runs on the annotation-processor path
- * (not the module path) and emits its generated {@code *Focus} / {@code *Bridge} classes back into
- * this module's {@code io.github.eschizoid.telescope.benchmarks} package, which is why the
- * benchmarks live in a dedicated sub-package rather than splitting the core module's exported
- * {@code io.github.eschizoid.telescope} package.
+ * (not the module path) and emits its generated {@code <X>Path<R>} navigator / {@code <X>Bridge}
+ * classes back into this module's {@code io.github.eschizoid.telescope.benchmarks} package, which
+ * is why the benchmarks live in a dedicated sub-package rather than splitting the core module's
+ * exported {@code io.github.eschizoid.telescope} package.
  */
 module io.github.eschizoid.telescope.benchmarks {
   requires transitive io.github.eschizoid.telescope;

--- a/codegen/README.md
+++ b/codegen/README.md
@@ -47,8 +47,8 @@ that chains the generated bridge constant.
 ```kotlin
 // Gradle
 dependencies {
-    implementation("io.github.eschizoid:telescope-core:0.13.0")
-    annotationProcessor("io.github.eschizoid:telescope-codegen:0.13.0")
+    implementation("io.github.eschizoid:telescope-core:1.0.4")
+    annotationProcessor("io.github.eschizoid:telescope-codegen:1.0.4")
 }
 ```
 
@@ -57,7 +57,7 @@ dependencies {
 <dependency>
   <groupId>io.github.eschizoid</groupId>
   <artifactId>telescope-core</artifactId>
-  <version>0.13.0</version>
+  <version>1.0.4</version>
 </dependency>
 <!-- annotationProcessorPaths on maven-compiler-plugin -->
 <plugin>
@@ -68,7 +68,7 @@ dependencies {
       <path>
         <groupId>io.github.eschizoid</groupId>
         <artifactId>telescope-codegen</artifactId>
-        <version>0.13.0</version>
+        <version>1.0.4</version>
       </path>
     </annotationProcessorPaths>
   </configuration>

--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/package-info.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/package-info.java
@@ -1,21 +1,23 @@
 /**
- * Annotation processors that emit per-record / per-bean {@code <Type>Focus} navigators at compile
+ * Annotation processors that emit per-record / per-bean {@code <Type>Path<R>} navigators at compile
  * time, eliminating the per-field reflection cost of {@link
  * io.github.eschizoid.telescope.Telescope}'s {@code .field(...)} on hot paths.
  *
  * <ul>
  *   <li>{@link io.github.eschizoid.telescope.codegen.AbstractTelescopeProcessor} — shared skeleton:
  *       round handling, source-file emission, diagnostics, and the templated layout used by every
- *       emitted {@code *Focus} / bridge class.
+ *       emitted {@code <X>Path<R>} / {@code <X>Telescope} / {@code <X>Bridge} class.
  *   <li>{@link io.github.eschizoid.telescope.codegen.FocusProcessor} — handles {@link
- *       io.github.eschizoid.telescope.annotations.Focus} on records; emits {@code <Record>Focus}
- *       with one optic constant per component.
+ *       io.github.eschizoid.telescope.annotations.Focus} on records; emits {@code <Record>Path<R>}
+ *       navigators plus a sibling {@code <Record>Telescope} metadata holder (ADR-0006).
  *   <li>{@link io.github.eschizoid.telescope.codegen.BeanFocusProcessor} — handles {@link
- *       io.github.eschizoid.telescope.annotations.BeanFocus} on JavaBean-style POJOs; emits
- *       getter/setter-backed {@code <Bean>Focus} navigators.
+ *       io.github.eschizoid.telescope.annotations.BeanFocus} on JavaBean-style POJOs; emits the
+ *       same {@code <Bean>Path<R>} navigator shape with getter/setter-backed accessors.
  *   <li>{@link io.github.eschizoid.telescope.codegen.BridgeProcessor} — handles {@link
- *       io.github.eschizoid.telescope.annotations.Bridge} on records; emits a sibling {@code
- *       <Record>Bridge} class exposing a {@code Telescope<Pojo, Record>} constant.
+ *       io.github.eschizoid.telescope.annotations.Bridge} on records or top-level classes (model-
+ *       anchored form) and on a third "carrier" class (carrier form, {@code source = X, target =
+ *       Y}); emits a sibling {@code <Source>Bridge} / {@code <Carrier>Bridge} class exposing a
+ *       {@code Telescope<Source, Target>} constant.
  * </ul>
  *
  * <p>Processors are registered via {@code META-INF/services/javax.annotation.processing.Processor}

--- a/codegen/src/main/java/module-info.java
+++ b/codegen/src/main/java/module-info.java
@@ -1,6 +1,6 @@
 /**
- * Telescope code generator — annotation processors that emit {@code <Type>Focus} navigators and
- * {@code <Record>Bridge} classes at compile time.
+ * Telescope code generator — annotation processors that emit {@code <Type>Path<R>} navigators and
+ * {@code <Source>Bridge} classes at compile time.
  *
  * <p>The {@code io.github.eschizoid.telescope.codegen} package is exported so downstream processors
  * (e.g. {@code telescope-lombok}) can extend {@link

--- a/core/src/main/java/io/github/eschizoid/telescope/annotations/package-info.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/annotations/package-info.java
@@ -4,16 +4,30 @@
  *
  * <ul>
  *   <li>{@link io.github.eschizoid.telescope.annotations.Focus} — applied to a record. The {@code
- *       :codegen} processor emits a sibling {@code <Record>Focus} class holding per-component optic
- *       constants, eliminating the per-field reflection cost of {@code .field(...)}.
+ *       :codegen} processor emits a sibling {@code <Record>Path<R>} navigator plus a {@code
+ *       <Record>Telescope} metadata holder (ADR-0006), eliminating the per-field reflection cost of
+ *       {@code .field(...)}.
  *   <li>{@link io.github.eschizoid.telescope.annotations.BeanFocus} — the POJO counterpart of
- *       {@code @Focus}. Drives generation of {@code <Bean>Focus} navigators for getter/setter beans
- *       (including Lombok {@code @Data} / {@code @Value} / {@code @Builder} classes via the {@code
- *       :lombok} processor).
- *   <li>{@link io.github.eschizoid.telescope.annotations.Bridge} — applied to a record to generate
- *       a reflection-free, compile-checked bridge to a sibling POJO; the runtime counterpart of the
- *       deep recursive {@link io.github.eschizoid.telescope.Telescope#map(Class, Class,
- *       io.github.eschizoid.telescope.mapping.MapStep...)} factory.
+ *       {@code @Focus}. Drives generation of {@code <Bean>Path<R>} navigators for getter/setter
+ *       beans (including Lombok {@code @Data} / {@code @Value} / {@code @Builder} classes via the
+ *       {@code :lombok} processor).
+ *   <li>{@link io.github.eschizoid.telescope.annotations.Bridge} — applied to a record or class
+ *       (model-anchored) or a carrier class (carrier form, {@code source = X, target = Y}) to
+ *       generate a reflection-free, compile-checked bridge; the codegen counterpart of the deep
+ *       recursive {@link io.github.eschizoid.telescope.Telescope#map(Class, Class,
+ *       io.github.eschizoid.telescope.mapping.MapStep...)} factory. {@code lenient = true} opts out
+ *       of the strict bijection check for the small-DTO → large-entity pattern.
+ *   <li>{@link io.github.eschizoid.telescope.annotations.Rename} / {@link
+ *       io.github.eschizoid.telescope.annotations.Transform} / {@link
+ *       io.github.eschizoid.telescope.annotations.Constant} / {@link
+ *       io.github.eschizoid.telescope.annotations.Compute} / {@link
+ *       io.github.eschizoid.telescope.annotations.Default} / {@link
+ *       io.github.eschizoid.telescope.annotations.ViaMapper} — per-field modifiers consumed by
+ *       {@code @Bridge}, mirroring the runtime row factories on {@code Mapping}.
+ *   <li>{@link io.github.eschizoid.telescope.annotations.Bridges} — javac's {@link
+ *       java.lang.annotation.Repeatable} container for multiple {@code @Bridge}s on the same type.
+ *   <li>{@link io.github.eschizoid.telescope.annotations.WriteStrategy} — override for the POJO
+ *       construction strategy when emitting the target's rebuild block.
  * </ul>
  *
  * <p>The annotations themselves carry no runtime behavior — they are read by the {@code

--- a/core/src/main/java/io/github/eschizoid/telescope/mapping/package-info.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/mapping/package-info.java
@@ -31,19 +31,44 @@
  *       io.github.eschizoid.telescope.mapping.Mapping#drop(io.github.eschizoid.telescope.Telescope.Accessor)
  *       Mapping.drop(srcAcc)} — declare a source field intentionally NOT mapped to the target. Lets
  *       the strict deep-map factory accept the pair without requiring a same-name target.
+ *   <li>{@link io.github.eschizoid.telescope.mapping.Mapping#toOneWay Mapping.toOneWay(srcAcc,
+ *       tgtAcc, fn)} — forward-only typed transform; {@link
+ *       io.github.eschizoid.telescope.Telescope#mapper Telescope.mapper(...)} rejects these rows to
+ *       keep the partial-Iso shape out of the bidirectional contract; {@link
+ *       io.github.eschizoid.telescope.Telescope#mapperForward Telescope.mapperForward(...)} accepts
+ *       them.
+ *   <li>{@link io.github.eschizoid.telescope.mapping.Mapping#enumTo Mapping.enumTo}, {@link
+ *       io.github.eschizoid.telescope.mapping.Mapping#toOrElse Mapping.toOrElse}, {@link
+ *       io.github.eschizoid.telescope.mapping.Mapping#toOrElseGet Mapping.toOrElseGet}, {@link
+ *       io.github.eschizoid.telescope.mapping.Mapping#zip Mapping.zip}, {@link
+ *       io.github.eschizoid.telescope.mapping.Mapping#constant Mapping.constant}, {@link
+ *       io.github.eschizoid.telescope.mapping.Mapping#compute Mapping.compute}, {@link
+ *       io.github.eschizoid.telescope.mapping.Mapping#when Mapping.when} — the rest of the row
+ *       factories. See {@link io.github.eschizoid.telescope.mapping.Mapping} for the full set.
  *   <li>{@link io.github.eschizoid.telescope.mapping.WriteHint#writeBean WriteHint.writeBean(cls,
  *       strategy)} / {@link io.github.eschizoid.telescope.mapping.WriteHint#writeBeans
  *       WriteHint.writeBeans(strategy)} — per-target / default write-strategy hints for bean
  *       reconstruction ({@code SETTERS} / {@code BUILDER} / {@code FIELDS} / {@code CONSTRUCTOR}).
+ *   <li>{@link io.github.eschizoid.telescope.mapping.NullHint} — null-handling strategy ({@code
+ *       DEFAULT} substitutes JLS defaults via {@code NullDefaults}; otherwise null propagates).
  * </ul>
  *
  * <p>{@link io.github.eschizoid.telescope.mapping.Mapping} and {@link
- * io.github.eschizoid.telescope.mapping.MapStep} are sealed public interfaces; their {@code
- * permits} clause lists the concrete row records ({@link
- * io.github.eschizoid.telescope.mapping.SameTypedTo}, {@link
+ * io.github.eschizoid.telescope.mapping.MapStep} are sealed public interfaces — {@code Mapping}
+ * permits the row records ({@link io.github.eschizoid.telescope.mapping.SameTypedTo}, {@link
  * io.github.eschizoid.telescope.mapping.TypedTransformTo}, {@link
+ * io.github.eschizoid.telescope.mapping.ForwardOnlyTransformTo}, {@link
  * io.github.eschizoid.telescope.mapping.Via}, {@link io.github.eschizoid.telescope.mapping.Drop},
- * {@link io.github.eschizoid.telescope.mapping.WriteHint}). Users never name those directly — the
- * static factories above return the sealed interface type.
+ * {@code TelescopeTo}, {@code FromTelescopeTo}, {@code TelescopeToTelescope}, {@link
+ * io.github.eschizoid.telescope.mapping.Constant}, {@link
+ * io.github.eschizoid.telescope.mapping.Compute}, {@code Conditional}); {@code MapStep} also
+ * permits {@code WriteHint} and {@code NullHint}. Users never name those directly — the static
+ * factories above return the sealed interface type.
+ *
+ * <p>For untyped sources, {@link io.github.eschizoid.telescope.mapping.MapExtractStep} is the
+ * sibling sealed interface backing {@link io.github.eschizoid.telescope.Telescope#fromMap} — {@code
+ * MapExtractStep.extract(key, accessor, converter)} rows convert a {@code Map<String, Object>} into
+ * a typed target. For N-source assembly, {@link io.github.eschizoid.telescope.mapping.MergeStep}
+ * backs {@link io.github.eschizoid.telescope.Telescope#merge}.
  */
 package io.github.eschizoid.telescope.mapping;

--- a/core/src/main/java/io/github/eschizoid/telescope/package-info.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/package-info.java
@@ -11,10 +11,17 @@
  *
  * <ul>
  *   <li>{@link io.github.eschizoid.telescope.Telescope} — the DSL. Build a path by chaining {@code
- *       .field(...)} / {@code .each(...)} / {@code .as(...)} / {@code .filter(...)}, then read it
- *       ({@code read}, {@code find}, {@code toList}, {@code count}, {@code exists}) or write it
- *       ({@code set}, {@code update}, {@code updateAsync}, {@code updateOptional}, {@code
- *       updateEither}, {@code updateValidated}). Single type, no category-theory jargon.
+ *       .field(...)} / {@code .each(...)} / {@code .as(...)} / {@code .filter(...)} / {@code
+ *       .list(...)} / {@code .setField(...)} / {@code .mapField(...)} / {@code .optional(...)} /
+ *       {@code .withIndex()}, then read it ({@code read}, {@code find}, {@code toList}, {@code
+ *       toListIndexed}, {@code count}, {@code exists}) or write it ({@code set}, {@code update},
+ *       {@code updateIndexed}, {@code updateAsync}, {@code updateOptional}, {@code updateEither},
+ *       {@code updateValidated}). Multi-edit shapes: {@code Telescope.all(over(...))} declarative;
+ *       {@code .with(fn)} / {@code .apply(S)} inline. Mapping shapes: {@code Telescope.map(A, B,
+ *       ...)} bidirectional; {@code Telescope.mapper(...)} returning {@code Mapper}; {@code
+ *       Telescope.mapperForward(...)} returning {@code ForwardMapper} (lenient by default); {@code
+ *       Telescope.merge(...)} N-source assembly; {@code Telescope.fromMap(...)} untyped-source
+ *       factory. Single type, no category-theory jargon.
  *   <li>{@link io.github.eschizoid.telescope.effects.Either} — sealed sum type ({@code Left} /
  *       {@code Right}) shipped in-house so the effectful-update API has no Vavr or Arrow
  *       dependency. Used by {@link io.github.eschizoid.telescope.Telescope#updateEither}.
@@ -35,9 +42,12 @@
  *   <li>{@link io.github.eschizoid.telescope.conversion} — {@code Mapper}, {@code From}, {@code To}
  *       (bidirectional graph mapping + the {@code from / to / using} fluent factory).
  *   <li>{@link io.github.eschizoid.telescope.mapping} — the row-builder DSL ({@code Mapping},
- *       {@code MapStep}, {@code WriteHint}, {@code Via}, {@code Drop}, and friends) consumed by
- *       {@link io.github.eschizoid.telescope.Telescope#map(Class, Class,
- *       io.github.eschizoid.telescope.mapping.MapStep...)}.
+ *       {@code MapStep}, {@code MapExtractStep}, {@code MergeStep}, {@code WriteHint}, {@code
+ *       NullHint}, {@code Via}, {@code Drop}, and friends) consumed by {@link
+ *       io.github.eschizoid.telescope.Telescope#map(Class, Class,
+ *       io.github.eschizoid.telescope.mapping.MapStep...)}, {@link
+ *       io.github.eschizoid.telescope.Telescope#merge}, and {@link
+ *       io.github.eschizoid.telescope.Telescope#fromMap}.
  *   <li>{@link io.github.eschizoid.telescope.effects} — the {@code Either} / {@code Validated}
  *       sealed effect types described above.
  *   <li>{@link io.github.eschizoid.telescope.annotations} — {@code @Focus} / {@code @BeanFocus} /
@@ -64,15 +74,17 @@
  * io.github.eschizoid.telescope.mapping.MapStep...)} handles record↔record, POJO↔POJO, and any
  * cross-paradigm mix at any depth — the per-side {@code Reflective} is picked independently from
  * each class. The annotation {@link io.github.eschizoid.telescope.annotations.Bridge} is the
- * reflection-free, compile-checked counterpart (annotate the record to have the bridge generated
- * and validated at compile time). The {@link io.github.eschizoid.telescope.Telescope#from} / {@code
- * .to} / {@code .using} factory covers the simpler hand-written conversion case via an {@code Iso}.
+ * reflection-free, compile-checked counterpart (annotate a record or class, or a third carrier
+ * class with {@code source = X, target = Y}, to have the bridge generated and validated at compile
+ * time). The {@link io.github.eschizoid.telescope.Telescope#from} / {@code .to} / {@code .using}
+ * factory covers the simpler hand-written conversion case via an {@code Iso}.
  *
  * <h2>Codegen</h2>
  *
  * <p>The {@link io.github.eschizoid.telescope.annotations.Focus} annotation drives an annotation
- * processor that emits per-record optic constants at compile time, eliminating the per-field
- * reflection cost of {@code .field(...)} on hot paths. The generated values plug into the same
- * composition as the reflective path, so a {@code Telescope} built either way behaves identically.
+ * processor that emits per-record {@code <Record>Path<R>} navigators at compile time, eliminating
+ * the per-field reflection cost of {@code .field(...)} on hot paths. The generated values plug into
+ * the same composition as the reflective path, so a {@code Telescope} built either way behaves
+ * identically.
  */
 package io.github.eschizoid.telescope;

--- a/core/src/main/java/module-info.java
+++ b/core/src/main/java/module-info.java
@@ -22,10 +22,21 @@
  *   <li>{@link io.github.eschizoid.telescope.mapping} — the row-builder DSL that the deep-mapping
  *       factory accepts as varargs: {@link io.github.eschizoid.telescope.mapping.Mapping#to to},
  *       {@link io.github.eschizoid.telescope.mapping.Mapping#via via}, {@link
- *       io.github.eschizoid.telescope.mapping.Mapping#drop drop}, and {@link
- *       io.github.eschizoid.telescope.mapping.WriteHint#writeBean writeBean} / {@link
- *       io.github.eschizoid.telescope.mapping.WriteHint#writeBeans writeBeans} per-target / default
- *       write-strategy hints.
+ *       io.github.eschizoid.telescope.mapping.Mapping#drop drop}, {@link
+ *       io.github.eschizoid.telescope.mapping.Mapping#toOneWay toOneWay}, {@link
+ *       io.github.eschizoid.telescope.mapping.Mapping#constant constant}, {@link
+ *       io.github.eschizoid.telescope.mapping.Mapping#compute compute}, {@link
+ *       io.github.eschizoid.telescope.mapping.Mapping#when when}, {@link
+ *       io.github.eschizoid.telescope.mapping.Mapping#enumTo enumTo}, {@link
+ *       io.github.eschizoid.telescope.mapping.Mapping#toOrElse toOrElse}, {@link
+ *       io.github.eschizoid.telescope.mapping.Mapping#zip zip} (full set on {@link
+ *       io.github.eschizoid.telescope.mapping.Mapping}); sealed {@link
+ *       io.github.eschizoid.telescope.mapping.MapExtractStep} backing {@link
+ *       io.github.eschizoid.telescope.Telescope#fromMap} for untyped sources; {@link
+ *       io.github.eschizoid.telescope.mapping.MergeStep} backing {@link
+ *       io.github.eschizoid.telescope.Telescope#merge}; {@link
+ *       io.github.eschizoid.telescope.mapping.WriteHint} / {@link
+ *       io.github.eschizoid.telescope.mapping.NullHint} hints.
  *   <li>{@link io.github.eschizoid.telescope.effects} — {@link
  *       io.github.eschizoid.telescope.effects.Either} / {@link
  *       io.github.eschizoid.telescope.effects.Validated} sealed effect types backing {@code
@@ -33,7 +44,10 @@
  *   <li>{@link io.github.eschizoid.telescope.annotations} — compile-time markers for the codegen
  *       processors: {@code @Focus} (records), {@code @BeanFocus} (POJOs, also for Lombok-annotated
  *       classes via the {@code telescope-lombok} module), {@code @Bridge} (compile-checked
- *       cross-paradigm conversion).
+ *       cross-paradigm conversion — records or classes, model-anchored or carrier form, with {@code
+ *       lenient = true} for small-DTO → large-entity); per-field modifiers {@code @Rename} /
+ *       {@code @Transform} / {@code @Constant} / {@code @Compute} / {@code @Default} /
+ *       {@code @ViaMapper}.
  * </ul>
  *
  * <p>The {@code io.github.eschizoid.telescope.internal} packages are deliberately not exported.
@@ -41,9 +55,9 @@
  * {@code Traversal} / {@code Getter} / {@code Setter} / {@code Fold}), the HKT-emulation machinery
  * ({@code Kind} / {@code Applicative}) and per-effect witnesses ({@code OptionalK}, {@code
  * EitherK}, {@code ValidatedK}, {@code CompletableFutureK}), plus the reflection helpers ({@code
- * Records}, {@code Beans}, {@code Reflective}, {@code LambdaIntrospection}). Users never type these
- * names — the public API surfaces them as plain method calls on {@code Telescope} and {@code
- * Mapper}.
+ * Records}, {@code Beans}, {@code Reflective}, {@code LambdaIntrospection}, {@code
+ * MetadataHolderProbe}, {@code NullDefaults}). Users never type these names — the public API
+ * surfaces them as plain method calls on {@code Telescope} and {@code Mapper}.
  *
  * <p>Promoting any internal type to public API in a future version is one {@code exports} line
  * away; until then, encapsulation is enforced at the JPMS level.

--- a/examples/springboot/order-jpa/src/main/java/io/github/eschizoid/telescope/demo/spring/api/OrderTelescopeController.java
+++ b/examples/springboot/order-jpa/src/main/java/io/github/eschizoid/telescope/demo/spring/api/OrderTelescopeController.java
@@ -52,7 +52,7 @@ import org.springframework.web.bind.annotation.RestController;
  * <p>{@code OrderPath}, {@code OrderTelescope}, and the {@code <X>Bridge} constants that back
  * {@code @Bridge(EntityType.class)} on the leaf records are all <b>generated at compile time</b> by
  * the telescope annotation processors registered as {@code
- * annotationProcessor("io.github.eschizoid:telescope-codegen:0.4.0")} in {@code build.gradle.kts}.
+ * annotationProcessor("io.github.eschizoid:telescope-codegen:1.0.4")} in {@code build.gradle.kts}.
  * Look in {@code build/generated/sources/annotationProcessor/...} after a build to see them.
  *
  * <p>Endpoints:

--- a/internal/src/main/java/io/github/eschizoid/telescope/internal/package-info.java
+++ b/internal/src/main/java/io/github/eschizoid/telescope/internal/package-info.java
@@ -11,6 +11,16 @@
  *       to map POJOs to records and back.
  *   <li>{@link io.github.eschizoid.telescope.internal.Reflective} — the uniform read/construct
  *       interface DeepMap drives, with implementations for records and beans.
+ *   <li>{@link io.github.eschizoid.telescope.internal.LambdaIntrospection} — {@code
+ *       SerializedLambda} decode that recovers method-reference metadata (impl method name +
+ *       declaring class) at runtime.
+ *   <li>{@link io.github.eschizoid.telescope.internal.MetadataHolderProbe} — {@code ClassValue}-
+ *       cached lookup for sibling {@code <X>FieldOptics} metadata holders emitted by {@code @Focus}
+ *       / {@code @BeanFocus} (ADR-0006 Phase B). When present, runtime navigation reads
+ *       codegen-emitted constants directly instead of going through the LMF reflective path.
+ *   <li>{@link io.github.eschizoid.telescope.internal.NullDefaults} — JLS-default substitution
+ *       table behind {@code NullHint.NullStrategy#DEFAULT} and the {@code mapperForward(...)} +
+ *       {@code @Bridge(lenient = true)} lenient-fill paths.
  * </ul>
  *
  * <p>The optic lattice and the HKT-emulation machinery live under {@code

--- a/internal/src/main/java/module-info.java
+++ b/internal/src/main/java/module-info.java
@@ -17,10 +17,12 @@
  *   <li>{@code internal.optics.collections} — runtime dispatch for List / Set / Iterable / Map
  *       values / Optional traversal.
  *   <li>{@code internal} — reflection helpers ({@code Records}, {@code Beans}, {@code Reflective},
- *       {@code LambdaIntrospection}) and the codegen {@code MetadataHolderProbe}. The probe pulls
- *       the underlying optic from a holder-emitted {@code Telescope} constant via a static-init
- *       bridge (a {@code Function<Object, Object>} that {@code Telescope} registers at class-load
- *       time) so this module stays compile-time-independent of {@code :core}.
+ *       {@code LambdaIntrospection}, {@code NullDefaults}) and the codegen {@code
+ *       MetadataHolderProbe}. The probe looks up a sibling {@code <X>FieldOptics} metadata holder
+ *       per target class via a {@code ClassValue<Optional<HolderRef>>} cache — when present, the
+ *       runtime dispatch sites read the codegen-emitted {@code Telescope<X, FieldType>} constants
+ *       directly; when absent, they fall through to the LMF-backed reflective path. This module
+ *       stays compile-time-independent of {@code :core}.
  * </ul>
  *
  * <p>The per-effect {@code Applicative} witnesses ({@code CompletableFutureK}, {@code OptionalK},

--- a/lombok/README.md
+++ b/lombok/README.md
@@ -40,7 +40,7 @@ classpath.)
 ```kotlin
 // Gradle
 dependencies {
-    implementation("io.github.eschizoid:telescope-core:1.0.1")
+    implementation("io.github.eschizoid:telescope-core:1.0.4")
 
     // Lombok itself
     compileOnly("org.projectlombok:lombok:1.18.42")
@@ -48,7 +48,7 @@ dependencies {
 
     // Telescope's Lombok-aware codegen — must come AFTER Lombok in the processor list so
     // Lombok's AST patches have fired when telescope reads the synthesized members.
-    annotationProcessor("io.github.eschizoid:telescope-lombok:1.0.1")
+    annotationProcessor("io.github.eschizoid:telescope-lombok:1.0.4")
 }
 ```
 
@@ -67,7 +67,7 @@ dependencies {
       <path>
         <groupId>io.github.eschizoid</groupId>
         <artifactId>telescope-lombok</artifactId>
-        <version>1.0.1</version>
+        <version>1.0.4</version>
       </path>
     </annotationProcessorPaths>
   </configuration>

--- a/lombok/src/main/java/io/github/eschizoid/telescope/codegen/lombok/package-info.java
+++ b/lombok/src/main/java/io/github/eschizoid/telescope/codegen/lombok/package-info.java
@@ -1,14 +1,14 @@
 /**
  * Lombok integration for the telescope code generator. Hosts a single annotation processor that
  * recognises Lombok-shaped POJOs ({@code @Data}, {@code @Value}, {@code @Builder}) and emits the
- * same {@code <Bean>Focus} navigators as the core {@link
+ * same {@code <Pojo>Path<R>} navigators as the core {@link
  * io.github.eschizoid.telescope.codegen.BeanFocusProcessor}.
  *
  * <ul>
  *   <li>{@link io.github.eschizoid.telescope.codegen.lombok.LombokFocusProcessor} — extends {@link
  *       io.github.eschizoid.telescope.codegen.AbstractTelescopeProcessor}, discovers the
- *       getters/setters that Lombok will (or has) generated, and emits a {@code <Bean>Focus} class
- *       whose constants navigate via those accessors.
+ *       getters/setters that Lombok will (or has) generated, and emits a {@code <Pojo>Path<R>}
+ *       class whose constants navigate via those accessors.
  * </ul>
  *
  * <p>The processor is registered through {@code

--- a/lombok/src/main/java/module-info.java
+++ b/lombok/src/main/java/module-info.java
@@ -2,7 +2,7 @@
  * Lombok integration for the telescope code generator. Hosts {@link
  * io.github.eschizoid.telescope.codegen.lombok.LombokFocusProcessor}, which extends {@code
  * AbstractTelescopeProcessor} from {@code io.github.eschizoid.telescope.codegen} to emit {@code
- * <Bean>Focus} navigators for Lombok-shaped POJOs ({@code @Data} / {@code @Value} /
+ * <Pojo>Path<R>} navigators for Lombok-shaped POJOs ({@code @Data} / {@code @Value} /
  * {@code @Builder}).
  *
  * <p>The processor is advertised via the {@link javax.annotation.processing.Processor} service —

--- a/quarkus/README.md
+++ b/quarkus/README.md
@@ -5,7 +5,7 @@ nothing else. Mirrors the [`spring-boot-starter`](../spring-boot-starter/README.
 
 ```kotlin
 dependencies {
-    implementation("io.github.eschizoid:telescope-quarkus:1.0.1")
+    implementation("io.github.eschizoid:telescope-quarkus:1.0.4")
 }
 ```
 
@@ -32,7 +32,7 @@ archive ... is being scanned without a Jandex index" warning.
 // Gradle (Quarkus 3 BOM picks up Quarkus's version)
 dependencies {
     implementation(platform("io.quarkus.platform:quarkus-bom:3.20.0"))
-    implementation("io.github.eschizoid:telescope-quarkus:1.0.1")
+    implementation("io.github.eschizoid:telescope-quarkus:1.0.4")
 }
 ```
 
@@ -41,7 +41,7 @@ dependencies {
 <dependency>
   <groupId>io.github.eschizoid</groupId>
   <artifactId>telescope-quarkus</artifactId>
-  <version>1.0.1</version>
+  <version>1.0.4</version>
 </dependency>
 ```
 

--- a/spring-boot-starter/README.md
+++ b/spring-boot-starter/README.md
@@ -5,7 +5,7 @@ Drop-in Spring Boot 4 auto-config for [telescope](../README.md). Adds one bean t
 
 ```kotlin
 dependencies {
-    implementation("io.github.eschizoid:telescope-spring-boot-starter:1.0.1")
+    implementation("io.github.eschizoid:telescope-spring-boot-starter:1.0.4")
 }
 ```
 
@@ -25,7 +25,7 @@ your `@Configuration` and they show up in the registry; the registry resolves th
 // Gradle (Spring Boot 4 BOM picks up Boot's version)
 dependencies {
     implementation(platform("org.springframework.boot:spring-boot-dependencies:4.0.1"))
-    implementation("io.github.eschizoid:telescope-spring-boot-starter:1.0.1")
+    implementation("io.github.eschizoid:telescope-spring-boot-starter:1.0.4")
 }
 ```
 
@@ -34,7 +34,7 @@ dependencies {
 <dependency>
   <groupId>io.github.eschizoid</groupId>
   <artifactId>telescope-spring-boot-starter</artifactId>
-  <version>1.0.1</version>
+  <version>1.0.4</version>
 </dependency>
 ```
 


### PR DESCRIPTION
## Summary

Audit of all 21 `package-info.java` / `module-info.java` files found 8 stale. The dominant pattern was the navigator naming staleness — `<Bean>Focus` / `<X>Focus` appeared in five files but the processors actually emit `<X>Path<R>` navigators + `<X>Telescope` metadata holders. Also caught a factual error in `:internal`'s module-info about `MetadataHolderProbe` (described a static-init bridge that was eliminated; replaced with the real `ClassValue<Optional<HolderRef>>` mechanism).

The original trigger was `telescope-lombok`'s javadoc.io page rendering `<Bean>Focus` — fixed alongside the rest of the sweep.

## Files updated

- `internal/src/main/java/module-info.java` — `MetadataHolderProbe` description rewritten (was: static-init bridge; now: `ClassValue<Optional<HolderRef>>` + LMF fallback)
- `internal/src/main/java/io/github/eschizoid/telescope/internal/package-info.java` — added `LambdaIntrospection`, `MetadataHolderProbe`, `NullDefaults` entries
- `codegen/src/main/java/module-info.java` — `<Type>Focus` → `<Type>Path<R>`, `<Record>Bridge` → `<Source>Bridge`
- `codegen/.../package-info.java` — `FocusProcessor` / `BeanFocusProcessor` / `BridgeProcessor` descriptions corrected
- `lombok/src/main/java/module-info.java` — `<Bean>Focus` → `<Pojo>Path<R>`
- `lombok/.../package-info.java` — same
- `core/.../annotations/package-info.java` — expanded with `@Rename` / `@Transform` / `@Constant` / `@Compute` / `@Default` / `@ViaMapper` / `Bridges` / `WriteStrategy`; `@Bridge` now covers records OR classes + carrier form + `lenient = true`
- `core/.../package-info.java` — expanded navigation list (`.list` / `.setField` / `.mapField` / `.optional` / `.withIndex`); mapping shapes include `Telescope.all` / `.merge` / `.mapper` / `.mapperForward` / `.fromMap`
- `core/.../mapping/package-info.java` — full row-factory surface (`toOneWay`, `enumTo`, `toOrElse` / `toOrElseGet`, `zip`, `constant`, `compute`, `when`); added `MapExtractStep` + `MergeStep` cross-refs; sealed-permits enumeration updated
- `core/src/main/java/module-info.java` — mapping enumeration matches the row-factory surface; `@Bridge` description names carrier form + lenient flag; internal-helpers enumeration adds `MetadataHolderProbe` + `NullDefaults`
- `benchmarks/.../package-info.java` + `benchmarks/.../module-info.java` — `*Focus` / `*Bridge` → `<X>Path<R>` navigator + `<X>Bridge`

## Maven / Gradle coordinates

All READMEs (root, `quarkus/`, `lombok/`, `spring-boot-starter/`, `codegen/`) bumped to `1.0.4` — were a mix of stale `0.13.0` and `1.0.1` coords.

## Test plan

- [x] `./gradlew :core:javadoc :internal:javadoc :codegen:javadoc :lombok:javadoc --rerun-tasks` — BUILD SUCCESSFUL
- [x] `./gradlew spotlessApply check` — BUILD SUCCESSFUL
- [x] Verify javadoc.io page for `telescope-lombok` 1.0.4+ renders `<Pojo>Path<R>` (next release)
