### PR TITLE
docs: surface accumulating validation as a MapStruct differentiator

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,14 +341,15 @@ branch, tune the iteration / fork knobs; the run prints `results.txt` and attach
 #### Then, what you gain
 
 The table is mostly "telescope: yes / MapStruct: not in scope" — bidirectional from one definition, deep navigation,
-effectful update, sealed-root dispatch, multi-source merge, JPA cycles + Hibernate `LAZY` unwrap. That asymmetry, not
-nanoseconds, is the decision.
+effectful update, accumulating validation, sealed-root dispatch, multi-source merge, JPA cycles + Hibernate `LAZY`
+unwrap. That asymmetry, not nanoseconds, is the decision.
 
 | Capability                                   | telescope                                                                                                                                                           | MapStruct                                                  |
 | -------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
 | **Bidirectional out of the box**             | Every `Mapping.to(srcAcc, tgtAcc)` row works both ways via `Mapper.forward(...)` / `.backward(...)`                                                                 | One direction per `@Mapper` interface; reverse is separate |
 | **Deep nested navigation + update**          | `Telescope.of(C).each(C::depts).field(D::address).update(c, fn)`                                                                                                    | Not in scope                                               |
 | **Effectful update**                         | `updateAsync` / `updateOptional` / `updateEither` / `updateValidated`                                                                                               | Not in scope                                               |
+| **Accumulating validation**                  | `Validated.combine(...)` / `combineAll(...)` builds the target only when every field passes, collecting _all_ failures in one pass                                  | Throw on first bad field, or hand-rolled `@AfterMapping`   |
 | **Compile-time codegen**                     | `@Focus` / `@BeanFocus` / `@Bridge` annotation processors                                                                                                           | `@Mapper` interfaces                                       |
 | **Runtime path (no codegen required)**       | `Telescope.of(Class)` with reflective metadata probe; users can opt into `@Focus` later                                                                             | Compile-time only                                          |
 | **Sealed types / pattern matching**          | `.as(Subtype.class)` narrows; the path stays type-safe                                                                                                              | Not in scope                                               |
@@ -362,6 +363,31 @@ nanoseconds, is the decision.
 | **Spring / Quarkus / CDI integration**       | `telescope-spring-boot-starter` (Spring Boot 4 autoconfig + `Mapper<A, B>` bean registry) + `telescope-quarkus` (Arc extension, Jandex-discovered)                  | Native via `componentModel = "spring"` / `"jsr330"` / etc. |
 | **Maturity**                                 | 1.0 line; JMH-backed perf claims                                                                                                                                    | Ten years; thousands of production deployments             |
 | **Dispatch perf — codegen vs codegen**       | **Same performance class — a tie at realistic depth** (1.15× deep, 1.5× on a trivial flat struct); both emit direct JIT-inlined calls. CI-reproducible matrix below | Direct bytecode, monomorphic call site                     |
+
+#### Accumulating validation — what MapStruct can't say
+
+Mapping a stringly-typed input into a typed domain object usually means validating several fields at once. MapStruct
+maps field-by-field with no way to _collect_ failures — you throw on the first bad field or hand-roll an `@AfterMapping`
+accumulator. Telescope ships `Validated` as a first-class effect, so "build the target only if every field passes, and
+report all failures in one pass" is a primitive:
+
+```java
+// Bad email AND bad age surface together — not just the first.
+final Validated<String, Account> account = Validated.combine(
+  validateEmail(form.email()),
+  validateAge(form.ageText()),
+  Account::new
+);
+
+// → Invalid[email: missing '@' …, age: out of range: 200]
+
+// combineAll folds a batch into one result — every error from every offending row:
+final Validated<String, List<Account>> batch = Validated.combineAll(rows.stream().map(this::mapForm).toList());
+```
+
+`combine` accumulates (applicative); `Either` short-circuits on the first failure. For 3+ fields, chain `combine`.
+Runnable in
+[`ValidatedMappingDemo`](examples/library/src/main/java/io/github/eschizoid/telescope/examples/ValidatedMappingDemo.java).
 
 #### Per-field source/target mapping — side by side
 

--- a/examples/library/build.gradle.kts
+++ b/examples/library/build.gradle.kts
@@ -31,6 +31,7 @@ val demos = listOf(
     "MultiEditDemo",
     "IndexedDemo",
     "EffectfulUpdateDemo",
+    "ValidatedMappingDemo",
     "ConversionDemo",
     "DeepMappingDemo",
     "CodegenDemo",

--- a/examples/library/src/main/java/io/github/eschizoid/telescope/examples/ValidatedMappingDemo.java
+++ b/examples/library/src/main/java/io/github/eschizoid/telescope/examples/ValidatedMappingDemo.java
@@ -1,0 +1,93 @@
+package io.github.eschizoid.telescope.examples;
+
+import io.github.eschizoid.telescope.effects.Validated;
+import java.util.List;
+
+/**
+ * Accumulating validated mapping — the conversion story MapStruct can't tell.
+ *
+ * <p>Mapping a raw, stringly-typed input (a form post, a CSV row, a JSON body) into a typed domain
+ * object usually means validating several fields at once. MapStruct maps field-by-field and has no
+ * built-in way to <em>collect every failure</em>: you throw on the first bad field or hand-roll an
+ * {@code @AfterMapping} accumulator. Telescope ships {@link Validated} as a first-class effect, so
+ * "construct the target only if every field validates, and report all failures in one pass" is a
+ * library primitive:
+ *
+ * <ul>
+ *   <li>{@link Validated#combine(Validated, Validated, java.util.function.BiFunction) combine} runs
+ *       both checks and accumulates both error lists — the applicative behaviour, distinct from
+ *       {@code Either} short-circuiting on the first failure.
+ *   <li>{@link Validated#combineAll(List) combineAll} folds a batch of per-row results into one
+ *       {@code Validated<E, List<A>>}, surfacing every error across every row at once.
+ * </ul>
+ */
+final class ValidatedMappingDemo {
+
+  private ValidatedMappingDemo() {}
+
+  static void main() {
+    run();
+  }
+
+  /** Raw input — every field is an unvalidated {@code String}. */
+  record SignupForm(String email, String ageText) {}
+
+  /** Typed domain target — built only once every field has passed. */
+  record Account(String email, int age) {}
+
+  static void run() {
+    singleFormAccumulatesEveryFieldError();
+    batchImportAccumulatesEveryRowError();
+  }
+
+  // One form, two field validators. A bad email AND a bad age surface together — not just the
+  // first.
+  // MapStruct maps each field independently; reporting both failures at once is on you to wire.
+  private static void singleFormAccumulatesEveryFieldError() {
+    final var valid = mapForm(new SignupForm("ada@x.io", "37"));
+    System.out.println("[combine] both fields valid : " + valid);
+
+    final var broken = mapForm(new SignupForm("not-an-email", "200"));
+    System.out.println("[combine] every error kept  : " + errorsOf(broken));
+  }
+
+  // A batch of rows. combineAll keeps every error from every offending row in a single Invalid —
+  // the "import 1000 records, tell me everything wrong with the file" case.
+  private static void batchImportAccumulatesEveryRowError() {
+    final var rows = List.of(
+      new SignupForm("ada@x.io", "37"),
+      new SignupForm("bad", "x"),
+      new SignupForm("grace@x.io", "200")
+    );
+
+    final Validated<String, List<Account>> batch = Validated.combineAll(
+      rows.stream().map(ValidatedMappingDemo::mapForm).toList()
+    );
+
+    System.out.println("[combineAll] valid?         : " + batch.isValid());
+    System.out.println("[combineAll] every row error: " + errorsOf(batch));
+  }
+
+  // The mapping: validate each field, accumulate across both, build Account only if both pass.
+  private static Validated<String, Account> mapForm(final SignupForm form) {
+    return Validated.combine(validateEmail(form.email()), validateAge(form.ageText()), Account::new);
+  }
+
+  private static Validated<String, String> validateEmail(final String raw) {
+    return raw.contains("@") ? Validated.valid(raw) : Validated.invalid("email: missing '@' in '" + raw + "'");
+  }
+
+  private static Validated<String, Integer> validateAge(final String raw) {
+    final int age;
+    try {
+      age = Integer.parseInt(raw);
+    } catch (final NumberFormatException e) {
+      return Validated.invalid("age: not a number: '" + raw + "'");
+    }
+    return age >= 18 && age <= 120 ? Validated.valid(age) : Validated.invalid("age: out of range: " + age);
+  }
+
+  private static List<String> errorsOf(final Validated<String, ?> v) {
+    return v instanceof Validated.Invalid<String, ?> invalid ? invalid.errors() : List.of();
+  }
+}


### PR DESCRIPTION
## What

Surfaces telescope's **accumulating validation** as a first-class MapStruct differentiator. `Validated` already ships as an effect (`combine` / `combineAll`); this PR makes the story discoverable — no new public API.

The pitch: mapping a stringly-typed input into a typed domain object usually means validating several fields at once. MapStruct maps field-by-field with no way to *collect* failures — you throw on the first bad field or hand-roll an `@AfterMapping` accumulator. Telescope makes "build the target only if every field passes, and report all failures in one pass" a primitive.

## Changes

- **New `ValidatedMappingDemo`** (`examples/library`) — runnable, wired into `runAllDemos`. Maps a `SignupForm(email, ageText)` into a typed `Account(email, age)` via a single binary `Validated.combine(validateEmail(…), validateAge(…), Account::new)` that accumulates both field errors, plus `combineAll` for batch-wide accumulation across rows. Live output:
  ```
  [combine] every error kept  : [email: missing '@' in 'not-an-email', age: out of range: 200]
  [combineAll] every row error: [email: missing '@' in 'bad', age: not a number: 'x', age: out of range: 200]
  ```
- **README** — a dedicated capability-table row (Accumulating validation) and a code vignette under "Then, what you gain".

## Notes

- No public API change; no behavioral change. Pure positioning + example.
- The example deliberately uses the clean 2-field binary `combine` (reads like English at the call site); the README reserves "3+ fields, chain `combine`" for prose rather than forcing a throwaway carrier record into the demo.
- Reviewed across four lenses (code / comments / type-design / mantra-compliance), two rounds, converged clean.
