### PR TITLE
docs: grammar + style pass on both READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,11 +284,11 @@ capability lists, vs-MapStruct callouts, and benchmark cross-links.
   typed optics: method-reference rows the compiler checks, bidirectional from one declaration, runtime _or_ codegen, and
   mapping is one capability among navigation, deep update, effectful update, and sealed dispatch. The codegen path runs
   at the **same performance class** — a tie at real-service depth (see [How it compares](#how-it-compares-to-mapstruct))
-  — over a strictly larger, more modern surface. It covers every common `@Mapping(...)` shape (same-name auto, renames,
+  — over a strictly larger, more modern surface. It covers every common `@Mapping(...)` shape — same-name auto, renames,
   typed transforms, nested mappers, flat → nested-path correspondences, eager literals, computed values, forward-only
   mappers, multi-source merge, by-name enum mapping, null-coalescing defaults, lifecycle hooks, Spring/Quarkus
-  autoconfig) plus the shapes MapStruct's architecture can't express. MapStruct still leads on raw maturity and a
-  handful of declarative features (inline `expression = "java(...)"` bodies, qualifier dispatch, full
+  autoconfig. And it reaches the shapes MapStruct's architecture can't express. MapStruct still leads on raw maturity
+  and a handful of declarative features (inline `expression = "java(...)"` bodies, qualifier dispatch, full
   `@SubclassMapping`, `@MappingTarget` update-in-place);
   [When MapStruct is the right pick](#when-mapstruct-is-the-right-pick) is honest about those. The
   [full row-by-row comparison](#how-it-compares-to-mapstruct) has the rest.
@@ -316,9 +316,9 @@ architecture stops. Two questions decide it — is it as fast, and what do you g
 #### First, the performance objection — settled
 
 **At the codegen level, telescope and MapStruct are the same performance class.** Both annotation processors emit direct
-constructor + accessor calls the JIT inlines into one tight basic block. On the shape real services run — deeply nested
-records with lists inside — they are a **tie**: 1.15×, about 7 ns on a 47 ns conversion. On a trivial flat 5-field
-struct MapStruct's hand-templated body is ~1.7 ns quicker (1.5×). At that scale you are choosing on **API and
+constructor and accessor calls the JIT inlines into one tight basic block. On the shape real services run — deeply
+nested records with lists inside — they are a **tie**: 1.15×, about 7 ns on a 47 ns conversion. On a trivial flat
+5-field struct MapStruct's hand-templated body is ~1.7 ns quicker (1.5×). At that scale you are choosing on **API and
 capability, not nanoseconds.**
 
 | Tier (codegen vs codegen)       | telescope vs MapStruct                                                           |
@@ -567,7 +567,7 @@ code. `telescope-codegen` is compile-time-only and isn't on the runtime module p
 
 **Codegen escape hatch.** The `@Focus` / `@BeanFocus` / `@Bridge` processors emit compile-time navigators that read
 components and call constructors / builders / setters directly — no `privateLookupIn`, no `LambdaMetafactory`, no
-`opens` requirement. If adding the `opens` is awkward (e.g. a downstream module you don't own), the codegen path
+`opens` requirement. If adding the `opens` is awkward (e.g., a downstream module you don't own), the codegen path
 sidesteps the JPMS constraint entirely. See
 [Compile-time, reflection-free navigation](#compile-time-reflection-free-navigation-focus--beanfocus).
 
@@ -969,7 +969,7 @@ Telescope.mapper(
 );
 ```
 
-The `via(...)` row works in two flavours: pass an **accessor-typed** mapper (e.g.
+The `via(...)` row works in two flavors: pass an **accessor-typed** mapper (e.g.,
 `Mapper<List<UserEntity>, List<UserDto>>`) and telescope uses it as-is, or pass an **element-typed** mapper
 (`Mapper<UserEntity, UserDto>`) and telescope detects the accessor's container shape (`List`, `Set`, `Optional`, `Map`
 values) and auto-lifts the mapper through it via `Iso.liftList` / `liftSet` / `liftOptional` / `liftMapValues`. One row
@@ -1007,7 +1007,7 @@ at every type pair the recursion encounters. The alternative is to navigate the 
 ### Convert — `Telescope.map` / `Telescope.mapper`
 
 The same factory described under [Type conversion](#type-conversion) handles POJO↔POJO and cross-paradigm record↔POJO
-pairs without ceremony — components match by name on either side (`Pojo::getX` / `RecordOrPojo::x` normalised to `x`),
+pairs without ceremony — components match by name on either side (`Pojo::getX` / `RecordOrPojo::x` normalized to `x`),
 nested POJOs recurse, and container hops auto-lift. The POJO mechanics this section covers are the bean-construction
 lever (`writeBean` / `writeBeans`) for when the auto-detect ladder can't pick a strategy.
 
@@ -1022,7 +1022,7 @@ class LegacyUser {
 
 record UserRecord(String id, String email, String name) {}
 
-// Same-name 1-liner — every getter/component lines up by normalised name.
+// Same-name 1-liner — every getter/component lines up by normalized name.
 final Telescope<LegacyUser, UserRecord> bridge = Telescope.map(LegacyUser.class, UserRecord.class);
 ```
 
@@ -1108,7 +1108,7 @@ Telescope.of(Page.class)
     .update(page, String::toLowerCase);
 ```
 
-For a worked end-to-end demo using every public Mapping / Mapper / Telescope row through a Spring Boot 4 + Hibernate +
+For a worked end-to-end demo using every public Mapping / Mapper / Telescope row through a Spring Boot 4, Hibernate, and
 Jackson REST pipeline, see [`examples/springboot/`](examples/springboot/).
 
 **`@Bridge` — reflection-free, compile-checked (any pair).** The codegen counterpart to `Telescope.map(...)`. Annotate
@@ -1193,7 +1193,7 @@ field-injection fallback) uses `setAccessible`, so under JPMS the POJO's package
 ## Compile-time, reflection-free navigation (`@Focus` / `@BeanFocus`)
 
 The reflection-based `Telescope.of(User.class).field(User::name)` path resolves the field name at runtime — fast enough
-for ordinary use (~100ns), but a typo or a rename surfaces as a runtime error, not a compile error. Annotate the types
+for ordinary use (~100 ns), but a typo or a rename surfaces as a runtime error, not a compile error. Annotate the types
 you navigate with `@Focus` (records) or `@BeanFocus` (POJOs) and add the processor to your build; for each annotated
 type the processor emits a sibling **fluent typed path navigator** that reads like the runtime DSL but is fully
 compile-checked and reflection-free.
@@ -1310,7 +1310,7 @@ UserBeanPath.of().email().update(user, String::toLowerCase);   // no reflection
 
 The same path that powers `.update(...)` lifts through four effects with one method change: **async**,
 **all-or-nothing**, **short-circuit**, and **error-accumulating**. Validate every email in a `Batch` and report all the
-bad ones in one call? Two lines. Run an HTTP normalisation call for every focused element with bounded concurrency? Pass
+bad ones in one call? Two lines. Run an HTTP normalization call for every focused element with bounded concurrency? Pass
 an `Executor`. The DSL writes the structural plumbing; you supply the per-element function.
 
 Pick the method by the function you have — the type system picks the applicative. Chaining stages of different effects
@@ -1331,7 +1331,8 @@ is handled by the bridge methods on `Either` / `Validated`; see [Chaining stages
 - Use **`updateEither`** when failures should _halt work_: parsers where a malformed root makes children meaningless,
   dependent stages, expensive per-element calls. Subsequent elements are never even called.
 - Use **`updateValidated`** when you want _every_ problem reported: form validation (show the user every wrong field at
-  once), batch quality reports, cheap predicates over many elements. Every element is processed; failures are collected.
+  once), batch quality reports, lightweight predicates over many elements. Every element is processed; failures are
+  collected.
 
 The difference is control flow, not just result shape. You can't recover short-circuit behavior by post-converting a
 Validated result, and you can't recover all-errors reporting from an Either that stopped after the first failure.
@@ -1391,8 +1392,8 @@ final Either<ParseError, Batch> result = ALL_EMAILS.updateEither(batch, EmailPar
 return result.fold(this::respondError, this::save);
 ```
 
-The first email that fails to parse wins; subsequent emails aren't even called. Use this when the first failure is
-enough — it's strictly cheaper than `updateValidated` because there's no accumulation.
+The first email that fails to parse wins; later emails aren't even called. Use this when the first failure is enough —
+it's strictly cheaper than `updateValidated` because there's no accumulation.
 
 **`updateOptional` — all-or-nothing.**
 
@@ -1504,12 +1505,12 @@ return afterUsers.flatMapAsync(ok -> enrichPath.updateAsync(ok, this::enrich));
    `each(Team::users)` works without a type witness — `Team::users` has compile-time type `Function<Team, List<User>>`
    and Java unifies `E = User`.
 4. **Reflection cost.** Field access uses `RecordComponent.getAccessor().invoke(...)` and the canonical constructor —
-   roughly ~100ns per reflective field access, vs ~10ns for a hand-written record copy; the reflection-free `lens` path
-   (`@Focus` codegen) sits in between. Fine for almost everything; matters for tight loops. See
+   roughly ~100 ns per reflective field access, vs ~10 ns for a hand-written record copy; the reflection-free `lens`
+   path (`@Focus` codegen) sits in between. Fine for almost everything; matters for tight loops. See
    [`benchmarks/`](benchmarks/README.md) for measured numbers.
 5. **Sibling-context updates close over the source.** A plain `update` lambda only sees the focused value. If you need
-   to read sibling fields (e.g. focus `LineItem::unitPrice` but want the sibling `sku` to call a price service), the
-   source is already in scope as the first argument — just reference it inside the lambda
+   to read sibling fields (e.g., focus `LineItem::unitPrice` but want the sibling `sku` to call a price service), the
+   source is already in scope as the first argument — reference it inside the lambda
    (`update(order, item -> … order.sku() …)`). Hoist the source to a local first if it's an expression.
 6. **One documented runtime-check point on the runtime DSL.** Every typed entry point (`.field(Accessor)`,
    `.each(Accessor)`, `.list(Accessor)` / `.set` / `.map` / `.optional` and their typed terminals,
@@ -1520,9 +1521,9 @@ return afterUsers.flatMapAsync(ok -> enrichPath.updateAsync(ok, this::enrich));
      can't verify the name exists or that the inferred type matches the actual field. Wrong name → runtime error.
 
    For zero runtime-check points, use the **`@Focus` / `@BeanFocus` / `@Bridge` annotation processors** — they generate
-   a typed `<X>Path<R>` navigator at compile time where every step is a typed method call.
+   a typed `<X>Path<R>` navigator at compile time, with every step a typed method call.
 
-7. **Versioning policy — semver.** Source + binary compatibility across minor versions; breaks only on majors.
+7. **Versioning policy — semver.** Source and binary compatibility across minor versions; breaks only on majors.
 
 ---
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -38,7 +38,7 @@ POJO benchmarks walk an identical mutable-bean mirror. The conversion benchmarks
 
 These benchmarks isolate the dispatch path on `@Focus`-annotated types vs unannotated ones. Each axis has paired `_lmf`
 (no annotation, runtime reflective + LMF path) and `_holder` (sibling codegen-emitted `<X>FieldOptics` constants on the
-classpath, dispatch short-circuits through them) rows. Fixtures are structurally identical between the two flavours —
+classpath, dispatch short-circuits through them) rows. Fixtures are structurally identical between the two flavors —
 same field names, same field types, same 3-level tree — so the only difference at dispatch time is whether the codegen
 holder is present.
 
@@ -104,7 +104,7 @@ across all rows per tier, so the engines time the SAME work — only the convers
 - `_telescope_runtime_*` establishes the upper bound on telescope when the consumer opts out of codegen entirely. The
   gap to `_telescope_codegen_*` is what `@Bridge` buys.
 
-**To run just this suite locally:**
+**To run only this suite locally:**
 
 ```
 ./gradlew :benchmarks:jmh -Pjmh.includes=MapStructComparisonBenchmark
@@ -152,13 +152,13 @@ A tighter LMF-tier capture at **5 warmup + 10 measurement × 3 fork** (single-st
 
 The thing that surprised me here: at the single-step level, LMF and `Method.invoke` are basically the same speed.
 `Method.invoke` is even a touch faster on the bean getter and setter in this microbenchmark. HotSpot has been working on
-`Method.invoke` for years and the old "100-260 ns per call" reflection cost just isn't real anymore for trivial
-accessors after warmup.
+`Method.invoke` for years and the old "100-260 ns per call" reflection cost isn't real anymore for trivial accessors
+after warmup.
 
 So why bother with LMF at all? Not the per-call cost — the per-call cost is a wash. The win is that there's no
 `Object[]` allocated per call, no access check, and the JIT sees a regular functional-interface call site it can inline
 through composed lens chains. None of that shows up when you time one isolated read. It shows up when bigger workloads
-turn `Method.invoke` into an inlining barrier and the JIT gives up. Post-LMF, the hot path is just a SAM call.
+turn `Method.invoke` into an inlining barrier and the JIT gives up. Post-LMF, the hot path is a plain SAM call.
 
 ### Codegen-routed dispatch — annotated vs reflective fallback
 
@@ -241,7 +241,7 @@ data than a laptop. The `static` column calls the codegen-emitted `<Source>Bridg
 
 #### How the runtime path stays fast
 
-Two structural choices keep the runtime path cheap:
+Two structural choices keep the runtime path lean:
 
 - **Fused source-and-remap** in `DeepMap.assembleIso`: no source-side `Object[]` intermediate. The forward body gathers
   directly from cached positional readers into the target `Object[]` per slot — one alloc + 5 array writes + 5 reads + 2
@@ -291,7 +291,7 @@ The runtime column above is the post-capture measurement (run on the optimized b
 columns are from the baseline run and are stable across both within error.
 
 A quick decision guide. If the problem is "convert this entity to this DTO and back, both directions known at build
-time, no nested-list iteration, just scalars," MapStruct's bytecode is ~1.5–1.6× faster on the row (3.11 vs 4.84 ns,
+time, no nested-list iteration, only scalars," MapStruct's bytecode is ~1.5–1.6× faster on the row (3.11 vs 4.84 ns,
 ~1.7 ns absolute). On realistic deep workloads — nested records with list-of-records inside — telescope codegen matches
 MapStruct.
 


### PR DESCRIPTION
## Summary

Addressed the IntelliJ **Grazie** grammar/style suggestions surfaced on `README.md` (pulled via the IDEA MCP inspection list) and applied the same cleanup to `benchmarks/README.md`. Prose only — no numbers, claims, code, or anchors changed.

## Fixes

- **Long sentence** (40 words) split; its parenthetical list converted to em-dash form.
- **`+` → "and"** in flowing prose — "constructor and accessor", "Spring Boot 4, Hibernate, and Jackson", "source and binary". Left technical/config `+` shorthand untouched (JMH config like "3 warmup + 5 measurement", mechanism enumeration, table cells) — those aren't prose conjunctions and the IDE didn't flag them.
- **`e.g.,`** — commas added (American English).
- **British → American spelling** — flavours→flavors, normalised→normalized, normalisation→normalization.
- **Number + unit spacing** — `~100ns`→`~100 ns`, `~10ns`→`~10 ns`.
- **Loaded/filler words** — "cheap"→"lightweight"/"lean", "subsequent"→"later", dropped the dismissive "just" (×4 in benchmarks).
- **"at compile time where"** → "at compile time, with".

## Test plan

- [x] `./gradlew spotlessCheck` — green
- [x] Residual grep sweep on both files — clean
- [x] Only the two README files touched (no code)
- [ ] CI