### PR TITLE
fix(ci): restore jgit auth in release workflow after actions/checkout v7

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -39,6 +39,17 @@ jobs:
           git config --global user.email "mariano.gonzalez.mx@gmail.com"
           git config --global user.name "Mariano Gonzalez"
 
+      # actions/checkout v5+ stores GITHUB_TOKEN in `git config http.extraheader`
+      # instead of embedding it in the origin URL. Native `git` honors extraheader;
+      # the jgit version pinned via `force(libs.jgit)` in build.gradle.kts does not.
+      # Axion-release pushes the release tag through jgit, so it falls back to
+      # anonymous and GitHub rejects the push as "not authorized". Embedding the
+      # token directly in the remote URL restores the v4-era behavior for the
+      # jgit-driven push without bumping the release-toolchain trio.
+      - name: Configure git remote auth for jgit
+        run: |
+          git remote set-url origin "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git"
+
       - name: Setup GPG
         uses: crazy-max/ghaction-import-gpg@v7
         with:


### PR DESCRIPTION
## Summary

Port of [kpipe#182](https://github.com/eschizoid/kpipe/pull/182) — same failure mode applies to telescope.

## What breaks

`actions/checkout@v5+` stores `GITHUB_TOKEN` in `git config http.extraheader` instead of embedding it in the origin URL. Native `git` honors extraheader; the jgit version pinned via `force(libs.jgit)` in `build.gradle.kts` (6.10.0.202406032230-r) does not.

Axion-release pushes the release tag through jgit, which falls back to anonymous and GitHub rejects the push as `not authorized`. Telescope's `release.yaml` is already on `actions/checkout@v7`, so the next release workflow run would fail at the `:release` task — well before JReleaser ever runs.

## Fix

One new workflow step between `Set Git Identity` and `Setup GPG` that re-embeds the token in the origin URL with `git remote set-url`, restoring the v4-era auth shape for the jgit-driven push:

```yaml
- name: Configure git remote auth for jgit
  run: |
    git remote set-url origin "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git"
```

## Why not bump the toolchain instead

- **jreleaser bump**: not in the failure path; failure is in `:release`, well before jreleaser runs.
- **axion-release bump alone**: doesn't help — `force(libs.jgit)` overrides whatever jgit axion bundles.
- **jgit alone (6.10 → 7.x)**: would also work (jgit 7 reads extraheader), but touches the release-toolchain trio we just ignored from Dependabot in `cf2f8f9`. Workflow fix is surgical and reversible.

## Test plan

- [ ] Merge to main
- [ ] Re-run the Release workflow with `releaseType: patch` (or wait for the next real release)
- [ ] Confirm the `:release` task completes (tag is created and pushed)
- [ ] Confirm `publish` and `jreleaserFullRelease` complete as before
