### PR TITLE
test(internal): meaningful coverage hardening for Beans / Records / Reflective

### DIFF
--- a/internal/src/main/java/io/github/eschizoid/telescope/internal/Reflective.java
+++ b/internal/src/main/java/io/github/eschizoid/telescope/internal/Reflective.java
@@ -73,9 +73,12 @@ public record Reflective(
    * (when non-null) and ultimately to {@link Beans#autoWriter}. Used by {@code DeepMap} when the
    * user supplies {@code writeBean(targetClass, strategy)} rows and/or a single {@code
    * writeBeans(strategy)} default — the per-class hint map is keyed on target class and provides a
-   * pre-instantiated {@link Beans.BeanWriter}; the default factory is consulted lazily on first
-   * encounter with each not-explicitly-hinted target, then cached, so a default-strategy
-   * incompatible with a particular target only throws when that target is actually constructed.
+   * pre-instantiated {@link Beans.BeanWriter}; the default factory is consulted on every
+   * not-explicitly-hinted call, so a default-strategy incompatible with a particular target only
+   * throws when that target is actually constructed. Per-class LMF reuse happens one layer down in
+   * {@link Beans#autoWriter} (and the underlying {@code SETTER_INVOKERS} / {@code GETTER_INVOKERS}
+   * caches) — this layer is intentionally stateless so a factory swap is observable on the next
+   * call.
    */
   public static Reflective beansWithHints(
     final Map<Class<?>, Beans.BeanWriter<?>> hints,

--- a/internal/src/test/java/io/github/eschizoid/telescope/internal/BeansTest.java
+++ b/internal/src/test/java/io/github/eschizoid/telescope/internal/BeansTest.java
@@ -1182,21 +1182,6 @@ class BeansTest {
       Beans.writeBeanProperty(pojo, "id", "parent-id");
       assertEquals("parent-id", pojo.getId());
     }
-
-    @Test
-    @DisplayName("subsequent writes for the same (class, property) reuse the cached invoker (hot path)")
-    void cachesInvokerAcrossWrites() {
-      // The cache lookup at Beans.writeBeanProperty:
-      //   SETTER_INVOKERS.get(cls).computeIfAbsent(name, n -> buildSetterInvoker(...))
-      // means the first write per (class, property) builds the LMF invoker and subsequent writes
-      // dispatch directly. Smoke-test the cache by writing twice and asserting the second write
-      // takes effect — a regression where the second call rebuilt from scratch would still pass,
-      // but a regression where the cache misbehaved (e.g. wrong cached value) would not.
-      final var pojo = new NoArgSetters();
-      Beans.writeBeanProperty(pojo, "name", "first");
-      Beans.writeBeanProperty(pojo, "name", "second");
-      assertEquals("second", pojo.getName());
-    }
   }
 
   @Nested

--- a/internal/src/test/java/io/github/eschizoid/telescope/internal/BeansTest.java
+++ b/internal/src/test/java/io/github/eschizoid/telescope/internal/BeansTest.java
@@ -2,12 +2,14 @@ package io.github.eschizoid.telescope.internal;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import io.github.eschizoid.telescope.internal.optics.Lens;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.Objects;
@@ -1128,6 +1130,147 @@ class BeansTest {
       final var proxy = new ProxyShape();
       proxy.setName("alice");
       assertEquals("alice", Beans.readProperty(proxy, "name"));
+    }
+  }
+
+  @Nested
+  @DisplayName("writeBeanProperty — single-property write through cached LMF setter invoker")
+  class WriteBeanProperty {
+
+    @Test
+    @DisplayName("happy path: writes a reference-typed property and the getter reflects the new value")
+    void writesReferenceTypedProperty() {
+      final var pojo = new NoArgSetters();
+      Beans.writeBeanProperty(pojo, "name", "alice");
+      assertEquals("alice", pojo.getName());
+    }
+
+    @Test
+    @DisplayName("primitive-typed setter unboxes a boxed source value end-to-end through the LMF invoker")
+    void primitiveSetterUnboxesBoxedSource() {
+      // The cached invoker is built from a BiConsumer<Object, Object> SAM whose instantiated
+      // method type is (Cls, Integer) -> void. LMF generates the unbox bridge to setX(int) —
+      // this test exercises that bridge end-to-end via writeBeanProperty's public surface.
+      final var pojo = new NoArgSetters();
+      Beans.writeBeanProperty(pojo, "score", Integer.valueOf(42));
+      assertEquals(42, pojo.getScore());
+    }
+
+    @Test
+    @DisplayName("getter-only / no-setter property silently no-ops (matches MapStruct's @MappingTarget contract)")
+    void getterOnlyPropertyIsSilentNoOp() {
+      // Documented contract at Beans.buildSetterInvoker: a property with no setX(value) method
+      // gets a no-op BiConsumer rather than throwing — Mapper.into(target, source) would
+      // otherwise blow up on a property pair that Mapper.forward (via SettersWriter) silently
+      // skipped, producing an asymmetric same-mapper contract. NoArgFields has a `name` field
+      // and getter but no setter; writeBeanProperty must succeed silently and leave the field
+      // at its JLS default (here: null).
+      final var pojo = new NoArgFields();
+      Beans.writeBeanProperty(pojo, "name", "ignored");
+      assertNull(pojo.name);
+    }
+
+    @Test
+    @DisplayName("inherited setter: writeBeanProperty routes through the parent's declaring class for privateLookupIn")
+    void inheritedSetterRoutesThroughDeclaringClass() {
+      // ChildBean inherits setId(String) from ParentBean. The LMF invoker must resolve a Lookup
+      // against ParentBean (where setId is declared) rather than ChildBean — using the child's
+      // class would fail at privateLookupIn when the two live in modules with different opens
+      // directives. Pins the inheritance-correctness contract for the write path, mirroring the
+      // SettersWriter test of the same shape.
+      final var pojo = new ChildBean();
+      Beans.writeBeanProperty(pojo, "id", "parent-id");
+      assertEquals("parent-id", pojo.getId());
+    }
+
+    @Test
+    @DisplayName("subsequent writes for the same (class, property) reuse the cached invoker (hot path)")
+    void cachesInvokerAcrossWrites() {
+      // The cache lookup at Beans.writeBeanProperty:
+      //   SETTER_INVOKERS.get(cls).computeIfAbsent(name, n -> buildSetterInvoker(...))
+      // means the first write per (class, property) builds the LMF invoker and subsequent writes
+      // dispatch directly. Smoke-test the cache by writing twice and asserting the second write
+      // takes effect — a regression where the second call rebuilt from scratch would still pass,
+      // but a regression where the cache misbehaved (e.g. wrong cached value) would not.
+      final var pojo = new NoArgSetters();
+      Beans.writeBeanProperty(pojo, "name", "first");
+      Beans.writeBeanProperty(pojo, "name", "second");
+      assertEquals("second", pojo.getName());
+    }
+  }
+
+  @Nested
+  @DisplayName("fieldLens — class-deferred Lens<P, A> driving Telescope.fieldByName(String)")
+  class FieldLensByName {
+
+    @Test
+    @DisplayName("get reads the focused property from the source via readProperty's class-deferred dispatch")
+    void getReadsFromAnyMatchingSource() {
+      final Lens<NoArgSetters, String> nameLens = Beans.fieldLens("name");
+      final var pojo = new NoArgSetters();
+      pojo.setName("alice");
+      assertEquals("alice", nameLens.get(pojo));
+    }
+
+    @Test
+    @DisplayName("set rebuilds the POJO with the focused property replaced; off-path values are carried through")
+    void setReplacesFocusedPropertyAndCarriesOffPath() {
+      final Lens<NoArgSetters, String> nameLens = Beans.fieldLens("name");
+      final var src = new NoArgSetters();
+      src.setName("alice");
+      src.setScore(7);
+      final var rebuilt = nameLens.set(src, "bob");
+      assertEquals("bob", rebuilt.getName());
+      assertEquals(7, rebuilt.getScore(), "off-path score must round-trip untouched");
+    }
+
+    @Test
+    @DisplayName("set(null, value) returns null — the documented null-source guard")
+    void setOnNullSourceReturnsNull() {
+      final Lens<NoArgSetters, String> nameLens = Beans.fieldLens("name");
+      assertNull(nameLens.set(null, "ignored"));
+    }
+
+    @Test
+    @DisplayName("modify(null, fn) returns null without invoking the function on a null get result")
+    void modifyOnNullSourceReturnsNull() {
+      final Lens<NoArgSetters, String> nameLens = Beans.fieldLens("name");
+      assertNull(
+        nameLens.modify(null, v -> {
+          throw new AssertionError("function must not be invoked on null source");
+        })
+      );
+    }
+
+    @Test
+    @DisplayName("set on a subtype source rebuilds using the subtype's class (writer is resolved at call time)")
+    void setOnSubtypeRebuildsAsSubtype() {
+      // fieldLens is class-deferred: the writer is resolved against source.getClass() per call,
+      // not captured at lens build time. A ChildBean carrying both inherited and own properties
+      // rebuilds as ChildBean — same lens instance can be applied across the hierarchy.
+      final Lens<ParentBean, String> idLens = Beans.fieldLens("id");
+      final var child = new ChildBean();
+      child.setId("p");
+      child.setName("c");
+      final var rebuilt = idLens.set(child, "p2");
+      assertInstanceOf(ChildBean.class, rebuilt, "rebuilt instance must be the subtype, not the supertype");
+      assertEquals("p2", rebuilt.getId());
+      assertEquals("c", ((ChildBean) rebuilt).getName(), "off-path subtype property must carry through");
+    }
+
+    @Test
+    @DisplayName("set(s, null) on a primitive property substitutes the JLS default via SettersWriter's null-guard")
+    void setNullOnPrimitiveSubstitutesJlsDefault() {
+      // Documented contract on Beans.fieldLens: when the focused property is a Java primitive,
+      // set(s, null) substitutes the JLS default (0 for int) rather than throwing on the
+      // unbox — the value flows through SettersWriter which null-guards primitive setters.
+      // Lens law `set(s, null).get == null` does NOT hold here; user must use a boxed wrapper
+      // type if null round-trip matters.
+      final Lens<NoArgSetters, Integer> scoreLens = Beans.fieldLens("score");
+      final var src = new NoArgSetters();
+      src.setScore(5);
+      final var rebuilt = scoreLens.set(src, null);
+      assertEquals(0, rebuilt.getScore());
     }
   }
 }

--- a/internal/src/test/java/io/github/eschizoid/telescope/internal/RecordsTest.java
+++ b/internal/src/test/java/io/github/eschizoid/telescope/internal/RecordsTest.java
@@ -2,7 +2,9 @@ package io.github.eschizoid.telescope.internal;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -215,16 +217,14 @@ class RecordsTest {
     }
 
     @Test
-    @DisplayName("repeated info() calls for the same class reuse the cached RecordInfo (no re-LMF-build)")
-    void infoCacheReusesAcrossCalls() {
-      // Smoke test: calling Records.read twice for different fields uses the same cached
-      // RecordInfo internally. A regression where the cache misfired (e.g. rebuilt per call)
-      // would still pass functionally — but a regression where the cache held stale info for
-      // a different class would fail this round-trip across two distinct record types in the
-      // same test.
-      assertEquals("alice", Records.read(new User("alice", 30), "name"));
-      assertEquals("acc-1", Records.read(new Account("acc-1", new User("alice", 30), List.of()), "id"));
-      assertEquals(30, Records.read(new User("bob", 30), "age"));
+    @DisplayName("info() returns the same RecordInfo instance across calls — per-class memoisation, no rebuild")
+    void infoCacheReturnsSameInstance() {
+      // The package-private info() method is the single cache entry point — calling it twice for
+      // the same class must return the very same RecordInfo (LMF-built readers + ctorFn) instead
+      // of rebuilding. A regression here would silently double the per-read overhead.
+      assertSame(Records.info(User.class), Records.info(User.class));
+      // And the cache must hold one entry per class — a second class doesn't collide.
+      assertNotEquals(Records.info(User.class), Records.info(Account.class));
     }
   }
 }

--- a/internal/src/test/java/io/github/eschizoid/telescope/internal/RecordsTest.java
+++ b/internal/src/test/java/io/github/eschizoid/telescope/internal/RecordsTest.java
@@ -1,0 +1,230 @@
+package io.github.eschizoid.telescope.internal;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.github.eschizoid.telescope.internal.optics.Lens;
+import java.lang.reflect.ParameterizedType;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Direct contract tests for {@link Records} — the canonical-constructor read/write substrate that
+ * the public {@code Telescope} record paths route through. Pins the null-source guards, the
+ * unknown-field / non-record diagnostics, and the per-class {@code RecordInfo} cache behaviour.
+ */
+class RecordsTest {
+
+  record User(String name, int age) {}
+
+  record Account(String id, User owner, List<String> tags) {}
+
+  static class NotARecord {}
+
+  @Nested
+  @DisplayName("Public read / write surface")
+  class PublicSurface {
+
+    @Test
+    @DisplayName("read returns the focused component value")
+    void readReturnsComponent() {
+      final var user = new User("alice", 30);
+      assertEquals("alice", Records.read(user, "name"));
+      assertEquals(30, Records.read(user, "age"));
+    }
+
+    @Test
+    @DisplayName("read(null, name) returns null — does not NPE on persistentClassOf-like lookup")
+    void readOnNullSourceReturnsNull() {
+      assertNull(Records.read(null, "name"));
+    }
+
+    @Test
+    @DisplayName("read with an unknown component name throws IllegalArgumentException naming the missing field")
+    void readUnknownComponentThrows() {
+      final var user = new User("alice", 30);
+      final var ex = assertThrows(IllegalArgumentException.class, () -> Records.read(user, "ghost"));
+      assertTrue(
+        ex.getMessage().contains("ghost"),
+        () -> "diagnostic must name the missing field, got: " + ex.getMessage()
+      );
+    }
+
+    @Test
+    @DisplayName("with rebuilds the record with one component replaced; off-path components carry over")
+    void withReplacesComponent() {
+      final var src = new User("alice", 30);
+      final User updated = Records.with(src, "age", 31);
+      assertEquals(new User("alice", 31), updated);
+    }
+
+    @Test
+    @DisplayName("with(null, ...) returns null — null source guard")
+    void withOnNullSourceReturnsNull() {
+      assertNull(Records.with((User) null, "name", "bob"));
+    }
+
+    @Test
+    @DisplayName("with on a non-record source throws IllegalArgumentException")
+    void withOnNonRecordThrows() {
+      final var ex = assertThrows(IllegalArgumentException.class, () -> Records.with(new NotARecord(), "x", 1));
+      assertTrue(ex.getMessage().contains("Not a record"), () -> ex.getMessage());
+    }
+
+    @Test
+    @DisplayName("with on an unknown component throws IllegalArgumentException naming the missing field")
+    void withUnknownComponentThrows() {
+      final var src = new User("alice", 30);
+      final var ex = assertThrows(IllegalArgumentException.class, () -> Records.with(src, "ghost", 1));
+      assertTrue(ex.getMessage().contains("ghost"), () -> ex.getMessage());
+    }
+
+    @Test
+    @DisplayName("construct assembles a record from a name-keyed value function")
+    void constructAssemblesByName() {
+      final var built = Records.construct(User.class, name ->
+        switch (name) {
+          case "name" -> "carol";
+          case "age" -> 27;
+          default -> throw new IllegalStateException("unexpected: " + name);
+        }
+      );
+      assertEquals(new User("carol", 27), built);
+    }
+
+    @Test
+    @DisplayName("componentNames returns the canonical-constructor order")
+    void componentNamesAreInCanonicalOrder() {
+      assertArrayEquals(new String[] { "name", "age" }, Records.componentNames(User.class));
+      assertArrayEquals(new String[] { "id", "owner", "tags" }, Records.componentNames(Account.class));
+    }
+
+    @Test
+    @DisplayName(
+      "componentType returns the generic Type — preserving parameterised List<String> for downstream shape detection"
+    )
+    void componentTypePreservesGenerics() {
+      // DeepMap shape detection (List<X>, Map<K, V>, Optional<X>) needs the generic Type, not the
+      // erased Class — verify the wrapping shape survives the round-trip.
+      final var type = Records.componentType(Account.class, "tags");
+      assertTrue(type instanceof ParameterizedType, () -> "expected ParameterizedType for List<String>, got " + type);
+      final var raw = ((ParameterizedType) type).getRawType();
+      assertEquals(List.class, raw);
+    }
+
+    @Test
+    @DisplayName("componentType throws on an unknown name")
+    void componentTypeUnknownThrows() {
+      assertThrows(IllegalArgumentException.class, () -> Records.componentType(User.class, "ghost"));
+    }
+  }
+
+  @Nested
+  @DisplayName("fieldLens(String) — class-deferred lens used by Telescope.fieldByName on records")
+  class FieldLensDeferred {
+
+    @Test
+    @DisplayName("get reads the focused component via late-bound class dispatch")
+    void getReadsComponent() {
+      final Lens<User, String> nameLens = Records.fieldLens("name");
+      assertEquals("alice", nameLens.get(new User("alice", 30)));
+    }
+
+    @Test
+    @DisplayName("get(null) returns null instead of NPEing on info(null.getClass())")
+    void getOnNullSourceIsNull() {
+      final Lens<User, String> nameLens = Records.fieldLens("name");
+      assertNull(nameLens.get(null));
+    }
+
+    @Test
+    @DisplayName("set rebuilds with the focused component replaced")
+    void setReplacesComponent() {
+      final Lens<User, String> nameLens = Records.fieldLens("name");
+      final var rebuilt = nameLens.set(new User("alice", 30), "bob");
+      assertEquals(new User("bob", 30), rebuilt);
+    }
+
+    @Test
+    @DisplayName("set(null, value) returns null — null source guard")
+    void setOnNullSourceIsNull() {
+      final Lens<User, String> nameLens = Records.fieldLens("name");
+      assertNull(nameLens.set(null, "bob"));
+    }
+
+    @Test
+    @DisplayName("modify applies the function to the current component and rebuilds")
+    void modifyAppliesFunction() {
+      final Lens<User, String> nameLens = Records.fieldLens("name");
+      final var rebuilt = nameLens.modify(new User("Alice", 30), String::toLowerCase);
+      assertEquals(new User("alice", 30), rebuilt);
+    }
+  }
+
+  @Nested
+  @DisplayName("fieldLens(Class, String) — class-aware lens used by method-reference .field(...) paths")
+  class FieldLensClassAware {
+
+    @Test
+    @DisplayName("captures the per-class RecordInfo at construction; per-call dispatch reads without name lookup")
+    void getReadsViaCapturedReader() {
+      final Lens<User, Integer> ageLens = Records.fieldLens(User.class, "age");
+      assertEquals(30, ageLens.get(new User("alice", 30)));
+    }
+
+    @Test
+    @DisplayName("get(null) on the class-aware variant returns null")
+    void getOnNullSourceIsNull() {
+      final Lens<User, Integer> ageLens = Records.fieldLens(User.class, "age");
+      assertNull(ageLens.get(null));
+    }
+
+    @Test
+    @DisplayName("set rebuilds via the captured RecordInfo with one component replaced")
+    void setReplacesComponent() {
+      final Lens<User, Integer> ageLens = Records.fieldLens(User.class, "age");
+      assertEquals(new User("alice", 31), ageLens.set(new User("alice", 30), 31));
+    }
+
+    @Test
+    @DisplayName("constructing a lens for an unknown component fails fast at lens build time, not at first read")
+    void unknownComponentFailsFastAtBuildTime() {
+      // The class-aware variant resolves info+idx at construction — the IAE must fire at the
+      // fieldLens(Class, String) call site, not later when .get/.set is invoked. Pins the
+      // "fail fast" intent so a future refactor that defers the lookup won't slip through.
+      assertThrows(IllegalArgumentException.class, () -> Records.fieldLens(User.class, "ghost"));
+    }
+  }
+
+  @Nested
+  @DisplayName("RecordInfo cache — info(...) and its non-record diagnostic")
+  class CacheBehaviour {
+
+    @Test
+    @DisplayName("info(non-record) throws IllegalArgumentException with a precise diagnostic")
+    void infoOnNonRecordThrows() {
+      // info() is package-private; reach it via the public surface to keep the test through the
+      // contract. componentNames is the simplest entry point that exercises info() directly.
+      final var ex = assertThrows(IllegalArgumentException.class, () -> Records.componentNames(NotARecord.class));
+      assertTrue(ex.getMessage().contains("Not a record"), () -> ex.getMessage());
+    }
+
+    @Test
+    @DisplayName("repeated info() calls for the same class reuse the cached RecordInfo (no re-LMF-build)")
+    void infoCacheReusesAcrossCalls() {
+      // Smoke test: calling Records.read twice for different fields uses the same cached
+      // RecordInfo internally. A regression where the cache misfired (e.g. rebuilt per call)
+      // would still pass functionally — but a regression where the cache held stale info for
+      // a different class would fail this round-trip across two distinct record types in the
+      // same test.
+      assertEquals("alice", Records.read(new User("alice", 30), "name"));
+      assertEquals("acc-1", Records.read(new Account("acc-1", new User("alice", 30), List.of()), "id"));
+      assertEquals(30, Records.read(new User("bob", 30), "age"));
+    }
+  }
+}

--- a/internal/src/test/java/io/github/eschizoid/telescope/internal/RecordsTest.java
+++ b/internal/src/test/java/io/github/eschizoid/telescope/internal/RecordsTest.java
@@ -2,7 +2,7 @@ package io.github.eschizoid.telescope.internal;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -223,8 +223,10 @@ class RecordsTest {
       // the same class must return the very same RecordInfo (LMF-built readers + ctorFn) instead
       // of rebuilding. A regression here would silently double the per-read overhead.
       assertSame(Records.info(User.class), Records.info(User.class));
-      // And the cache must hold one entry per class — a second class doesn't collide.
-      assertNotEquals(Records.info(User.class), Records.info(Account.class));
+      // And the cache must hold one entry per class — a second class doesn't collide. Reference
+      // identity (not structural equality) is the right pin: a cache-bleed regression where
+      // info(User) returned Account's entry would have the wrong reference, not the wrong value.
+      assertNotSame(Records.info(User.class), Records.info(Account.class));
     }
   }
 }

--- a/internal/src/test/java/io/github/eschizoid/telescope/internal/ReflectiveSurfaceTest.java
+++ b/internal/src/test/java/io/github/eschizoid/telescope/internal/ReflectiveSurfaceTest.java
@@ -1,0 +1,283 @@
+package io.github.eschizoid.telescope.internal;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.reflect.ParameterizedType;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Surface tests for {@link Reflective} — the polymorphic record/bean dispatch substrate that
+ * DeepMap drives. Pins the {@code of(Class)} routing, the per-instance delegate wrappers ({@code
+ * names} / {@code genericType} / {@code read} / {@code construct} / {@code normalize}), the
+ * hint-aware bean variant, and {@code positionalBuilder} fast paths.
+ */
+class ReflectiveSurfaceTest {
+
+  record SimpleUser(String name, int age) {}
+
+  record AccountRecord(String id, List<String> tags) {}
+
+  public static class SimpleBean {
+
+    private String name;
+    private int age;
+
+    public SimpleBean() {}
+
+    public String getName() {
+      return name;
+    }
+
+    public int getAge() {
+      return age;
+    }
+
+    public void setName(final String name) {
+      this.name = name;
+    }
+
+    public void setAge(final int age) {
+      this.age = age;
+    }
+  }
+
+  @Nested
+  @DisplayName("of(Class) — record/bean dispatch")
+  class FactoryDispatch {
+
+    @Test
+    @DisplayName("of(Record.class) routes to the RECORDS singleton; of(BeanClass) routes to BEANS")
+    void ofRoutesByClassKind() {
+      assertSame(Reflective.RECORDS, Reflective.of(SimpleUser.class));
+      assertSame(Reflective.BEANS, Reflective.of(SimpleBean.class));
+    }
+  }
+
+  @Nested
+  @DisplayName("Delegate wrappers — names / genericType / read / construct / normalize")
+  class DelegateWrappers {
+
+    @Test
+    @DisplayName("RECORDS#names returns component names in canonical order")
+    void recordNames() {
+      assertArrayEquals(new String[] { "name", "age" }, Reflective.RECORDS.names(SimpleUser.class));
+    }
+
+    @Test
+    @DisplayName("BEANS#names returns property names in scan order")
+    void beanNames() {
+      final var names = Reflective.BEANS.names(SimpleBean.class);
+      assertTrue(List.of(names).contains("name"));
+      assertTrue(List.of(names).contains("age"));
+    }
+
+    @Test
+    @DisplayName("genericType preserves parameterised types so DeepMap can detect List<String> containers")
+    void genericTypePreservesParameterisedShape() {
+      final var t = Reflective.RECORDS.genericType(AccountRecord.class, "tags");
+      assertTrue(t instanceof ParameterizedType, () -> "expected ParameterizedType, got " + t);
+      assertEquals(List.class, ((ParameterizedType) t).getRawType());
+    }
+
+    @Test
+    @DisplayName("read delegates to Records.read for the record reflective")
+    void recordReadDelegates() {
+      assertEquals("alice", Reflective.RECORDS.read(new SimpleUser("alice", 30), "name"));
+    }
+
+    @Test
+    @DisplayName("read delegates to Beans.readProperty for the bean reflective")
+    void beanReadDelegates() {
+      final var bean = new SimpleBean();
+      bean.setName("alice");
+      assertEquals("alice", Reflective.BEANS.read(bean, "name"));
+    }
+
+    @Test
+    @DisplayName("construct delegates to Records.construct for records and rebuilds the canonical instance")
+    void recordConstructDelegates() {
+      final var built = Reflective.RECORDS.construct(SimpleUser.class, name ->
+        switch (name) {
+          case "name" -> "bob";
+          case "age" -> 21;
+          default -> throw new IllegalStateException();
+        }
+      );
+      assertEquals(new SimpleUser("bob", 21), built);
+    }
+
+    @Test
+    @DisplayName("construct delegates to autoWriter for beans and populates the no-arg-ctor instance")
+    void beanConstructDelegates() {
+      final var built = (SimpleBean) Reflective.BEANS.construct(SimpleBean.class, name ->
+        switch (name) {
+          case "name" -> "carol";
+          case "age" -> 27;
+          default -> null;
+        }
+      );
+      assertEquals("carol", built.getName());
+      assertEquals(27, built.getAge());
+    }
+
+    @Test
+    @DisplayName("RECORDS#normalize is identity (record component names need no transformation)")
+    void recordNormalizeIsIdentity() {
+      assertEquals("name", Reflective.RECORDS.normalize("name"));
+      assertEquals("getAge", Reflective.RECORDS.normalize("getAge"));
+    }
+
+    @Test
+    @DisplayName("BEANS#normalize strips the get/is prefix and decapitalises (mirrors JavaBeans rules)")
+    void beanNormalizeStripsPrefixAndDecapitalises() {
+      assertEquals("name", Reflective.BEANS.normalize("getName"));
+      assertEquals("active", Reflective.BEANS.normalize("isActive"));
+      assertEquals("URL", Reflective.BEANS.normalize("getURL"), "two-leading-caps rule keeps the name as-is");
+    }
+  }
+
+  @Nested
+  @DisplayName("beansWithHints — per-class hint + lazy default writer factory")
+  class HintAwareBean {
+
+    @Test
+    @DisplayName("hint map drives the construct path: a SettersWriter hint produces a populated instance")
+    void hintWriterDrivesConstruct() {
+      // SettersWriter is a sealed-interface implementor so we can't use a lambda — but we can
+      // verify the hint took precedence over autoWriter by confirming the constructed instance
+      // is exactly the SimpleBean shape the hint produces.
+      final Map<Class<?>, Beans.BeanWriter<?>> hints = Map.of(SimpleBean.class, Beans.settersWriter(SimpleBean.class));
+      final var refl = Reflective.beansWithHints(hints, null);
+
+      final var built = (SimpleBean) refl.construct(SimpleBean.class, name ->
+        switch (name) {
+          case "name" -> "dave";
+          case "age" -> 19;
+          default -> null;
+        }
+      );
+
+      assertEquals("dave", built.getName());
+      assertEquals(19, built.getAge());
+    }
+
+    @Test
+    @DisplayName("default factory fires for non-hinted classes when no hint is present (lazy resolution)")
+    void defaultFactoryFiresForUnhintedClasses() {
+      // Track factory-call count to prove the lazy path is reached — the factory must be invoked
+      // when no hint covers the class. (The lambda runs at first encounter; if the result is
+      // memoised internally the count stays at 1 across multiple construct() calls.)
+      final var factoryCalls = new int[] { 0 };
+      final var refl = Reflective.beansWithHints(new HashMap<>(), cls -> {
+        factoryCalls[0]++;
+        return Beans.settersWriter(SimpleBean.class);
+      });
+
+      refl.construct(SimpleBean.class, name -> name.equals("name") ? "x" : 1);
+      assertTrue(factoryCalls[0] >= 1, "factory must fire at least once for the unhinted class");
+    }
+  }
+
+  @Nested
+  @DisplayName("positionalBuilder — Object[arity] → T fast-path for the runtime mapper")
+  class PositionalBuilder {
+
+    @Test
+    @DisplayName("record fast-path: no holder data → cached canonical-ctor function applies the array directly")
+    void recordFastPathBindsCanonicalCtor() {
+      final var builder = Reflective.RECORDS.<SimpleUser>positionalBuilder(SimpleUser.class, null, null);
+      assertNotNull(builder);
+      final SimpleUser built = builder.apply(new Object[] { "eve", 24 });
+      assertEquals(new SimpleUser("eve", 24), built);
+    }
+
+    @Test
+    @DisplayName("bean fallback: no holder data → array-positional construct path resolves via autoWriter")
+    void beanFallbackUsesAutoWriter() {
+      final String[] names = Reflective.BEANS.names(SimpleBean.class);
+      final var builder = Reflective.BEANS.<SimpleBean>positionalBuilder(SimpleBean.class, null, null);
+      // Build a values array matched to the bean's name order so the rebuild can reverse-lookup.
+      final var arr = new Object[names.length];
+      for (var i = 0; i < names.length; i++) {
+        arr[i] = names[i].equals("name") ? "frank" : 17;
+      }
+      final SimpleBean built = builder.apply(arr);
+      assertEquals("frank", built.getName());
+      assertEquals(17, built.getAge());
+    }
+  }
+
+  @Nested
+  @DisplayName("positionalReaders — exposes the per-slot reader array (holder-aware)")
+  class PositionalReaders {
+
+    @Test
+    @DisplayName("record path reads each component via the LMF-cached positional reader")
+    void recordReadersReturnComponentValues() {
+      final var readers = Reflective.RECORDS.positionalReaders(SimpleUser.class, null);
+      final var user = new SimpleUser("gabe", 33);
+      assertEquals(2, readers.length);
+      assertEquals("gabe", readers[0].apply(user));
+      assertEquals(33, readers[1].apply(user));
+    }
+
+    @Test
+    @DisplayName("bean path captures the property name per slot and reads through Beans.readProperty's substrate")
+    void beanReadersReadByPropertyName() {
+      final var refl = Reflective.BEANS;
+      final var readers = refl.positionalReaders(SimpleBean.class, null);
+      final var bean = new SimpleBean();
+      bean.setName("hank");
+      bean.setAge(41);
+      final var names = refl.names(SimpleBean.class);
+      // Find the slots for name and age — the bean fallback doesn't promise a specific order, only
+      // the same order as #names. Use the names array as the indirection.
+      final var nameIdx = indexOf(names, "name");
+      final var ageIdx = indexOf(names, "age");
+      assertEquals("hank", readers[nameIdx].apply(bean));
+      assertEquals(41, readers[ageIdx].apply(bean));
+    }
+
+    private static int indexOf(final String[] arr, final String needle) {
+      for (var i = 0; i < arr.length; i++) if (arr[i].equals(needle)) return i;
+      throw new IllegalArgumentException("not found: " + needle);
+    }
+  }
+
+  @Nested
+  @DisplayName("Holder-aware structuralIso path through positionalBuilder")
+  class HolderAware {
+
+    @Test
+    @DisplayName(
+      "holderConstructor short-circuits the reflective construct path: returned function is applied with a name-indexed array view"
+    )
+    void holderConstructorTakesPriorityOverReflectiveBuild() {
+      // Stand-in for a codegen FieldOptics' bound construct(Function<String, Object>): if the
+      // caller passes a non-null holderConstructor, positionalBuilder must invoke it instead of
+      // going through Reflective#construct. Pins the contract by routing the result through a
+      // sentinel record-builder lambda that's distinct from the canonical ctor's behaviour.
+      final Function<String, Object> sentinel = name ->
+        switch (name) {
+          case "name" -> "via-holder";
+          case "age" -> 99;
+          default -> null;
+        };
+      final var builder = Reflective.RECORDS.<SimpleUser>positionalBuilder(SimpleUser.class, Map.of(), ignored ->
+        new SimpleUser((String) sentinel.apply("name"), (Integer) sentinel.apply("age"))
+      );
+      final SimpleUser built = builder.apply(new Object[] { "ignored", 0 });
+      assertEquals(new SimpleUser("via-holder", 99), built);
+    }
+  }
+}

--- a/internal/src/test/java/io/github/eschizoid/telescope/internal/ReflectiveSurfaceTest.java
+++ b/internal/src/test/java/io/github/eschizoid/telescope/internal/ReflectiveSurfaceTest.java
@@ -10,6 +10,8 @@ import java.lang.reflect.ParameterizedType;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -151,13 +153,24 @@ class ReflectiveSurfaceTest {
   class HintAwareBean {
 
     @Test
-    @DisplayName("hint map drives the construct path: a SettersWriter hint produces a populated instance")
-    void hintWriterDrivesConstruct() {
-      // SettersWriter is a sealed-interface implementor so we can't use a lambda — but we can
-      // verify the hint took precedence over autoWriter by confirming the constructed instance
-      // is exactly the SimpleBean shape the hint produces.
-      final Map<Class<?>, Beans.BeanWriter<?>> hints = Map.of(SimpleBean.class, Beans.settersWriter(SimpleBean.class));
-      final var refl = Reflective.beansWithHints(hints, null);
+    @DisplayName(
+      "hint map is consulted before falling through to autoWriter — wrapping HashMap records the get() probe"
+    )
+    void hintMapIsConsultedBeforeAutoWriter() {
+      // The hint payload alone can't distinguish "hint fired" from "autoWriter happened to pick the
+      // same writer" — for SimpleBean both routes end at SettersWriter. Wrap the HashMap so we can
+      // observe the lookup directly: if the resolution path consults the hint map at all, our
+      // tracking get() runs and the sentinel flips.
+      final var consulted = new AtomicBoolean(false);
+      final var tracking = new HashMap<Class<?>, Beans.BeanWriter<?>>() {
+        @Override
+        public Beans.BeanWriter<?> get(final Object key) {
+          if (SimpleBean.class.equals(key)) consulted.set(true);
+          return super.get(key);
+        }
+      };
+      tracking.put(SimpleBean.class, Beans.settersWriter(SimpleBean.class));
+      final var refl = Reflective.beansWithHints(tracking, null);
 
       final var built = (SimpleBean) refl.construct(SimpleBean.class, name ->
         switch (name) {
@@ -167,24 +180,32 @@ class ReflectiveSurfaceTest {
         }
       );
 
+      assertTrue(consulted.get(), "hint map must be consulted before fallthrough to autoWriter");
       assertEquals("dave", built.getName());
       assertEquals(19, built.getAge());
     }
 
     @Test
-    @DisplayName("default factory fires for non-hinted classes when no hint is present (lazy resolution)")
-    void defaultFactoryFiresForUnhintedClasses() {
-      // Track factory-call count to prove the lazy path is reached — the factory must be invoked
-      // when no hint covers the class. (The lambda runs at first encounter; if the result is
-      // memoised internally the count stays at 1 across multiple construct() calls.)
+    @DisplayName(
+      "default factory is consulted on every construct() call for unhinted classes (no per-class memoisation today)"
+    )
+    void defaultFactoryFiresOncePerConstructCall() {
+      // Pins the actual (non-memoised) resolution behaviour at the constructBeanWithHints call
+      // site: each construct() pass for an unhinted target consults the default factory fresh.
+      // If a future refactor adds caching here, this test fires — the change should be a
+      // deliberate decision, not silent drift. (The Beans.autoWriter ladder underneath does
+      // memoise per class on its own, so per-call factory invocation doesn't rebuild LMF sites
+      // every time — the cost is just the factory function call.)
       final var factoryCalls = new int[] { 0 };
       final var refl = Reflective.beansWithHints(new HashMap<>(), cls -> {
         factoryCalls[0]++;
         return Beans.settersWriter(SimpleBean.class);
       });
 
-      refl.construct(SimpleBean.class, name -> name.equals("name") ? "x" : 1);
-      assertTrue(factoryCalls[0] >= 1, "factory must fire at least once for the unhinted class");
+      refl.construct(SimpleBean.class, name -> name.equals("name") ? "first" : 1);
+      refl.construct(SimpleBean.class, name -> name.equals("name") ? "second" : 2);
+
+      assertEquals(2, factoryCalls[0], "default factory fires once per construct() call for unhinted classes");
     }
   }
 
@@ -265,19 +286,24 @@ class ReflectiveSurfaceTest {
     void holderConstructorTakesPriorityOverReflectiveBuild() {
       // Stand-in for a codegen FieldOptics' bound construct(Function<String, Object>): if the
       // caller passes a non-null holderConstructor, positionalBuilder must invoke it instead of
-      // going through Reflective#construct. Pins the contract by routing the result through a
-      // sentinel record-builder lambda that's distinct from the canonical ctor's behaviour.
+      // going through Reflective#construct. Pins the contract two ways: the holder builds a
+      // SimpleUser whose values are distinct from what the canonical ctor would produce from
+      // the input array, AND a call counter inside the holder lambda must increment once per
+      // builder.apply — so a regression silently bypassing the holder would fail both assertions.
+      final var holderInvocations = new AtomicInteger(0);
       final Function<String, Object> sentinel = name ->
         switch (name) {
           case "name" -> "via-holder";
           case "age" -> 99;
           default -> null;
         };
-      final var builder = Reflective.RECORDS.<SimpleUser>positionalBuilder(SimpleUser.class, Map.of(), ignored ->
-        new SimpleUser((String) sentinel.apply("name"), (Integer) sentinel.apply("age"))
-      );
+      final var builder = Reflective.RECORDS.<SimpleUser>positionalBuilder(SimpleUser.class, Map.of(), ignored -> {
+        holderInvocations.incrementAndGet();
+        return new SimpleUser((String) sentinel.apply("name"), (Integer) sentinel.apply("age"));
+      });
       final SimpleUser built = builder.apply(new Object[] { "ignored", 0 });
       assertEquals(new SimpleUser("via-holder", 99), built);
+      assertEquals(1, holderInvocations.get(), "holderConstructor must have been invoked exactly once");
     }
   }
 }


### PR DESCRIPTION
## Summary

Coverage hardening for the three `:internal` files that sat below 60% on the codecov dashboard. Each new test pins a real contract or edge-case behaviour, not a line-touch — one deep test per gap as the project's meaningful-tests rule prescribes.

## Coverage movement

| File | Before | After | Delta |
|---|---|---|---|
| `Beans.java` | 59.96% | **73.09%** | +13 pp |
| `Records.java` | 56.84% | **84.21%** | +27 pp — now green |
| `Reflective.java` | 57.33% | **93.33%** | +36 pp — now green |

### What's still missed in `Beans.java`

The 127 residual missed lines fall into four buckets:

- **Hibernate lazy-initializer path** (`buildHibernateLazyInitializerFn` / `buildHibernatePersistentClassFn`) — only fires when Hibernate is on the classpath. Out of scope without adding Hibernate as a test dep.
- **JPMS-opens diagnostic branches** in `privateLookupOrThrow` — the `IllegalAccessException` catch can't be reached from inside the same module without a deliberately-broken module-info.
- **LMF writer error / recovery paths** in `buildSetterInvoker` / `buildGetterInvokerMap` — `LambdaMetafactory.metafactory` failure modes that don't surface for well-formed JavaBeans.
- **Cache hot path** (`SETTER_INVOKERS.computeIfAbsent` at line 412) — exercised transitively by every `writeBeanProperty` test, but no dedicated test pins the "second call hits the cache" contract because none of the cached-invoker fields are package-accessible.

## What's pinned

### Beans (additions to `BeansTest`)

- `writeBeanProperty` round-trips reference- and primitive-typed setters, silently no-ops getter-only properties (the MapStruct-`@MappingTarget` contract), routes through the declaring class for inherited setters.
- `fieldLens(String)` class-deferred lens covers get / set / modify, null-source guards on set + modify, subtype rebuild via the call-time-resolved writer, and the documented primitive null substitution (`set(s, null)` → JLS default for primitive components).

### Records (new `RecordsTest`)

- `read` / `with` / `construct` / `componentNames` / `componentType` contract surface, including the unknown-name / non-record diagnostics and the null-source guards.
- `fieldLens(String)` class-deferred + `fieldLens(Class, String)` class-aware variants; the latter fails fast at lens build time when the component name is unknown.
- `info()` per-class memoisation via direct `assertSame` identity check plus cross-class `assertNotSame` cache-bleed pin.

### Reflective (new `ReflectiveSurfaceTest`)

- `of(Class)` record-vs-bean dispatch through the `RECORDS` / `BEANS` singletons.
- Delegate wrappers (`names` / `genericType` / `read` / `construct` / `normalize`) routed end-to-end, including the two-leading-caps `normalize` rule for `getURL` → `URL`.
- `beansWithHints` hint-map consultation pinned via a tracking `HashMap` subclass that records `get()` probes — proves the hint path is taken before fallthrough to `autoWriter`.
- `defaultFactory` invocation behaviour pinned at per-call (no per-instance memoisation at this layer — see source comment below).
- `positionalBuilder` fast paths for both record (canonical-ctor cache) and bean (autoWriter) shapes; `positionalReaders` exposes per-slot LMF readers.
- Holder-aware path: a non-null `holderConstructor` takes priority over the reflective build, with an `AtomicInteger` counter confirming exactly-one invocation per `builder.apply`.

## Source change

- **`Reflective.beansWithHints` javadoc fix.** The doc previously claimed the default factory was "consulted lazily on first encounter with each not-explicitly-hinted target, then cached". The implementation never cached at this layer — per-class LMF reuse happens one tier down in `Beans.autoWriter`. Test investigation surfaced the mismatch; the doc now matches the actual stateless-resolution behaviour and points readers at the right cache.

## Test plan

- [x] `./gradlew :internal:test` — all tests pass
- [x] `./gradlew check` — green across all modules
- [x] `./gradlew :internal:jacocoTestReport` — confirms the coverage movement above
- [x] Spotless clean
