### PR TITLE
docs(readmes): bump Gradle/Maven coords to 1.0.5 ahead of release

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Quarkus extension ship as separate artifacts.
 ```kotlin
 // Gradle (Kotlin DSL)
 dependencies {
-  implementation("io.github.eschizoid:telescope-core:1.0.4")
+  implementation("io.github.eschizoid:telescope-core:1.0.5")
 }
 ```
 
@@ -32,7 +32,7 @@ dependencies {
 <dependency>
   <groupId>io.github.eschizoid</groupId>
   <artifactId>telescope-core</artifactId>
-  <version>1.0.4</version>
+  <version>1.0.5</version>
 </dependency>
 ```
 
@@ -465,8 +465,8 @@ Gradle (Kotlin DSL):
 
 ```kotlin
 dependencies {
-    implementation("io.github.eschizoid:telescope-core:1.0.4")
-    annotationProcessor("io.github.eschizoid:telescope-codegen:1.0.4")
+    implementation("io.github.eschizoid:telescope-core:1.0.5")
+    annotationProcessor("io.github.eschizoid:telescope-codegen:1.0.5")
 }
 ```
 
@@ -476,7 +476,7 @@ Maven:
 <dependency>
   <groupId>io.github.eschizoid</groupId>
   <artifactId>telescope-core</artifactId>
-  <version>1.0.4</version>
+  <version>1.0.5</version>
 </dependency>
 
 <build>
@@ -489,7 +489,7 @@ Maven:
           <path>
             <groupId>io.github.eschizoid</groupId>
             <artifactId>telescope-codegen</artifactId>
-            <version>1.0.4</version>
+            <version>1.0.5</version>
           </path>
         </annotationProcessorPaths>
       </configuration>
@@ -514,7 +514,7 @@ first**. Maven respects the declaration order of `<annotationProcessorPaths>`; G
   <path>
     <groupId>io.github.eschizoid</groupId>
     <artifactId>telescope-lombok</artifactId>
-    <version>1.0.4</version>
+    <version>1.0.5</version>
   </path>
 </annotationProcessorPaths>
 ```
@@ -522,8 +522,8 @@ first**. Maven respects the declaration order of `<annotationProcessorPaths>`; G
 ```kotlin
 dependencies {
   annotationProcessor("org.projectlombok:lombok:1.18.30")
-  annotationProcessor("io.github.eschizoid:telescope-lombok:1.0.4")
-  annotationProcessor("io.github.eschizoid:telescope-codegen:1.0.4")
+  annotationProcessor("io.github.eschizoid:telescope-lombok:1.0.5")
+  annotationProcessor("io.github.eschizoid:telescope-codegen:1.0.5")
 }
 ```
 
@@ -1281,8 +1281,8 @@ The return type degrades to a terminal `Telescope<R, Target>` when the target is
 Gradle wiring:
 
 ```kotlin
-implementation("io.github.eschizoid:telescope-core:1.0.4")
-annotationProcessor("io.github.eschizoid:telescope-codegen:1.0.4")
+implementation("io.github.eschizoid:telescope-core:1.0.5")
+annotationProcessor("io.github.eschizoid:telescope-codegen:1.0.5")
 ```
 
 `@Focus` and `@BeanFocus` are source-retention and inert without the processor, so annotating costs nothing if you don't

--- a/codegen/README.md
+++ b/codegen/README.md
@@ -47,8 +47,8 @@ that chains the generated bridge constant.
 ```kotlin
 // Gradle
 dependencies {
-    implementation("io.github.eschizoid:telescope-core:1.0.4")
-    annotationProcessor("io.github.eschizoid:telescope-codegen:1.0.4")
+    implementation("io.github.eschizoid:telescope-core:1.0.5")
+    annotationProcessor("io.github.eschizoid:telescope-codegen:1.0.5")
 }
 ```
 
@@ -57,7 +57,7 @@ dependencies {
 <dependency>
   <groupId>io.github.eschizoid</groupId>
   <artifactId>telescope-core</artifactId>
-  <version>1.0.4</version>
+  <version>1.0.5</version>
 </dependency>
 <!-- annotationProcessorPaths on maven-compiler-plugin -->
 <plugin>
@@ -68,7 +68,7 @@ dependencies {
       <path>
         <groupId>io.github.eschizoid</groupId>
         <artifactId>telescope-codegen</artifactId>
-        <version>1.0.4</version>
+        <version>1.0.5</version>
       </path>
     </annotationProcessorPaths>
   </configuration>

--- a/examples/springboot/order-jpa/src/main/java/io/github/eschizoid/telescope/demo/spring/api/OrderTelescopeController.java
+++ b/examples/springboot/order-jpa/src/main/java/io/github/eschizoid/telescope/demo/spring/api/OrderTelescopeController.java
@@ -52,7 +52,7 @@ import org.springframework.web.bind.annotation.RestController;
  * <p>{@code OrderPath}, {@code OrderTelescope}, and the {@code <X>Bridge} constants that back
  * {@code @Bridge(EntityType.class)} on the leaf records are all <b>generated at compile time</b> by
  * the telescope annotation processors registered as {@code
- * annotationProcessor("io.github.eschizoid:telescope-codegen:1.0.4")} in {@code build.gradle.kts}.
+ * annotationProcessor("io.github.eschizoid:telescope-codegen:1.0.5")} in {@code build.gradle.kts}.
  * Look in {@code build/generated/sources/annotationProcessor/...} after a build to see them.
  *
  * <p>Endpoints:

--- a/lombok/README.md
+++ b/lombok/README.md
@@ -40,7 +40,7 @@ classpath.)
 ```kotlin
 // Gradle
 dependencies {
-    implementation("io.github.eschizoid:telescope-core:1.0.4")
+    implementation("io.github.eschizoid:telescope-core:1.0.5")
 
     // Lombok itself
     compileOnly("org.projectlombok:lombok:1.18.42")
@@ -48,7 +48,7 @@ dependencies {
 
     // Telescope's Lombok-aware codegen — must come AFTER Lombok in the processor list so
     // Lombok's AST patches have fired when telescope reads the synthesized members.
-    annotationProcessor("io.github.eschizoid:telescope-lombok:1.0.4")
+    annotationProcessor("io.github.eschizoid:telescope-lombok:1.0.5")
 }
 ```
 
@@ -67,7 +67,7 @@ dependencies {
       <path>
         <groupId>io.github.eschizoid</groupId>
         <artifactId>telescope-lombok</artifactId>
-        <version>1.0.4</version>
+        <version>1.0.5</version>
       </path>
     </annotationProcessorPaths>
   </configuration>

--- a/quarkus/README.md
+++ b/quarkus/README.md
@@ -5,7 +5,7 @@ nothing else. Mirrors the [`spring-boot-starter`](../spring-boot-starter/README.
 
 ```kotlin
 dependencies {
-    implementation("io.github.eschizoid:telescope-quarkus:1.0.4")
+    implementation("io.github.eschizoid:telescope-quarkus:1.0.5")
 }
 ```
 
@@ -32,7 +32,7 @@ archive ... is being scanned without a Jandex index" warning.
 // Gradle (Quarkus 3 BOM picks up Quarkus's version)
 dependencies {
     implementation(platform("io.quarkus.platform:quarkus-bom:3.20.0"))
-    implementation("io.github.eschizoid:telescope-quarkus:1.0.4")
+    implementation("io.github.eschizoid:telescope-quarkus:1.0.5")
 }
 ```
 
@@ -41,7 +41,7 @@ dependencies {
 <dependency>
   <groupId>io.github.eschizoid</groupId>
   <artifactId>telescope-quarkus</artifactId>
-  <version>1.0.4</version>
+  <version>1.0.5</version>
 </dependency>
 ```
 

--- a/spring-boot-starter/README.md
+++ b/spring-boot-starter/README.md
@@ -5,7 +5,7 @@ Drop-in Spring Boot 4 auto-config for [telescope](../README.md). Adds one bean t
 
 ```kotlin
 dependencies {
-    implementation("io.github.eschizoid:telescope-spring-boot-starter:1.0.4")
+    implementation("io.github.eschizoid:telescope-spring-boot-starter:1.0.5")
 }
 ```
 
@@ -25,7 +25,7 @@ your `@Configuration` and they show up in the registry; the registry resolves th
 // Gradle (Spring Boot 4 BOM picks up Boot's version)
 dependencies {
     implementation(platform("org.springframework.boot:spring-boot-dependencies:4.0.1"))
-    implementation("io.github.eschizoid:telescope-spring-boot-starter:1.0.4")
+    implementation("io.github.eschizoid:telescope-spring-boot-starter:1.0.5")
 }
 ```
 
@@ -34,7 +34,7 @@ dependencies {
 <dependency>
   <groupId>io.github.eschizoid</groupId>
   <artifactId>telescope-spring-boot-starter</artifactId>
-  <version>1.0.4</version>
+  <version>1.0.5</version>
 </dependency>
 ```
 


### PR DESCRIPTION
## Summary

Bumps all `telescope-*` artifact coords across the five module READMEs (root, `codegen`, `lombok`, `quarkus`, `spring-boot-starter`) and the `OrderTelescopeController` javadoc snippet from `1.0.4` → `1.0.5` ahead of cutting the 1.0.5 release.

## 1.0.5 contents

Commits between `v1.0.4` and `main`:

| PR | Type | Summary |
|---|---|---|
| #154 | fix | null-safety parity for `@BeanFocus` codegen path — Bugs 12 + 13 (P1 adopter-reported) |
| #155 | test | meaningful coverage hardening for `:internal` (`Beans` / `Records` / `Reflective`) |
| #156 | test | Lombok `LombokFocusProcessor` coverage 0% → 91% via `ProcessorHarness` |
| #152 | docs | `package-info` + `module-info` refresh for v1.0.2 surface |

## Test plan

- [x] `./gradlew spotlessCheck` — green
- [x] Coords verified `1.0.5` across all six files
- [ ] After this lands: trigger `.github/workflows/release.yaml` with `releaseType=patch`
