### PR TITLE
perf(codegen): emit a directly-callable BRIDGE_FN constant per @Bridge

### DIFF
--- a/benchmarks/src/jmh/java/io/github/eschizoid/telescope/benchmarks/MapStructComparisonBenchmark.java
+++ b/benchmarks/src/jmh/java/io/github/eschizoid/telescope/benchmarks/MapStructComparisonBenchmark.java
@@ -123,6 +123,14 @@ public class MapStructComparisonBenchmark {
     bh.consume(McFlatBeanBridge.forward(flatBean));
   }
 
+  @Benchmark
+  public void flat_telescope_codegen_bridgefn_forward(final Blackhole bh) {
+    // The emitted BRIDGE_FN constant — one interface hop, the same dispatch shape as MapStruct's
+    // INSTANCE.toRec(...). The passable, composition-free value an adopter calls in a hot loop;
+    // should land between BRIDGE.read (lattice) and the static forward (zero-hop) floor.
+    bh.consume(McFlatBeanBridge.BRIDGE_FN.forward(flatBean));
+  }
+
   // ---------- Flat — backward (record → bean) ----------
 
   @Benchmark

--- a/benchmarks/src/jmh/java/io/github/eschizoid/telescope/benchmarks/MapStructComparisonBenchmark.java
+++ b/benchmarks/src/jmh/java/io/github/eschizoid/telescope/benchmarks/MapStructComparisonBenchmark.java
@@ -21,7 +21,8 @@ import org.openjdk.jmh.infra.Blackhole;
  * <h2>What the rows measure</h2>
  *
  * <p>Three depth tiers × two directions × three engines, plus one static-forward row per tier and a
- * {@code BRIDGE_FN.forward} row on the flat tier (the directly-callable one-interface-hop constant):
+ * {@code BRIDGE_FN.forward} row on the flat tier (the directly-callable one-interface-hop
+ * constant):
  *
  * <ul>
  *   <li>{@code flat_*} — five scalar fields, no nesting.

--- a/benchmarks/src/jmh/java/io/github/eschizoid/telescope/benchmarks/MapStructComparisonBenchmark.java
+++ b/benchmarks/src/jmh/java/io/github/eschizoid/telescope/benchmarks/MapStructComparisonBenchmark.java
@@ -20,7 +20,8 @@ import org.openjdk.jmh.infra.Blackhole;
  *
  * <h2>What the rows measure</h2>
  *
- * <p>Three depth tiers × two directions × three engines, plus one static-forward row per tier:
+ * <p>Three depth tiers × two directions × three engines, plus one static-forward row per tier and a
+ * {@code BRIDGE_FN.forward} row on the flat tier (the directly-callable one-interface-hop constant):
  *
  * <ul>
  *   <li>{@code flat_*} — five scalar fields, no nesting.

--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
@@ -1699,7 +1699,15 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
         out.println("  }");
         out.println();
         out.println(
-          "  public static final Telescope<" + sourceFq + ", " + targetFq + "> BRIDGE = Telescope.bridge(new Fn());"
+          "  /** Directly-callable mapper value — one interface hop, MapStruct's {@code INSTANCE.toRec(s)} cost."
+        );
+        out.println(
+          "   * Call {@code BRIDGE_FN.forward(s)} / {@code .backward(t)} in a hot loop; use {@code BRIDGE} for the"
+        );
+        out.println("   * composable lattice value. */");
+        out.println("  public static final BridgeFn<" + sourceFq + ", " + targetFq + "> BRIDGE_FN = new Fn();");
+        out.println(
+          "  public static final Telescope<" + sourceFq + ", " + targetFq + "> BRIDGE = Telescope.bridge(BRIDGE_FN);"
         );
         emitContainerHelpers(out, fieldPlans, nonDroppedSourceFields, targetFields, renames);
       }
@@ -1909,7 +1917,15 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
         out.println("  }");
         out.println();
         out.println(
-          "  public static final Telescope<" + sourceFq + ", " + targetFq + "> BRIDGE = Telescope.bridge(new Fn());"
+          "  /** Directly-callable mapper value — one interface hop, MapStruct's {@code INSTANCE.toRec(s)} cost."
+        );
+        out.println(
+          "   * Call {@code BRIDGE_FN.forward(s)} / {@code .backward(t)} in a hot loop; use {@code BRIDGE} for the"
+        );
+        out.println("   * composable lattice value. */");
+        out.println("  public static final BridgeFn<" + sourceFq + ", " + targetFq + "> BRIDGE_FN = new Fn();");
+        out.println(
+          "  public static final Telescope<" + sourceFq + ", " + targetFq + "> BRIDGE = Telescope.bridge(BRIDGE_FN);"
         );
       }
     );

--- a/codegen/src/test/java/io/github/eschizoid/telescope/codegen/BridgeProcessorTest.java
+++ b/codegen/src/test/java/io/github/eschizoid/telescope/codegen/BridgeProcessorTest.java
@@ -61,8 +61,12 @@ class BridgeProcessorTest {
       assertNotNull(generated, () -> "RecBridge not generated; saw " + compilation.generated().keySet());
 
       assertTrue(
-        generated.contains("public static final Telescope<demo.Rec, demo.Pojo> BRIDGE = Telescope.bridge(new Fn());"),
-        generated
+        generated.contains("public static final BridgeFn<demo.Rec, demo.Pojo> BRIDGE_FN = new Fn();"),
+        () -> "expected a directly-callable BRIDGE_FN constant; saw " + generated
+      );
+      assertTrue(
+        generated.contains("public static final Telescope<demo.Rec, demo.Pojo> BRIDGE = Telescope.bridge(BRIDGE_FN);"),
+        () -> "BRIDGE should wrap the shared BRIDGE_FN constant; saw " + generated
       );
       assertTrue(generated.contains("import io.github.eschizoid.telescope.conversion.BridgeFn;"), generated);
       assertTrue(
@@ -104,7 +108,7 @@ class BridgeProcessorTest {
       assertNotNull(generated, () -> "ABridge not generated; saw " + compilation.generated().keySet());
 
       assertTrue(
-        generated.contains("public static final Telescope<demo.A, demo.B> BRIDGE = Telescope.bridge(new Fn());"),
+        generated.contains("public static final Telescope<demo.A, demo.B> BRIDGE = Telescope.bridge(BRIDGE_FN);"),
         generated
       );
       assertTrue(generated.contains("private static final class Fn implements BridgeFn<demo.A, demo.B>"), generated);
@@ -151,7 +155,7 @@ class BridgeProcessorTest {
       assertNotNull(generated, () -> "PABridge not generated; saw " + compilation.generated().keySet());
 
       assertTrue(
-        generated.contains("public static final Telescope<demo.PA, demo.PB> BRIDGE = Telescope.bridge(new Fn());"),
+        generated.contains("public static final Telescope<demo.PA, demo.PB> BRIDGE = Telescope.bridge(BRIDGE_FN);"),
         generated
       );
       assertTrue(generated.contains("private static final class Fn implements BridgeFn<demo.PA, demo.PB>"), generated);
@@ -810,7 +814,7 @@ class BridgeProcessorTest {
       // The umbrella BRIDGE constant exposes the composed Telescope at the sealed-root level.
       assertTrue(
         sealedBridge.contains(
-          "public static final Telescope<demo.payment.Payment, demo.bean.PaymentEntity> BRIDGE = Telescope.bridge(new Fn());"
+          "public static final Telescope<demo.payment.Payment, demo.bean.PaymentEntity> BRIDGE = Telescope.bridge(BRIDGE_FN);"
         ),
         sealedBridge
       );
@@ -1007,13 +1011,13 @@ class BridgeProcessorTest {
 
       assertTrue(
         entityBridge.contains(
-          "public static final Telescope<demo.Product, demo.ProductEntity> BRIDGE = Telescope.bridge(new Fn());"
+          "public static final Telescope<demo.Product, demo.ProductEntity> BRIDGE = Telescope.bridge(BRIDGE_FN);"
         ),
         entityBridge
       );
       assertTrue(
         dtoBridge.contains(
-          "public static final Telescope<demo.Product, demo.ProductDto> BRIDGE = Telescope.bridge(new Fn());"
+          "public static final Telescope<demo.Product, demo.ProductDto> BRIDGE = Telescope.bridge(BRIDGE_FN);"
         ),
         dtoBridge
       );

--- a/docs/adr/0007-cross-module-bridge-carrier.md
+++ b/docs/adr/0007-cross-module-bridge-carrier.md
@@ -1,6 +1,6 @@
 # ADR-0007: Cross-module `@Bridge` via a declarative carrier class
 
-**Status:** Proposed (v1.1+ candidate) · **Date:** 2026-06-16
+**Status:** Accepted — shipped in #149 · **Date:** 2026-06-16 (accepted 2026-06-21)
 
 ## Context
 

--- a/docs/adr/0008-fromMap-untyped-source-factory.md
+++ b/docs/adr/0008-fromMap-untyped-source-factory.md
@@ -1,6 +1,6 @@
 # ADR-0008: `Telescope.fromMap(Class<T>, MapExtractStep...)` for untyped sources
 
-**Status:** Proposed (v1.1+ candidate) · **Date:** 2026-06-16
+**Status:** Accepted — shipped in #150 · **Date:** 2026-06-16 (accepted 2026-06-21)
 
 ## Context
 

--- a/docs/adr/0009-bridge-lenient-mode.md
+++ b/docs/adr/0009-bridge-lenient-mode.md
@@ -1,6 +1,6 @@
 # ADR-0009: `@Bridge(lenient = true)` for the small-DTO → large-entity pattern
 
-**Status:** Proposed (v1.1+ candidate) · **Date:** 2026-06-16
+**Status:** Accepted — shipped in #148 · **Date:** 2026-06-16 (accepted 2026-06-21)
 
 ## Context
 


### PR DESCRIPTION
## What

Generated `<X>Bridge` classes already build a private `Fn implements BridgeFn<S, T>` and pass it to `Telescope.bridge(...)`. This hoists that `Fn` into a public `static final BridgeFn<S, T> BRIDGE_FN` constant and has `BRIDGE` wrap it:

```java
public static final BridgeFn<Src, Tgt> BRIDGE_FN = new Fn();
public static final Telescope<Src, Tgt> BRIDGE = Telescope.bridge(BRIDGE_FN);
```

Adopters in a hot loop can now call `BRIDGE_FN.forward(s)` / `.backward(t)` **directly** — one interface hop, the same dispatch shape as MapStruct's `INSTANCE.toRec(s)` — instead of paying the `BRIDGE.read(...)` lattice-dispatch sandwich (`Telescope.read → BridgeTelescope.read → BridgeFn.forward → Fn.forward → static forward`). `BRIDGE` stays for the composable lattice value. This is remediation `#1` from `docs/perf-mapstruct-comparison.md`.

## Scope

- **Purely additive** — one new public field per generated bridge; no change to `forward`/`backward`/`patch` bodies. Both emit sites (model-anchored + carrier form) updated.
- TDD: `BridgeProcessorTest` asserts the `BRIDGE_FN` constant + that `BRIDGE` wraps it; the five existing `Telescope.bridge(new Fn())` assertions updated to the new shape.
- Adds `flat_telescope_codegen_bridgefn_forward` to `MapStructComparisonBenchmark`.

## Perf — to validate on CI, not locally

Local laptop numbers are **noise-dominated** (±17–60 ns error bars on ~17–30 ns means; `BRIDGE.read` even shows up *faster* than the zero-hop static floor — the JMH/escape-analysis artifact the perf doc documents). So this PR makes **no perf claim from local runs**; the new benchmark exists to be measured on the dedicated-hardware **Benchmarks** workflow. The change is justified structurally (one interface hop vs the lattice sandwich) + functionally tested.

## Also

Marks **ADR-0007 / 0008 / 0009** `Accepted` — they shipped in #149 / #150 / #148 but the status lines still read "Proposed (v1.1+ candidate)".

## Verification

- `./gradlew check` green across all modules (the codegen change regenerates every `@Bridge` in core/examples/lombok/benchmarks)
- `spotlessApply` clean; wrapper untouched
