### PR TITLE
chore(internal): drop redundant "cast" from Traversals suppression

### DIFF
--- a/internal/src/main/java/io/github/eschizoid/telescope/internal/optics/collections/Traversals.java
+++ b/internal/src/main/java/io/github/eschizoid/telescope/internal/optics/collections/Traversals.java
@@ -117,7 +117,7 @@ public final class Traversals {
    *
    * <p>Arrays are NOT supported — wrap as a List or Set if your model uses arrays.
    */
-  @SuppressWarnings({ "unchecked", "cast" })
+  @SuppressWarnings("unchecked")
   public static <C extends Iterable<E>, E> Traversal<C, E> eachIterable() {
     return new Traversal<>() {
       @Override


### PR DESCRIPTION
## Summary

Minimal hygiene PR: drop one verified-redundant `@SuppressWarnings` token. Everything else audited was legitimate.

## What's in this PR

**`Traversals.eachIterable` (`internal/.../optics/collections/Traversals.java:120`)** — was `@SuppressWarnings({ "unchecked", "cast" })`, now `@SuppressWarnings("unchecked")`. The `(C) Collections.unmodifiableList(out)` cast is necessary (compiler can't prove `List<E> ⊆ C extends Iterable<E>`), but it's the **`unchecked`** path that carries the warning — `"cast"` was over-broad. Verified with `-Werror`: drops to single `"unchecked"` still compiles clean.

## Audited and kept

The earlier sweep flagged four atypical suppression sites; three are load-bearing:

- **`@SuppressWarnings("OptionalAssignedToNull")`** ×3 — `Getter.java:89`, `Iso.java:172`, `Iso.java:194`. Records/beans may legally hold null `Optional<X>` references and deep-mapping treats null as pass-through. Returning `null` (not `Optional.empty()`) on a null source is intentional and documented in javadoc above each site.
- **`@SafeVarargs` + `@SuppressWarnings("varargs")`** — `Telescope.merge:790-791`. Both are required: `@SafeVarargs` eliminates the caller-side warning, `"varargs"` silences the body-side heap-pollution check on the `steps` array.

## Out of scope (not what it looked like)

The MCP dead-code scan flagged 194 unreferenced symbols across the repo, but spot-checking confirmed every sampled "dead" method (`DeepMap.writerFor`, `placeholderIsoFor`, `wrapWithTelescopeFixups`, `rawClassOf`) is actually called from within `DeepMap` itself. The Markov-based call-graph indexer was missing intra-file edges on a freshly-indexed project. A real dead-code audit needs either a re-indexed run + manual filter for public DSL surface, or IntelliJ's `Unused declaration` inspection (the IDEA MCP needs the IDE running to drive it; will revisit when that's available).

## Test plan

- [x] `./gradlew check` — green
- [x] `./gradlew spotlessCheck` — green
- [x] CI on the one-line diff
