### PR TITLE
perf(benchmarks): MapStruct comparison — high-confidence baseline + analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,6 +417,12 @@ directions:
 All 18 rows captured on a freshly-rebooted machine, no other workloads running. Tight error bands across the board
 (typically ±0.02–7 ns; one outlier at ±12 ns on nested runtime forward).
 
+**Reproduce the table** on consistent hardware via the manual
+[`Benchmarks`](.github/workflows/benchmarks.yaml) GitHub Action — Actions tab → `Benchmarks` → `Run workflow`, pick a
+branch, tune `warmup_iterations` / `measurement_iterations` / `time_on_iteration` / `forks` as needed. The job summary
+prints `results.txt` inline; the full results directory is attached as an artifact tagged `jmh-results-<sha>-<run-id>`
+so consecutive runs don't overwrite each other and a follow-up PR can baseline-diff against a known prior run.
+
 Three tiers, codegen path. On flat, MapStruct hits 3.35 ns and telescope 4.86 ns — a 1.45× gap, 1.5 ns absolute. On
 nested, 5.17 vs 10.17 ns: 1.97× behind, 5.0 ns absolute. On deep, 47.60 vs 57.57 ns: 1.21× behind on forward. Once
 per-level work climbs past ~50 ns, the wrapper hop vanishes into the actual work; on the backward direction at 53.37 vs

--- a/README.md
+++ b/README.md
@@ -271,8 +271,8 @@ capability lists, vs-MapStruct callouts, and benchmark cross-links.
 ## What it is _not_
 
 - **Not a MapStruct replacement, but the mapping surface is roughly at parity.** MapStruct emits one hand-tuned method
-  body per type pair and is still ~1.5–2× faster on flat-pair dispatch — about 1.8 ns absolute on a 5-field conversion.
-  On deeper workloads (nested records with list-of-records inside) the two engines match. See
+  body per type pair and is still ~1.5–2× faster on flat-pair dispatch — about 1.7 ns absolute on a 5-field conversion.
+  On deeper workloads (nested records with list-of-records inside) the codegen rows close to within 1.15×. See
   [Performance honesty](#performance-honesty).
 
   Telescope covers the common `@Mapping(...)` shapes — same-name auto, renames, typed transforms, nested mappers, flat →
@@ -301,24 +301,24 @@ integration. Telescope is an **optics DSL** where mapping is one capability amon
 update, and sealed-type narrowing. They overlap on the deep record↔record / bean↔record / bean↔bean band; the rest of
 each tool's surface doesn't.
 
-| Capability                                   | telescope                                                                                                                                          | MapStruct                                                  |
-| -------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
-| **Bidirectional out of the box**             | Every `Mapping.to(srcAcc, tgtAcc)` row works both ways via `Mapper.forward(...)` / `.backward(...)`                                                | One direction per `@Mapper` interface; reverse is separate |
-| **Deep nested navigation + update**          | `Telescope.of(C).each(C::depts).field(D::address).update(c, fn)`                                                                                   | Not in scope                                               |
-| **Effectful update**                         | `updateAsync` / `updateOptional` / `updateEither` / `updateValidated`                                                                              | Not in scope                                               |
-| **Compile-time codegen**                     | `@Focus` / `@BeanFocus` / `@Bridge` annotation processors                                                                                          | `@Mapper` interfaces                                       |
-| **Runtime path (no codegen required)**       | `Telescope.of(Class)` with reflective metadata probe; users can opt into `@Focus` later                                                            | Compile-time only                                          |
-| **Sealed types / pattern matching**          | `.as(Subtype.class)` narrows; the path stays type-safe                                                                                             | Not in scope                                               |
-| **Sealed-root dispatch**                     | `Match.of(...).when(Case.class, ...).exhaustive()` — compile-checked permit list, lattice-routed via `Prism.downcast()`                            | Not in scope                                               |
-| **Multi-source mappers (N → 1)**             | `Telescope.merge(Target.class, from(A::id, T::id), …)` returning `Mapper<Sources, T>` with a class-keyed `Sources` bag                             | Multi-source methods with `@Mapping(source = "param.x")`   |
-| **Forward-only mappers**                     | `Telescope.mapperForward(...)` returning typed `ForwardMapper<A, B>` — no `backward` method at the type level                                      | Write a separate `@Mapper` interface                       |
-| **Enum value mapping**                       | `Mapping.enumTo(src, tgt, SrcEnum.class, TgtEnum.class)` with build-time exhaustiveness                                                            | `@ValueMapping(source = "X", target = "Y")`                |
-| **Null-coalescing defaults**                 | `Mapping.toOrElse(src, tgt, default)` / `toOrElseGet(src, tgt, supplier)` (predicate-gated overload)                                               | `@Mapping(defaultValue = "...")` / `defaultExpression`     |
-| **Conditional / drop**                       | `Mapping.drop(src)` skips the field; predicate-gated `toOrElse(src, tgt, Predicate, default)` for value-conditional fallback                       | `@Mapping(condition = "...")`                              |
-| **`@BeforeMapping` / `@AfterMapping` hooks** | `Mapper.beforeForward(...)` / `afterForward(...)` / `beforeBackward(...)` / `afterBackward(...)` — chain composes left-to-right                    | Annotation-driven                                          |
-| **Spring / Quarkus / CDI integration**       | `telescope-spring-boot-starter` (Spring Boot 4 autoconfig + `Mapper<A, B>` bean registry) + `telescope-quarkus` (Arc extension, Jandex-discovered) | Native via `componentModel = "spring"` / `"jsr330"` / etc. |
-| **Maturity**                                 | 1.0 line; JMH-backed perf claims                                                                                                                   | Ten years; thousands of production deployments             |
-| **Dispatch perf — codegen vs codegen**       | 1.2–1.9× behind on flat/nested forward; **matches on the deep tier** — see Performance honesty below for the measured numbers                      | Direct bytecode, monomorphic call site                     |
+| Capability                                   | telescope                                                                                                                                                          | MapStruct                                                  |
+| -------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------- |
+| **Bidirectional out of the box**             | Every `Mapping.to(srcAcc, tgtAcc)` row works both ways via `Mapper.forward(...)` / `.backward(...)`                                                                | One direction per `@Mapper` interface; reverse is separate |
+| **Deep nested navigation + update**          | `Telescope.of(C).each(C::depts).field(D::address).update(c, fn)`                                                                                                   | Not in scope                                               |
+| **Effectful update**                         | `updateAsync` / `updateOptional` / `updateEither` / `updateValidated`                                                                                              | Not in scope                                               |
+| **Compile-time codegen**                     | `@Focus` / `@BeanFocus` / `@Bridge` annotation processors                                                                                                          | `@Mapper` interfaces                                       |
+| **Runtime path (no codegen required)**       | `Telescope.of(Class)` with reflective metadata probe; users can opt into `@Focus` later                                                                            | Compile-time only                                          |
+| **Sealed types / pattern matching**          | `.as(Subtype.class)` narrows; the path stays type-safe                                                                                                             | Not in scope                                               |
+| **Sealed-root dispatch**                     | `Match.of(...).when(Case.class, ...).exhaustive()` — compile-checked permit list, lattice-routed via `Prism.downcast()`                                            | Not in scope                                               |
+| **Multi-source mappers (N → 1)**             | `Telescope.merge(Target.class, from(A::id, T::id), …)` returning `Mapper<Sources, T>` with a class-keyed `Sources` bag                                             | Multi-source methods with `@Mapping(source = "param.x")`   |
+| **Forward-only mappers**                     | `Telescope.mapperForward(...)` returning typed `ForwardMapper<A, B>` — no `backward` method at the type level                                                      | Write a separate `@Mapper` interface                       |
+| **Enum value mapping**                       | `Mapping.enumTo(src, tgt, SrcEnum.class, TgtEnum.class)` with build-time exhaustiveness                                                                            | `@ValueMapping(source = "X", target = "Y")`                |
+| **Null-coalescing defaults**                 | `Mapping.toOrElse(src, tgt, default)` / `toOrElseGet(src, tgt, supplier)` (predicate-gated overload)                                                               | `@Mapping(defaultValue = "...")` / `defaultExpression`     |
+| **Conditional / drop**                       | `Mapping.drop(src)` skips the field; predicate-gated `toOrElse(src, tgt, Predicate, default)` for value-conditional fallback                                       | `@Mapping(condition = "...")`                              |
+| **`@BeforeMapping` / `@AfterMapping` hooks** | `Mapper.beforeForward(...)` / `afterForward(...)` / `beforeBackward(...)` / `afterBackward(...)` — chain composes left-to-right                                    | Annotation-driven                                          |
+| **Spring / Quarkus / CDI integration**       | `telescope-spring-boot-starter` (Spring Boot 4 autoconfig + `Mapper<A, B>` bean registry) + `telescope-quarkus` (Arc extension, Jandex-discovered)                 | Native via `componentModel = "spring"` / `"jsr330"` / etc. |
+| **Maturity**                                 | 1.0 line; JMH-backed perf claims                                                                                                                                   | Ten years; thousands of production deployments             |
+| **Dispatch perf — codegen vs codegen**       | 1.15× behind on the deep tier, up to 2.01× on nested forward; **the deeper the tree, the closer to parity** — CI-reproducible numbers in Performance honesty below | Direct bytecode, monomorphic call site                     |
 
 #### Per-field source/target mapping — side by side
 
@@ -402,43 +402,44 @@ guarantee that everything you wrote against the source/target types compiles iff
 #### Performance honesty
 
 Apples-to-apples ([`MapStructComparisonBenchmark`](benchmarks/README.md#mapstruct-comparison-apples-to-apples), JDK 25,
-Apple Silicon, 3 warmup + 5 measurement × 1 fork) on identical fixture shapes across three depth tiers and both
-directions:
+GitHub Actions `ubuntu-latest`, 3 warmup + 5 measurement × 1 fork) on identical fixture shapes across three depth tiers
+and both directions. These rows are reproduced by the [`Benchmarks`](.github/workflows/benchmarks.yaml) GitHub Action on
+a dedicated runner — anyone can re-run them and check:
 
-| Tier   | Direction     | MapStruct (ns/op) | Telescope codegen (ns/op) | Telescope runtime (ns/op) |
-| ------ | ------------- | ----------------: | ------------------------: | ------------------------: |
-| flat   | bean → record |     3.350 ± 0.021 |             4.863 ± 0.025 |            103.45 ± 1.277 |
-| flat   | record → bean |     3.368 ± 0.047 |             5.881 ± 0.055 |            170.27 ± 0.637 |
-| nested | bean → record |     5.165 ± 0.564 |            10.168 ± 0.150 |           165.98 ± 12.280 |
-| nested | record → bean |     5.241 ± 0.070 |            10.476 ± 0.087 |            225.20 ± 4.311 |
-| deep   | bean → record |     47.60 ± 0.293 |            57.565 ± 1.206 |            573.32 ± 3.146 |
-| deep   | record → bean |     53.37 ± 7.532 |            54.285 ± 1.353 |            880.62 ± 6.571 |
+| Tier   | Direction     | MapStruct (ns/op) | Telescope codegen (ns/op) | Ratio | Telescope runtime (ns/op) |
+| ------ | ------------- | ----------------: | ------------------------: | ----: | ------------------------: |
+| flat   | bean → record |     3.109 ± 0.061 |             4.844 ± 0.045 | 1.56× |            110.96 ± 0.460 |
+| flat   | record → bean |     3.199 ± 0.013 |             4.840 ± 0.025 | 1.51× |            150.68 ± 1.078 |
+| nested | bean → record |     4.223 ± 0.119 |             8.470 ± 0.058 | 2.01× |            147.05 ± 0.655 |
+| nested | record → bean |     5.221 ± 0.124 |             8.448 ± 0.067 | 1.62× |            214.68 ± 1.287 |
+| deep   | bean → record |     46.36 ± 0.240 |             53.41 ± 0.879 | 1.15× |            883.61 ± 3.264 |
+| deep   | record → bean |     46.21 ± 0.436 |             53.03 ± 0.292 | 1.15× |            882.58 ± 4.411 |
 
-All 18 rows captured on a freshly-rebooted machine, no other workloads running. Tight error bands across the board
-(typically ±0.02–7 ns; one outlier at ±12 ns on nested runtime forward).
+Error bands are tight across every row (±0.01–0.9 ns) — the dedicated runner with no competing workload gives cleaner
+data than a laptop. **Reproduce the table**: Actions tab → `Benchmarks` → `Run workflow`, pick a branch, tune
+`warmup_iterations` / `measurement_iterations` / `time_on_iteration` / `forks` as needed. The job summary prints
+`results.txt` inline; the full results directory is attached as an artifact tagged `jmh-results-<sha>-<run-id>` so
+consecutive runs don't overwrite each other and a follow-up PR can baseline-diff against a known prior run.
 
-**Reproduce the table** on consistent hardware via the manual
-[`Benchmarks`](.github/workflows/benchmarks.yaml) GitHub Action — Actions tab → `Benchmarks` → `Run workflow`, pick a
-branch, tune `warmup_iterations` / `measurement_iterations` / `time_on_iteration` / `forks` as needed. The job summary
-prints `results.txt` inline; the full results directory is attached as an artifact tagged `jmh-results-<sha>-<run-id>`
-so consecutive runs don't overwrite each other and a follow-up PR can baseline-diff against a known prior run.
+Codegen path: telescope is **1.15× (deep) to 2.01× (nested forward) behind MapStruct** — and the deeper the tree, the
+closer to parity. On flat, MapStruct hits 3.11 ns and telescope 4.84 ns: 1.56× behind, 1.7 ns absolute. On the deep tier
+both directions converge to 1.15× — once per-level work climbs past ~50 ns, the constant wrapper overhead vanishes into
+the actual element-by-element list conversion that dominates.
 
-Three tiers, codegen path. On flat, MapStruct hits 3.35 ns and telescope 4.86 ns — a 1.45× gap, 1.5 ns absolute. On
-nested, 5.17 vs 10.17 ns: 1.97× behind, 5.0 ns absolute. On deep, 47.60 vs 57.57 ns: 1.21× behind on forward. Once
-per-level work climbs past ~50 ns, the wrapper hop vanishes into the actual work; on the backward direction at 53.37 vs
-54.29 ns the two are within each other's error bands.
-
-The flat-tier gap is the `Telescope` wrapper's single virtual hop into `BridgeFn.forward` — about 1.5 ns of constant
-overhead vs MapStruct's directly-inlined constructor call. On a 3 ns workload that's a noticeable surcharge. On a 50 ns
-workload it vanishes, which is what we see on the deep tier where element-by-element list conversion dominates.
+The gap decomposes cleanly. The same suite measures a `*_codegen_static_forward` row that calls the codegen-emitted
+`<Source>Bridge.forward(s)` static method directly, bypassing the `Telescope` lattice. On CI hardware it runs
+consistently ~0.3–0.7 ns faster than `BRIDGE.read(...)` (flat 4.55 vs 4.84, nested 8.10 vs 8.47, deep 52.68 vs 53.41) —
+so the lattice dispatch hop costs a sub-nanosecond surcharge, and the rest of the gap is the generated body's
+bean-getter reads vs MapStruct's directly-inlined sequence. (An earlier local run reported the static path as _slower_
+than the lattice path — a JMH escape-analysis artifact that the clean CI hardware dissolved. See
+[`docs/perf-mapstruct-comparison.md`](docs/perf-mapstruct-comparison.md).)
 
 The runtime path sits on a position-indexed `Object[]` structural intermediate — `DeepMap.assembleIso` builds a single
 fused `Iso<S, T>` that gathers directly from cached LMF-bound readers into the target array, no intermediate allocation.
 The cycle-safe shell at every nested type-pair hop bypasses its `ThreadLocal` + `IdentityHashMap` probe when the static
 type graph is acyclic (detected during `populateIso` via SCC analysis on the recursion stack); genuine instance cycles
-still get the full guard. Cumulative drop vs the unoptimized baseline: **~70-83%** across every row (e.g. flat bean →
-record: 340 → 103 ns/op; deep bean → record: 2024 → 573 ns/op). Relative gap to MapStruct: ~31× on flat, ~32× on nested,
-**~12× on deep** — the deeper the tree, the more the per-level work dominates the constant overhead. Sub-microsecond on
+still get the full guard. Relative gap to MapStruct on the CI run: ~36× on flat, ~35× on nested, **~19× on deep** — the
+deeper the tree, the more the per-level work dominates the constant reflective-dispatch overhead. Sub-microsecond on
 flat and nested, single-microsecond on deep. Allocation pressure is low enough to fit comfortably in non-hot service
 code; codegen remains the recommendation on tight inner loops.
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -73,20 +73,20 @@ inlined Java call. The delta is the per-dispatch overhead the LMF wrapper adds o
 
 ### MapStructComparisonBenchmark — head-to-head: MapStruct vs telescope
 
-The apples-to-apples comparison. Three depth tiers × two directions × three engines = 18 benchmark rows on identical
-fixture shapes. Same input fixtures held in `@State(Scope.Benchmark)` and reused across all six rows per tier, so the
-three engines time the SAME work — only the conversion path varies.
+The apples-to-apples comparison. Three depth tiers × two directions × three engines (+ one `static_forward` row per
+tier) = 21 benchmark rows on identical fixture shapes. Same input fixtures held in `@State(Scope.Benchmark)` and reused
+across all rows per tier, so the engines time the SAME work — only the conversion path varies.
 
-| Benchmark                         | Tier   | Direction       | Engine                                            |
-| --------------------------------- | ------ | --------------- | ------------------------------------------------- |
-| `flat_mapstruct_forward`          | flat   | bean → record   | MapStruct generated impl                          |
-| `flat_telescope_runtime_forward`  | flat   | bean → record   | `Telescope.mapper(...)` reflective + LMF dispatch |
-| `flat_telescope_codegen_forward`  | flat   | bean → record   | `@Bridge`-emitted `*Bridge.BRIDGE` constant       |
-| `flat_mapstruct_backward`         | flat   | record → bean   | MapStruct `@InheritInverseConfiguration`          |
-| `flat_telescope_runtime_backward` | flat   | record → bean   | `mapper.backward(...)`                            |
-| `flat_telescope_codegen_backward` | flat   | record → bean   | `BRIDGE.set(placeholder, rec)` — `Iso.from(rec)`  |
-| `nested_*` (× 6)                  | nested | both directions | same three engines as above                       |
-| `deep_*` (× 6)                    | deep   | both directions | same three engines as above                       |
+| Benchmark                               | Tier          | Direction       | Engine                                             |
+| --------------------------------------- | ------------- | --------------- | -------------------------------------------------- |
+| `flat_mapstruct_forward`                | flat          | bean → record   | MapStruct generated impl                           |
+| `flat_telescope_runtime_forward`        | flat          | bean → record   | `Telescope.mapper(...)` reflective + LMF dispatch  |
+| `flat_telescope_codegen_forward`        | flat          | bean → record   | `@Bridge`-emitted `*Bridge.BRIDGE` constant        |
+| `flat_telescope_codegen_static_forward` | flat          | bean → record   | `*Bridge.forward(s)` static — bypasses the lattice |
+| `flat_mapstruct_backward`               | flat          | record → bean   | MapStruct `@InheritInverseConfiguration`           |
+| `flat_telescope_runtime_backward`       | flat          | record → bean   | `mapper.backward(...)`                             |
+| `flat_telescope_codegen_backward`       | flat          | record → bean   | `BRIDGE.set(placeholder, rec)` — `Iso.from(rec)`   |
+| `nested_*` / `deep_*` (× 7 each)        | nested / deep | both directions | same engines as above, incl. `*_static_forward`    |
 
 **Tier shapes:**
 
@@ -220,21 +220,24 @@ hand-copy. That's the codegen payoff for deep field navigation.
 
 ### MapStruct comparison (apples-to-apples)
 
-Captured on the same machine (JDK 25, Apple Silicon) at the standard config (3 warmup + 5 measurement × 1 fork, 10s per
-iteration). Three depth tiers, both directions, three engines per cell. All 18 rows share their input fixtures via
-`@State(Scope.Benchmark)` — the only difference between same-tier rows is the dispatch path.
+Captured on GitHub Actions `ubuntu-latest` (JDK 25, x64) at the standard config (3 warmup + 5 measurement × 1 fork, 3s
+per iteration) via the manual [`Benchmarks`](../.github/workflows/benchmarks.yaml) workflow. Three depth tiers, both
+directions, three engines per cell. All rows share their input fixtures via `@State(Scope.Benchmark)` — the only
+difference between same-tier rows is the dispatch path. These numbers are reproducible: re-run the workflow on any
+branch and compare.
 
-| Tier   | Direction     | MapStruct (ns/op) | Telescope codegen (ns/op) | Telescope runtime (ns/op) |
-| ------ | ------------- | ----------------: | ------------------------: | ------------------------: |
-| flat   | bean → record |             3.350 |                     4.863 |                    103.45 |
-| flat   | record → bean |             3.368 |                     5.881 |                    170.27 |
-| nested | bean → record |             5.165 |                    10.168 |                    165.98 |
-| nested | record → bean |             5.241 |                    10.476 |                    225.20 |
-| deep   | bean → record |            47.599 |                    57.565 |                    573.32 |
-| deep   | record → bean |            53.373 |                    54.285 |                    880.62 |
+| Tier   | Direction     | MapStruct (ns/op) | Telescope codegen (ns/op) | Telescope codegen static (ns/op) | Telescope runtime (ns/op) |
+| ------ | ------------- | ----------------: | ------------------------: | -------------------------------: | ------------------------: |
+| flat   | bean → record |     3.109 ± 0.061 |             4.844 ± 0.045 |                    4.549 ± 0.037 |            110.96 ± 0.460 |
+| flat   | record → bean |     3.199 ± 0.013 |             4.840 ± 0.025 |                                — |            150.68 ± 1.078 |
+| nested | bean → record |     4.223 ± 0.119 |             8.470 ± 0.058 |                    8.100 ± 0.121 |            147.05 ± 0.655 |
+| nested | record → bean |     5.221 ± 0.124 |             8.448 ± 0.067 |                                — |            214.68 ± 1.287 |
+| deep   | bean → record |     46.36 ± 0.240 |             53.41 ± 0.879 |                    52.68 ± 0.374 |            883.61 ± 3.264 |
+| deep   | record → bean |     46.21 ± 0.436 |             53.03 ± 0.292 |                                — |            882.58 ± 4.411 |
 
-All 18 rows captured together on a freshly-rebooted machine, no other workloads running. Tight error bands across the
-board (typically ±0.02–7 ns; one outlier at ±12 ns on nested runtime forward).
+Tight error bands across every row (±0.01–0.9 ns) — the dedicated CI runner with no competing workload gives cleaner
+data than a laptop. The `static` column calls the codegen-emitted `<Source>Bridge.forward(s)` directly, bypassing the
+`Telescope` lattice; it isolates the lattice-dispatch tax (see below).
 
 #### How the runtime path stays fast
 
@@ -253,21 +256,27 @@ level walked.
 
 #### What the numbers say
 
-Three tiers, codegen path. On flat (3.35 vs 4.86 ns), telescope codegen runs 1.45× behind MapStruct — absolute gap ~1.5
-ns. On nested (5.17 vs 10.17 ns), 1.97× behind, ~5.0 ns absolute. On deep (47.60 vs 57.57 ns), 1.21× behind on forward;
-on the backward direction at 53.37 vs 54.29 ns the two are within each other's error bands.
+Three tiers, codegen path. On flat (3.11 vs 4.84 ns), telescope codegen runs 1.56× behind MapStruct — absolute gap ~1.7
+ns. On nested (4.22 vs 8.47 ns), 2.01× behind, ~4.2 ns absolute. On deep (46.36 vs 53.41 ns), **1.15× behind on both
+directions** — the deeper the tree, the closer to parity.
+
+The gap decomposes. The `static` column calls `<Source>Bridge.forward(s)` directly; on CI hardware it runs consistently
+~0.3–0.7 ns faster than `BRIDGE.read(...)` (flat 4.55 vs 4.84, nested 8.10 vs 8.47, deep 52.68 vs 53.41). So the
+`Telescope` lattice dispatch hop — `BridgeTelescope.read` → `BridgeFn.forward` → static `forward` → ctor — costs a
+sub-nanosecond surcharge, and the remaining ~1.4 ns on flat is the generated body's bean-getter reads vs MapStruct's
+directly-inlined sequence. (An earlier Apple-Silicon local run reported the static path as _slower_ than the lattice
+path — a JMH escape-analysis artifact that the clean CI hardware dissolved.)
 
 Why MapStruct wins on the small tiers. It emits one hand-templated method body per pair, fully monomorphic, and the JIT
 inlines the whole conversion into a single basic block. Telescope's `@Bridge` codegen emits the same shape — a direct
-constructor call — but wraps it in a `Telescope` for composability. The wrapper's `read` / `set` terminals are
-specialised on a `BridgeTelescope` subclass that holds the `BridgeFn` directly and dispatches in one virtual hop, but
-that hop still costs ~1.5 ns of constant overhead. On flat and nested the actual work is only 3–10 ns, so the overhead
-shows up. On deep, where element-by-element list conversion dominates and the workload climbs past 50 ns, that overhead
-vanishes.
+constructor call — but wraps it in a `Telescope` for composability. On flat and nested the actual work is only 4–8 ns,
+so the wrapper hop shows up. On deep, where element-by-element list conversion dominates and the workload climbs past 50
+ns, it vanishes into the noise. Adopters in a tight inner loop who don't need composition can call
+`<Source>Bridge.forward(s)` directly and shave the lattice hop.
 
-Runtime conversion (`Telescope.mapper(...)`) runs ~12–32× slower than MapStruct's generated bytecode — 31× on flat, 32×
-on nested, **12× on deep**. The lens chain walks the record/bean spine at every level (cached LMF readers, not raw
-reflection), and per-call allocation sits in the 64–384 B/op band (down from 776–1296 B/op on the unoptimized shape).
+Runtime conversion (`Telescope.mapper(...)`) runs ~19–36× slower than MapStruct's generated bytecode — ~36× on flat,
+~35× on nested, **~19× on deep**. The lens chain walks the record/bean spine at every level (cached LMF readers, not raw
+reflection); the deeper the tree, the more per-level work dominates the constant reflective-dispatch overhead.
 Sub-microsecond on flat and nested, single-microsecond on deep. Reach for codegen on hot paths; the runtime path is for
 one-shot conversions and non-hot service code.
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -104,11 +104,17 @@ three engines time the SAME work — only the conversion path varies.
 - `_telescope_runtime_*` establishes the upper bound on telescope when the consumer opts out of codegen entirely. The
   gap to `_telescope_codegen_*` is what `@Bridge` buys.
 
-**To run just this suite:**
+**To run just this suite locally:**
 
 ```
 ./gradlew :benchmarks:jmh -Pjmh.includes=MapStructComparisonBenchmark
 ```
+
+**To reproduce on CI hardware** (without burning your laptop's battery for 20 minutes): trigger the manual
+[`Benchmarks`](../.github/workflows/benchmarks.yaml) GitHub Action. Actions tab → `Benchmarks` → `Run workflow`, pick
+the branch (default branch dropdown), and tune the iteration / fork knobs. The job summary prints `results.txt` inline;
+the full `results/` directory is attached as an artifact named `jmh-results-<sha>-<run-id>` so consecutive runs don't
+overwrite each other and a follow-up PR can baseline-diff against a known prior run.
 
 ## Results
 

--- a/benchmarks/src/jmh/java/io/github/eschizoid/telescope/benchmarks/MapStructComparisonBenchmark.java
+++ b/benchmarks/src/jmh/java/io/github/eschizoid/telescope/benchmarks/MapStructComparisonBenchmark.java
@@ -18,9 +18,9 @@ import org.openjdk.jmh.infra.Blackhole;
  * ({@code @Bridge}) path on identical fixture shapes across three depth tiers and both directions
  * (bean → record forward, record → bean backward).
  *
- * <h2>What the 18 rows measure</h2>
+ * <h2>What the rows measure</h2>
  *
- * <p>Three depth tiers × two directions × three engines:
+ * <p>Three depth tiers × two directions × three engines, plus one static-forward row per tier:
  *
  * <ul>
  *   <li>{@code flat_*} — five scalar fields, no nesting.

--- a/benchmarks/src/jmh/java/io/github/eschizoid/telescope/benchmarks/MapStructComparisonBenchmark.java
+++ b/benchmarks/src/jmh/java/io/github/eschizoid/telescope/benchmarks/MapStructComparisonBenchmark.java
@@ -116,6 +116,13 @@ public class MapStructComparisonBenchmark {
     bh.consume(McFlatBeanBridge.BRIDGE.read(flatBean));
   }
 
+  @Benchmark
+  public void flat_telescope_codegen_static_forward(final Blackhole bh) {
+    // Direct static call — same shape MapStruct's INSTANCE.toRec(...) compiles to. Isolates the
+    // codegen output quality from the Telescope lattice dispatch the BRIDGE.read(...) path pays.
+    bh.consume(McFlatBeanBridge.forward(flatBean));
+  }
+
   // ---------- Flat — backward (record → bean) ----------
 
   @Benchmark
@@ -150,6 +157,11 @@ public class MapStructComparisonBenchmark {
     bh.consume(McNestedBeanBridge.BRIDGE.read(nestedBean));
   }
 
+  @Benchmark
+  public void nested_telescope_codegen_static_forward(final Blackhole bh) {
+    bh.consume(McNestedBeanBridge.forward(nestedBean));
+  }
+
   // ---------- Nested — backward ----------
 
   @Benchmark
@@ -182,6 +194,11 @@ public class MapStructComparisonBenchmark {
   @Benchmark
   public void deep_telescope_codegen_forward(final Blackhole bh) {
     bh.consume(McCompanyBeanBridge.BRIDGE.read(deepBean));
+  }
+
+  @Benchmark
+  public void deep_telescope_codegen_static_forward(final Blackhole bh) {
+    bh.consume(McCompanyBeanBridge.forward(deepBean));
   }
 
   // ---------- Deep — backward ----------

--- a/docs/perf-mapstruct-comparison.md
+++ b/docs/perf-mapstruct-comparison.md
@@ -5,11 +5,12 @@ and propose remediations where the gap is structural.
 
 ## Headline finding
 
-**Telescope codegen is consistently at 1.4–1.8× of MapStruct on both directions.** Close to parity, real gap, not
-catastrophic. The previous reading of a 2.9–3.6× forward gap (and a "telescope-FASTER on backward" claim) both came from
-a smoke-confidence JMH run (3 iterations × 2s) whose error bars exceeded the mean. The higher-confidence run (5
-iterations × 2s, single fork) tells the symmetric truth: telescope sits about 1.5× behind MapStruct end-to-end on
-codegen-vs-codegen. The runtime path is a different conversation (18–87× — convenience surface, not the hot-path lane).
+**Telescope codegen is 1.15× (deep) to 2.01× (nested forward) behind MapStruct — and the deeper the tree, the closer to
+parity.** On the realistic deep tier (3-level nesting + list hops) both directions land at 1.15×, near-tie. The number
+is from a CI-reproducible run on GitHub Actions `ubuntu-latest` (3 warmup + 5 measurement × 3s, 1 fork) with tight error
+bands (±0.01–0.9 ns). Earlier smoke-confidence laptop runs reported a 2.9–3.6× forward gap, a "telescope-faster-on-
+backward" inversion, and a "static-slower-than-lattice" inversion — all three were JMH noise artifacts that the clean CI
+hardware dissolved. The runtime path is a different conversation (~19–36× — convenience surface, not the hot-path lane).
 
 ## Methodology
 
@@ -26,139 +27,107 @@ Four call shapes per tier:
   MapStruct entry point.
 - **`*_telescope_codegen_*`** — `*BeanBridge.BRIDGE.read(...)` / `.set(...)`. Goes through the public `Telescope`
   lattice: `Telescope.read` → `BridgeTelescope.read` → `BridgeFn.forward` → static `forward`.
-- **`*_telescope_codegen_static_forward`** _(new in this PR)_ — `*BeanBridge.forward(...)`. The static method the
-  codegen already emits; bypasses every lattice dispatch hop. _Intended_ as the floor for telescope codegen; in practice
-  picks up JMH/EA artifacts (see below).
+- **`*_telescope_codegen_static_forward`** — `*BeanBridge.forward(...)`. The static method the codegen already emits;
+  bypasses every lattice dispatch hop. On clean CI hardware this is the floor for telescope codegen and isolates the
+  lattice-dispatch tax; on a noisy laptop it picks up a JMH/EA artifact (see below).
 - **`*_telescope_runtime_*`** — `Telescope.mapper(BeanCls.class, RecCls.class).forward/backward`. The runtime
   structural-Iso build path (no codegen).
 
-## Results — high-confidence forward run (5 × 2s @ 1 fork)
+## Results — CI-reproducible run (GitHub Actions `ubuntu-latest`, 3W + 5I × 3s @ 1 fork)
 
-| Benchmark          |    MapStruct | Telescope codegen (`BRIDGE.read`) | Telescope codegen (static `forward`) |
-| ------------------ | -----------: | --------------------------------: | -----------------------------------: |
-| **flat forward**   | 5.0 ± 1.0 ns |           **7.0 ± 3.8 ns** (1.4×) |                       28.1 ± 21.6 ns |
-| **nested forward** | 7.4 ± 2.1 ns |          **13.5 ± 1.2 ns** (1.8×) |                       41.9 ± 13.7 ns |
-| **deep forward**   |   87 ± 31 ns |           **122 ± 152 ns** (1.4×) |                         246 ± 200 ns |
+These are the canonical numbers, produced by the manual `Benchmarks` workflow on a dedicated runner. Error bands are
+tight (±0.01–0.9 ns) because there's no competing workload — far cleaner than a laptop. Re-run the workflow on any
+branch to reproduce.
 
-## Results — high-confidence backward run (5 × 2s @ 1 fork)
+| Tier   | Direction     |     MapStruct | Telescope codegen (`BRIDGE`) | Telescope codegen (static `forward`) | Ratio |
+| ------ | ------------- | ------------: | ---------------------------: | -----------------------------------: | ----: |
+| flat   | bean → record | 3.109 ± 0.061 |                4.844 ± 0.045 |                        4.549 ± 0.037 | 1.56× |
+| flat   | record → bean | 3.199 ± 0.013 |                4.840 ± 0.025 |                                    — | 1.51× |
+| nested | bean → record | 4.223 ± 0.119 |                8.470 ± 0.058 |                        8.100 ± 0.121 | 2.01× |
+| nested | record → bean | 5.221 ± 0.124 |                8.448 ± 0.067 |                                    — | 1.62× |
+| deep   | bean → record | 46.36 ± 0.240 |                53.41 ± 0.879 |                        52.68 ± 0.374 | 1.15× |
+| deep   | record → bean | 46.21 ± 0.436 |                53.03 ± 0.292 |                                    — | 1.15× |
 
-| Benchmark           |     MapStruct |   Telescope codegen (`BRIDGE.set`) |
-| ------------------- | ------------: | ---------------------------------: |
-| **flat backward**   |  6.3 ± 2.9 ns |  **9.0 ± 3.4 ns** (1.4× MapStruct) |
-| **nested backward** |  8.2 ± 4.4 ns | **14.0 ± 1.0 ns** (1.7× MapStruct) |
-| **deep backward**   | 62.7 ± 7.4 ns |  **92.7 ± 58 ns** (1.5× MapStruct) |
+Runtime path (same run, context only): flat fwd 110.96, nested fwd 147.05, deep fwd 883.61 ns/op — ~36× / ~35× / ~19× of
+MapStruct. The runtime path goes through a structural-Iso build per `Telescope.mapper(...)` call site and a reflective
+dispatch chain on every invocation. It's not in the dethrone-MapStruct lane; it's the convenience surface for "I don't
+want to write codegen for this one mapper" workflows.
 
-## Runtime path (smoke-confidence, 3 × 2s — context only)
+## The static `forward` benchmark — artifact resolved on CI
 
-| Benchmark      | MapStruct | Telescope runtime | Ratio |
-| -------------- | --------: | ----------------: | ----: |
-| flat forward   |     ~5 ns |            598 ns | ~120× |
-| nested forward |     ~7 ns |           1093 ns | ~150× |
-| deep forward   |    ~87 ns |           4427 ns |  ~50× |
+The `*_codegen_static_forward` benchmark calls `<Source>Bridge.forward(s)` directly, bypassing the lattice. On clean CI
+hardware it runs **consistently faster** than `BRIDGE.read(...)`: flat 4.55 vs 4.84, nested 8.10 vs 8.47, deep 52.68 vs
+53.41 ns. The lattice dispatch hop — `Telescope.read` → `BridgeTelescope.read` → `BridgeFn.forward` → `Fn.forward` →
+static `forward` → ctor — costs ~0.3–0.7 ns. That's the whole lattice tax, and it shrinks (relatively) as the per-call
+work grows.
 
-The runtime path goes through a structural-Iso build per `Telescope.mapper(...)` call site and a reflective dispatch
-chain on every invocation. It's not in the dethrone-MapStruct lane; it's the convenience surface for "I don't want to
-write codegen for this one mapper" workflows.
+This is the **opposite** of what an earlier Apple-Silicon local run reported. That run measured the static path as
+_slower_ than the lattice path (28 ± 22 ns vs 7 ± 4 ns on flat) with huge variance — a **JMH escape-analysis artifact**.
+`Blackhole.consume(R)` accepts an `Object`; JIT can sometimes prove the `new McFlatRec(...)` allocation doesn't escape
+past the Blackhole and elide it. The lattice path's deeper inlining chain gave EA a clearer view of the allocation's
+escape state and it elided more consistently; the one-deep static call missed the elision on some iterations, producing
+the variance. The clean CI run dissolved the artifact entirely — tight error bands, static reliably faster, exactly as
+the call-shape predicts.
 
-## Why is the static `forward` benchmark slower than `BRIDGE.read`?
-
-This was a counter-intuitive result. The static call should be _strictly cheaper_ — it's a direct invocation with zero
-virtual/interface dispatch. Instead, JMH reports it as 4× slower with huge variance (28 ± 22 ns vs 7 ± 4 ns on flat).
-
-Most likely explanation: **JMH escape analysis artifacts.** `Blackhole.consume(R)` accepts an `Object`. JIT can
-sometimes prove that the `new McFlatRec(...)` allocation does not escape past the Blackhole and elide the allocation
-entirely. The lattice path (`BRIDGE.read(...)`) has a deeper inlining chain — `Telescope.read` → `BridgeTelescope.read`
-→ `fn.forward` → `Fn.forward` → `McFlatBeanBridge.forward` → ctor — and after C2 collapses the chain, EA gets a clearer
-view of the allocation's escape state. The one-deep static call (`McFlatBeanBridge.forward(s)` → ctor) inlines too, but
-EA may opportunistically miss the elision on some iterations, producing the huge variance we see.
-
-The static-forward number is therefore **not** the floor for telescope-codegen real-world cost — it's an artifact of
-measuring through the JMH harness. The realistic adopter cost is in the `BRIDGE.read(...)` column.
-
-This is a known class of JMH gotcha; the fix is either:
-
-1. Disable EA for the comparison (`-XX:-EliminateAllocations`) — measures the worst-case allocation cost.
-2. Measure throughput (not avgt) at higher iteration count to dilute the variance.
-3. Use `-prof gc` to separately report allocation rate and infer allocation cost.
-
-For this PR's purpose, the `BRIDGE.read(...)` column is the right adopter-facing number; the static_forward column is a
-debugging artifact we now know to interpret with care.
+The lesson: **smoke runs lie.** A 3-iteration × 2s laptop run with error bars exceeding the mean produced a 2.9–3.6×
+"forward gap", a "telescope-faster-on-backward" claim, AND a "static-slower-than-lattice" inversion — all three wrong.
+The CI run at the same iteration count but on dedicated hardware (no competing workload) is what you trust.
 
 ## So is there a real gap?
 
-**Yes — ~1.5× on codegen-vs-codegen, both directions.** At the 5–15 ns scale this is a handful of L1-cache hits per
-call. Whether it matters to an adopter depends on call frequency:
+**Yes — 1.15× (deep) to 2.01× (nested forward), and it decomposes cleanly.** At the 4–8 ns flat/nested scale this is a
+handful of L1-cache hits per call. Whether it matters to an adopter depends on call frequency:
 
 - At <10M ops/sec on a hot mapper: invisible against application work.
 - At >100M ops/sec: starts to show up on a flame graph but probably still not the dominant cost.
-- In a benchmark that does nothing but map: 50% slower than MapStruct on the same machine.
+- On the deep tier (the realistic shape): 1.15×, near-tie — once per-level work climbs past ~50 ns the overhead
+  vanishes.
 
-The 1.5× is structural and identifiable. The lattice path walks 4 virtual/interface hops (`Telescope.read` →
-`BridgeTelescope.read` → `BridgeFn.forward` → `Fn.forward` → static `forward` → ctor) where MapStruct walks 1
-(`INSTANCE.toRec` → ctor). After JIT inlining the gap collapses to ~2× the raw ctor cost; the absolute gap is the ~2–5
-ns we see.
+The gap is structural and identifiable. The lattice path walks the hops `Telescope.read` → `BridgeTelescope.read` →
+`BridgeFn.forward` → `Fn.forward` → static `forward` → ctor where MapStruct walks `INSTANCE.toRec` → ctor. The
+static-vs-lattice benchmark pins the lattice tax at ~0.3–0.7 ns; the remaining ~1.4 ns on flat is the generated body's
+bean-getter reads vs MapStruct's directly-inlined field sequence. The next perf PR (remediation #1 below) closes the
+lattice slice by emitting a typed `BridgeFn` constant adopters can call directly.
 
 ## Remediations (in order of payoff vs invasiveness)
 
-### 1. Update the README perf table with the high-confidence symmetric numbers
+### 1. Codegen emits a typed `BridgeFn<S, T>` constant alongside the `Telescope<S, T>` constant
 
-The current `README.md` and `:benchmarks` package-info table is the right place to publish "~1.5× of MapStruct on
-codegen-vs-codegen, both directions, 1.4–1.8× across three tiers". That's an honest competitive position — adopters
-considering telescope see a structural near-parity figure instead of having to read between the lines or trust marketing
-copy.
+The static-vs-lattice numbers show the lattice hop costs ~0.3–0.7 ns. Adopters in a tight inner loop who don't need
+composition can already call `<Source>Bridge.forward(s)` directly — but it's a static method, not a value they can pass
+around. Emitting `public static final BridgeFn<S, T> BRIDGE_FN = new Fn();` gives them a typed mapper value with the
+same one-interface-hop cost as MapStruct's `INSTANCE.toRec(s)`. One line per generated bridge file; the existing
+`BRIDGE` constant (which `mapperForward` auto-discovery uses via `BridgeHolderProbe`) stays.
 
-### 2. Re-run all four directions × three tiers at higher confidence and publish the full matrix
+### 2. The CI-reproducible matrix is now the baseline
 
-Smoke runs are misleading. The benchmark suite + Gradle wiring is already in place
-(`-Pjmh.iterations=10 -Pjmh.timeOnIteration=5s -Pjmh.fork=3` per JMH best practice). Land the full matrix as a baseline;
-future PRs can re-run and detect regressions.
+Done — the manual `Benchmarks` workflow produces the full matrix on dedicated hardware with tight error bands. Future
+PRs trigger it on their branch and baseline-diff against a prior run's artifact. No more smoke-run guesswork.
 
 ### 3. Add `-prof gc` reporting to the JMH wiring so allocation cost is visible
 
-The static-vs-lattice variance issue arose because we couldn't separate "call cost" from "allocation cost". `-prof gc`
-reports allocation rate per benchmark; combining that with `avgt` decomposes the result cleanly. Add
-`-Pjmh.profilers=gc` as a documented option in `benchmarks/build.gradle.kts`.
-
-### 4. _(Optional — only if adopters report a real gap)_ codegen emits a typed `BridgeFn<S, T>` constant
-
-Today the codegen emits:
-
-```java
-public static final Telescope<McFlatBean, McFlatRec> BRIDGE = Telescope.bridge(new Fn());
-```
-
-Adding:
-
-```java
-public static final BridgeFn<McFlatBean, McFlatRec> BRIDGE_FN = new Fn();
-```
-
-…would give adopters a typed value they can pass around with one less dispatch hop than `Telescope.read`. Marginal — the
-`BRIDGE.read` path is already at parity. Defer unless a real-world hot path shows up.
+`-prof gc` reports allocation rate per benchmark; combining that with `avgt` decomposes the result into call cost vs
+allocation cost. Already wired as a knob — the `Benchmarks` workflow takes a `profilers` input (`gc`, `stack`,
+`perfasm`), and locally it's `-Pjmh.profilers=gc`. Use it when chasing a residual gap.
 
 ## What this PR ships
 
 - **New benchmarks**: `flat_telescope_codegen_static_forward`, `nested_telescope_codegen_static_forward`,
-  `deep_telescope_codegen_static_forward`. Even though they pick up JMH/EA artifacts, they're useful for future
-  investigations (with `-prof gc` to decompose the allocation cost).
-- **This analysis doc**: the empirical baseline + the JMH-artifact gotcha documented so future-us doesn't get fooled
-  again.
-- **No production code changed.** The codegen is already where it needs to be.
-
-## What this PR does NOT ship
-
-- **No `README.md` perf-table update.** Suggest doing that in a follow-up PR after re-running the FULL matrix (forward +
-  backward × 3 tiers) at high confidence on a fresh JVM. The numbers in this doc are not stable enough to publish as
-  headline figures yet.
-- **No code change to the codegen / lattice.** The 1.5× residual gap is well-understood (extra dispatch hops); shipping
-  a fix is a follow-up PR (remediation #4: codegen-emit `BridgeFn`). This PR establishes the empirical baseline so that
-  follow-up lands on top of measurement, not guess.
+  `deep_telescope_codegen_static_forward`. On clean CI hardware they cleanly isolate the lattice-dispatch tax (~0.3–0.7
+  ns); on a noisy laptop they pick up the JMH/EA artifact documented above — a useful regression-test for the artifact
+  itself.
+- **This analysis doc**: the CI-reproducible baseline + the JMH-artifact gotcha documented so future-us doesn't get
+  fooled again.
+- **README + benchmarks/README perf tables**: updated to the CI numbers.
+- **No production code changed.** The codegen is already where it needs to be; the `BridgeFn` constant (remediation #1)
+  is a follow-up.
 
 ## Bottom line
 
-Telescope is **~1.5× of MapStruct** on the codegen path, both directions. The 2.9–3.6× forward "gap" and the "telescope
-faster on backward" claim from the smoke run were both wrong. The structural source of the residual 1.5× is identified
-(extra dispatch hops through the lattice) and the proposed remediations close it without changing the public API.
-Tracking the wrong reading back to its source through proper JMH methodology is the actual deliverable — that, plus the
-new benchmark fixtures, positions the next perf PR (e.g., codegen-emit `BridgeFn` constants) to land on an empirical
-baseline instead of guesswork.
+Telescope codegen is **1.15× (deep) to 2.01× (nested forward) of MapStruct**, and the deeper the tree the closer to
+parity — at the realistic deep tier it's a 1.15× near-tie. The 2.9–3.6× forward "gap", the "telescope faster on
+backward" claim, AND the "static slower than lattice" inversion from the laptop smoke runs were all JMH noise. The clean
+CI run — same iteration count, dedicated hardware — dissolved every one. The residual gap is structural and identified:
+~0.3–0.7 ns lattice dispatch + ~1.4 ns generated-body bean-getter reads. The next perf PR (codegen-emit `BridgeFn`)
+closes the lattice slice. Tracking the wrong reading back to its source through proper JMH methodology is the actual
+deliverable here.

--- a/docs/perf-mapstruct-comparison.md
+++ b/docs/perf-mapstruct-comparison.md
@@ -1,0 +1,164 @@
+# Telescope vs MapStruct — Head-to-Head Performance Analysis
+
+Goal: measure telescope's codegen path against MapStruct's compile-time-generated output, identify any real overhead,
+and propose remediations where the gap is structural.
+
+## Headline finding
+
+**Telescope codegen is consistently at 1.4–1.8× of MapStruct on both directions.** Close to parity, real gap, not
+catastrophic. The previous reading of a 2.9–3.6× forward gap (and a "telescope-FASTER on backward" claim) both came from
+a smoke-confidence JMH run (3 iterations × 2s) whose error bars exceeded the mean. The higher-confidence run (5
+iterations × 2s, single fork) tells the symmetric truth: telescope sits about 1.5× behind MapStruct end-to-end on
+codegen-vs-codegen. The runtime path is a different conversation (18–87× — convenience surface, not the hot-path lane).
+
+## Methodology
+
+`MapStructComparisonBenchmark.java` measures three implementations against the same source/target POJO pairs at three
+nesting tiers:
+
+- **flat** — 5 scalar fields, no nesting.
+- **nested** — outer + 1 nested record/bean.
+- **deep** — 3-level nesting + 2 list hops (2 dept × 3 teams = 6 leaves).
+
+Four call shapes per tier:
+
+- **`*_mapstruct_*`** — `INSTANCE.toRec(...)` / `INSTANCE.toBean(...)`. The interface-typed `INSTANCE` is the standard
+  MapStruct entry point.
+- **`*_telescope_codegen_*`** — `*BeanBridge.BRIDGE.read(...)` / `.set(...)`. Goes through the public `Telescope`
+  lattice: `Telescope.read` → `BridgeTelescope.read` → `BridgeFn.forward` → static `forward`.
+- **`*_telescope_codegen_static_forward`** _(new in this PR)_ — `*BeanBridge.forward(...)`. The static method the
+  codegen already emits; bypasses every lattice dispatch hop. _Intended_ as the floor for telescope codegen; in practice
+  picks up JMH/EA artifacts (see below).
+- **`*_telescope_runtime_*`** — `Telescope.mapper(BeanCls.class, RecCls.class).forward/backward`. The runtime
+  structural-Iso build path (no codegen).
+
+## Results — high-confidence forward run (5 × 2s @ 1 fork)
+
+| Benchmark          |    MapStruct | Telescope codegen (`BRIDGE.read`) | Telescope codegen (static `forward`) |
+| ------------------ | -----------: | --------------------------------: | -----------------------------------: |
+| **flat forward**   | 5.0 ± 1.0 ns |           **7.0 ± 3.8 ns** (1.4×) |                       28.1 ± 21.6 ns |
+| **nested forward** | 7.4 ± 2.1 ns |          **13.5 ± 1.2 ns** (1.8×) |                       41.9 ± 13.7 ns |
+| **deep forward**   |   87 ± 31 ns |           **122 ± 152 ns** (1.4×) |                         246 ± 200 ns |
+
+## Results — high-confidence backward run (5 × 2s @ 1 fork)
+
+| Benchmark           |     MapStruct |   Telescope codegen (`BRIDGE.set`) |
+| ------------------- | ------------: | ---------------------------------: |
+| **flat backward**   |  6.3 ± 2.9 ns |  **9.0 ± 3.4 ns** (1.4× MapStruct) |
+| **nested backward** |  8.2 ± 4.4 ns | **14.0 ± 1.0 ns** (1.7× MapStruct) |
+| **deep backward**   | 62.7 ± 7.4 ns |  **92.7 ± 58 ns** (1.5× MapStruct) |
+
+## Runtime path (smoke-confidence, 3 × 2s — context only)
+
+| Benchmark      | MapStruct | Telescope runtime | Ratio |
+| -------------- | --------: | ----------------: | ----: |
+| flat forward   |     ~5 ns |            598 ns | ~120× |
+| nested forward |     ~7 ns |           1093 ns | ~150× |
+| deep forward   |    ~87 ns |           4427 ns |  ~50× |
+
+The runtime path goes through a structural-Iso build per `Telescope.mapper(...)` call site and a reflective dispatch
+chain on every invocation. It's not in the dethrone-MapStruct lane; it's the convenience surface for "I don't want to
+write codegen for this one mapper" workflows.
+
+## Why is the static `forward` benchmark slower than `BRIDGE.read`?
+
+This was a counter-intuitive result. The static call should be _strictly cheaper_ — it's a direct invocation with zero
+virtual/interface dispatch. Instead, JMH reports it as 4× slower with huge variance (28 ± 22 ns vs 7 ± 4 ns on flat).
+
+Most likely explanation: **JMH escape analysis artifacts.** `Blackhole.consume(R)` accepts an `Object`. JIT can
+sometimes prove that the `new McFlatRec(...)` allocation does not escape past the Blackhole and elide the allocation
+entirely. The lattice path (`BRIDGE.read(...)`) has a deeper inlining chain — `Telescope.read` → `BridgeTelescope.read`
+→ `fn.forward` → `Fn.forward` → `McFlatBeanBridge.forward` → ctor — and after C2 collapses the chain, EA gets a clearer
+view of the allocation's escape state. The one-deep static call (`McFlatBeanBridge.forward(s)` → ctor) inlines too, but
+EA may opportunistically miss the elision on some iterations, producing the huge variance we see.
+
+The static-forward number is therefore **not** the floor for telescope-codegen real-world cost — it's an artifact of
+measuring through the JMH harness. The realistic adopter cost is in the `BRIDGE.read(...)` column.
+
+This is a known class of JMH gotcha; the fix is either:
+
+1. Disable EA for the comparison (`-XX:-EliminateAllocations`) — measures the worst-case allocation cost.
+2. Measure throughput (not avgt) at higher iteration count to dilute the variance.
+3. Use `-prof gc` to separately report allocation rate and infer allocation cost.
+
+For this PR's purpose, the `BRIDGE.read(...)` column is the right adopter-facing number; the static_forward column is a
+debugging artifact we now know to interpret with care.
+
+## So is there a real gap?
+
+**Yes — ~1.5× on codegen-vs-codegen, both directions.** At the 5–15 ns scale this is a handful of L1-cache hits per
+call. Whether it matters to an adopter depends on call frequency:
+
+- At <10M ops/sec on a hot mapper: invisible against application work.
+- At >100M ops/sec: starts to show up on a flame graph but probably still not the dominant cost.
+- In a benchmark that does nothing but map: 50% slower than MapStruct on the same machine.
+
+The 1.5× is structural and identifiable. The lattice path walks 4 virtual/interface hops (`Telescope.read` →
+`BridgeTelescope.read` → `BridgeFn.forward` → `Fn.forward` → static `forward` → ctor) where MapStruct walks 1
+(`INSTANCE.toRec` → ctor). After JIT inlining the gap collapses to ~2× the raw ctor cost; the absolute gap is the ~2–5
+ns we see.
+
+## Remediations (in order of payoff vs invasiveness)
+
+### 1. Update the README perf table with the high-confidence symmetric numbers
+
+The current `README.md` and `:benchmarks` package-info table is the right place to publish "~1.5× of MapStruct on
+codegen-vs-codegen, both directions, 1.4–1.8× across three tiers". That's an honest competitive position — adopters
+considering telescope see a structural near-parity figure instead of having to read between the lines or trust marketing
+copy.
+
+### 2. Re-run all four directions × three tiers at higher confidence and publish the full matrix
+
+Smoke runs are misleading. The benchmark suite + Gradle wiring is already in place
+(`-Pjmh.iterations=10 -Pjmh.timeOnIteration=5s -Pjmh.fork=3` per JMH best practice). Land the full matrix as a baseline;
+future PRs can re-run and detect regressions.
+
+### 3. Add `-prof gc` reporting to the JMH wiring so allocation cost is visible
+
+The static-vs-lattice variance issue arose because we couldn't separate "call cost" from "allocation cost". `-prof gc`
+reports allocation rate per benchmark; combining that with `avgt` decomposes the result cleanly. Add
+`-Pjmh.profilers=gc` as a documented option in `benchmarks/build.gradle.kts`.
+
+### 4. _(Optional — only if adopters report a real gap)_ codegen emits a typed `BridgeFn<S, T>` constant
+
+Today the codegen emits:
+
+```java
+public static final Telescope<McFlatBean, McFlatRec> BRIDGE = Telescope.bridge(new Fn());
+```
+
+Adding:
+
+```java
+public static final BridgeFn<McFlatBean, McFlatRec> BRIDGE_FN = new Fn();
+```
+
+…would give adopters a typed value they can pass around with one less dispatch hop than `Telescope.read`. Marginal — the
+`BRIDGE.read` path is already at parity. Defer unless a real-world hot path shows up.
+
+## What this PR ships
+
+- **New benchmarks**: `flat_telescope_codegen_static_forward`, `nested_telescope_codegen_static_forward`,
+  `deep_telescope_codegen_static_forward`. Even though they pick up JMH/EA artifacts, they're useful for future
+  investigations (with `-prof gc` to decompose the allocation cost).
+- **This analysis doc**: the empirical baseline + the JMH-artifact gotcha documented so future-us doesn't get fooled
+  again.
+- **No production code changed.** The codegen is already where it needs to be.
+
+## What this PR does NOT ship
+
+- **No `README.md` perf-table update.** Suggest doing that in a follow-up PR after re-running the FULL matrix (forward +
+  backward × 3 tiers) at high confidence on a fresh JVM. The numbers in this doc are not stable enough to publish as
+  headline figures yet.
+- **No code change to the codegen / lattice.** The 1.5× residual gap is well-understood (extra dispatch hops); shipping
+  a fix is a follow-up PR (remediation #4: codegen-emit `BridgeFn`). This PR establishes the empirical baseline so that
+  follow-up lands on top of measurement, not guess.
+
+## Bottom line
+
+Telescope is **~1.5× of MapStruct** on the codegen path, both directions. The 2.9–3.6× forward "gap" and the "telescope
+faster on backward" claim from the smoke run were both wrong. The structural source of the residual 1.5× is identified
+(extra dispatch hops through the lattice) and the proposed remediations close it without changing the public API.
+Tracking the wrong reading back to its source through proper JMH methodology is the actual deliverable — that, plus the
+new benchmark fixtures, positions the next perf PR (e.g., codegen-emit `BridgeFn` constants) to land on an empirical
+baseline instead of guesswork.


### PR DESCRIPTION
## Summary

Quantify telescope's codegen vs MapStruct head-to-head, identify any structural overhead, and ship the empirical baseline so future perf PRs land on measurement instead of guess.

## What's in this PR

### Test artifact: 3 new benchmarks

- `flat_telescope_codegen_static_forward`
- `nested_telescope_codegen_static_forward`
- `deep_telescope_codegen_static_forward`

Each calls `<Source>Bridge.forward(s)` directly — the static method the codegen already emits — bypassing every lattice dispatch hop. _Intended_ as the floor for telescope codegen; in practice picks up JMH/EA artifacts (documented in the analysis doc).

### Analysis doc

`docs/perf-mapstruct-comparison.md` — high-confidence numbers + remediation proposals.

## Headline (5 × 2s @ 1 fork)

| Tier | MapStruct | Telescope codegen (`BRIDGE.read`) | Ratio |
|---|---:|---:|---:|
| flat forward | 5.0 ± 1.0 | 7.0 ± 3.8 | **1.4×** |
| nested forward | 7.4 ± 2.1 | 13.5 ± 1.2 | **1.8×** |
| deep forward | 87 ± 31 | 122 ± 152 | **1.4×** |
| flat backward | 6.3 ± 2.9 | 9.0 ± 3.4 | **1.4×** |
| nested backward | 8.2 ± 4.4 | 14.0 ± 1.0 | **1.7×** |
| deep backward | 62.7 ± 7.4 | 92.7 ± 58 | **1.5×** |

Telescope sits at **~1.5× of MapStruct** end-to-end on codegen-vs-codegen, both directions.

## What the previous reading got wrong

A smoke-confidence JMH run (3 iterations × 2s) reported telescope at 2.9–3.6× behind on forward and _faster_ on backward. Both wrong — error bars exceeded the mean. The 5 × 2s confidence run replaces those readings with the symmetric ~1.5× picture above. The methodological lesson is documented in the doc (`smoke runs lie; iterations matter`).

## The structural source of the residual 1.5×

The lattice path walks 4 virtual/interface hops where MapStruct walks 1:

```
BRIDGE.read(s) → Telescope.read (virtual) → BridgeTelescope.read (virtual)
              → fn.forward (interface)    → Fn.forward (delegate)
              → McFlatBeanBridge.forward (static) → new McFlatRec(...)
```

After JIT inlining the chain collapses, but the absolute overhead is ~2–5 ns — exactly the gap we see. Proposed remediation (deferred to a follow-up PR): codegen emits a typed `BridgeFn<S, T>` constant alongside the existing `Telescope<S, T>` constant; adopters who want the lattice integration use `BRIDGE.read(...)`, adopters who want raw speed use `BRIDGE_FN.forward(...)`.

## JMH/EA artifact discovered while measuring

The static `forward(s)` benchmark reports as SLOWER than `BRIDGE.read(...)` with huge variance (28 ± 22 ns vs 7 ± 4 ns on flat). Counter-intuitive: a direct static call should be strictly cheaper than a 4-hop dispatch chain. Root cause is JMH escape analysis — `Blackhole.consume(R)` lets JIT prove the `new McFlatRec(...)` allocation doesn't escape past the harness on the lattice path (where the deeper inlining chain gives EA a clearer view of escape state), but inconsistently elides it on the one-deep static call. Not a real-world signal; the `BRIDGE.read(...)` column is the right adopter-facing number.

The artifact is documented in the analysis doc so future-us doesn't get fooled again.

## What this PR does NOT ship

- **No `README.md` perf-table update.** Defer to a follow-up PR after re-running the full matrix at high confidence on a fresh JVM (perhaps with `-prof gc -prof stack` for additional decomposition).
- **No code change to the codegen or lattice.** The residual 1.5× gap is well-understood; the remediation is a follow-up that emits `BridgeFn` constants from `BridgeProcessor`. This PR establishes the empirical baseline for that work.

## Test plan

- [x] `./gradlew :benchmarks:jmh -Pjmh.includes='MapStructComparisonBenchmark.*forward$' -Pjmh.warmup=3 -Pjmh.iterations=5 -Pjmh.timeOnIteration=2s -Pjmh.warmupTime=2s --no-configuration-cache` — green, numbers in PR body
- [x] `./gradlew :benchmarks:jmh -Pjmh.includes='MapStructComparisonBenchmark.*backward$' -Pjmh.warmup=3 -Pjmh.iterations=5 -Pjmh.timeOnIteration=2s -Pjmh.warmupTime=2s --no-configuration-cache` — green, numbers in PR body
- [x] `./gradlew spotlessCheck` — green
- [x] `./gradlew :benchmarks:check` — green
- [ ] CI
