### PR TITLE
fix(core): Bug #14 null-safety parity + Enh #10/#11 — bundled v1.0.5 follow-ups

### DIFF
--- a/core/src/main/java/io/github/eschizoid/telescope/DeepMap.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/DeepMap.java
@@ -742,11 +742,10 @@ public final class DeepMap {
           );
           t = tgtT.updateIndexed(t, (i, _ignored) -> values.get(i));
         } else {
-          // Lenient: mirrors the overrideTargetField shape — when the source path resolves to an
-          // empty focus (null intermediate in a chained bean read, or an Affine miss further down
-          // the path), write null to the target field rather than aborting the mapper with
-          // NoSuchElementException. Downstream type-default handling — where configured — takes
-          // over from there.
+          // Lenient: when the source path resolves to an empty focus (null intermediate in a
+          // chained bean read, or an Affine miss further down the path), write null to the target
+          // field rather than throwing. Downstream type-default handling — where configured —
+          // takes over from there.
           t = tgtT.set(t, srcT.find(s).orElse(null));
         }
       } else if (fx instanceof Constant<?, ?, ?> r) {

--- a/core/src/main/java/io/github/eschizoid/telescope/DeepMap.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/DeepMap.java
@@ -742,7 +742,12 @@ public final class DeepMap {
           );
           t = tgtT.updateIndexed(t, (i, _ignored) -> values.get(i));
         } else {
-          t = tgtT.set(t, srcT.read(s));
+          // Lenient: mirrors the overrideTargetField shape — when the source path resolves to an
+          // empty focus (null intermediate in a chained bean read, or an Affine miss further down
+          // the path), write null to the target field rather than aborting the mapper with
+          // NoSuchElementException. Downstream type-default handling — where configured — takes
+          // over from there.
+          t = tgtT.set(t, srcT.find(s).orElse(null));
         }
       } else if (fx instanceof Constant<?, ?, ?> r) {
         final var tgtT = (Telescope<T, Object>) r.targetTelescope();

--- a/core/src/main/java/io/github/eschizoid/telescope/Telescope.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/Telescope.java
@@ -612,6 +612,19 @@ public sealed class Telescope<
    * large-entity migration shape. Use the bidirectional {@link #mapper(Class, Class, MapStep...)}
    * instead if you need the strict bijection check (which guards {@code backward()} against
    * silently losing data).
+   *
+   * <p><b>Auto-discovery from {@code @Bridge}.</b> When {@code steps} is empty AND the {@code
+   * source} class has a sibling {@code <Source>Bridge.BRIDGE} (or {@code <Source>To<Target>Bridge.
+   * BRIDGE}) constant emitted by the {@code @Bridge} annotation processor, the forward direction
+   * routes through that bridge directly. The bridge's full configuration is surfaced in the result
+   * — {@code @Rename}, {@code @Transform}, {@code @Constant}, {@code @Compute}, {@code @Default},
+   * {@code drops}, and the {@code lenient} flag are all encoded inside the bridge and apply to
+   * every {@code mapperForward(source, target)} call. The annotation's defaults are NOT the same as
+   * this method's lenient-by-default — {@code @Bridge(lenient = false)} (the annotation's default)
+   * produces a strict bijection bridge, so the resulting mapper rejects mappings the row-free
+   * fallback would have accepted. To keep the row-free lenient-default-everything path, pass any
+   * explicit row (even a no-op {@code nullSourceValues(DEFAULT)}); per-field rows force the {@link
+   * DeepMap#resolveForward} path.
    */
   public static <A, B> ForwardMapper<A, B> mapperForward(
     final Class<A> source,
@@ -623,11 +636,10 @@ public sealed class Telescope<
     // for the common "small DTO → large entity" migration shape. Matches MapStruct's default.
     // Bidirectional `mapper(...)` keeps the strict bijection check.
 
-    // Auto-discover a sibling @Bridge-generated <Source>Bridge.BRIDGE constant when the caller
-    // supplied no overrides. The bridge already encodes any @Rename / lenient / @Transform
-    // configuration from the @Bridge annotation, so adopters writing both @Bridge(renames = …)
-    // and matching to(…) rows no longer have to state the mapping twice. When per-field rows
-    // are supplied (steps.length > 0), the caller has opted into explicit configuration; skip
+    // No per-field rows: probe for a sibling @Bridge-generated <Source>Bridge.BRIDGE constant.
+    // When present, route directly through it (the bridge already encodes any @Rename / lenient
+    // / @Transform / @Constant / @Compute / @Default / drops configuration from the @Bridge
+    // annotation). With rows present, the caller has opted into explicit configuration; skip
     // the probe and run the rows through DeepMap as usual.
     if (steps.length == 0) {
       final var probed = BridgeHolderProbe.probeFor(source, target);

--- a/core/src/main/java/io/github/eschizoid/telescope/Telescope.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/Telescope.java
@@ -637,12 +637,11 @@ public sealed class Telescope<
     // for the common "small DTO → large entity" migration shape. Matches MapStruct's default.
     // Bidirectional `mapper(...)` keeps the strict bijection check.
 
-    // No per-field rows: probe for a sibling @Bridge-generated <Source>Bridge.BRIDGE constant.
-    // When present, route directly through it (the bridge already encodes any @Rename (incl.
-    // forwardOnly fan-out) / @Transform / @Constant / @Compute / @Default / @ViaMapper / drops
-    // / writeStrategy / lenient configuration from the @Bridge annotation). With rows present,
-    // the caller has opted into explicit configuration; skip the probe and run the rows through
-    // DeepMap as usual.
+    // No per-field rows: probe for a sibling @Bridge-generated <Source>Bridge.BRIDGE constant
+    // and route directly through it when present. See the javadoc's "Auto-discovery from
+    // @Bridge" paragraph for the full bridge-baked configuration surface. With rows present,
+    // the caller has opted into explicit configuration; skip the probe and run the rows
+    // through DeepMap as usual.
     if (steps.length == 0) {
       final var probed = BridgeHolderProbe.probeFor(source, target);
       if (probed.isPresent()) {

--- a/core/src/main/java/io/github/eschizoid/telescope/Telescope.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/Telescope.java
@@ -8,6 +8,7 @@ import io.github.eschizoid.telescope.conversion.MapperBuilder;
 import io.github.eschizoid.telescope.effects.Either;
 import io.github.eschizoid.telescope.effects.Validated;
 import io.github.eschizoid.telescope.internal.Beans;
+import io.github.eschizoid.telescope.internal.BridgeHolderProbe;
 import io.github.eschizoid.telescope.internal.LambdaIntrospection;
 import io.github.eschizoid.telescope.internal.MetadataHolderProbe;
 import io.github.eschizoid.telescope.internal.NullDefaults;
@@ -621,6 +622,21 @@ public sealed class Telescope<
     // unmatched source fields are silently ignored — no `drop()` / `constant()` rows required
     // for the common "small DTO → large entity" migration shape. Matches MapStruct's default.
     // Bidirectional `mapper(...)` keeps the strict bijection check.
+
+    // Auto-discover a sibling @Bridge-generated <Source>Bridge.BRIDGE constant when the caller
+    // supplied no overrides. The bridge already encodes any @Rename / lenient / @Transform
+    // configuration from the @Bridge annotation, so adopters writing both @Bridge(renames = …)
+    // and matching to(…) rows no longer have to state the mapping twice. When per-field rows
+    // are supplied (steps.length > 0), the caller has opted into explicit configuration; skip
+    // the probe and run the rows through DeepMap as usual.
+    if (steps.length == 0) {
+      final var probed = BridgeHolderProbe.probeFor(source, target);
+      if (probed.isPresent()) {
+        @SuppressWarnings("unchecked")
+        final var bridge = (Telescope<A, B>) probed.get().bridge();
+        return ForwardMapper.create(bridge::read, source, target);
+      }
+    }
     final var iso = DeepMap.resolveForward(source, target, steps);
     return ForwardMapper.create(iso::to, source, target);
   }

--- a/core/src/main/java/io/github/eschizoid/telescope/Telescope.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/Telescope.java
@@ -617,14 +617,15 @@ public sealed class Telescope<
    * source} class has a sibling {@code <Source>Bridge.BRIDGE} (or {@code <Source>To<Target>Bridge.
    * BRIDGE}) constant emitted by the {@code @Bridge} annotation processor, the forward direction
    * routes through that bridge directly. The bridge's full configuration is surfaced in the result
-   * — {@code @Rename}, {@code @Transform}, {@code @Constant}, {@code @Compute}, {@code @Default},
-   * {@code drops}, and the {@code lenient} flag are all encoded inside the bridge and apply to
-   * every {@code mapperForward(source, target)} call. The annotation's defaults are NOT the same as
-   * this method's lenient-by-default — {@code @Bridge(lenient = false)} (the annotation's default)
-   * produces a strict bijection bridge, so the resulting mapper rejects mappings the row-free
-   * fallback would have accepted. To keep the row-free lenient-default-everything path, pass any
-   * explicit row (even a no-op {@code nullSourceValues(DEFAULT)}); per-field rows force the {@link
-   * DeepMap#resolveForward} path.
+   * — {@code @Rename} (including {@code forwardOnly} fan-out), {@code @Transform},
+   * {@code @Constant}, {@code @Compute}, {@code @Default}, {@code @ViaMapper}, {@code drops}, the
+   * {@code writeStrategy} ({@code AUTO/CTOR/BUILDER/SETTERS}), and the {@code lenient} flag are all
+   * encoded inside the bridge and apply to every {@code mapperForward(source, target)} call. The
+   * annotation's defaults are NOT the same as this method's lenient-by-default —
+   * {@code @Bridge(lenient = false)} (the annotation's default) produces a strict bijection bridge,
+   * so the resulting mapper rejects mappings the row-free fallback would have accepted. To keep the
+   * row-free lenient-default-everything path, pass any explicit row (even a no-op {@code
+   * nullSourceValues(DEFAULT)}); per-field rows force the {@link DeepMap#resolveForward} path.
    */
   public static <A, B> ForwardMapper<A, B> mapperForward(
     final Class<A> source,
@@ -637,10 +638,11 @@ public sealed class Telescope<
     // Bidirectional `mapper(...)` keeps the strict bijection check.
 
     // No per-field rows: probe for a sibling @Bridge-generated <Source>Bridge.BRIDGE constant.
-    // When present, route directly through it (the bridge already encodes any @Rename / lenient
-    // / @Transform / @Constant / @Compute / @Default / drops configuration from the @Bridge
-    // annotation). With rows present, the caller has opted into explicit configuration; skip
-    // the probe and run the rows through DeepMap as usual.
+    // When present, route directly through it (the bridge already encodes any @Rename (incl.
+    // forwardOnly fan-out) / @Transform / @Constant / @Compute / @Default / @ViaMapper / drops
+    // / writeStrategy / lenient configuration from the @Bridge annotation). With rows present,
+    // the caller has opted into explicit configuration; skip the probe and run the rows through
+    // DeepMap as usual.
     if (steps.length == 0) {
       final var probed = BridgeHolderProbe.probeFor(source, target);
       if (probed.isPresent()) {

--- a/core/src/test/java/io/github/eschizoid/telescope/MigrationRegressionTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/MigrationRegressionTest.java
@@ -2141,4 +2141,34 @@ class MigrationRegressionTest {
       assertEquals(null, dto.getResolvedName());
     }
   }
+
+  @Nested
+  @DisplayName("DeepMap#applyForward TelescopeToTelescope path matches the same null-intermediate leniency")
+  class TelescopeToTelescopeForwardLeniency {
+
+    @Test
+    @DisplayName(
+      "to(srcTelescope, tgtTelescope) over a source whose nested intermediate is null yields null on the target field"
+    )
+    void telescopeToTelescopeRowOverNullIntermediateShortCircuitsToNull() {
+      // The DeepMap forward path has two sibling call sites that read from a source telescope. The
+      // FromTelescopeTo arm (overrideTargetField) was made lenient earlier; this test pins the
+      // TelescopeToTelescope arm in applyForward, which previously kept the strict srcT.read(s)
+      // form and surfaced a NoSuchElementException when the source path navigated through a null
+      // nested bean field. Both arms now short-circuit to null in the target field.
+      final var mapper = Telescope.mapperForward(
+        NullIntermediateOuter.class,
+        NullIntermediateTargetDto.class,
+        Mapping.to(
+          Telescope.ofBean(NullIntermediateOuter.class)
+            .field(NullIntermediateOuter::getInner)
+            .field(NullIntermediateInner::getName),
+          Telescope.ofBean(NullIntermediateTargetDto.class).field(NullIntermediateTargetDto::getInnerName)
+        )
+      );
+      final var outer = new NullIntermediateOuter(); // outer.inner left null on purpose
+      final var dto = assertDoesNotThrow(() -> mapper.forward(outer));
+      assertEquals(null, dto.getInnerName());
+    }
+  }
 }

--- a/core/src/test/java/io/github/eschizoid/telescope/MigrationRegressionTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/MigrationRegressionTest.java
@@ -8,6 +8,12 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import io.github.eschizoid.telescope.beans.BridgePojoA;
+import io.github.eschizoid.telescope.beans.BridgePojoABridge;
+import io.github.eschizoid.telescope.beans.BridgePojoB;
+import io.github.eschizoid.telescope.beans.BridgeRecA;
+import io.github.eschizoid.telescope.beans.BridgeRecABridge;
+import io.github.eschizoid.telescope.beans.BridgeRecB;
 import io.github.eschizoid.telescope.conversion.ForwardMapper;
 import io.github.eschizoid.telescope.focus.NullIntermediateInner;
 import io.github.eschizoid.telescope.focus.NullIntermediateOuter;
@@ -2190,6 +2196,77 @@ class MigrationRegressionTest {
       final var src = new OptionalSourceBean(); // maybeName left at Optional.empty()
       final var dto = assertDoesNotThrow(() -> mapper.forward(src));
       assertNull(dto.getResolvedName());
+    }
+  }
+
+  @Nested
+  @DisplayName("Telescope.mapperForward auto-discovers a sibling @Bridge-generated bridge constant")
+  class MapperForwardAutoDiscoversBridge {
+
+    @Test
+    @DisplayName("record→record: mapperForward(A.class, B.class) with no rows routes through <A>Bridge.BRIDGE")
+    void recordToRecordRoutesThroughBridge() {
+      // BridgeRecA carries @Bridge(BridgeRecB.class); the codegen emits BridgeRecABridge.BRIDGE.
+      // mapperForward called with no per-field rows must produce the same output as invoking the
+      // bridge constant directly — closes the "mapping defined twice in @Bridge renames + to()
+      // rows"
+      // pain reported in adopter Round 3 feedback.
+      final var mapper = Telescope.mapperForward(BridgeRecA.class, BridgeRecB.class);
+      final var src = new BridgeRecA("u1", 10);
+      assertEquals(BridgeRecABridge.BRIDGE.read(src), mapper.forward(src));
+    }
+
+    @Test
+    @DisplayName("pojo→pojo: auto-discovery succeeds on a Lombok-style POJO pair")
+    void pojoToPojoRoutesThroughBridge() {
+      final var mapper = Telescope.mapperForward(BridgePojoA.class, BridgePojoB.class);
+      final var src = new BridgePojoA();
+      src.setId("p1");
+      src.setEmail("p1@example.com");
+
+      final var viaMapper = mapper.forward(src);
+      final var viaBridge = BridgePojoABridge.BRIDGE.read(src);
+      assertEquals(viaBridge.getId(), viaMapper.getId());
+      assertEquals(viaBridge.getEmail(), viaMapper.getEmail());
+    }
+
+    public static class PlainA {
+
+      private String id;
+
+      public PlainA() {}
+
+      public String getId() {
+        return id;
+      }
+
+      public void setId(final String id) {
+        this.id = id;
+      }
+    }
+
+    public static class PlainB {
+
+      private String id;
+
+      public PlainB() {}
+
+      public String getId() {
+        return id;
+      }
+
+      public void setId(final String id) {
+        this.id = id;
+      }
+    }
+
+    @Test
+    @DisplayName("plain POJO pair without @Bridge falls through to DeepMap.resolveForward")
+    void plainPairFallsThrough() {
+      final var mapper = Telescope.mapperForward(PlainA.class, PlainB.class);
+      final var src = new PlainA();
+      src.setId("x");
+      assertEquals("x", mapper.forward(src).getId());
     }
   }
 }

--- a/core/src/test/java/io/github/eschizoid/telescope/MigrationRegressionTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/MigrationRegressionTest.java
@@ -3,6 +3,7 @@ package io.github.eschizoid.telescope;
 import static io.github.eschizoid.telescope.mapping.WriteHint.writeBeans;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -2143,7 +2144,7 @@ class MigrationRegressionTest {
   }
 
   @Nested
-  @DisplayName("DeepMap#applyForward TelescopeToTelescope path matches the same null-intermediate leniency")
+  @DisplayName("DeepMap#applyForward TelescopeToTelescope path writes null on empty source focus")
   class TelescopeToTelescopeForwardLeniency {
 
     @Test
@@ -2151,11 +2152,10 @@ class MigrationRegressionTest {
       "to(srcTelescope, tgtTelescope) over a source whose nested intermediate is null yields null on the target field"
     )
     void telescopeToTelescopeRowOverNullIntermediateShortCircuitsToNull() {
-      // The DeepMap forward path has two sibling call sites that read from a source telescope. The
-      // FromTelescopeTo arm (overrideTargetField) was made lenient earlier; this test pins the
-      // TelescopeToTelescope arm in applyForward, which previously kept the strict srcT.read(s)
-      // form and surfaced a NoSuchElementException when the source path navigated through a null
-      // nested bean field. Both arms now short-circuit to null in the target field.
+      // Forward mapping over a `to(srcTelescope, tgtTelescope)` row whose source path navigates
+      // through a null intermediate writes null to the target field instead of throwing
+      // NoSuchElementException — the lenient contract applies uniformly across the forward
+      // direction's source-read sites.
       final var mapper = Telescope.mapperForward(
         NullIntermediateOuter.class,
         NullIntermediateTargetDto.class,
@@ -2168,7 +2168,28 @@ class MigrationRegressionTest {
       );
       final var outer = new NullIntermediateOuter(); // outer.inner left null on purpose
       final var dto = assertDoesNotThrow(() -> mapper.forward(outer));
-      assertEquals(null, dto.getInnerName());
+      assertNull(dto.getInnerName());
+    }
+
+    @Test
+    @DisplayName(
+      "to(srcTelescope, tgtTelescope) over a source Affine miss (.whenPresent on empty Optional) yields null on the target field"
+    )
+    void telescopeToTelescopeRowOverAffineMissShortCircuitsToNull() {
+      // Forward mapping over a `to(srcTelescope, tgtTelescope)` row whose source path is an
+      // Affine (.whenPresent over an Optional) that resolves to empty yields null on the target
+      // field — same lenient contract as the null-intermediate case, different empty-focus cause.
+      final var mapper = Telescope.mapperForward(
+        OptionalSourceBean.class,
+        OptionalTargetBean.class,
+        Mapping.to(
+          Telescope.ofBean(OptionalSourceBean.class).whenPresent(OptionalSourceBean::getMaybeName),
+          Telescope.ofBean(OptionalTargetBean.class).field(OptionalTargetBean::getResolvedName)
+        )
+      );
+      final var src = new OptionalSourceBean(); // maybeName left at Optional.empty()
+      final var dto = assertDoesNotThrow(() -> mapper.forward(src));
+      assertNull(dto.getResolvedName());
     }
   }
 }

--- a/core/src/test/java/io/github/eschizoid/telescope/MigrationRegressionTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/MigrationRegressionTest.java
@@ -2139,7 +2139,7 @@ class MigrationRegressionTest {
       );
       final var src = new OptionalSourceBean(); // maybeName left at Optional.empty()
       final var dto = assertDoesNotThrow(() -> mapper.forward(src));
-      assertEquals(null, dto.getResolvedName());
+      assertNull(dto.getResolvedName());
     }
   }
 

--- a/core/src/test/java/io/github/eschizoid/telescope/MigrationRegressionTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/MigrationRegressionTest.java
@@ -2206,11 +2206,9 @@ class MigrationRegressionTest {
     @Test
     @DisplayName("record→record: mapperForward(A.class, B.class) with no rows routes through <A>Bridge.BRIDGE")
     void recordToRecordRoutesThroughBridge() {
-      // BridgeRecA carries @Bridge(BridgeRecB.class); the codegen emits BridgeRecABridge.BRIDGE.
       // mapperForward called with no per-field rows must produce the same output as invoking the
-      // bridge constant directly — closes the "mapping defined twice in @Bridge renames + to()
-      // rows"
-      // pain reported in adopter Round 3 feedback.
+      // bridge constant directly — the routing has to be observably equivalent to a direct
+      // BridgeRecABridge.BRIDGE.read(src) call.
       final var mapper = Telescope.mapperForward(BridgeRecA.class, BridgeRecB.class);
       final var src = new BridgeRecA("u1", 10);
       assertEquals(BridgeRecABridge.BRIDGE.read(src), mapper.forward(src));
@@ -2229,6 +2227,56 @@ class MigrationRegressionTest {
       assertEquals(viaBridge.getId(), viaMapper.getId());
       assertEquals(viaBridge.getEmail(), viaMapper.getEmail());
     }
+
+    @Test
+    @DisplayName("plain POJO pair without @Bridge falls through to DeepMap.resolveForward")
+    void plainPairFallsThrough() {
+      final var mapper = Telescope.mapperForward(PlainA.class, PlainB.class);
+      final var src = new PlainA();
+      src.setId("x");
+      assertEquals("x", mapper.forward(src).getId());
+    }
+
+    @Test
+    @DisplayName(
+      "target mismatch: mapperForward(A, X) skips an A->B bridge when X != B (probe rejects, DeepMap takes over)"
+    )
+    void targetMismatchSilentlyFallsThrough() {
+      // BridgeRecA carries @Bridge(BridgeRecB.class) → BridgeRecABridge.BRIDGE is
+      // Telescope<BridgeRecA, BridgeRecB>. Calling mapperForward with a different target must NOT
+      // route through that bridge — the probe's ParameterizedType check rejects, mapperForward
+      // falls through to DeepMap, and the structural-iso build produces the requested target
+      // directly. Pins the BridgeHolderProbe bridgeTargetMatches false branch.
+      final var mapper = Telescope.mapperForward(BridgeRecA.class, SiblingTarget.class);
+      final var src = new BridgeRecA("u1", 10);
+      assertEquals(new SiblingTarget("u1", 10), mapper.forward(src));
+    }
+
+    @Test
+    @DisplayName(
+      "explicit per-field rows opt out of auto-discovery — the bridge is not consulted when steps are present"
+    )
+    void explicitRowsOptOutOfAutoDiscovery() {
+      // When the caller supplies any per-field row, mapperForward routes through DeepMap as the
+      // explicit-overrides escape hatch. Force a clearly-different output via a constant row that
+      // overrides the score field; the auto-discovered bridge would have produced score = 10.
+      final var src = new BridgeRecA("u1", 10);
+      final var explicit = Telescope.mapperForward(
+        BridgeRecA.class,
+        BridgeRecB.class,
+        Mapping.to(BridgeRecA::id, BridgeRecB::id),
+        Mapping.constant(BridgeRecB::score, 999)
+      );
+      final var dst = explicit.forward(src);
+      assertEquals("u1", dst.id());
+      assertEquals(
+        999,
+        dst.score(),
+        "explicit constant row must take precedence over the auto-discovered bridge value (10)"
+      );
+    }
+
+    // ---------- Fixtures local to this nested class ----------
 
     public static class PlainA {
 
@@ -2260,13 +2308,11 @@ class MigrationRegressionTest {
       }
     }
 
-    @Test
-    @DisplayName("plain POJO pair without @Bridge falls through to DeepMap.resolveForward")
-    void plainPairFallsThrough() {
-      final var mapper = Telescope.mapperForward(PlainA.class, PlainB.class);
-      final var src = new PlainA();
-      src.setId("x");
-      assertEquals("x", mapper.forward(src).getId());
-    }
+    /**
+     * Sibling target sharing the BridgeRecB shape but a different class identity. Used to verify
+     * the probe correctly rejects a single-target {@code @Bridge} whose declared target doesn't
+     * match the requested {@code mapperForward} target.
+     */
+    public record SiblingTarget(String id, int score) {}
   }
 }

--- a/core/src/test/java/io/github/eschizoid/telescope/MigrationRegressionTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/MigrationRegressionTest.java
@@ -2309,9 +2309,8 @@ class MigrationRegressionTest {
     }
 
     /**
-     * Sibling target sharing the BridgeRecB shape but a different class identity. Used to verify
-     * the probe correctly rejects a single-target {@code @Bridge} whose declared target doesn't
-     * match the requested {@code mapperForward} target.
+     * Sibling target sharing the BridgeRecB shape but a different class identity — exercises the
+     * probe's target-mismatch rejection branch.
      */
     public record SiblingTarget(String id, int score) {}
   }

--- a/docs/migration-feedback.md
+++ b/docs/migration-feedback.md
@@ -1034,7 +1034,7 @@ PR #144.
 
 ---
 
-### 11. `Telescope.merge()` requires `@SuppressWarnings("unchecked")` at every call site — Fixed (v1.0.5)
+### 11. `Telescope.merge()` requires `@SuppressWarnings("unchecked")` at every call site — Verified (v1.0.5)
 
 **Source:** Round 3 adopter feedback (v1.0.5 intake).
 
@@ -1070,10 +1070,15 @@ bloat — exactly the kind of thing that hurts the world-class-ergonomics mantra
 leaking the reference outside the method body), so `@SafeVarargs` is genuinely safe; applying it eliminates the
 unchecked warning at every call site without introducing a new API surface.
 
-**Resolution:** Added `@SafeVarargs` to the `Telescope.merge` and `Telescope.mergeBuilder` (and any other
-generic-varargs entry points where the same applies). Adopters' existing `Telescope.merge(...)` call sites no longer
-require `@SuppressWarnings("unchecked")` — the warning is suppressed at the library boundary where it can be statically
-audited rather than per-caller. The `mergeBuilder(...)` shape from the proposal is intentionally not added.
+**Resolution:** Verified `@SafeVarargs` is already in place at the merge entry point — `Telescope.merge` carries both
+`@SafeVarargs` and `@SuppressWarnings("varargs")` from prior work; the parallel `Telescope.all(Edit<S>...)` entry point
+is similarly annotated. Adopter call sites invoking `Telescope.merge(...)` directly should not require their own
+`@SuppressWarnings("unchecked")`. If a warning still surfaces in the field, the most likely cause is a generic-varargs
+site elsewhere in the chain (an `afterForward`, a `Sources` builder, a custom row factory) that lacks the annotation —
+file as a separate bug naming the offending entry point.
+
+The `mergeBuilder(...)` shape from the proposal is intentionally not added — the underlying warning concern is addressed
+at the library boundary, no parallel API needed.
 
 ---
 
@@ -1190,6 +1195,6 @@ forward direction through `<A>Bridge.BRIDGE`. Explicit `to()` rows become per-fi
 | Enh 8  | `Mapping.forward()` naming                                              | Low      | Fixed (v1.0.2)    |
 | Enh 9  | `mapperForward()` lenient by default                                    | High     | Fixed (v1.0.2)    |
 | Enh 10 | `:internal` test coverage hardening                                     | Medium   | Fixed (v1.0.2)    |
-| Enh 11 | `@SafeVarargs` on `Telescope.merge` (declined the `mergeBuilder` shape) | Low      | Fixed (v1.0.5)    |
+| Enh 11 | `@SafeVarargs` on `Telescope.merge` (declined the `mergeBuilder` shape) | Low      | Verified (v1.0.5) |
 | Enh 12 | `Telescope.fromMap()` nested map → sub-POJO composition                 | Medium   | Proposed (v1.0.6) |
 | Enh 13 | `Telescope.mapperForward()` auto-discover `@Bridge`-generated bridges   | High     | Proposed (v1.0.6) |

--- a/docs/migration-feedback.md
+++ b/docs/migration-feedback.md
@@ -741,6 +741,72 @@ the user's getter does — strict-lens semantics for direct gets are unchanged.
 
 ---
 
+### 14. `DeepMap.applyForward()` missed the null-safety fix on the `TelescopeToTelescope` path — Fixed (v1.0.5)
+
+**Severity:** P1 — regression in 1.0.5 for any mapping that reads through a `to(Telescope, Telescope)` row over a source
+whose nested intermediate is `null`. Works on 1.0.4, crashes on 1.0.5 (post-Bug-13 fix).
+
+**Reproduction:**
+
+```java
+@Data
+public class Source {
+  private NestedData nestedData; // null in sparse test data
+}
+
+@Data
+public class NestedData {
+  private String value;
+}
+
+@Data
+public class Target {
+  private String flatValue;
+}
+
+Telescope.mapperForward(Source.class, Target.class,
+  to(Telescope.ofBean(Source.class).field(Source::getNestedData).field(NestedData::getValue),
+     Telescope.ofBean(Target.class).field(Target::getFlatValue)),
+  writeBeans(SETTERS));
+
+// When source.nestedData is null:
+mapper.forward(source);   // NoSuchElementException!
+```
+
+**Observed:**
+
+```
+java.util.NoSuchElementException: Telescope has no value in this source (path starts at field 'getNestedData')
+   at io.github.eschizoid.telescope.Telescope.noValue(Telescope.java:1121)
+   at io.github.eschizoid.telescope.Telescope.read(Telescope.java:1102)
+   at io.github.eschizoid.telescope.DeepMap.applyForward(DeepMap.java:745)
+```
+
+**Root cause:** Bug 13 (PR #154) fixed `DeepMap#overrideTargetField` at line 835 (the `FromTelescopeTo` row path) to use
+`srcT.find(s).orElse(null)`. The sibling site at line 745 (the `TelescopeToTelescope` forward-overlay path in
+`applyForward`) was missed — it still calls `srcT.read(s)`, which now surfaces the improved `firstHopName` diagnostic
+but still throws.
+
+**Codebase audit** (Round 3 feedback intake): swept `DeepMap.java` for every Telescope read site that participates in
+the forward direction. Found:
+
+- **Line 745** — `TelescopeToTelescope` BROADCAST forward overlay: ❌ unfixed, exact mirror of the line 835 pattern.
+- **Line 835** — `FromTelescopeTo` forward overlay: ✓ already fixed in PR #154.
+- **Line 779** — `TelescopeTo` backward overlay: safe (reads from target, not source).
+- **Line 807** — `TelescopeToTelescope` backward overlay: safe (reads from target, not source).
+
+Single missed site, no other latent bugs.
+
+**Fix:** Line 745 change from `t = tgtT.set(t, srcT.read(s));` to `t = tgtT.set(t, srcT.find(s).orElse(null));`,
+matching the line 835 form. One-line patch + a regression test in `MigrationRegressionTest` pinning the
+`to(Telescope, Telescope)` shape.
+
+**Resolution:** Applied the one-line fix at `DeepMap.java:745`. Both forward call sites now use the lenient
+`find().orElse(null)` form; the backward call sites stay strict because they read from the freshly-built target where a
+null intermediate is a real invariant violation. Regression test in `MigrationRegressionTest` pins the new contract.
+
+---
+
 ## Enhancement Requests
 
 ### 1. Cross-module `@Bridge` support (MapStruct parity) — Fixed (v1.0.2)
@@ -968,6 +1034,121 @@ PR #144.
 
 ---
 
+### 11. `Telescope.merge()` requires `@SuppressWarnings("unchecked")` at every call site — Fixed (v1.0.5)
+
+**Source:** Round 3 adopter feedback (v1.0.5 intake).
+
+**Problem:** Every `Telescope.merge(target, MergeStep<T>...)` call site triggers Java's unchecked-warning on
+generic-array creation because the varargs slot is `MergeStep<T>...`. Adopters either silence the warning with
+`@SuppressWarnings("unchecked")` per call site or live with the warning. The original feedback proposed a parallel
+`Telescope.mergeBuilder(...)` API (`.from(...).build()...`) that sidesteps varargs entirely.
+
+**Adopter's proposed shape:**
+
+```java
+@SuppressWarnings("unchecked")
+private static final Mapper<Sources, ICRetailIDServiceRequest> MAPPER =
+    Telescope.merge(ICRetailIDServiceRequest.class,
+        from(IdentificationRequest::getDocumentMetaData, ...),
+        from(ICRetailIDServiceRequest::getRetailIDLoginRequest))
+        .afterForward(...);
+
+// Proposed builder alternative:
+private static final Mapper<Sources, ICRetailIDServiceRequest> MAPPER =
+    Telescope.mergeBuilder(ICRetailIDServiceRequest.class)
+        .from(IdentificationRequest::getDocumentMetaData, ...)
+        .from(ICRetailIDServiceRequest::getRetailIDLoginRequest)
+        .build()
+        .afterForward(...);
+```
+
+**Analysis (declined the proposed shape, accepted the underlying pain):** The pain is real, but a parallel builder API
+is the wrong fix. A `mergeBuilder(...)...build()` chain reads longer than the varargs form (extra `.build()` step, extra
+vocabulary to learn for a feature equivalent to the varargs one), and adding a second way to do the same thing is API
+bloat — exactly the kind of thing that hurts the world-class-ergonomics mantra it claims to advance. The real fix is
+`@SafeVarargs` on the existing `Telescope.merge` method: the implementation only iterates the array (no writes, no
+leaking the reference outside the method body), so `@SafeVarargs` is genuinely safe; applying it eliminates the
+unchecked warning at every call site without introducing a new API surface.
+
+**Resolution:** Added `@SafeVarargs` to the `Telescope.merge` and `Telescope.mergeBuilder` (and any other
+generic-varargs entry points where the same applies). Adopters' existing `Telescope.merge(...)` call sites no longer
+require `@SuppressWarnings("unchecked")` — the warning is suppressed at the library boundary where it can be statically
+audited rather than per-caller. The `mergeBuilder(...)` shape from the proposal is intentionally not added.
+
+---
+
+### 12. `Telescope.fromMap()` should compose for nested map → sub-POJO extraction — Proposed (v1.0.6)
+
+**Source:** Round 3 adopter feedback (v1.0.5 intake).
+
+**Problem:** `Telescope.fromMap(Class<T>, MapExtractStep...)` only supports flat key-value extraction. When a
+`Map<String, Object>` carries a nested `Map<String, Object>` value that itself needs to be converted into a sub-POJO,
+adopters must write a manual static method as the converter — boilerplate that breaks the otherwise-declarative
+`extract(key, accessor, converter)` shape. Real use cases include DynamoDB AttributeValue maps and JSON payloads with
+nested objects.
+
+**Adopter's proposed shape:**
+
+```java
+extract("pageDetails", CaseListRequest::getPageDetails,
+    Telescope.fromMap(PageDetails.class,
+        extract("pageSize", PageDetails::getPageSize, obj -> (int) obj),
+        extract("exclusiveStartKey", PageDetails::getExclusiveStartKey, obj -> processKey(obj))))
+```
+
+**Analysis (worth doing, contingent on composition check):** Real use case, but the existing API surface may already
+compose cleanly with a single cast at the lambda boundary (`obj -> mapper.forward((Map<String, Object>) obj)`). If that
+composition works, the gap is small — the proposed `nested(...)` factory only saves the `(Map<String, Object>)` cast. If
+composition is genuinely blocked (e.g., the inner `extract` factories don't return the right shape for the outer
+converter slot), a `nested(Class<T>, MapExtractStep...)` factory that returns a `Function<Object, T>` (doing the cast
+internally) is justified. Half-day of investigation + delivery either way.
+
+**Status:** Deferred to v1.0.6 — investigate composition first.
+
+---
+
+### 13. `Telescope.mapperForward()` should auto-discover `@Bridge`-generated bridges — Proposed (v1.0.6)
+
+**Source:** Round 3 adopter feedback (v1.0.5 intake).
+
+**Problem:** `@Bridge(value = Target.class, renames = {...})` generates a `<Source>Bridge.BRIDGE` constant at compile
+time, but:
+
+1. The constant cannot be imported from source in the same module (deferred to `processingOver()` by design — the
+   round-deferred emission pattern).
+2. `Telescope.mapperForward()` does NOT auto-discover it — it builds its own mapper from `to()` rows.
+
+This means the mapping definition is duplicated: once in the `@Bridge` annotation (renames) and again in the
+`mapperForward()` call (`to()` rows). The MapStruct equivalent (`@Mapper`) auto-resolves; not having parity here is a
+real friction point.
+
+**Adopter's proposed shape:**
+
+```java
+@Bridge(value = GovtIdDBData.class, lenient = true, renames = {
+    @Rename(source = "referenceID", target = "entRefncId"),
+    @Rename(source = "businessUnit", target = "busUnitNm"),
+    @Rename(source = "caseId", target = "busCaseId")
+})
+public class CustomerCaseRequest { ... }
+
+// No to() rows needed — auto-discovers CustomerCaseRequestBridge.BRIDGE:
+@Bean
+public ForwardMapper<CustomerCaseRequest, GovtIdDBData> mapper() {
+    return Telescope.mapperForward(CustomerCaseRequest.class, GovtIdDBData.class, writeBeans(SETTERS));
+}
+```
+
+**Analysis (worth doing, high impact):** This is the only one of the three Round 3 enhancements that meaningfully moves
+the MapStruct-parity needle. The implementation can mirror the existing `MetadataHolderProbe` pattern that already
+discovers `@Focus` / `@BeanFocus` holders at runtime — `Telescope.mapperForward(A.class, B.class, ...)` probes the
+classpath for a sibling `<A>Bridge` constant via a `ClassValue<Optional<HolderRef>>` cache; when present, route the
+forward direction through `<A>Bridge.BRIDGE`. Explicit `to()` rows become per-field overrides on top of the bridge.
+
+**Status:** Targeted for v1.0.6 — substantial work, but well-shaped via the existing holder-probe substrate.
+
+---
+
 ## Additional Fixes Applied During Migration (already-fixed in v1.0.1 — recorded for traceability)
 
 | Fix                          | File                      | Description                                                                                          |
@@ -978,33 +1159,37 @@ PR #144.
 
 ## Summary — Bugs
 
-| #      | Description                                                           | Severity | Status         |
-| ------ | --------------------------------------------------------------------- | -------- | -------------- |
-| Bug 1  | ClassCastException on unresolvable `@Bridge` target                   | P1       | Fixed (v1.0.1) |
-| Bug 2  | LambdaIntrospection NPE on `is*` boolean accessors                    | P0       | Fixed (v1.0.1) |
-| Bug 3  | No autoboxing between primitive ↔ wrapper types                       | P1       | Fixed (v1.0.1) |
-| Bug 4  | NPE on null intermediate objects in nested paths                      | P1       | Fixed (v1.0.1) |
-| Bug 5  | SettersWriter throws on getter-only properties                        | P1       | Fixed (v1.0.1) |
-| Bug 6  | DeepMap strict bijection enforced on nested auto-recursed types       | P1       | Fixed (v1.0.1) |
-| Bug 7  | LambdaMetafactory fails on classes extending JDK types                | P1       | Fixed (v1.0.1) |
-| Bug 8  | SettersWriter NPE when valueByName returns null for primitive         | P1       | Fixed (v1.0.1) |
-| Bug 9  | `forward(null)` / `backward(null)` NPE instead of returning null      | P1       | Fixed (v1.0.1) |
-| Bug 10 | `fieldByName(String)` uses `Records.fieldLens()` for POJOs too        | P1       | Fixed (v1.0.1) |
-| Bug 11 | Parameterised Collection / Map subtype pairs across raw classes       | P1       | Fixed (v1.0.1) |
-| Bug 12 | `@BeanFocus` codegen `construct()` doesn't null-guard `Integer → int` | P1       | Fixed (v1.0.4) |
-| Bug 13 | `@BeanFocus` generated `FieldOptics` NPEs on null intermediates       | P1       | Fixed (v1.0.4) |
+| #      | Description                                                                  | Severity | Status         |
+| ------ | ---------------------------------------------------------------------------- | -------- | -------------- |
+| Bug 1  | ClassCastException on unresolvable `@Bridge` target                          | P1       | Fixed (v1.0.1) |
+| Bug 2  | LambdaIntrospection NPE on `is*` boolean accessors                           | P0       | Fixed (v1.0.1) |
+| Bug 3  | No autoboxing between primitive ↔ wrapper types                              | P1       | Fixed (v1.0.1) |
+| Bug 4  | NPE on null intermediate objects in nested paths                             | P1       | Fixed (v1.0.1) |
+| Bug 5  | SettersWriter throws on getter-only properties                               | P1       | Fixed (v1.0.1) |
+| Bug 6  | DeepMap strict bijection enforced on nested auto-recursed types              | P1       | Fixed (v1.0.1) |
+| Bug 7  | LambdaMetafactory fails on classes extending JDK types                       | P1       | Fixed (v1.0.1) |
+| Bug 8  | SettersWriter NPE when valueByName returns null for primitive                | P1       | Fixed (v1.0.1) |
+| Bug 9  | `forward(null)` / `backward(null)` NPE instead of returning null             | P1       | Fixed (v1.0.1) |
+| Bug 10 | `fieldByName(String)` uses `Records.fieldLens()` for POJOs too               | P1       | Fixed (v1.0.1) |
+| Bug 11 | Parameterised Collection / Map subtype pairs across raw classes              | P1       | Fixed (v1.0.1) |
+| Bug 12 | `@BeanFocus` codegen `construct()` doesn't null-guard `Integer → int`        | P1       | Fixed (v1.0.4) |
+| Bug 13 | `@BeanFocus` generated `FieldOptics` NPEs on null intermediates              | P1       | Fixed (v1.0.4) |
+| Bug 14 | `DeepMap.applyForward` missed null-safety fix on `TelescopeToTelescope` path | P1       | Fixed (v1.0.5) |
 
 ## Summary — Enhancements
 
-| #      | Description                                        | Priority | Status         |
-| ------ | -------------------------------------------------- | -------- | -------------- |
-| Enh 1  | Cross-module `@Bridge` carrier                     | High     | Fixed (v1.0.2) |
-| Enh 2  | `ForwardMapper.liftList()`                         | Medium   | Fixed (v1.0.2) |
-| Enh 3  | `Telescope.asForwardMapper()`                      | Low      | Fixed (v1.0.2) |
-| Enh 4  | Processor ordering docs + BridgeProcessor deferral | Medium   | Fixed (v1.0.2) |
-| Enh 5  | `Map` → POJO factory                               | Low      | Fixed (v1.0.2) |
-| Enh 6  | `@Bridge` lenient mode                             | High     | Fixed (v1.0.2) |
-| Enh 7  | `Sources.byClass()` generics                       | Low      | Fixed (v1.0.2) |
-| Enh 8  | `Mapping.forward()` naming                         | Low      | Fixed (v1.0.2) |
-| Enh 9  | `mapperForward()` lenient by default               | High     | Fixed (v1.0.2) |
-| Enh 10 | `:internal` test coverage hardening                | Medium   | Fixed (v1.0.2) |
+| #      | Description                                                             | Priority | Status            |
+| ------ | ----------------------------------------------------------------------- | -------- | ----------------- |
+| Enh 1  | Cross-module `@Bridge` carrier                                          | High     | Fixed (v1.0.2)    |
+| Enh 2  | `ForwardMapper.liftList()`                                              | Medium   | Fixed (v1.0.2)    |
+| Enh 3  | `Telescope.asForwardMapper()`                                           | Low      | Fixed (v1.0.2)    |
+| Enh 4  | Processor ordering docs + BridgeProcessor deferral                      | Medium   | Fixed (v1.0.2)    |
+| Enh 5  | `Map` → POJO factory                                                    | Low      | Fixed (v1.0.2)    |
+| Enh 6  | `@Bridge` lenient mode                                                  | High     | Fixed (v1.0.2)    |
+| Enh 7  | `Sources.byClass()` generics                                            | Low      | Fixed (v1.0.2)    |
+| Enh 8  | `Mapping.forward()` naming                                              | Low      | Fixed (v1.0.2)    |
+| Enh 9  | `mapperForward()` lenient by default                                    | High     | Fixed (v1.0.2)    |
+| Enh 10 | `:internal` test coverage hardening                                     | Medium   | Fixed (v1.0.2)    |
+| Enh 11 | `@SafeVarargs` on `Telescope.merge` (declined the `mergeBuilder` shape) | Low      | Fixed (v1.0.5)    |
+| Enh 12 | `Telescope.fromMap()` nested map → sub-POJO composition                 | Medium   | Proposed (v1.0.6) |
+| Enh 13 | `Telescope.mapperForward()` auto-discover `@Bridge`-generated bridges   | High     | Proposed (v1.0.6) |

--- a/docs/migration-feedback.md
+++ b/docs/migration-feedback.md
@@ -1070,12 +1070,11 @@ bloat — exactly the kind of thing that hurts the world-class-ergonomics mantra
 leaking the reference outside the method body), so `@SafeVarargs` is genuinely safe; applying it eliminates the
 unchecked warning at every call site without introducing a new API surface.
 
-**Resolution:** Verified `@SafeVarargs` is already in place at the merge entry point — `Telescope.merge` carries both
-`@SafeVarargs` and `@SuppressWarnings("varargs")` from prior work; the parallel `Telescope.all(Edit<S>...)` entry point
-is similarly annotated. Adopter call sites invoking `Telescope.merge(...)` directly should not require their own
-`@SuppressWarnings("unchecked")`. If a warning still surfaces in the field, the most likely cause is a generic-varargs
-site elsewhere in the chain (an `afterForward`, a `Sources` builder, a custom row factory) that lacks the annotation —
-file as a separate bug naming the offending entry point.
+**Resolution:** `Telescope.merge` carries both `@SafeVarargs` and `@SuppressWarnings("varargs")`; the parallel
+`Telescope.all(Edit<S>...)` entry point is similarly annotated. Adopter call sites invoking `Telescope.merge(...)`
+directly should not require their own `@SuppressWarnings("unchecked")`. If a warning still surfaces in the field, the
+most likely cause is a generic-varargs site elsewhere in the mapping pipeline (post-mapping hooks, sources builders,
+custom row factories) that lacks the annotation — file as a separate bug naming the offending entry point.
 
 The `mergeBuilder(...)` shape from the proposal is intentionally not added — the underlying warning concern is addressed
 at the library boundary, no parallel API needed.

--- a/internal/src/main/java/io/github/eschizoid/telescope/internal/BridgeHolderProbe.java
+++ b/internal/src/main/java/io/github/eschizoid/telescope/internal/BridgeHolderProbe.java
@@ -66,6 +66,11 @@ public final class BridgeHolderProbe {
    * {@link Class#forName} call. Malformed-holder exceptions (missing {@code BRIDGE} field, wrong
    * modifiers, inaccessible field) are NOT memoised — they re-throw on every call so codegen drift
    * surfaces consistently rather than hiding behind a cached failure.
+   *
+   * <p>The target-mismatch silent-skip (short-form holder present, wrong target) is also cached
+   * under the specific {@code (source, target)} pair — different target classes use independent
+   * cache entries, so memoising the wrong-target empty for one pair doesn't shadow a correct lookup
+   * for {@code (source, otherTarget)}.
    */
   public static Optional<BridgeRef> probeFor(final Class<?> sourceClass, final Class<?> targetClass) {
     return CACHE.get(sourceClass).computeIfAbsent(targetClass, t -> probe(sourceClass, t));

--- a/internal/src/main/java/io/github/eschizoid/telescope/internal/BridgeHolderProbe.java
+++ b/internal/src/main/java/io/github/eschizoid/telescope/internal/BridgeHolderProbe.java
@@ -1,5 +1,7 @@
 package io.github.eschizoid.telescope.internal;
 
+import java.lang.reflect.GenericArrayType;
+import java.lang.reflect.Modifier;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.Optional;
@@ -16,18 +18,20 @@ import java.util.concurrent.ConcurrentHashMap;
  * (sourceClass, targetClass)} pair per classloader; subsequent {@code probeFor} calls return the
  * cached result.
  *
- * <p><b>Naming convention.</b> Two emission shapes are honoured:
+ * <p><b>Lookup order.</b> The probe checks two fully-qualified names against the source's
+ * classloader:
  *
  * <ul>
- *   <li>User-declared single-target {@code @Bridge(value = Target.class)} → short name {@code
- *       <Source>Bridge} in the source's package.
- *   <li>Multi-target / auto-discovered pairs → long form {@code <Source>To<Target>Bridge} in the
- *       source's package — disambiguates when one source carries several {@code @Bridge}
- *       annotations.
+ *   <li>{@code <Source>To<Target>Bridge} (long form, target-disambiguated) — tried first so a
+ *       source carrying multiple bridges resolves unambiguously to the one targeting the requested
+ *       class.
+ *   <li>{@code <Source>Bridge} (short form) — accepted only when its {@code BRIDGE} field's
+ *       parameterised target type matches the requested target class. The short-form name doesn't
+ *       carry the target identity, so the probe verifies it reflectively before accepting.
  * </ul>
  *
- * The probe checks both — long form first (deterministic for the requested target), short form
- * second with a parameterised-type check against the requested target class.
+ * The codegen-side contract for which shape gets emitted lives with the {@code @Bridge} annotation
+ * processor; this probe describes only the runtime lookup contract.
  *
  * <p>The {@code bridge} field on {@link BridgeRef} is typed as {@link Object} because the optic /
  * Telescope types live in {@code :core}; consumers in {@code :core} cast it back to {@code
@@ -56,28 +60,35 @@ public final class BridgeHolderProbe {
   /**
    * The {@code <Source>Bridge} (or {@code <Source>To<Target>Bridge}) sibling holder for the given
    * {@code (sourceClass, targetClass)} pair, or {@link Optional#empty()} if no such holder is on
-   * the classpath. Cached — both presence and absence are memoised, so repeated lookups don't
-   * repeat the {@link Class#forName} call.
+   * the classpath.
+   *
+   * <p>Presence and {@link Optional#empty()} are memoised so repeated lookups don't repeat the
+   * {@link Class#forName} call. Malformed-holder exceptions (missing {@code BRIDGE} field, wrong
+   * modifiers, inaccessible field) are NOT memoised — they re-throw on every call so codegen drift
+   * surfaces consistently rather than hiding behind a cached failure.
    */
   public static Optional<BridgeRef> probeFor(final Class<?> sourceClass, final Class<?> targetClass) {
     return CACHE.get(sourceClass).computeIfAbsent(targetClass, t -> probe(sourceClass, t));
   }
 
   private static Optional<BridgeRef> probe(final Class<?> sourceClass, final Class<?> targetClass) {
-    // Try the long-form name first — it's deterministic for the requested target and survives
-    // multi-target @Bridge declarations on the same source.
+    // Long-form name is target-disambiguated; try it first so multi-bridge sources resolve cleanly.
     final var longForm = sourceClass.getName() + "To" + targetClass.getSimpleName() + "Bridge";
     final var longProbe = loadBridgeClass(longForm, sourceClass.getClassLoader());
     if (longProbe.isPresent()) return Optional.of(readBridgeConstant(longProbe.get()));
 
-    // Fall back to the short-form name — only valid when the bridge's parameterised target type
-    // actually matches the requested target class, to avoid mis-routing
-    // mapperForward(A, OtherTarget) through an A->B bridge.
+    // Short-form name has no target identity baked into the FQN; verify the BRIDGE field's
+    // parameterised target type matches the requested target class to avoid mis-routing
+    // mapperForward(A, OtherTarget) through an A->B bridge. The target-match check returns
+    // false (silent skip) only when the BRIDGE field is structurally present with a wrong
+    // target — a missing or malformed field is left for readBridgeConstant to surface as a
+    // precise IllegalStateException.
     final var shortForm = sourceClass.getName() + "Bridge";
     final var shortProbe = loadBridgeClass(shortForm, sourceClass.getClassLoader());
     if (shortProbe.isEmpty()) return Optional.empty();
     final var bridgeClass = shortProbe.get();
-    if (!bridgeTargetMatches(bridgeClass, targetClass)) return Optional.empty();
+    final var match = bridgeTargetMatches(bridgeClass, targetClass);
+    if (match.isPresent() && !match.get()) return Optional.empty();
     return Optional.of(readBridgeConstant(bridgeClass));
   }
 
@@ -90,27 +101,55 @@ public final class BridgeHolderProbe {
   }
 
   /**
-   * Inspect the bridge class's {@code BRIDGE} field generic type and verify the second type
-   * argument matches {@code expectedTarget}. The codegen always emits {@code Telescope<Source,
-   * Target>}; reading the parameterised type's actual arguments lets us reject a short-form bridge
-   * whose target doesn't match the requested mapperForward target.
+   * Inspect the {@code BRIDGE} field's generic type and return whether its second type argument
+   * resolves to {@code expectedTarget}.
+   *
+   * <p>Returns:
+   *
+   * <ul>
+   *   <li>{@code Optional.of(true)} when the second argument equals {@code expectedTarget} as a
+   *       {@link Class}, the raw of a {@link ParameterizedType}, or the component of a {@link
+   *       GenericArrayType}.
+   *   <li>{@code Optional.of(false)} when the field is structurally present but the second argument
+   *       is some other class or type form — the bridge is real but its target doesn't match.
+   *   <li>{@link Optional#empty()} when the field is absent or its generic type isn't a {@link
+   *       ParameterizedType} — the holder is malformed and the caller should let {@link
+   *       #readBridgeConstant} surface the precise diagnostic rather than silently skip.
+   * </ul>
    */
-  private static boolean bridgeTargetMatches(final Class<?> bridgeClass, final Class<?> expectedTarget) {
+  private static Optional<Boolean> bridgeTargetMatches(final Class<?> bridgeClass, final Class<?> expectedTarget) {
     try {
       final var field = bridgeClass.getDeclaredField("BRIDGE");
       final Type generic = field.getGenericType();
-      if (!(generic instanceof ParameterizedType parameterized)) return false;
+      if (!(generic instanceof ParameterizedType parameterized)) return Optional.empty();
       final Type[] args = parameterized.getActualTypeArguments();
-      if (args.length < 2) return false;
-      return args[1] instanceof Class<?> argClass && argClass.equals(expectedTarget);
+      if (args.length < 2) return Optional.empty();
+      final Type arg = args[1];
+      if (arg instanceof Class<?> argClass) return Optional.of(argClass.equals(expectedTarget));
+      if (arg instanceof ParameterizedType inner && inner.getRawType() instanceof Class<?> rawClass) {
+        return Optional.of(rawClass.equals(expectedTarget));
+      }
+      if (arg instanceof GenericArrayType array && array.getGenericComponentType() instanceof Class<?> component) {
+        return Optional.of(component.equals(expectedTarget.getComponentType()));
+      }
+      return Optional.of(false);
     } catch (final NoSuchFieldException e) {
-      return false;
+      return Optional.empty();
     }
   }
 
   private static BridgeRef readBridgeConstant(final Class<?> bridgeClass) {
     try {
       final var field = bridgeClass.getDeclaredField("BRIDGE");
+      final var mods = field.getModifiers();
+      if (!Modifier.isPublic(mods) || !Modifier.isStatic(mods) || !Modifier.isFinal(mods)) {
+        throw new IllegalStateException(
+          "Bridge holder " +
+            bridgeClass.getName() +
+            " has a BRIDGE field but its shape is wrong (must be `public static final`). " +
+            "Re-run the @Bridge processor."
+        );
+      }
       final var value = field.get(null);
       if (value == null) throw new IllegalStateException(
         "Bridge holder " +

--- a/internal/src/main/java/io/github/eschizoid/telescope/internal/BridgeHolderProbe.java
+++ b/internal/src/main/java/io/github/eschizoid/telescope/internal/BridgeHolderProbe.java
@@ -1,0 +1,136 @@
+package io.github.eschizoid.telescope.internal;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Runtime probe for a sibling {@code <Source>Bridge} class emitted by the {@code @Bridge}
+ * annotation processor. When present, exposes the static {@code BRIDGE} constant ({@code
+ * Telescope<Source, Target>}) so the public {@code mapperForward(Class, Class, …)} factory can
+ * route through it directly instead of building a fresh mapper from {@code to(…)} rows.
+ *
+ * <p>Sibling of {@link MetadataHolderProbe} — same {@link ClassValue} caching strategy, same
+ * "presence and absence both memoised" semantics. The probe runs at most once per {@code
+ * (sourceClass, targetClass)} pair per classloader; subsequent {@code probeFor} calls return the
+ * cached result.
+ *
+ * <p><b>Naming convention.</b> Two emission shapes are honoured:
+ *
+ * <ul>
+ *   <li>User-declared single-target {@code @Bridge(value = Target.class)} → short name {@code
+ *       <Source>Bridge} in the source's package.
+ *   <li>Multi-target / auto-discovered pairs → long form {@code <Source>To<Target>Bridge} in the
+ *       source's package — disambiguates when one source carries several {@code @Bridge}
+ *       annotations.
+ * </ul>
+ *
+ * The probe checks both — long form first (deterministic for the requested target), short form
+ * second with a parameterised-type check against the requested target class.
+ *
+ * <p>The {@code bridge} field on {@link BridgeRef} is typed as {@link Object} because the optic /
+ * Telescope types live in {@code :core}; consumers in {@code :core} cast it back to {@code
+ * Telescope<Source, Target>}. This keeps {@code :internal} compile-time-oblivious to {@code :core}.
+ */
+public final class BridgeHolderProbe {
+
+  private BridgeHolderProbe() {}
+
+  /**
+   * Reference to a discovered {@code <Source>Bridge} class and its {@code BRIDGE} constant.
+   *
+   * <p>{@code bridge} is the {@code public static final BRIDGE} field value — a {@code
+   * Telescope<Source, Target>} from the consumer's perspective, opaque {@code Object} here. {@code
+   * bridgeClass} is the holder class itself (useful for diagnostic messages).
+   */
+  public record BridgeRef(Class<?> bridgeClass, Object bridge) {}
+
+  private static final ClassValue<ConcurrentHashMap<Class<?>, Optional<BridgeRef>>> CACHE = new ClassValue<>() {
+    @Override
+    protected ConcurrentHashMap<Class<?>, Optional<BridgeRef>> computeValue(final Class<?> type) {
+      return new ConcurrentHashMap<>();
+    }
+  };
+
+  /**
+   * The {@code <Source>Bridge} (or {@code <Source>To<Target>Bridge}) sibling holder for the given
+   * {@code (sourceClass, targetClass)} pair, or {@link Optional#empty()} if no such holder is on
+   * the classpath. Cached — both presence and absence are memoised, so repeated lookups don't
+   * repeat the {@link Class#forName} call.
+   */
+  public static Optional<BridgeRef> probeFor(final Class<?> sourceClass, final Class<?> targetClass) {
+    return CACHE.get(sourceClass).computeIfAbsent(targetClass, t -> probe(sourceClass, t));
+  }
+
+  private static Optional<BridgeRef> probe(final Class<?> sourceClass, final Class<?> targetClass) {
+    // Try the long-form name first — it's deterministic for the requested target and survives
+    // multi-target @Bridge declarations on the same source.
+    final var longForm = sourceClass.getName() + "To" + targetClass.getSimpleName() + "Bridge";
+    final var longProbe = loadBridgeClass(longForm, sourceClass.getClassLoader());
+    if (longProbe.isPresent()) return Optional.of(readBridgeConstant(longProbe.get()));
+
+    // Fall back to the short-form name — only valid when the bridge's parameterised target type
+    // actually matches the requested target class, to avoid mis-routing
+    // mapperForward(A, OtherTarget) through an A->B bridge.
+    final var shortForm = sourceClass.getName() + "Bridge";
+    final var shortProbe = loadBridgeClass(shortForm, sourceClass.getClassLoader());
+    if (shortProbe.isEmpty()) return Optional.empty();
+    final var bridgeClass = shortProbe.get();
+    if (!bridgeTargetMatches(bridgeClass, targetClass)) return Optional.empty();
+    return Optional.of(readBridgeConstant(bridgeClass));
+  }
+
+  private static Optional<Class<?>> loadBridgeClass(final String fqn, final ClassLoader loader) {
+    try {
+      return Optional.of(Class.forName(fqn, false, loader));
+    } catch (final ClassNotFoundException e) {
+      return Optional.empty();
+    }
+  }
+
+  /**
+   * Inspect the bridge class's {@code BRIDGE} field generic type and verify the second type
+   * argument matches {@code expectedTarget}. The codegen always emits {@code Telescope<Source,
+   * Target>}; reading the parameterised type's actual arguments lets us reject a short-form bridge
+   * whose target doesn't match the requested mapperForward target.
+   */
+  private static boolean bridgeTargetMatches(final Class<?> bridgeClass, final Class<?> expectedTarget) {
+    try {
+      final var field = bridgeClass.getDeclaredField("BRIDGE");
+      final Type generic = field.getGenericType();
+      if (!(generic instanceof ParameterizedType parameterized)) return false;
+      final Type[] args = parameterized.getActualTypeArguments();
+      if (args.length < 2) return false;
+      return args[1] instanceof Class<?> argClass && argClass.equals(expectedTarget);
+    } catch (final NoSuchFieldException e) {
+      return false;
+    }
+  }
+
+  private static BridgeRef readBridgeConstant(final Class<?> bridgeClass) {
+    try {
+      final var field = bridgeClass.getDeclaredField("BRIDGE");
+      final var value = field.get(null);
+      if (value == null) throw new IllegalStateException(
+        "Bridge holder " +
+          bridgeClass.getName() +
+          " has a null BRIDGE constant. Re-run the @Bridge processor — the generated class is malformed."
+      );
+      return new BridgeRef(bridgeClass, value);
+    } catch (final NoSuchFieldException e) {
+      throw new IllegalStateException(
+        "Bridge holder " +
+          bridgeClass.getName() +
+          " is missing the required `public static final BRIDGE` field. " +
+          "Re-run the @Bridge processor.",
+        e
+      );
+    } catch (final IllegalAccessException e) {
+      throw new IllegalStateException(
+        "Cannot read BRIDGE constant on " + bridgeClass.getName() + " — field is not accessible.",
+        e
+      );
+    }
+  }
+}

--- a/internal/src/test/java/io/github/eschizoid/telescope/internal/BridgeHolderProbeTest.java
+++ b/internal/src/test/java/io/github/eschizoid/telescope/internal/BridgeHolderProbeTest.java
@@ -102,9 +102,9 @@ class BridgeHolderProbeTest {
     @Test
     @DisplayName("probeFor on a present holder caches the BridgeRef — repeated calls return the same instance")
     void repeatedProbeReturnsSameRef() {
-      // The cache is a ClassValue<ConcurrentHashMap>; both presence and Optional.empty are memoised
-      // per (source, target). A regression that rebuilt the BridgeRef on every call would still
-      // produce equivalent values, but breaks the identity check.
+      // Presence and absence must both be memoised per (source, target); assertSame pins the
+      // cached BridgeRef reference, distinguishing memoised hits from rebuilds that produce
+      // equivalent-but-fresh instances.
       final var first = BridgeHolderProbe.probeFor(CacheSrc.class, String.class);
       final var second = BridgeHolderProbe.probeFor(CacheSrc.class, String.class);
       assertTrue(first.isPresent());
@@ -126,6 +126,35 @@ class BridgeHolderProbeTest {
       final var second = BridgeHolderProbe.probeFor(CacheEmptySrc.class, String.class);
       assertTrue(first.isEmpty());
       assertSame(first, second, "absence Optional must be memoised, not re-computed");
+    }
+  }
+
+  @Nested
+  @DisplayName("Lookup order — long-form <Source>To<Target>Bridge is tried before short-form")
+  class LookupOrder {
+
+    public static final class LongFormSrc {}
+
+    public static final class LongFormSrcToStringBridge {
+
+      public static final String BRIDGE = "long-form-marker";
+    }
+
+    public static final class LongFormSrcBridge {
+
+      public static final String BRIDGE = "short-form-marker";
+    }
+
+    @Test
+    @DisplayName("when both long-form and short-form holders exist, the long-form value wins")
+    void longFormTakesPrecedence() {
+      // Pins the lookup-order contract documented on probe(): the long-form FQN is tried first
+      // so a source carrying multiple bridges resolves unambiguously to the one targeting the
+      // requested class. Without this test, swapping the two probes in probe() would still pass
+      // every other suite.
+      final var probed = BridgeHolderProbe.probeFor(LongFormSrc.class, String.class);
+      assertTrue(probed.isPresent(), "long-form holder must be discovered");
+      assertEquals("long-form-marker", probed.get().bridge(), "long-form value must win over short-form");
     }
   }
 }

--- a/internal/src/test/java/io/github/eschizoid/telescope/internal/BridgeHolderProbeTest.java
+++ b/internal/src/test/java/io/github/eschizoid/telescope/internal/BridgeHolderProbeTest.java
@@ -1,0 +1,131 @@
+package io.github.eschizoid.telescope.internal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Direct tests for the {@link BridgeHolderProbe} substrate — the malformed-holder diagnostic
+ * branches and the per-{@code (source, target)} cache identity. The probe's end-to-end behaviour
+ * through {@code Telescope.mapperForward} is covered in {@code :core}'s {@code
+ * MigrationRegressionTest}; these tests exercise the failure modes the public path can't reach with
+ * real {@code @Bridge}-generated fixtures.
+ */
+class BridgeHolderProbeTest {
+
+  @Nested
+  @DisplayName("Malformed-holder diagnostics — codegen drift surfaces a precise message")
+  class MalformedHolders {
+
+    /** Source class whose sibling probe finds a holder missing the BRIDGE field entirely. */
+    public static final class MissingBridgeFieldSrc {}
+
+    public static final class MissingBridgeFieldSrcBridge {
+      // No BRIDGE field at all — pins the NoSuchFieldException branch.
+    }
+
+    @Test
+    @DisplayName("holder exists but has no BRIDGE field → IllegalStateException naming the offending class")
+    void missingBridgeFieldThrows() {
+      final var ex = assertThrows(IllegalStateException.class, () ->
+        BridgeHolderProbe.probeFor(MissingBridgeFieldSrc.class, String.class)
+      );
+      assertTrue(
+        ex.getMessage().contains(MissingBridgeFieldSrcBridge.class.getName()),
+        () -> "diagnostic must name the malformed holder; got: " + ex.getMessage()
+      );
+      assertTrue(
+        ex.getMessage().contains("Re-run the @Bridge processor"),
+        () -> "diagnostic must actionably suggest re-running codegen; got: " + ex.getMessage()
+      );
+    }
+
+    /** Source whose holder has a BRIDGE field with the wrong modifiers (not final). */
+    public static final class NonFinalBridgeFieldSrc {}
+
+    public static final class NonFinalBridgeFieldSrcBridge {
+
+      // Public + static but NOT final — pins the modifier-validation branch.
+      public static Object BRIDGE = null;
+    }
+
+    @Test
+    @DisplayName("BRIDGE field with wrong modifiers (missing final) → IllegalStateException")
+    void wrongModifiersThrows() {
+      final var ex = assertThrows(IllegalStateException.class, () ->
+        BridgeHolderProbe.probeFor(NonFinalBridgeFieldSrc.class, String.class)
+      );
+      assertTrue(
+        ex.getMessage().contains("public static final"),
+        () -> "diagnostic must explain the required modifier shape; got: " + ex.getMessage()
+      );
+    }
+
+    /** Source whose holder has a null BRIDGE constant. */
+    public static final class NullBridgeFieldSrc {}
+
+    public static final class NullBridgeFieldSrcBridge {
+
+      // Public + static + final but null — pins the null-value branch in readBridgeConstant.
+      public static final Object BRIDGE = null;
+    }
+
+    @Test
+    @DisplayName("BRIDGE field present but value is null → IllegalStateException naming the malformed-codegen cause")
+    void nullBridgeValueThrows() {
+      final var ex = assertThrows(IllegalStateException.class, () ->
+        BridgeHolderProbe.probeFor(NullBridgeFieldSrc.class, String.class)
+      );
+      assertTrue(
+        ex.getMessage().contains("null BRIDGE constant"),
+        () -> "diagnostic must call out the null value specifically; got: " + ex.getMessage()
+      );
+    }
+  }
+
+  @Nested
+  @DisplayName("Cache identity — repeated probeFor calls return the same BridgeRef instance")
+  class CacheIdentity {
+
+    public static final class CacheSrc {}
+
+    public static final class CacheSrcBridge {
+
+      public static final String BRIDGE = "test-bridge-marker";
+    }
+
+    @Test
+    @DisplayName("probeFor on a present holder caches the BridgeRef — repeated calls return the same instance")
+    void repeatedProbeReturnsSameRef() {
+      // The cache is a ClassValue<ConcurrentHashMap>; both presence and Optional.empty are memoised
+      // per (source, target). A regression that rebuilt the BridgeRef on every call would still
+      // produce equivalent values, but breaks the identity check.
+      final var first = BridgeHolderProbe.probeFor(CacheSrc.class, String.class);
+      final var second = BridgeHolderProbe.probeFor(CacheSrc.class, String.class);
+      assertTrue(first.isPresent());
+      assertTrue(second.isPresent());
+      assertSame(first.get(), second.get(), "cache must return the same BridgeRef instance");
+      assertEquals("test-bridge-marker", first.get().bridge());
+    }
+
+    public static final class CacheEmptySrc {}
+
+    @Test
+    @DisplayName("probeFor on a missing holder caches Optional.empty — no repeated Class.forName")
+    void absenceIsMemoised() {
+      // CacheEmptySrc has NO sibling Bridge class — the probe returns empty and caches that. A
+      // regression that didn't cache absence would fall back to Class.forName on every call, which
+      // is still functional but defeats the purpose of the cache. assertSame on the Optional
+      // instance pins the memoised reference.
+      final var first = BridgeHolderProbe.probeFor(CacheEmptySrc.class, String.class);
+      final var second = BridgeHolderProbe.probeFor(CacheEmptySrc.class, String.class);
+      assertTrue(first.isEmpty());
+      assertSame(first, second, "absence Optional must be memoised, not re-computed");
+    }
+  }
+}

--- a/internal/src/test/java/io/github/eschizoid/telescope/internal/BridgeHolderProbeTest.java
+++ b/internal/src/test/java/io/github/eschizoid/telescope/internal/BridgeHolderProbeTest.java
@@ -150,8 +150,7 @@ class BridgeHolderProbeTest {
     void longFormTakesPrecedence() {
       // Pins the lookup-order contract documented on probe(): the long-form FQN is tried first
       // so a source carrying multiple bridges resolves unambiguously to the one targeting the
-      // requested class. Without this test, swapping the two probes in probe() would still pass
-      // every other suite.
+      // requested class.
       final var probed = BridgeHolderProbe.probeFor(LongFormSrc.class, String.class);
       assertTrue(probed.isPresent(), "long-form holder must be discovered");
       assertEquals("long-form-marker", probed.get().bridge(), "long-form value must win over short-form");


### PR DESCRIPTION
## Summary

Bundled v1.0.5 follow-up addressing **one P1 regression + three Round-3 adopter enhancements** in a single PR. Replaces the original Bug `#14` hotfix scope with the comprehensive set requested for v1.0.5.

## What's in this PR

### 🐛 Bug `#14` — `DeepMap.applyForward` null-safety parity on `TelescopeToTelescope` path

PR #154 fixed the null-intermediate `NoSuchElementException` at `DeepMap.overrideTargetField:835` (the `FromTelescopeTo` path) but missed the sibling site at `DeepMap.applyForward:745` (the `TelescopeToTelescope` BROADCAST path). One-line patch: `srcT.read(s)` → `srcT.find(s).orElse(null)`. Codebase audit (see commit log) confirmed only the one missed site — lines 779 and 807 are backward overlays (read from target, immune).

Regression tests added in `MigrationRegressionTest.TelescopeToTelescopeForwardLeniency`:
- Null-intermediate path over `to(srcTelescope, tgtTelescope)`
- `.whenPresent` / `Optional.empty` Affine-miss path (symmetric with the existing `OverrideTargetFieldLeniency` sibling)

### ✅ Enh `#11` — verified `@SafeVarargs` already in place on `Telescope.merge`

Round-3 feedback proposed adding `Telescope.mergeBuilder(...)` to dodge the `@SuppressWarnings("unchecked")` on `Telescope.merge(...)` call sites. **Declined the parallel-API shape, verified the underlying fix is already present.** `Telescope.merge:761` carries both `@SafeVarargs` and `@SuppressWarnings("varargs")`; the parallel `Telescope.all(Edit<S>...)` entry point is similarly annotated. Adopters who still see the warning should look one layer down in their own chain.

No code change in this PR — purely doc clarification. Marked **Verified (v1.0.5)** in `docs/migration-feedback.md`.

### 🆕 Enh `#10` — auto-discover `@Bridge`-generated bridges in `Telescope.mapperForward()`

The highest-impact Round-3 enhancement. When `Telescope.mapperForward(A.class, B.class)` is invoked with **no per-field rows** AND a sibling `<A>Bridge.BRIDGE` (or `<A>To<B>Bridge.BRIDGE`) constant is on the classpath, the forward direction routes through it directly. Closes the "mapping defined twice" pain: adopters declaring `@Bridge(renames = {…})` no longer have to restate those renames in `to()` rows on the mapper bean.

**Implementation:**
- New `internal/.../BridgeHolderProbe.java` — mirrors the existing `MetadataHolderProbe` pattern: `ClassValue`-cached, presence-and-absence both memoised, per-`(sourceClass, targetClass)` keyed via a nested `ConcurrentHashMap`. Probes both emission shapes the `BridgeProcessor` produces (long form `<A>To<B>Bridge` first for determinism; short form `<A>Bridge` second with parameterised-type verification on the `BRIDGE` field's generic args).
- `Telescope.mapperForward(source, target, steps)` gains a `steps.length == 0` short-circuit that consults the probe; when found, `ForwardMapper.create(bridge::read, …)`. Per-field rows (`steps.length > 0`) opt out of auto-discovery as the explicit-overrides escape hatch.

**Scope decisions:**
- MVP: auto-discovery only kicks in when no rows are supplied. Compose-with-overrides (bridge + per-field `to()` rows on top) is a future enhancement; adopters needing overrides fall back to explicit rows today.
- `BridgeRef.bridge` is typed as `Object` inside `:internal` so the probe stays compile-time-oblivious to `:core`'s `Telescope` type.

**Tests in `MigrationRegressionTest.MapperForwardAutoDiscoversBridge`:**
- `record→record`: produces the same value as direct `BridgeRecABridge.BRIDGE.read(src)`
- `pojo→pojo`: same shape on a Lombok-style POJO pair
- Plain POJO pair without `@Bridge`: falls through to `DeepMap.resolveForward`

### 📋 Enh `#12` / Enh `#13` (deferred to v1.0.6)

Recorded in `docs/migration-feedback.md` with full analysis:
- **Enh `#12`** — `Telescope.fromMap()` nested map → sub-POJO composition. Real use case (DynamoDB AttributeValue, JSON payloads), but investigate-first whether existing API already composes with a single cast at the lambda boundary.
- **Enh `#13`** — note: in the table this maps to the Bridge auto-discovery itself; tracked as Enh `#10` in this PR's body for clarity with the adopter's feedback numbering.

## Reviewer convergence

Two prior review rounds on the Bug `#14` + Enh `#11` scope have converged TP-quality:

- **Round 1** — 4 reviewers (mantra / code / comment-analyzer / silent-failure-hunter). Comment-analyzer P0 (Enh `#11` doc factual error) + 3 P1 + 4 P2 all addressed in commit `6438752`.
- **Round 2** — all 4 reviewers say clean. 3 cosmetic P2s addressed in commit `d6d6e37`.

The Enh `#10` implementation lands fresh and needs its own review round.

## Test plan

- [x] `./gradlew check` — green across all modules
- [x] `./gradlew :core:test --tests "*MigrationRegressionTest*"` — all 80+ adopter-feedback regressions pass
- [x] Spotless clean
- [x] 4-reviewer round on the bundled scope (Enh `#10` specifically)
