### PR TITLE
test(internal+codegen): meaningful coverage hardening for Beans + BridgeProcessor

### DIFF
--- a/codegen/src/test/java/io/github/eschizoid/telescope/codegen/BridgeProcessorTest.java
+++ b/codegen/src/test/java/io/github/eschizoid/telescope/codegen/BridgeProcessorTest.java
@@ -3739,8 +3739,8 @@ class BridgeProcessorTest {
       // AUTO probes CONSTRUCTOR before BUILDER, so picking CONSTRUCTOR explicitly produces the
       // same generated code on this fixture. The behavioural pin: if a future refactor swaps the
       // AUTO probe order to prefer BUILDER, the explicit CONSTRUCTOR hint must still bind the
-      // constructor — adopters set the hint precisely to escape AUTO's default and rely on the
-      // explicit success path completing instead of falling through to BUILDER.
+      // constructor — the hint is the documented way to escape AUTO's default; falling through to
+      // BUILDER on an explicit CONSTRUCTOR hint would be a silent semantic regression.
       final var compilation = compile(
         source(
           "demo.SrcEC",
@@ -3796,10 +3796,10 @@ class BridgeProcessorTest {
       "writeStrategy = BUILDER fails with a per-field diagnostic when the builder lacks a method for one field"
     )
     void builderMissingPerFieldMethodRejected() {
-      // Real adopter shape: Lombok @Builder where one field's name was changed but the builder
+      // Real-world shape: a Lombok @Builder where one field's name was changed but the builder
       // method wasn't regenerated (or a hand-written builder that forgot one fluent setter). The
-      // diagnostic must name the missing field AND the builder class so the adopter can find
-      // both ends of the mismatch in one read.
+      // diagnostic must name the missing field AND the builder class so both ends of the
+      // mismatch are visible in one read.
       final var compilation = compile(
         source(
           "demo.SrcMB",

--- a/codegen/src/test/java/io/github/eschizoid/telescope/codegen/BridgeProcessorTest.java
+++ b/codegen/src/test/java/io/github/eschizoid/telescope/codegen/BridgeProcessorTest.java
@@ -3728,4 +3728,248 @@ class BridgeProcessorTest {
       );
     }
   }
+
+  @Nested
+  @DisplayName("writeStrategy — explicit hints succeed when the matching shape is present")
+  class ExplicitWriteStrategy {
+
+    @Test
+    @DisplayName("writeStrategy = CONSTRUCTOR succeeds on a POJO that also has a builder() — picks ctor, not builder")
+    void explicitConstructorWinsOverAvailableBuilder() {
+      // AUTO probes CONSTRUCTOR before BUILDER, so picking CONSTRUCTOR explicitly produces the
+      // same generated code on this fixture. The behavioural pin: if a future refactor swaps the
+      // AUTO probe order to prefer BUILDER, the explicit CONSTRUCTOR hint must still bind the
+      // constructor — adopters set the hint precisely to escape AUTO's default and rely on the
+      // explicit success path completing instead of falling through to BUILDER.
+      final var compilation = compile(
+        source(
+          "demo.SrcEC",
+          """
+          package demo;
+          import io.github.eschizoid.telescope.annotations.Bridge;
+          import io.github.eschizoid.telescope.annotations.WriteStrategy;
+          @Bridge(value = demo.DstEC.class, writeStrategy = WriteStrategy.CONSTRUCTOR)
+          public record SrcEC(String id, int score) {}
+          """
+        ),
+        source(
+          "demo.DstEC",
+          """
+          package demo;
+          public class DstEC {
+            private final String id;
+            private final int score;
+            public DstEC(String id, int score) { this.id = id; this.score = score; }
+            public String getId() { return id; }
+            public int getScore() { return score; }
+            public static Builder builder() { return new Builder(); }
+            public static final class Builder {
+              private String id;
+              private int score;
+              public Builder id(String id) { this.id = id; return this; }
+              public Builder score(int score) { this.score = score; return this; }
+              public DstEC build() { return new DstEC(id, score); }
+            }
+          }
+          """
+        )
+      );
+
+      assertTrue(
+        compilation.success(),
+        () -> "explicit CONSTRUCTOR must bind the ctor; saw " + compilation.errorMessages()
+      );
+      final var bridge = compilation.generated().get("demo.SrcECBridge");
+      assertNotNull(bridge);
+      assertTrue(
+        bridge.contains("new demo.DstEC(s.id(), s.score())"),
+        () -> "forward must call the matched ctor directly; saw:\n" + bridge
+      );
+      assertFalse(
+        bridge.contains(".builder()"),
+        () -> "explicit CONSTRUCTOR must NOT fall through to BUILDER even when builder() exists; saw:\n" + bridge
+      );
+    }
+
+    @Test
+    @DisplayName(
+      "writeStrategy = BUILDER fails with a per-field diagnostic when the builder lacks a method for one field"
+    )
+    void builderMissingPerFieldMethodRejected() {
+      // Real adopter shape: Lombok @Builder where one field's name was changed but the builder
+      // method wasn't regenerated (or a hand-written builder that forgot one fluent setter). The
+      // diagnostic must name the missing field AND the builder class so the adopter can find
+      // both ends of the mismatch in one read.
+      final var compilation = compile(
+        source(
+          "demo.SrcMB",
+          """
+          package demo;
+          import io.github.eschizoid.telescope.annotations.Bridge;
+          import io.github.eschizoid.telescope.annotations.WriteStrategy;
+          @Bridge(value = demo.DstMB.class, writeStrategy = WriteStrategy.BUILDER)
+          public record SrcMB(String id, String email) {}
+          """
+        ),
+        source(
+          "demo.DstMB",
+          """
+          package demo;
+          public class DstMB {
+            private final String id;
+            private final String email;
+            private DstMB(String id, String email) { this.id = id; this.email = email; }
+            public String getId() { return id; }
+            public String getEmail() { return email; }
+            public static Builder builder() { return new Builder(); }
+            public static final class Builder {
+              private String id;
+              private String email;
+              public Builder id(String id) { this.id = id; return this; }
+              // No method for 'email' — pins the per-field rejection diagnostic.
+              public DstMB build() { return new DstMB(id, email); }
+            }
+          }
+          """
+        )
+      );
+
+      assertFalse(compilation.success(), "builder without a per-field setter must fail");
+      assertTrue(
+        compilation.hasError("no method for 'email'"),
+        () -> "expected per-field missing-method diagnostic; saw " + compilation.errorMessages()
+      );
+    }
+  }
+
+  @Nested
+  @DisplayName("Sealed roots — additional rejection diagnostics")
+  class SealedRejections {
+
+    @Test
+    @DisplayName(
+      "sealed source subtype carrying multiple @Bridges, none targeting the sealed-target permits, is rejected"
+    )
+    void multiBridgeSubtypeWithNoMatchingPermitRejected() {
+      // A subtype of a @Bridge'd sealed source can legitimately carry multiple @Bridge
+      // annotations (one for the sealed-dispatch target, others for unrelated DTOs). When NONE
+      // of those targets is in the sealed-target's permits list, the multi-target diagnostic
+      // (distinct from the single-target one) must fire. Pins the multi-target branch so a
+      // refactor of collectBridgeAnnotations can't silently fall into the single-target message.
+      final var compilation = compile(
+        source(
+          "a.SealedSrc",
+          """
+          package a;
+          import io.github.eschizoid.telescope.annotations.Bridge;
+          @Bridge(b.SealedDst.class)
+          public sealed interface SealedSrc permits SrcCase {}
+          """
+        ),
+        source(
+          "a.SrcCase",
+          """
+          package a;
+          import io.github.eschizoid.telescope.annotations.Bridge;
+          @Bridge(c.UnrelatedDtoA.class)
+          @Bridge(c.UnrelatedDtoB.class)
+          public record SrcCase(String id) implements SealedSrc {}
+          """
+        ),
+        source(
+          "b.SealedDst",
+          """
+          package b;
+          public sealed interface SealedDst permits DstCase {}
+          """
+        ),
+        source("b.DstCase", "package b; public record DstCase(String id) implements SealedDst {}"),
+        source("c.UnrelatedDtoA", "package c; public record UnrelatedDtoA(String id) {}"),
+        source("c.UnrelatedDtoB", "package c; public record UnrelatedDtoB(String id) {}")
+      );
+
+      assertFalse(compilation.success(), "multi-target subtype with no permit match must fail");
+      assertTrue(
+        compilation.hasError("multiple @Bridge targets, none of which is a permits of"),
+        () -> "expected multi-target rejection diagnostic; saw " + compilation.errorMessages()
+      );
+    }
+
+    @Test
+    @DisplayName("sealed source with no permits clause is rejected before any subtype probe runs")
+    void sealedSourceWithEmptyPermitsRejected() {
+      // A sealed interface compiles even when its permits clause is implicit AND no subtype is
+      // declared in the same file. The dispatch generation needs at least one permit to emit a
+      // switch, so this guard fires before any other sealed analysis touches the type — pins the
+      // empty-permits branch independent of the multi-target / no-bridge subtype branches.
+      final var compilation = compile(
+        source(
+          "demo.EmptySealed",
+          """
+          package demo;
+          import io.github.eschizoid.telescope.annotations.Bridge;
+          @Bridge(demo.EmptySealedDst.class)
+          public sealed interface EmptySealed {}
+          """
+        ),
+        source(
+          "demo.EmptySealedDst",
+          "package demo; public sealed interface EmptySealedDst permits demo.EmptySealedDstCase {}"
+        ),
+        source(
+          "demo.EmptySealedDstCase",
+          "package demo; public record EmptySealedDstCase(String id) implements EmptySealedDst {}"
+        )
+      );
+
+      assertFalse(compilation.success(), "sealed source with no permits must fail");
+      assertTrue(
+        compilation.hasError("requires an explicit permits clause"),
+        () -> "expected explicit-permits diagnostic; saw " + compilation.errorMessages()
+      );
+    }
+  }
+
+  @Nested
+  @DisplayName("Carrier form — source/target top-level enforcement also covers the carrier path")
+  class CarrierTopLevelEnforcement {
+
+    @Test
+    @DisplayName(
+      "carrier form: source = NestedType.class is rejected with the same top-level diagnostic as the model-anchored form"
+    )
+    void carrierWithNestedSourceRejected() {
+      // The model-anchored nested-rejection test (`nestedIsRejected`) pins the target-side guard.
+      // The carrier form's source-side guard sits next to it and would silently regress if a
+      // refactor of the top-level check special-cased the carrier path. Pins the source-side
+      // top-level enforcement on the carrier path specifically.
+      final var compilation = compile(
+        source(
+          "demo.Outer",
+          """
+          package demo;
+          public class Outer {
+            public record InnerSrc(String id) {}
+          }
+          """
+        ),
+        source("demo.TopTarget", "package demo; public record TopTarget(String id) {}"),
+        source(
+          "demo.Carrier",
+          """
+          package demo;
+          import io.github.eschizoid.telescope.annotations.Bridge;
+          @Bridge(source = demo.Outer.InnerSrc.class, target = demo.TopTarget.class)
+          public class Carrier {}
+          """
+        )
+      );
+
+      assertFalse(compilation.success(), "carrier with a nested source must fail");
+      assertTrue(
+        compilation.hasError("source must be a top-level type"),
+        () -> "expected top-level source diagnostic; saw " + compilation.errorMessages()
+      );
+    }
+  }
 }

--- a/internal/src/test/java/io/github/eschizoid/telescope/internal/BeansTest.java
+++ b/internal/src/test/java/io/github/eschizoid/telescope/internal/BeansTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -490,9 +491,12 @@ class BeansTest {
 
   // Fixture extending java.util.ArrayList: its inherited getters (size(), isEmpty(), ...) come from
   // the java.base module. scanGetters must skip everything declared in java.*/jdk.* modules — both
-  // because privateLookupIn cannot reach into a sealed platform module, and because no adopter
+  // because privateLookupIn cannot reach into a sealed platform module, and because no caller
   // wants
   // their domain POJO surfaced as having an `empty` property because it extends Collection.
+  // No serialVersionUID: test-only fixture, never serialized. Extending ArrayList is load-bearing
+  // here (the whole point is to exercise the platform-module skip in scanGetters), so composing
+  // around it would defeat the test.
   @SuppressWarnings("serial")
   static final class ListBackedBean extends ArrayList<String> {
 
@@ -1370,7 +1374,7 @@ class BeansTest {
       assertInstanceOf(NoArgFields.class, built);
       assertNull(((NoArgFields) built).getName(), "fresh instance must hold ctor-default field values");
       // Each call to get() must allocate a new instance — the supplier is not memoising state.
-      assertFalse(built == supplier.get(), "supplier must allocate a fresh instance per get()");
+      assertNotSame(built, supplier.get(), "supplier must allocate a fresh instance per get()");
     }
 
     @Test
@@ -1409,8 +1413,7 @@ class BeansTest {
       // called with a ChildBean instance, source.getClass() != pojoClass, so the fast-path
       // capturedReaders.get(name).apply(source) is bypassed in favour of readProperty(source,
       // name) which routes through the GETTER_INVOKERS ClassValue keyed by the runtime class.
-      // The writer is the captured ParentBean writer, so the rebuild produces a ParentBean —
-      // the Child-only `name` property is not carried because it isn't in ParentBean's names.
+      // The writer is the captured ParentBean writer, so the rebuild produces a ParentBean.
       final Lens<ParentBean, String> idLens = Beans.lens(
         ParentBean.class,
         "id",
@@ -1450,13 +1453,14 @@ class BeansTest {
 
     @Test
     @DisplayName(
-      "every primitive variant of Beans.wrap binds an LMF unbox bridge that round-trips through SettersWriter"
+      "long/double/float/byte/short/char setters each bind an LMF unbox bridge end-to-end through SettersWriter"
     )
-    void everyPrimitiveVariantRoundTripsThroughSettersWriter() {
+    void sixPrimitiveVariantsRoundTripThroughSettersWriter() {
       // Each setter forces wrap() to map its primitive type to the matching wrapper class; the
       // SettersWriter then binds an LMF invoker whose instantiatedMethodType ends in that
-      // wrapper. The metafactory generates the unbox bridge from Object to the primitive — this
-      // test exercises every arm of wrap end-to-end through the public construct path.
+      // wrapper. The metafactory generates the unbox bridge from Object to the primitive. The
+      // int and boolean arms of wrap are covered by existing WithPrimitives / NoArgSetters
+      // fixtures; this test exercises the six remaining primitives end-to-end.
       final var writer = Beans.<AllPrimitives>settersWriter(AllPrimitives.class);
       final var names = new String[] { "longVal", "doubleVal", "floatVal", "byteVal", "shortVal", "charVal" };
       final Map<String, Object> values = Map.of(

--- a/internal/src/test/java/io/github/eschizoid/telescope/internal/BeansTest.java
+++ b/internal/src/test/java/io/github/eschizoid/telescope/internal/BeansTest.java
@@ -10,9 +10,11 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.github.eschizoid.telescope.internal.optics.Lens;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.Objects;
+import java.util.function.Supplier;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -483,6 +485,88 @@ class BeansTest {
       public BuilderWithVoidSetter build() {
         return new BuilderWithVoidSetter(id);
       }
+    }
+  }
+
+  // Fixture extending java.util.ArrayList: its inherited getters (size(), isEmpty(), ...) come from
+  // the java.base module. scanGetters must skip everything declared in java.*/jdk.* modules — both
+  // because privateLookupIn cannot reach into a sealed platform module, and because no adopter
+  // wants
+  // their domain POJO surfaced as having an `empty` property because it extends Collection.
+  @SuppressWarnings("serial")
+  static final class ListBackedBean extends ArrayList<String> {
+
+    private String label;
+
+    public String getLabel() {
+      return label;
+    }
+
+    public void setLabel(final String label) {
+      this.label = label;
+    }
+  }
+
+  // Fixture pinning every primitive variant in Beans#wrap. Each setter forces SettersWriter to bind
+  // an LMF invoker whose instantiated method type ends in the matching wrapper class — the unbox
+  // bridge LMF generates is what `wrap` exists to enable.
+  static final class AllPrimitives {
+
+    private long longVal;
+    private double doubleVal;
+    private float floatVal;
+    private byte byteVal;
+    private short shortVal;
+    private char charVal;
+
+    public AllPrimitives() {}
+
+    public long getLongVal() {
+      return longVal;
+    }
+
+    public double getDoubleVal() {
+      return doubleVal;
+    }
+
+    public float getFloatVal() {
+      return floatVal;
+    }
+
+    public byte getByteVal() {
+      return byteVal;
+    }
+
+    public short getShortVal() {
+      return shortVal;
+    }
+
+    public char getCharVal() {
+      return charVal;
+    }
+
+    public void setLongVal(final long v) {
+      this.longVal = v;
+    }
+
+    public void setDoubleVal(final double v) {
+      this.doubleVal = v;
+    }
+
+    public void setFloatVal(final float v) {
+      this.floatVal = v;
+    }
+
+    public void setByteVal(final byte v) {
+      this.byteVal = v;
+    }
+
+    public void setShortVal(final short v) {
+      this.shortVal = v;
+    }
+
+    public void setCharVal(final char v) {
+      this.charVal = v;
     }
   }
 
@@ -1228,6 +1312,21 @@ class BeansTest {
     }
 
     @Test
+    @DisplayName("modify(non-null, fn) applies fn to the current value and rebuilds the POJO with the result")
+    void modifyOnNonNullSourceAppliesFnAndRebuilds() {
+      // The non-null branch of modify reads the current value through get, applies the function,
+      // and delegates to set for the rebuild. Off-path properties round-trip through the writer's
+      // standard rebuild path; the lens-law set/modify duality holds on reference-typed properties.
+      final Lens<NoArgSetters, String> nameLens = Beans.fieldLens("name");
+      final var src = new NoArgSetters();
+      src.setName("alice");
+      src.setScore(11);
+      final var rebuilt = nameLens.modify(src, String::toUpperCase);
+      assertEquals("ALICE", rebuilt.getName(), "modify must apply fn to the current value and write the result");
+      assertEquals(11, rebuilt.getScore(), "off-path score must round-trip untouched");
+    }
+
+    @Test
     @DisplayName("set on a subtype source rebuilds using the subtype's class (writer is resolved at call time)")
     void setOnSubtypeRebuildsAsSubtype() {
       // fieldLens is class-deferred: the writer is resolved against source.getClass() per call,
@@ -1256,6 +1355,131 @@ class BeansTest {
       src.setScore(5);
       final var rebuilt = scoreLens.set(src, null);
       assertEquals(0, rebuilt.getScore());
+    }
+  }
+
+  @Nested
+  @DisplayName("intermediateAllocator — DeepMap.recursiveDefault's per-class default-instance Supplier")
+  class IntermediateAllocator {
+
+    @Test
+    @DisplayName("class with a public no-arg ctor yields a fresh instance via the LMF-bound ctor Supplier")
+    void noArgCtorYieldsFreshInstance() {
+      final Supplier<Object> supplier = Beans.intermediateAllocator(NoArgFields.class);
+      final var built = supplier.get();
+      assertInstanceOf(NoArgFields.class, built);
+      assertNull(((NoArgFields) built).getName(), "fresh instance must hold ctor-default field values");
+      // Each call to get() must allocate a new instance — the supplier is not memoising state.
+      assertFalse(built == supplier.get(), "supplier must allocate a fresh instance per get()");
+    }
+
+    @Test
+    @DisplayName("class lacking a public no-arg ctor but exposing static builder().build() yields a built instance")
+    void staticBuilderChainYieldsBuiltInstance() {
+      // WithBuilder's ctor is private — the no-arg attempt fails and falls through to the
+      // builder() lookup. The chained LMF Supplier composes builder() with build() and produces
+      // a default-built WithBuilder. Off-path values take the builder's own field defaults.
+      final Supplier<Object> supplier = Beans.intermediateAllocator(WithBuilder.class);
+      final var built = supplier.get();
+      assertInstanceOf(WithBuilder.class, built);
+      assertNull(((WithBuilder) built).getName(), "builder default for name (unset) is null");
+      assertEquals(0, ((WithBuilder) built).getScore(), "builder default for score (unset) is 0");
+    }
+
+    @Test
+    @DisplayName("class with neither a public no-arg ctor nor a static builder() yields a null supplier")
+    void neitherCtorNorBuilderYieldsNullSupplier() {
+      // NothingBuildable has a private all-args ctor and no builder() factory. Both probe arms
+      // fall through; the cached Supplier is `() -> null` rather than throwing — DeepMap reads
+      // null as "no intermediate available" and skips that branch of the default tree.
+      final Supplier<Object> supplier = Beans.intermediateAllocator(NothingBuildable.class);
+      assertNotNull(supplier, "the allocator Supplier itself must be cached even when it returns null");
+      assertNull(supplier.get(), "no-buildable class yields a null result, not a thrown exception");
+    }
+  }
+
+  @Nested
+  @DisplayName("Beans.lens — slow-path read fires when the source's runtime class differs from pojoClass")
+  class LensSubtypeSlowPath {
+
+    @Test
+    @DisplayName("set on a subtype instance reads off-path values through readProperty and rebuilds as pojoClass")
+    void setOnSubtypeUsesSlowPathReadAndRebuildsAsCapturedClass() {
+      // Lens<ParentBean, String> captures the writer + reader-map for ParentBean. When set is
+      // called with a ChildBean instance, source.getClass() != pojoClass, so the fast-path
+      // capturedReaders.get(name).apply(source) is bypassed in favour of readProperty(source,
+      // name) which routes through the GETTER_INVOKERS ClassValue keyed by the runtime class.
+      // The writer is the captured ParentBean writer, so the rebuild produces a ParentBean —
+      // the Child-only `name` property is not carried because it isn't in ParentBean's names.
+      final Lens<ParentBean, String> idLens = Beans.lens(
+        ParentBean.class,
+        "id",
+        Beans.<ParentBean>settersWriter(ParentBean.class)
+      );
+      final var child = new ChildBean();
+      child.setId("inherited");
+      child.setName("child-only");
+      final var rebuilt = idLens.set(child, "updated");
+      assertEquals(ParentBean.class, rebuilt.getClass(), "rebuild uses the captured writer's class, not the source's");
+      assertEquals("updated", rebuilt.getId(), "focused property replaced through the slow-path-aware writer call");
+    }
+  }
+
+  @Nested
+  @DisplayName("scanGetters — inherited platform-module methods are skipped, not surfaced as properties")
+  class ScanGettersModuleSkip {
+
+    @Test
+    @DisplayName("a POJO extending java.util.ArrayList does not surface the inherited isEmpty/size as properties")
+    void platformInheritedAccessorsDoNotLeakAsProperties() {
+      // Defence-in-depth against any caller that touches a JDK-derived class directly. Without
+      // the java.*/jdk.* skip, propertyNames would include `empty` (from isEmpty) and downstream
+      // LMF binding via privateLookupIn(ArrayList.class) would fail because java.base does not
+      // grant private lookup to application code. The skip leaves only the POJO's own getter.
+      final var names = Beans.propertyNames(ListBackedBean.class);
+      final var collected = Arrays.asList(names);
+      assertTrue(collected.contains("label"), "the POJO's own getter must survive the scan");
+      assertFalse(collected.contains("empty"), "inherited isEmpty from java.util must be skipped");
+      assertFalse(collected.contains("class"), "Object.getClass() must remain skipped (declared by Object)");
+    }
+  }
+
+  @Nested
+  @DisplayName("SettersWriter — primitive-variant unbox bridges for every long/double/float/byte/short/char setter")
+  class PrimitiveSetterDispatch {
+
+    @Test
+    @DisplayName(
+      "every primitive variant of Beans.wrap binds an LMF unbox bridge that round-trips through SettersWriter"
+    )
+    void everyPrimitiveVariantRoundTripsThroughSettersWriter() {
+      // Each setter forces wrap() to map its primitive type to the matching wrapper class; the
+      // SettersWriter then binds an LMF invoker whose instantiatedMethodType ends in that
+      // wrapper. The metafactory generates the unbox bridge from Object to the primitive — this
+      // test exercises every arm of wrap end-to-end through the public construct path.
+      final var writer = Beans.<AllPrimitives>settersWriter(AllPrimitives.class);
+      final var names = new String[] { "longVal", "doubleVal", "floatVal", "byteVal", "shortVal", "charVal" };
+      final Map<String, Object> values = Map.of(
+        "longVal",
+        Long.valueOf(9_223_372_036L),
+        "doubleVal",
+        Double.valueOf(3.14d),
+        "floatVal",
+        Float.valueOf(2.5f),
+        "byteVal",
+        Byte.valueOf((byte) 7),
+        "shortVal",
+        Short.valueOf((short) 1234),
+        "charVal",
+        Character.valueOf('Z')
+      );
+      final var built = writer.construct(names, values::get);
+      assertEquals(9_223_372_036L, built.getLongVal());
+      assertEquals(3.14d, built.getDoubleVal());
+      assertEquals(2.5f, built.getFloatVal());
+      assertEquals((byte) 7, built.getByteVal());
+      assertEquals((short) 1234, built.getShortVal());
+      assertEquals('Z', built.getCharVal());
     }
   }
 }

--- a/internal/src/test/java/io/github/eschizoid/telescope/internal/BeansTest.java
+++ b/internal/src/test/java/io/github/eschizoid/telescope/internal/BeansTest.java
@@ -1459,8 +1459,8 @@ class BeansTest {
       // Each setter forces wrap() to map its primitive type to the matching wrapper class; the
       // SettersWriter then binds an LMF invoker whose instantiatedMethodType ends in that
       // wrapper. The metafactory generates the unbox bridge from Object to the primitive. The
-      // int and boolean arms of wrap are covered by existing WithPrimitives / NoArgSetters
-      // fixtures; this test exercises the six remaining primitives end-to-end.
+      // int setter arm of wrap is covered by NoArgSetters.setScore elsewhere in this suite; this
+      // test exercises the six remaining primitive setter variants end-to-end.
       final var writer = Beans.<AllPrimitives>settersWriter(AllPrimitives.class);
       final var names = new String[] { "longVal", "doubleVal", "floatVal", "byteVal", "shortVal", "charVal" };
       final Map<String, Object> values = Map.of(


### PR DESCRIPTION
## Summary

12 new tests across `:internal/BeansTest` and `:codegen/BridgeProcessorTest`, derived from two parallel coverage audits that filtered ~330 missed lines down to the ~10% worth defending. Everything else (Hibernate-conditional, JPMS-closed `IllegalAccessException`, defensive LMF `Throwable` re-wraps, validator symmetry twins) is coverage-bait or unreachable from application code on JDK 25.

## What's pinned

### `Beans.java` (7 new test bodies)

- `IntermediateAllocator` ×3 — the three rungs of the per-class default-instance `Supplier` consumed by `DeepMap.recursiveDefault`: public no-arg ctor → fresh instance, static `builder().build()` chain → default-built instance, neither shape → cached `() -> null`.
- `FieldLensByName.modifyOnNonNullSourceAppliesFnAndRebuilds` — the existing suite only pinned the null-source short-circuit; this exercises the apply + rebuild branch.
- `LensSubtypeSlowPath` — `Lens<Parent, A>` applied to a `Child` instance must take the slow-path read (`readProperty`) and rebuild as the captured `pojoClass`.
- `ScanGettersModuleSkip` — a POJO extending `ArrayList` must not surface inherited `isEmpty`/`size` from `java.base` as properties (the JPMS-strict gate documented at `Beans.java:594-604`).
- `PrimitiveSetterDispatch` — every primitive variant of `Beans#wrap` (long/double/float/byte/short/char) round-trips through an LMF unbox bridge end-to-end via `SettersWriter#construct`.

### `BridgeProcessor.java` (5 new tests)

- `ExplicitWriteStrategy.explicitConstructorWinsOverAvailableBuilder` — `writeStrategy = CONSTRUCTOR` must bind the ctor and NOT fall through to `BUILDER` when `builder()` also exists.
- `ExplicitWriteStrategy.builderMissingPerFieldMethodRejected` — `writeStrategy = BUILDER` must emit a per-field diagnostic naming the missing field when the builder lacks a setter (real adopter shape: Lombok `@Builder` after a field rename).
- `SealedRejections.multiBridgeSubtypeWithNoMatchingPermitRejected` — multi-target subtype where none of the `@Bridge` targets is in the sealed-target's permits list must hit the multi-target branch, distinct from the single-target diagnostic.
- `SealedRejections.sealedSourceWithEmptyPermitsRejected` — sealed source with an implicit empty permits clause must be rejected before any subtype probe runs.
- `CarrierTopLevelEnforcement.carrierWithNestedSourceRejected` — carrier-form `@Bridge(source = NestedType, target = ...)` must hit the source-side top-level guard; the model-anchored variant of this guard is already covered.

## Out of scope

The audit-suggested `FieldsWriter` final-field IAE hint test at `Beans.java:1077-1083` turned out to be unreachable from typical application-class instance final fields on JDK 25 — `Lookup.unreflectSetter` only rejects "trusted final fields" (statics + hidden-class fields), and `FieldsWriter`'s iteration already skips statics. The diagnostic branch survives as defence-in-depth.

## Test plan

- [x] `./gradlew :internal:test --tests "*BeansTest"` — green
- [x] `./gradlew :codegen:test --tests "*BridgeProcessorTest"` — green
- [x] `./gradlew spotlessCheck` — green
- [ ] CI on the bundled scope
- [ ] 4-reviewer pass (mantra / code / comment / silent-failure)
