### PR TITLE
perf: flatten effectful traversal accumulator to O(n)

### DIFF
--- a/benchmarks/src/jmh/java/io/github/eschizoid/telescope/benchmarks/EffectfulTraversalBenchmark.java
+++ b/benchmarks/src/jmh/java/io/github/eschizoid/telescope/benchmarks/EffectfulTraversalBenchmark.java
@@ -20,12 +20,13 @@ import org.openjdk.jmh.infra.Blackhole;
  * Scaling benchmark for effectful traversal updates. Each benchmark traverses a list of {@code N}
  * elements and rebuilds it through one effect, where {@code N} is swept across orders of magnitude.
  *
- * <p>The purpose is to expose the complexity class of {@code Traversal#modifyF}'s accumulator, not
- * to produce an absolute ns/op headline. The default {@code modifyF} folds results into a fresh
- * {@code ArrayList} copy per element ({@code O(n^2)} total copying); the pure {@code update} path
- * walks {@code modify} once ({@code O(n)}). Reading the result: divide each row's ns/op by its
- * {@code size} to get per-element cost. If that per-element number is flat across sizes the path is
- * linear; if it climbs roughly proportionally with {@code size} the path is quadratic.
+ * <p>The purpose is to guard the complexity class of {@code Traversal#modifyF}'s accumulator, not
+ * to produce an absolute ns/op headline. {@code modifyF} writes each element's effectful result
+ * into its own slot of a pre-sized {@code Object[]} ({@code O(n)} total); the pure {@code update}
+ * path walks {@code modify} once ({@code O(n)}). Reading the result: divide each row's ns/op by its
+ * {@code size} to get per-element cost. A flat per-element number across sizes confirms the path
+ * stays linear; a number that climbs roughly proportionally with {@code size} is the failure signal
+ * — a regression back to a per-element list-copy fold ({@code O(n^2)}).
  *
  * <p>The synchronous effects ({@code updateOptional}, {@code updateValidated}) are measured with
  * every element succeeding, so the whole traversal is processed — no short-circuit masks the fold

--- a/benchmarks/src/jmh/java/io/github/eschizoid/telescope/benchmarks/EffectfulTraversalBenchmark.java
+++ b/benchmarks/src/jmh/java/io/github/eschizoid/telescope/benchmarks/EffectfulTraversalBenchmark.java
@@ -1,0 +1,81 @@
+package io.github.eschizoid.telescope.benchmarks;
+
+import io.github.eschizoid.telescope.Telescope;
+import io.github.eschizoid.telescope.effects.Validated;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.infra.Blackhole;
+
+/**
+ * Scaling benchmark for effectful traversal updates. Each benchmark traverses a list of {@code N}
+ * elements and rebuilds it through one effect, where {@code N} is swept across orders of magnitude.
+ *
+ * <p>The purpose is to expose the complexity class of {@code Traversal#modifyF}'s accumulator, not
+ * to produce an absolute ns/op headline. The default {@code modifyF} folds results into a fresh
+ * {@code ArrayList} copy per element ({@code O(n^2)} total copying); the pure {@code update} path
+ * walks {@code modify} once ({@code O(n)}). Reading the result: divide each row's ns/op by its
+ * {@code size} to get per-element cost. If that per-element number is flat across sizes the path is
+ * linear; if it climbs roughly proportionally with {@code size} the path is quadratic.
+ *
+ * <p>The synchronous effects ({@code updateOptional}, {@code updateValidated}) are measured with
+ * every element succeeding, so the whole traversal is processed — no short-circuit masks the fold
+ * cost. {@code updatePure} is the {@code O(n)} control: same traversal, no effect.
+ *
+ * <pre>{@code
+ * ./gradlew :benchmarks:jmh -Pjmh.includes=EffectfulTraversalBenchmark
+ * }</pre>
+ */
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+public class EffectfulTraversalBenchmark {
+
+  /** Single-field record whose list is the traversal target. */
+  public record Bag(List<Integer> items) {}
+
+  @Param({ "16", "64", "256", "1024" })
+  public int size;
+
+  private Bag bag;
+  private Telescope<Bag, Integer> each;
+
+  @Setup
+  public void setup() {
+    final var items = new ArrayList<Integer>(size);
+    for (var i = 0; i < size; i++) {
+      items.add(i);
+    }
+    bag = new Bag(items);
+    each = Telescope.of(Bag.class).each(Bag::items);
+  }
+
+  /** O(n) control: pure update walks {@code modify} once, no effect accumulator. */
+  @Benchmark
+  public void updatePure(final Blackhole bh) {
+    bh.consume(each.update(bag, n -> n + 1));
+  }
+
+  /** Synchronous effect through {@code modifyF}; every element present (full traversal). */
+  @Benchmark
+  public void updateOptionalAllPresent(final Blackhole bh) {
+    final Optional<Bag> result = each.updateOptional(bag, n -> Optional.of(n + 1));
+    bh.consume(result);
+  }
+
+  /** Synchronous accumulating effect through {@code modifyF}; every element valid. */
+  @Benchmark
+  public void updateValidatedAllValid(final Blackhole bh) {
+    final Validated<String, Bag> result = each.updateValidated(bag, n -> new Validated.Valid<>(n + 1));
+    bh.consume(result);
+  }
+}

--- a/internal/src/main/java/io/github/eschizoid/telescope/internal/optics/Traversal.java
+++ b/internal/src/main/java/io/github/eschizoid/telescope/internal/optics/Traversal.java
@@ -1,6 +1,5 @@
 package io.github.eschizoid.telescope.internal.optics;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -61,13 +60,22 @@ public interface Traversal<S, A> extends Fold<S, A>, Setter<S, A> {
    * short-circuiting, error accumulation, empty-propagation) live entirely in the {@link
    * Applicative} instance — this method is effect-agnostic.
    *
-   * <p>Default implementation handles the many-focus case via an iterator trick: collect all
-   * focused values, sequence the effectful results into one effectful list, then map the result
-   * back through {@link #modify} pulling new values from the list in order. Relies on the invariant
-   * that {@code modify} visits focused elements in the same order {@link #getAll} enumerates them —
-   * true for every implementor in this package.
+   * <p>Default implementation handles the many-focus case by sequencing into a pre-sized positional
+   * array: collect all focused values, then fold each element's effectful result into its own slot
+   * of a fixed {@code Object[]}, and finally map the completed array back through {@link #modify},
+   * walking a cursor in order. Each slot is written exactly once, so the accumulator is {@code
+   * O(n)} — no per-element list copy. Relies on the invariant that {@code modify} visits focused
+   * elements in the same order {@link #getAll} enumerates them — true for every implementor in this
+   * package.
    *
-   * <p>Single-focus optics override this for a more direct path that skips the list allocation.
+   * <p>The {@link Applicative#map2 map2} fold threads the effect (sequencing, short-circuiting,
+   * error accumulation, empty-propagation) while the per-element slot writes stay cheap. The fold's
+   * dependency chain ({@code acc[i]} derives from {@code acc[i-1]}) serializes the combine
+   * callbacks in index order even for parallel effects like {@code CompletableFuture}, so the
+   * shared array is written one slot at a time under a happens-before chain — the futures
+   * themselves still run concurrently; only the cheap slot assignment is linearized.
+   *
+   * <p>Single-focus optics override this for a more direct path that skips the array allocation.
    */
   default <F extends Kind.Witness> Kind<F, S> modifyF(
     final Applicative<F> applicative,
@@ -77,25 +85,29 @@ public interface Traversal<S, A> extends Fold<S, A>, Setter<S, A> {
     final List<A> allAs = getAll(source).toList();
     if (allAs.isEmpty()) return applicative.pure(source);
 
-    Kind<F, List<A>> sequenced = applicative.pure(new ArrayList<>());
-    for (final var a : allAs) {
+    final Object[] slots = new Object[allAs.size()];
+    Kind<F, Object[]> sequenced = applicative.pure(slots);
+    for (var i = 0; i < allAs.size(); i++) {
       // True short-circuit: skip fn invocation on remaining elements once the accumulator
       // is in a non-recoverable failed state (Either.Left, Optional.empty). For applicatives
       // that accumulate (Validated) or evaluate in parallel (CompletableFuture), isFailed
       // returns false and every element is processed.
       if (applicative.isFailed(sequenced)) break;
-      final Kind<F, A> fa = fn.apply(a);
-      sequenced = applicative.map2(sequenced, fa, (list, newA) -> {
-        final var copy = new ArrayList<A>(list.size() + 1);
-        copy.addAll(list);
-        copy.add(newA);
-        return copy;
+      final var slot = i;
+      final Kind<F, A> fa = fn.apply(allAs.get(i));
+      sequenced = applicative.map2(sequenced, fa, (arr, newA) -> {
+        arr[slot] = newA;
+        return arr;
       });
     }
 
-    return applicative.map(sequenced, newValues -> {
-      final var iter = newValues.iterator();
-      return modify(source, ignored -> iter.next());
+    return applicative.map(sequenced, arr -> {
+      final int[] cursor = { 0 };
+      return modify(source, ignored -> {
+        @SuppressWarnings("unchecked")
+        final A next = (A) arr[cursor[0]++];
+        return next;
+      });
     });
   }
 

--- a/internal/src/test/java/io/github/eschizoid/telescope/internal/optics/TraversalModifyFTest.java
+++ b/internal/src/test/java/io/github/eschizoid/telescope/internal/optics/TraversalModifyFTest.java
@@ -1,0 +1,89 @@
+package io.github.eschizoid.telescope.internal.optics;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+import io.github.eschizoid.telescope.effects.Validated;
+import io.github.eschizoid.telescope.internal.optics.collections.Traversals;
+import io.github.eschizoid.telescope.runtime.instances.CompletableFutureK;
+import io.github.eschizoid.telescope.runtime.instances.OptionalK;
+import io.github.eschizoid.telescope.runtime.instances.ValidatedK;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Direct coverage of the many-focus {@link Traversal#modifyF} default — the positional-array
+ * accumulator that lifts a traversal over an effect. The public {@code Telescope} effect terminals
+ * exercise this end-to-end too, but those tests live in another module; pinning it here at the
+ * substrate level proves the order-preservation invariant and the per-effect semantics (empty
+ * early-return, short-circuit break, error accumulation, sequential rebuild) where the code lives.
+ */
+class TraversalModifyFTest {
+
+  private static final Traversal<List<Integer>, Integer> EACH = Traversals.eachList();
+
+  @Test
+  @DisplayName("empty focus returns pure(source) without invoking fn")
+  void emptyFocusReturnsPureWithoutInvokingFn() {
+    final var calls = new int[] { 0 };
+    final var result = OptionalK.unbox(
+      EACH.modifyF(OptionalK.applicative(), List.of(), a -> {
+        calls[0]++;
+        return OptionalK.box(Optional.of(a));
+      })
+    );
+    assertEquals(Optional.of(List.of()), result);
+    assertEquals(0, calls[0], "fn must not be called when there are no foci");
+  }
+
+  @Test
+  @DisplayName("all-present Optional rebuilds every slot in getAll order")
+  void allPresentRebuildsEverySlotInOrder() {
+    final var result = OptionalK.unbox(
+      EACH.modifyF(OptionalK.applicative(), List.of(1, 2, 3, 4, 5), a -> OptionalK.box(Optional.of(a * 10)))
+    );
+    assertEquals(Optional.of(List.of(10, 20, 30, 40, 50)), result);
+  }
+
+  @Test
+  @DisplayName("Optional.empty mid-traversal short-circuits the remaining foci")
+  void optionalEmptyMidTraversalShortCircuits() {
+    final var calls = new int[] { 0 };
+    final var result = OptionalK.unbox(
+      EACH.modifyF(OptionalK.applicative(), List.of(1, 2, 3), a -> {
+        calls[0]++;
+        final Optional<Integer> next = a == 2 ? Optional.empty() : Optional.of(a);
+        return OptionalK.box(next);
+      })
+    );
+    assertEquals(Optional.empty(), result);
+    assertEquals(2, calls[0], "fn must stop being called once the accumulator is empty");
+  }
+
+  @Test
+  @DisplayName("Validated accumulates every focus error (no short-circuit)")
+  void validatedAccumulatesEveryFocusError() {
+    final var result = ValidatedK.unbox(
+      EACH.modifyF(ValidatedK.<String>forError(), List.of(1, 2, 3, 4), a -> {
+        final Validated<String, Integer> v = a % 2 == 0 ? Validated.valid(a) : Validated.invalid("odd: " + a);
+        return ValidatedK.box(v);
+      })
+    );
+    assertInstanceOf(Validated.Invalid.class, result);
+    assertEquals(List.of("odd: 1", "odd: 3"), ((Validated.Invalid<String, ?>) result).errors());
+  }
+
+  @Test
+  @DisplayName("CompletableFuture rebuilds every slot, order preserved")
+  void completableFutureRebuildsEverySlotInOrder() throws Exception {
+    final var result = CompletableFutureK.unbox(
+      EACH.modifyF(CompletableFutureK.applicative(), List.of(1, 2, 3), a ->
+        CompletableFutureK.box(CompletableFuture.completedFuture(a + 100))
+      )
+    ).get();
+    assertEquals(List.of(101, 102, 103), result);
+  }
+}


### PR DESCRIPTION
## What

`Traversal#modifyF` — the engine behind every `update{Async,Optional,Either,Validated}` — folded each focused element's effectful result into a **fresh `ArrayList` copy per step**. Over an n-element traversal that's `1+2+…+n` copies → **O(n²)** total. Invisible at tiny fan-outs, but it explodes on list-heavy traversals and generates enough garbage to stall on GC.

## Fix

Replace the growing-list fold with a **pre-sized positional `Object[]`**: each element writes its own slot exactly once, then a single `modify` pass walks a cursor in order. O(n²) → **O(n)**.

The `map2` fold still threads the effect (sequencing, short-circuit, error accumulation, empty-propagation) — only the accumulator shape changed. The fold's dependency chain (`acc[i]` derives from `acc[i-1]`) serializes the cheap slot writes in index order **even for `CompletableFuture`**, so the array fills under a happens-before chain while the futures themselves still run concurrently. Single-focus optics (`Affine`/`Lens`/`Prism`/`Iso`) already override `modifyF` with an O(1) path and are untouched.

## Evidence

New `EffectfulTraversalBenchmark` sweeps traversal size 16 → 1024 across `updateOptional` / `updateValidated`, with `updatePure` as the O(n) control. Per-element cost (ns/op ÷ size), **before → after**:

| size | `updateOptional` before | after | `updateValidated` before | after |
|-----:|------------:|-----------:|------------:|-----------:|
| 16   | 256 | 446 | — | 447 |
| 64   | 530 | 272 | 545 | 545 |
| 256  | 802 | 111 | 810 | 346 |
| 1024 | **10,400** | **100** | **2,959** | **277** |

Before, per-element cost *climbs* with size (the O(n²) signature). After, it *converges to a flat plateau* — linear with fixed setup amortizing. Total-time scaling for a 64× size increase (16→1024): `updateOptional` went from **2601×** (quadratic) to **14.3×** (linear). At size 1024, `updateOptional` dropped ~10.6 ms → ~0.10 ms (**~105×**), `updateValidated` ~3.0 ms → ~0.28 ms (**~10.7×**).

> Numbers are a laptop smoke run (2 warmup + 3 iterations × 1s) — wide error bars, but the *scaling shape* is unambiguous. The benchmark stays in-tree as the regression guard; run on CI for tight bands.

## Verification

- `./gradlew check` green across all modules under `-Werror`
- Effect/law tests pass unchanged: `EffectfulUpdateTest`, `ApplicativeLawsTest`, `BoundedAsyncTest`, `HttpEffectsIntegrationTest`, `OpticLawsTest`, `IndexedTraversalTest` — short-circuit / accumulate / empty / async semantics preserved
- No public API change
