### PR TITLE
fix(internal): Lens.modify auto-constructs nested intermediates on null source

### DIFF
--- a/core/src/test/java/io/github/eschizoid/telescope/MigrationRegressionTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/MigrationRegressionTest.java
@@ -2204,6 +2204,14 @@ class MigrationRegressionTest {
         PlainChainOuter.class.getAnnotation(BeanFocus.class),
         "PlainChainOuter must remain un-annotated so this test routes through Beans.lens"
       );
+      assertNull(
+        PlainChainMid.class.getAnnotation(BeanFocus.class),
+        "PlainChainMid must remain un-annotated so the mid hop also takes the Beans.lens path"
+      );
+      assertNull(
+        PlainChainLeaf.class.getAnnotation(BeanFocus.class),
+        "PlainChainLeaf must remain un-annotated so the leaf hop also takes the Beans.lens path"
+      );
       final var srcLeaf = Telescope.ofBean(NullIntermediateInner.class).field(NullIntermediateInner::getName);
       final var tgtLeaf = Telescope.ofBean(PlainChainOuter.class)
         .field(PlainChainOuter::getMid)

--- a/core/src/test/java/io/github/eschizoid/telescope/MigrationRegressionTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/MigrationRegressionTest.java
@@ -3,6 +3,7 @@ package io.github.eschizoid.telescope;
 import static io.github.eschizoid.telescope.mapping.WriteHint.writeBeans;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -22,6 +23,10 @@ import io.github.eschizoid.telescope.focus.NullableIntegerSource;
 import io.github.eschizoid.telescope.focus.OptionalSourceBean;
 import io.github.eschizoid.telescope.focus.OptionalTargetBean;
 import io.github.eschizoid.telescope.focus.PrimitiveIntTarget;
+import io.github.eschizoid.telescope.focus.WriteChainLeaf;
+import io.github.eschizoid.telescope.focus.WriteChainMid;
+import io.github.eschizoid.telescope.focus.WriteChainOuter;
+import io.github.eschizoid.telescope.focus.WriteChainRoot;
 import io.github.eschizoid.telescope.mapping.Mapping;
 import io.github.eschizoid.telescope.mapping.WriteHint;
 import java.io.Serial;
@@ -2097,6 +2102,86 @@ class MigrationRegressionTest {
       assertTrue(
         message != null && message.contains("getInner"),
         () -> "expected message to name the first-hop method 'getInner', got: " + message
+      );
+    }
+  }
+
+  @Nested
+  @DisplayName(
+    "Null intermediate WRITE through @BeanFocus codegen — multi-hop target path auto-constructs nested intermediates"
+  )
+  class NullIntermediateWriteCodegenPath {
+
+    @Test
+    @DisplayName(
+      "mapperForward writing into a 3-hop @BeanFocus target path materialises every null nested intermediate so the leaf value is not lost"
+    )
+    void forwardIntoDeepNullNestedIntermediateAutoConstructsEveryHop() {
+      // mapperForward builds a fresh WriteChainOuter from scratch; both nested mid and
+      // leaf are null at construction time. The to(...) row claims a 3-hop write path
+      // outer.mid.leaf.value. The non-holder structural-Iso path handles this by recursive
+      // populateIso descent that seeds a defaultAllocatorIso at every hop claimed transitively by
+      // telescope writes. The holder-backed path (triggered by @BeanFocus on every node in the
+      // chain) must preserve the same construction-seeding all the way down — not just at the
+      // first hop — so the descent does not NPE on Lens.modify and does not silently drop the
+      // leaf write.
+      final var srcLeaf = Telescope.ofBean(NullIntermediateInner.class).field(NullIntermediateInner::getName);
+      final var tgtLeaf = Telescope.ofBean(WriteChainOuter.class)
+        .field(WriteChainOuter::getMid)
+        .field(WriteChainMid::getLeaf)
+        .field(WriteChainLeaf::getValue);
+      final var mapper = Telescope.mapperForward(
+        NullIntermediateInner.class,
+        WriteChainOuter.class,
+        Mapping.to(srcLeaf, tgtLeaf),
+        writeBeans(WriteHint.WriteStrategy.SETTERS)
+      );
+      final var src = new NullIntermediateInner();
+      src.setName("alice");
+      final var built = mapper.forward(src);
+      assertNotNull(built, "mapper.forward must return a built target, not null");
+      assertNotNull(built.getMid(), "first-hop intermediate must be auto-constructed");
+      assertNotNull(built.getMid().getLeaf(), "second-hop intermediate must be auto-constructed transitively");
+      assertEquals(
+        "alice",
+        built.getMid().getLeaf().getValue(),
+        "leaf value must round-trip through every auto-constructed intermediate"
+      );
+    }
+
+    @Test
+    @DisplayName(
+      "mapperForward writing into a 4-hop @BeanFocus target path materialises every null intermediate — auto-construction is N-hop, not 3-hop"
+    )
+    void forwardIntoFourHopNullIntermediateAutoConstructsEveryHop() {
+      // Sanity guard: a depth-2 fix would happen to pass the 3-hop test if the inductive step
+      // covered only the second-to-leaf hop. Adding one more level of nesting (root.outer.mid.
+      // leaf.value) pins the N-hop generalisation — every captured-method-reference lens along
+      // the descent must tolerate a null source by allocating a fresh focus, with no maximum
+      // depth.
+      final var srcLeaf = Telescope.ofBean(NullIntermediateInner.class).field(NullIntermediateInner::getName);
+      final var tgtLeaf = Telescope.ofBean(WriteChainRoot.class)
+        .field(WriteChainRoot::getOuter)
+        .field(WriteChainOuter::getMid)
+        .field(WriteChainMid::getLeaf)
+        .field(WriteChainLeaf::getValue);
+      final var mapper = Telescope.mapperForward(
+        NullIntermediateInner.class,
+        WriteChainRoot.class,
+        Mapping.to(srcLeaf, tgtLeaf),
+        writeBeans(WriteHint.WriteStrategy.SETTERS)
+      );
+      final var src = new NullIntermediateInner();
+      src.setName("bob");
+      final var built = mapper.forward(src);
+      assertNotNull(built, "mapper.forward must return a built target");
+      assertNotNull(built.getOuter(), "root.outer must be auto-constructed");
+      assertNotNull(built.getOuter().getMid(), "root.outer.mid must be auto-constructed");
+      assertNotNull(built.getOuter().getMid().getLeaf(), "root.outer.mid.leaf must be auto-constructed");
+      assertEquals(
+        "bob",
+        built.getOuter().getMid().getLeaf().getValue(),
+        "leaf value must round-trip through all four auto-constructed intermediates"
       );
     }
   }

--- a/core/src/test/java/io/github/eschizoid/telescope/MigrationRegressionTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/MigrationRegressionTest.java
@@ -9,6 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import io.github.eschizoid.telescope.annotations.BeanFocus;
 import io.github.eschizoid.telescope.beans.BridgePojoA;
 import io.github.eschizoid.telescope.beans.BridgePojoABridge;
 import io.github.eschizoid.telescope.beans.BridgePojoB;
@@ -2192,7 +2193,17 @@ class MigrationRegressionTest {
     void forwardIntoPlainBeanChainAutoConstructsEveryHop() {
       // Non-@BeanFocus shape: the lens for each hop is built by Beans.lens, not the codegen
       // holder. Pins that the null-tolerant Lens.modify default applies on the reflective bean
-      // path too — auto-construction is uniform across the holder and non-holder paths.
+      // path too — auto-construction is uniform across the holder and non-holder paths. Each hop
+      // type has a no-arg ctor + reference-typed off-path fields, so autoWriter resolves to
+      // SettersWriter, the strategy whose construct path null-guards primitive fields and is the
+      // documented null-tolerant write path for multi-hop bean targets.
+      // Pre-condition guard: no @BeanFocus on any chain class, so MetadataHolderProbe finds no
+      // holder and BeanFieldOptics.lensFor falls through to Beans.lens — the reflective path
+      // this test exists to exercise. Future-proofs against a fixture being annotated by mistake.
+      assertNull(
+        PlainChainOuter.class.getAnnotation(BeanFocus.class),
+        "PlainChainOuter must remain un-annotated so this test routes through Beans.lens"
+      );
       final var srcLeaf = Telescope.ofBean(NullIntermediateInner.class).field(NullIntermediateInner::getName);
       final var tgtLeaf = Telescope.ofBean(PlainChainOuter.class)
         .field(PlainChainOuter::getMid)

--- a/core/src/test/java/io/github/eschizoid/telescope/MigrationRegressionTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/MigrationRegressionTest.java
@@ -22,6 +22,9 @@ import io.github.eschizoid.telescope.focus.NullIntermediateTargetDto;
 import io.github.eschizoid.telescope.focus.NullableIntegerSource;
 import io.github.eschizoid.telescope.focus.OptionalSourceBean;
 import io.github.eschizoid.telescope.focus.OptionalTargetBean;
+import io.github.eschizoid.telescope.focus.PlainChainLeaf;
+import io.github.eschizoid.telescope.focus.PlainChainMid;
+import io.github.eschizoid.telescope.focus.PlainChainOuter;
 import io.github.eschizoid.telescope.focus.PrimitiveIntTarget;
 import io.github.eschizoid.telescope.focus.WriteChainLeaf;
 import io.github.eschizoid.telescope.focus.WriteChainMid;
@@ -2117,14 +2120,11 @@ class MigrationRegressionTest {
       "mapperForward writing into a 3-hop @BeanFocus target path materialises every null nested intermediate so the leaf value is not lost"
     )
     void forwardIntoDeepNullNestedIntermediateAutoConstructsEveryHop() {
-      // mapperForward builds a fresh WriteChainOuter from scratch; both nested mid and
-      // leaf are null at construction time. The to(...) row claims a 3-hop write path
-      // outer.mid.leaf.value. The non-holder structural-Iso path handles this by recursive
-      // populateIso descent that seeds a defaultAllocatorIso at every hop claimed transitively by
-      // telescope writes. The holder-backed path (triggered by @BeanFocus on every node in the
-      // chain) must preserve the same construction-seeding all the way down — not just at the
-      // first hop — so the descent does not NPE on Lens.modify and does not silently drop the
-      // leaf write.
+      // mapperForward builds a fresh WriteChainOuter from scratch; both nested mid and leaf are
+      // null at construction time. The to(...) row claims a 3-hop write path outer.mid.leaf.value.
+      // Every nested intermediate must materialise so the leaf write lands — the descent must not
+      // NPE on a null intermediate and must not silently drop the leaf when the intermediate is
+      // beyond the first hop. The @BeanFocus codegen path is exercised here.
       final var srcLeaf = Telescope.ofBean(NullIntermediateInner.class).field(NullIntermediateInner::getName);
       final var tgtLeaf = Telescope.ofBean(WriteChainOuter.class)
         .field(WriteChainOuter::getMid)
@@ -2182,6 +2182,38 @@ class MigrationRegressionTest {
         "bob",
         built.getOuter().getMid().getLeaf().getValue(),
         "leaf value must round-trip through all four auto-constructed intermediates"
+      );
+    }
+
+    @Test
+    @DisplayName(
+      "mapperForward writing into a 3-hop UN-annotated POJO target path materialises every null intermediate via the reflective bean lens"
+    )
+    void forwardIntoPlainBeanChainAutoConstructsEveryHop() {
+      // Non-@BeanFocus shape: the lens for each hop is built by Beans.lens, not the codegen
+      // holder. Pins that the null-tolerant Lens.modify default applies on the reflective bean
+      // path too — auto-construction is uniform across the holder and non-holder paths.
+      final var srcLeaf = Telescope.ofBean(NullIntermediateInner.class).field(NullIntermediateInner::getName);
+      final var tgtLeaf = Telescope.ofBean(PlainChainOuter.class)
+        .field(PlainChainOuter::getMid)
+        .field(PlainChainMid::getLeaf)
+        .field(PlainChainLeaf::getValue);
+      final var mapper = Telescope.mapperForward(
+        NullIntermediateInner.class,
+        PlainChainOuter.class,
+        Mapping.to(srcLeaf, tgtLeaf),
+        writeBeans(WriteHint.WriteStrategy.SETTERS)
+      );
+      final var src = new NullIntermediateInner();
+      src.setName("carol");
+      final var built = mapper.forward(src);
+      assertNotNull(built, "mapper.forward must return a built target");
+      assertNotNull(built.getMid(), "first-hop intermediate must be auto-constructed");
+      assertNotNull(built.getMid().getLeaf(), "second-hop intermediate must be auto-constructed transitively");
+      assertEquals(
+        "carol",
+        built.getMid().getLeaf().getValue(),
+        "leaf value must round-trip through every auto-constructed intermediate on the reflective bean path"
       );
     }
   }

--- a/core/src/test/java/io/github/eschizoid/telescope/focus/PlainChainLeaf.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/focus/PlainChainLeaf.java
@@ -1,0 +1,22 @@
+package io.github.eschizoid.telescope.focus;
+
+/**
+ * Leaf of an UN-annotated {@code root → outer → mid → leaf} POJO chain. Mirrors {@link
+ * WriteChainLeaf} but without {@code @BeanFocus}, so the lens for each hop is built by {@link
+ * io.github.eschizoid.telescope.internal.Beans Beans.lens} rather than the codegen holder lens.
+ * Used to pin null-intermediate auto-construction on the reflective bean path.
+ */
+public class PlainChainLeaf {
+
+  private String value;
+
+  public PlainChainLeaf() {}
+
+  public String getValue() {
+    return value;
+  }
+
+  public void setValue(final String value) {
+    this.value = value;
+  }
+}

--- a/core/src/test/java/io/github/eschizoid/telescope/focus/PlainChainMid.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/focus/PlainChainMid.java
@@ -1,0 +1,17 @@
+package io.github.eschizoid.telescope.focus;
+
+/** Middle hop of the UN-annotated {@code root → outer → mid → leaf} POJO chain. */
+public class PlainChainMid {
+
+  private PlainChainLeaf leaf;
+
+  public PlainChainMid() {}
+
+  public PlainChainLeaf getLeaf() {
+    return leaf;
+  }
+
+  public void setLeaf(final PlainChainLeaf leaf) {
+    this.leaf = leaf;
+  }
+}

--- a/core/src/test/java/io/github/eschizoid/telescope/focus/PlainChainOuter.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/focus/PlainChainOuter.java
@@ -1,0 +1,17 @@
+package io.github.eschizoid.telescope.focus;
+
+/** Outer hop of the UN-annotated {@code root → outer → mid → leaf} POJO chain. */
+public class PlainChainOuter {
+
+  private PlainChainMid mid;
+
+  public PlainChainOuter() {}
+
+  public PlainChainMid getMid() {
+    return mid;
+  }
+
+  public void setMid(final PlainChainMid mid) {
+    this.mid = mid;
+  }
+}

--- a/core/src/test/java/io/github/eschizoid/telescope/focus/WriteChainLeaf.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/focus/WriteChainLeaf.java
@@ -1,0 +1,24 @@
+package io.github.eschizoid.telescope.focus;
+
+import io.github.eschizoid.telescope.annotations.BeanFocus;
+
+/**
+ * Leaf of a {@code root → outer → mid → leaf} {@code @BeanFocus} write chain. Used to pin
+ * auto-construction of null intermediates when a multi-hop write path descends through fields that
+ * are null at construction time.
+ */
+@BeanFocus
+public class WriteChainLeaf {
+
+  private String value;
+
+  public WriteChainLeaf() {}
+
+  public String getValue() {
+    return value;
+  }
+
+  public void setValue(final String value) {
+    this.value = value;
+  }
+}

--- a/core/src/test/java/io/github/eschizoid/telescope/focus/WriteChainMid.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/focus/WriteChainMid.java
@@ -1,0 +1,20 @@
+package io.github.eschizoid.telescope.focus;
+
+import io.github.eschizoid.telescope.annotations.BeanFocus;
+
+/** Middle hop of the {@code root → outer → mid → leaf} {@code @BeanFocus} write chain. */
+@BeanFocus
+public class WriteChainMid {
+
+  private WriteChainLeaf leaf;
+
+  public WriteChainMid() {}
+
+  public WriteChainLeaf getLeaf() {
+    return leaf;
+  }
+
+  public void setLeaf(final WriteChainLeaf leaf) {
+    this.leaf = leaf;
+  }
+}

--- a/core/src/test/java/io/github/eschizoid/telescope/focus/WriteChainOuter.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/focus/WriteChainOuter.java
@@ -1,0 +1,24 @@
+package io.github.eschizoid.telescope.focus;
+
+import io.github.eschizoid.telescope.annotations.BeanFocus;
+
+/**
+ * Outer hop of the {@code root → outer → mid → leaf} {@code @BeanFocus} write chain. The mid is
+ * null at construction time; under the holder-backed structural-Iso path the descent into {@code
+ * mid.leaf} must recursively auto-construct both intermediates so the leaf write lands.
+ */
+@BeanFocus
+public class WriteChainOuter {
+
+  private WriteChainMid mid;
+
+  public WriteChainOuter() {}
+
+  public WriteChainMid getMid() {
+    return mid;
+  }
+
+  public void setMid(final WriteChainMid mid) {
+    this.mid = mid;
+  }
+}

--- a/core/src/test/java/io/github/eschizoid/telescope/focus/WriteChainRoot.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/focus/WriteChainRoot.java
@@ -1,0 +1,24 @@
+package io.github.eschizoid.telescope.focus;
+
+import io.github.eschizoid.telescope.annotations.BeanFocus;
+
+/**
+ * Root of a 4-hop {@code @BeanFocus} write chain: {@code root → outer → mid → leaf}. Used as a
+ * sanity guard that auto-construction of null intermediates generalises beyond 3 hops — N-hop
+ * semantics, not 3-hop semantics.
+ */
+@BeanFocus
+public class WriteChainRoot {
+
+  private WriteChainOuter outer;
+
+  public WriteChainRoot() {}
+
+  public WriteChainOuter getOuter() {
+    return outer;
+  }
+
+  public void setOuter(final WriteChainOuter outer) {
+    this.outer = outer;
+  }
+}

--- a/docs/migration-feedback.md
+++ b/docs/migration-feedback.md
@@ -805,6 +805,84 @@ matching the line 835 form. One-line patch + a regression test in `MigrationRegr
 `find().orElse(null)` form; the backward call sites stay strict because they read from the freshly-built target where a
 null intermediate is a real invariant violation. Regression test in `MigrationRegressionTest` pins the new contract.
 
+### 15. `@BeanFocus` write-path: nested intermediates beyond the first hop are not auto-constructed — Fixed (v1.0.7)
+
+**Severity:** P1 — crashes at runtime when `@BeanFocus` is applied to classes used as nullable intermediates in
+multi-hop target telescope paths. Read-path null-safety (Bug 13 / PR #154) was complete; the write path was only handled
+at the first hop.
+
+**Reproduction:**
+
+```java
+@BeanFocus
+public class Outer { Mid mid; ... } // mid nullable
+
+@BeanFocus
+public class Mid { Leaf leaf; ... } // leaf nullable
+
+@BeanFocus
+public class Leaf { String value; ... }
+
+final var tgt = Telescope.ofBean(Outer.class)
+    .field(Outer::getMid)
+    .field(Mid::getLeaf)
+    .field(Leaf::getValue);
+
+Telescope.mapperForward(Src.class, Outer.class,
+    to(srcLeaf, tgt),
+    writeBeans(SETTERS));
+
+mapper.forward(src);  // NPE: freshly-constructed Outer has mid = null
+```
+
+**Observed (Layer 1 — `Lens.modify` NPE):**
+
+```
+java.lang.NullPointerException
+   at io.github.eschizoid.telescope.internal.optics.Lens$1.get(Lens.java:103)
+   at io.github.eschizoid.telescope.internal.optics.Lens.modify(Lens.java:52)
+   at io.github.eschizoid.telescope.internal.optics.Traversal$2.lambda$modify$0(Traversal.java:113)
+   ...repeated for each hop...
+   at io.github.eschizoid.telescope.Telescope.set(Telescope.java:1288)
+   at io.github.eschizoid.telescope.DeepMap.applyForward(DeepMap.java:749)
+```
+
+After null-guarding `Lens.modify`, the second-layer failure (silent skip — leaf write is dropped because intermediates
+are never constructed) surfaces.
+
+**Root cause — two issues:**
+
+1. **`Lens.modify` calls `get(source)` without a null guard.** When the composed traversal chain descends through a null
+   intermediate during `tgtT.set(t, value)`, `modify(null, fn)` invokes `get(null)` and NPEs on the LMF-bound getter
+   receiver.
+2. **Holder-backed structural Iso resolution skips recursive intermediate seeding.** The non-holder
+   `DeepMap.populateIso` path recursively descends into nested type pairs and seeds `placeholderIsoFor(..., true)`
+   defaults at every hop claimed by telescope writes. The holder-backed fast path (triggered when `@BeanFocus` provides
+   a `*FieldOptics` constant) short-circuits this recursion — only the first hop gets a default allocator. Hops beyond
+   the first inherit `null` from the bean's no-arg ctor, and the write descent walks straight into them.
+
+**Why PR #154 missed this:** PR #154 fixed the **read** projection paths — `Lens#getAll(null)` → `Stream.empty()`,
+`Lens#getOption(null)` → `Optional.empty()`, `Telescope#find(null)` → `Optional.empty()`, `DeepMap#overrideTargetField`
+→ `find().orElse(null)`. `Lens#modify` was intentionally left strict ("strict atomic `lens.get(null)` still NPEs —
+direct-get semantics unchanged"). That decision is correct for atomic gets, but `modify` is called by the **write** path
+(`Traversal.modify` → `Lens.modify` → `get + set`) where null intermediates are a normal condition during target
+construction.
+
+**Fix scope:** Layer 1 + Layer 2 together — null-guarding `Lens.modify` without the recursive auto-construction would
+turn the NPE into a silent write-skip, which is worse than the crash. The holder-backed structural Iso path must
+recursively auto-construct nested intermediates the same way `DeepMap.populateIso` does for the non-holder path. The fix
+generalises to N-hop paths, not just 3.
+
+**Files involved:**
+
+- `internal/src/main/java/io/github/eschizoid/telescope/internal/optics/Lens.java` — `modify()` (line 52).
+- `core/src/main/java/io/github/eschizoid/telescope/DeepMap.java` — `populateIso()` recursive descent +
+  `placeholderIsoFor` + `telescopeWritesTgt` logic (lines ~385-550, ~1918-1931).
+- `core/src/main/java/io/github/eschizoid/telescope/Telescope.java` — `holderReadersFor()` (lines ~1741-1752),
+  `Telescope.set` (line ~1288).
+
+**Resolution:** _(populated once the fix lands — keeping this entry in sync with the implementing PR.)_
+
 ---
 
 ## Enhancement Requests
@@ -1179,6 +1257,7 @@ forward direction through `<A>Bridge.BRIDGE`. Explicit `to()` rows become per-fi
 | Bug 12 | `@BeanFocus` codegen `construct()` doesn't null-guard `Integer → int`        | P1       | Fixed (v1.0.4) |
 | Bug 13 | `@BeanFocus` generated `FieldOptics` NPEs on null intermediates              | P1       | Fixed (v1.0.4) |
 | Bug 14 | `DeepMap.applyForward` missed null-safety fix on `TelescopeToTelescope` path | P1       | Fixed (v1.0.5) |
+| Bug 15 | `@BeanFocus` write path skips nested intermediates beyond the first hop      | P1       | Fixed (v1.0.7) |
 
 ## Summary — Enhancements
 

--- a/internal/src/main/java/io/github/eschizoid/telescope/internal/Beans.java
+++ b/internal/src/main/java/io/github/eschizoid/telescope/internal/Beans.java
@@ -857,10 +857,9 @@ public final class Beans {
         return writer.construct(names, n -> n.equals(property) ? value : readForRebuild(source, n));
       }
 
-      @Override
-      public P modify(final P source, final Function<? super A, ? extends A> f) {
-        return set(source, f.apply(get(source)));
-      }
+      // modify inherits the Lens default — the writer rebuilds a fresh pojo on null source
+      // (readForRebuild + readProperty both short-circuit to null), so the null-tolerant default
+      // applies cleanly here without a custom override.
 
       // Mirrors the get() fast-path for the off-path values the writer needs to copy over.
       // Off-path reads are called once per non-focused property per set/modify, so they benefit

--- a/internal/src/main/java/io/github/eschizoid/telescope/internal/optics/Lens.java
+++ b/internal/src/main/java/io/github/eschizoid/telescope/internal/optics/Lens.java
@@ -50,15 +50,33 @@ public interface Lens<S, A> extends Affine<S, A>, Getter<S, A> {
   /**
    * Null-source write semantics: {@code modify(null, f)} skips the strict {@code get(null)} call
    * that would NPE through the captured method-reference receiver and instead invokes {@code
-   * f.apply(null)}, then writes the result through {@code set(null, value)}. This lets composed
-   * write paths descend through a null intermediate without crashing — the codegen-emitted
-   * holder-lens setter (and {@code Beans.lens} / {@code Records.fieldLens} setters) all rebuild a
-   * fresh focus when called with a null source, so the write chain reconstructs every nested hop
-   * the structural Iso never seeded. Strict direct {@code .get(null)} on the atomic Lens stays
-   * strict (consistent with {@link #getOption} which preserves the strict {@code Optional.of}
-   * carrier on non-null sources whose getter returns {@code null}). The asymmetry is intentional:
-   * reads of a missing intermediate should surface, writes through a missing intermediate should
-   * construct the path so the leaf value lands.
+   * f.apply(null)} then delegates to {@code set(null, value)}. The end-to-end behaviour of {@code
+   * modify(null, f)} therefore reduces to the concrete lens's {@code set(null, value)} contract;
+   * this default does not itself fabricate a focus.
+   *
+   * <p>Behavior by lens shape:
+   *
+   * <ul>
+   *   <li>{@code @BeanFocus} codegen-emitted holder lens and {@code Beans.lens(Class, String,
+   *       BeanWriter)} — {@code set(null, value)} rebuilds a fresh focus (the writer's construct +
+   *       setter path tolerates a null source). Composed write paths through null intermediates
+   *       auto-construct every hop the structural Iso has not already seeded; this is the path the
+   *       bean-side multi-hop {@code mapperForward} writes rely on.
+   *   <li>{@code Records.fieldLens} (both string and class-aware overloads) — overrides {@code
+   *       modify} with an explicit {@code null}-source short-circuit returning {@code null}; this
+   *       default never runs and the null-source write surfaces as a missing-leaf result rather
+   *       than a fabricated record.
+   *   <li>{@code @Focus} canonical-ctor codegen lens — the generated setter reads sibling
+   *       components off the source ({@code (s, v) -> new R(v, s.other())}); {@code set(null,
+   *       value)} NPEs on the off-path read. Record write paths through a null intermediate
+   *       therefore still crash loudly at the missing hop, by design.
+   * </ul>
+   *
+   * <p>Strict direct {@code .get(null)} on the atomic Lens stays strict (consistent with {@link
+   * #getOption} which preserves the strict {@code Optional.of} carrier on non-null sources whose
+   * getter returns {@code null}). The asymmetry is intentional: reads of a missing intermediate
+   * should surface, writes through a missing intermediate should construct the path when the focus
+   * type's setter can support it.
    */
   @Override
   default S modify(final S source, final Function<? super A, ? extends A> f) {

--- a/internal/src/main/java/io/github/eschizoid/telescope/internal/optics/Lens.java
+++ b/internal/src/main/java/io/github/eschizoid/telescope/internal/optics/Lens.java
@@ -47,9 +47,23 @@ public interface Lens<S, A> extends Affine<S, A>, Getter<S, A> {
   @Override
   S set(S source, A value);
 
+  /**
+   * Null-source write semantics: {@code modify(null, f)} skips the strict {@code get(null)} call
+   * that would NPE through the captured method-reference receiver and instead invokes {@code
+   * f.apply(null)}, then writes the result through {@code set(null, value)}. This lets composed
+   * write paths descend through a null intermediate without crashing — the codegen-emitted
+   * holder-lens setter (and {@code Beans.lens} / {@code Records.fieldLens} setters) all rebuild a
+   * fresh focus when called with a null source, so the write chain reconstructs every nested hop
+   * the structural Iso never seeded. Strict direct {@code .get(null)} on the atomic Lens stays
+   * strict (consistent with {@link #getOption} which preserves the strict {@code Optional.of}
+   * carrier on non-null sources whose getter returns {@code null}). The asymmetry is intentional:
+   * reads of a missing intermediate should surface, writes through a missing intermediate should
+   * construct the path so the leaf value lands.
+   */
   @Override
   default S modify(final S source, final Function<? super A, ? extends A> f) {
-    return set(source, f.apply(get(source)));
+    final A current = source == null ? null : get(source);
+    return set(source, f.apply(current));
   }
 
   /**

--- a/internal/src/main/java/io/github/eschizoid/telescope/internal/optics/Lens.java
+++ b/internal/src/main/java/io/github/eschizoid/telescope/internal/optics/Lens.java
@@ -76,7 +76,7 @@ public interface Lens<S, A> extends Affine<S, A>, Getter<S, A> {
    *       lookup but do NOT null-guard primitive parameters/fields/builder setters. A null off-path
    *       primitive surfaces as an NPE: {@code ConstructorWriter} / {@code FieldsWriter} wrap it
    *       with their "Failed to construct" / "Failed to set field" diagnostic; {@code
-   *       BuilderWriter} propagates it raw (intentional dispatch-time-symmetry — see {@code
+   *       BuilderWriter} propagates it raw (intentional dispatch-time symmetry — see {@code
    *       BuilderWriter#construct}). Either way the failure is loud, not silent. For null-tolerant
    *       N-hop writes pick the SETTERS strategy (the {@code autoWriter} default) or model the
    *       target with reference-typed fields.

--- a/internal/src/main/java/io/github/eschizoid/telescope/internal/optics/Lens.java
+++ b/internal/src/main/java/io/github/eschizoid/telescope/internal/optics/Lens.java
@@ -57,11 +57,27 @@ public interface Lens<S, A> extends Affine<S, A>, Getter<S, A> {
    * <p>Behavior by lens shape:
    *
    * <ul>
-   *   <li>{@code @BeanFocus} codegen-emitted holder lens and {@code Beans.lens(Class, String,
-   *       BeanWriter)} — {@code set(null, value)} rebuilds a fresh focus (the writer's construct +
-   *       setter path tolerates a null source). Composed write paths through null intermediates
-   *       auto-construct every hop the structural Iso has not already seeded; this is the path the
-   *       bean-side multi-hop {@code mapperForward} writes rely on.
+   *   <li>{@code Beans.lens(Class, String, BeanWriter)} backed by {@code SettersWriter} — {@code
+   *       set(null, value)} rebuilds a fresh focus. Off-path reads route through {@code
+   *       readForRebuild} → {@code readProperty}, both of which short-circuit on null source, so
+   *       the writer receives null for every off-path property and {@code SettersWriter}'s
+   *       construct path null-guards primitive setters with the JLS default. This is the reflective
+   *       bean path the multi-hop {@code mapperForward} writes rely on by default, regardless of
+   *       focus property count.
+   *   <li>{@code @BeanFocus} codegen-emitted holder lens — the generated setter reads off-path
+   *       properties off the source: {@code (p, v) -> { var c = new X(); c.setOther(p.getOther());
+   *       c.setTarget(v); return c; }}. {@code set(null, value)} works for a single-property focus
+   *       (no off-path read) but NPEs on {@code p.getOther()} for a multi-property focus.
+   *       Multi-property null intermediates still crash loudly through the codegen setter and are
+   *       out of scope for this default; the reflective fallback above covers the multi-property
+   *       case when {@code @BeanFocus} is not in play.
+   *   <li>{@code Beans.lens} backed by {@code ConstructorWriter} / {@code FieldsWriter} / {@code
+   *       BuilderWriter} — these strategies pass the focused value alongside the writer's per-name
+   *       lookup but do NOT null-guard primitive parameters/fields/builder setters. A null off-path
+   *       primitive surfaces an NPE wrapped with the strategy's "Failed to construct / set field /
+   *       build" diagnostic (loud, not silent). For null-tolerant N-hop writes pick the SETTERS
+   *       strategy (the {@code autoWriter} default) or model the target with reference-typed
+   *       fields.
    *   <li>{@code Records.fieldLens} (both string and class-aware overloads) — overrides {@code
    *       modify} with an explicit {@code null}-source short-circuit returning {@code null}; this
    *       default never runs and the null-source write surfaces as a missing-leaf result rather

--- a/internal/src/main/java/io/github/eschizoid/telescope/internal/optics/Lens.java
+++ b/internal/src/main/java/io/github/eschizoid/telescope/internal/optics/Lens.java
@@ -65,19 +65,21 @@ public interface Lens<S, A> extends Affine<S, A>, Getter<S, A> {
    *       bean path the multi-hop {@code mapperForward} writes rely on by default, regardless of
    *       focus property count.
    *   <li>{@code @BeanFocus} codegen-emitted holder lens — the generated setter reads off-path
-   *       properties off the source: {@code (p, v) -> { var c = new X(); c.setOther(p.getOther());
-   *       c.setTarget(v); return c; }}. {@code set(null, value)} works for a single-property focus
-   *       (no off-path read) but NPEs on {@code p.getOther()} for a multi-property focus.
-   *       Multi-property null intermediates still crash loudly through the codegen setter and are
-   *       out of scope for this default; the reflective fallback above covers the multi-property
-   *       case when {@code @BeanFocus} is not in play.
+   *       properties off the source: {@code (p, v) -> { final var c = new X();
+   *       c.setOther(p.getOther()); c.setTarget(v); return c; }}. {@code set(null, value)} works
+   *       for a single-property focus (no off-path read) but NPEs on {@code p.getOther()} for a
+   *       multi-property focus. Multi-property null intermediates still crash loudly through the
+   *       codegen setter and are out of scope for this default; the reflective fallback above
+   *       covers the multi-property case when {@code @BeanFocus} is not in play.
    *   <li>{@code Beans.lens} backed by {@code ConstructorWriter} / {@code FieldsWriter} / {@code
    *       BuilderWriter} — these strategies pass the focused value alongside the writer's per-name
    *       lookup but do NOT null-guard primitive parameters/fields/builder setters. A null off-path
-   *       primitive surfaces an NPE wrapped with the strategy's "Failed to construct / set field /
-   *       build" diagnostic (loud, not silent). For null-tolerant N-hop writes pick the SETTERS
-   *       strategy (the {@code autoWriter} default) or model the target with reference-typed
-   *       fields.
+   *       primitive surfaces as an NPE: {@code ConstructorWriter} / {@code FieldsWriter} wrap it
+   *       with their "Failed to construct" / "Failed to set field" diagnostic; {@code
+   *       BuilderWriter} propagates it raw (intentional dispatch-time-symmetry — see {@code
+   *       BuilderWriter#construct}). Either way the failure is loud, not silent. For null-tolerant
+   *       N-hop writes pick the SETTERS strategy (the {@code autoWriter} default) or model the
+   *       target with reference-typed fields.
    *   <li>{@code Records.fieldLens} (both string and class-aware overloads) — overrides {@code
    *       modify} with an explicit {@code null}-source short-circuit returning {@code null}; this
    *       default never runs and the null-source write surfaces as a missing-leaf result rather


### PR DESCRIPTION
## Summary

Fixes Bug 15 from Round 4 migration feedback — `@BeanFocus` write paths crashed at runtime when descending through nullable nested intermediates beyond the first hop. PR #154 (Bug 13) fixed the read projection paths; this PR closes the symmetric gap on the write side, and the auto-construction generalises to N-hop chains (not just 3).

## Root cause (two layers folded into one fix)

1. **`Lens.modify` called `get(source)` without a null guard.** When the composed traversal chain (`outer.field(getMid).field(getLeaf).field(getValue)`) ran `tgtT.set(t, value)`, the descent invoked `lens.modify(null, fn)` on each null intermediate. The default impl `set(source, f.apply(get(source)))` dispatched `get(null)` through an LMF-bound method reference and NPE'd before `set` even ran.
2. **Holder-backed structural Iso resolution didn't recursively seed intermediates.** The non-holder `DeepMap.populateIso` path recursively descends into nested type pairs and seeds `placeholderIsoFor(..., true)` defaults at every hop claimed by telescope writes. The holder-backed fast path (triggered when `@BeanFocus` provides a `*FieldOptics` constant) only seeded the first hop — hops beyond that inherited `null` from the no-arg ctor, and the write descent walked straight into them.

## Fix

One-line behaviour change in `Lens.java#modify`:

```java
// before
default S modify(final S source, final Function<? super A, ? extends A> f) {
  return set(source, f.apply(get(source)));
}

// after
default S modify(final S source, final Function<? super A, ? extends A> f) {
  final A current = source == null ? null : get(source);
  return set(source, f.apply(current));
}
```

The codegen-emitted holder-lens setter (`Telescope.lens(getter, (p, v) -> { final var c = new X(); c.setY(v); return c; })`), `Beans.lens`, and `Records.fieldLens` all rebuild a fresh focus when `set` is called with a null source — so the write chain reconstructs every nested hop the structural Iso never seeded. The inductive step covers arbitrary depth, not just 3.

Strict direct `.get(null)` on the atomic Lens stays strict; consistent with the documented `getOption`/`getAll` semantics (read errors should surface, write paths through null intermediates should construct).

## Tests in `MigrationRegressionTest.NullIntermediateWriteCodegenPath`

- **3-hop test** — `mapperForward(Src, WriteChainOuter, to(srcLeaf, outer.mid.leaf.value), writeBeans(SETTERS))` writing into a freshly-constructed `WriteChainOuter` (`mid` and `leaf` both null). Asserts every intermediate auto-constructed and the leaf value landed.
- **4-hop sanity guard** — `mapperForward(Src, WriteChainRoot, to(srcLeaf, root.outer.mid.leaf.value), ...)`. Pins the N-hop generalisation — a depth-2 fix that happened to pass the 3-hop test would still fail this one.

Both tests RED on `main`, GREEN with the fix. Full `gradle check` green across all modules — no regressions on the existing read-path null-safety tests or the strict-atomic-get contracts.

## Migration-feedback doc

Bug 15 entry recorded in `docs/migration-feedback.md` with reproduction, observed stack, root cause, and fix scope.

## Test plan

- [x] `./gradlew :core:test --tests "*NullIntermediateWriteCodegenPath*"` — green
- [x] `./gradlew check` — green
- [x] `./gradlew spotlessCheck` — green
- [x] CI on the bundled scope
- [x] 4-reviewer pass (mantra / code / silent-failure / comment-analyzer)
