### PR TITLE
fix(codegen): @Bridge primitive↔wrapper auto-bridge + lenient propagation to nested sub-pairs

### DIFF
--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/AbstractTelescopeProcessor.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/AbstractTelescopeProcessor.java
@@ -1013,7 +1013,7 @@ public abstract class AbstractTelescopeProcessor extends AbstractProcessor {
    * ""}, {@code List → List.of()}, etc.) live only in {@code NullDefaults}; the codegen path emits
    * a plain reference cast there and lets the runtime substitution kick in.
    */
-  private static Optional<String> primitiveDefaultLiteral(final TypeKind kind) {
+  protected static Optional<String> primitiveDefaultLiteral(final TypeKind kind) {
     return switch (kind) {
       case BOOLEAN -> Optional.of("false");
       case BYTE -> Optional.of("(byte) 0");

--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
@@ -161,7 +161,17 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
   // its own (it falls back to BridgeConfig.EMPTY, which is strict), so without this its bijection
   // check would fail when the nested target has extra fields — even though the lenient parent
   // intends those to default. generate() ORs this into the per-pair lenient flag so leniency
-  // propagates to every nesting level, matching the runtime mapperForward(...) behaviour.
+  // propagates to every nested field/container level, matching the runtime mapperForward(...)
+  // behaviour. Cleared in processingOver() so a reused processor instance starts clean.
+  //
+  // Sticky-wins resolution: a sub-bridge class is emitted once per type pair, so if the SAME pair
+  // is
+  // reached from both a lenient and a strict parent the single emitted sub-bridge is lenient for
+  // both. That is more permissive, never less, so it cannot lose data the strict parent would have
+  // kept; the trade is that a strict parent's nested mismatch no longer fails when a lenient
+  // sibling
+  // also references the pair. Splitting into per-parent sub-bridges would be the stricter (and much
+  // larger) alternative.
   private final Set<TypePair> lenientPairs = new HashSet<>();
 
   // Set true around the deferred drain in processingOver() so sub-pair discovery inside
@@ -400,6 +410,7 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
     if (roundEnv.processingOver()) {
       multiTargetSources.clear();
       configsByPair.clear();
+      lenientPairs.clear();
     }
     return true;
   }
@@ -2082,9 +2093,12 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
         continue;
       }
       // (1b) Primitive ↔ its boxed wrapper (boolean↔Boolean, int↔Integer, …) → identity. The
-      //      generated read auto-boxes on the forward direction and auto-unboxes on the backward
-      //      direction exactly as Java does, matching the runtime DeepMap's primitive/wrapper
-      //      handling. Neither side is a reflectable declared type, but no sub-bridge is needed.
+      //      generated read auto-boxes on the forward direction (always safe) and auto-unboxes on
+      //      the backward direction. A null wrapper unboxes to an NPE there — the same as the
+      //      runtime's default PROPAGATE null strategy; the runtime's opt-in null-defaulting
+      //      strategy has no codegen equivalent. Neither side is a reflectable declared type, but
+      // no
+      //      sub-bridge is needed.
       if (isPrimitiveWrapperPair(sf.type(), tf.type())) {
         plans.put(sf.name(), FieldPlan.identity());
         continue;
@@ -2491,7 +2505,7 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
 
   // True when one of {a, b} is a primitive and the other is exactly its boxed wrapper (boolean ↔
   // Boolean, int ↔ Integer, …). Order-independent. Lets field-bridge planning treat such pairs as
-  // identity, matching the runtime DeepMap autobox/unbox behaviour.
+  // identity (forward auto-boxes, backward auto-unboxes).
   private boolean isPrimitiveWrapperPair(final TypeMirror a, final TypeMirror b) {
     return isBoxedOf(a, b) || isBoxedOf(b, a);
   }

--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
@@ -2092,13 +2092,12 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
         plans.put(sf.name(), FieldPlan.identity());
         continue;
       }
-      // (1b) Primitive ↔ its boxed wrapper (boolean↔Boolean, int↔Integer, …) → identity. The
-      //      generated read auto-boxes on the forward direction (always safe) and auto-unboxes on
-      //      the backward direction. A null wrapper unboxes to an NPE there — the same as the
-      //      runtime's default PROPAGATE null strategy; the runtime's opt-in null-defaulting
-      //      strategy has no codegen equivalent. Neither side is a reflectable declared type, but
-      // no
-      //      sub-bridge is needed.
+      // (1b) Primitive ↔ its boxed wrapper (boolean↔Boolean, int↔Integer, …) → identity, so no
+      //      sub-bridge is derived (the primitive isn't a declared type and the wrapper isn't
+      //      telescope-recursable). The generated read auto-boxes on the forward direction (always
+      //      safe) and auto-unboxes on the backward direction; a null wrapper unboxes to an NPE
+      //      there, the same as the runtime's default PROPAGATE null strategy (the runtime's opt-in
+      //      null-defaulting strategy has no codegen equivalent).
       if (isPrimitiveWrapperPair(sf.type(), tf.type())) {
         plans.put(sf.name(), FieldPlan.identity());
         continue;

--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
@@ -1978,6 +1978,8 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
    *
    * <ul>
    *   <li>{@code IDENTITY} — types match exactly; pass the value through unchanged.
+   *   <li>{@code PRIM_WRAPPER} — one side primitive, the other its boxed wrapper; auto box/unbox,
+   *       null-coalescing to the primitive's JLS default on the unbox direction.
    *   <li>{@code RECURSE} — scalar sub-pair with both sides reflectable; reference its
    *       forward/backward methods directly.
    *   <li>{@code LIST}, {@code SET}, {@code MAP_VALUES}, {@code OPTIONAL} — same-kind container on
@@ -1987,9 +1989,20 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
    *   <li>{@code NULLABLE_TO_OPTIONAL} — mirror direction.
    * </ul>
    */
-  private record FieldPlan(Kind kind, String subBridgeName, String qualifierMethod) {
+  private record FieldPlan(
+    Kind kind,
+    String subBridgeName,
+    String qualifierMethod,
+    // PRIM_WRAPPER only: the JLS-default literal to coalesce a null read to, per direction, or
+    // null
+    // when that direction writes the wrapper side (which tolerates null). Mirrors the runtime
+    // primitiveWrapperIso's fwdDefault / bwdDefault.
+    String fwdNullDefault,
+    String bwdNullDefault
+  ) {
     enum Kind {
       IDENTITY,
+      PRIM_WRAPPER,
       RECURSE,
       LIST,
       SET,
@@ -2001,22 +2014,36 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
     }
 
     static FieldPlan identity() {
-      return new FieldPlan(Kind.IDENTITY, null, null);
+      return new FieldPlan(Kind.IDENTITY, null, null, null, null);
+    }
+
+    // Primitive ↔ boxed wrapper. The direction that writes the primitive side null-coalesces a null
+    // read to that primitive's JLS default; the direction that writes the wrapper passes through
+    // (null is a legal wrapper value). Exactly one of the two defaults is non-null for any given
+    // pair. Matches the runtime DeepMap.primitiveWrapperIso.
+    static FieldPlan primWrapper(final String fwdNullDefault, final String bwdNullDefault) {
+      return new FieldPlan(Kind.PRIM_WRAPPER, null, null, fwdNullDefault, bwdNullDefault);
     }
 
     static FieldPlan recurse(final String subBridgeName) {
-      return new FieldPlan(Kind.RECURSE, Objects.requireNonNull(subBridgeName), null);
+      return new FieldPlan(Kind.RECURSE, Objects.requireNonNull(subBridgeName), null, null, null);
     }
 
     static FieldPlan ofKind(final Kind kind, final String subBridgeName) {
-      return new FieldPlan(kind, Objects.requireNonNull(subBridgeName), null);
+      return new FieldPlan(kind, Objects.requireNonNull(subBridgeName), null, null, null);
     }
 
     // Qualifier-dispatch TRANSFORM variant: the `using` class hosts a named static method, NOT a
     // BridgeFn implementor. Codegen emits a direct {@code UsingClass.methodName(value)} call and
     // does not declare a {@code __tx_<field>} singleton instance.
     static FieldPlan ofTransformQualified(final String usingClassFqn, final String method) {
-      return new FieldPlan(Kind.TRANSFORM, Objects.requireNonNull(usingClassFqn), Objects.requireNonNull(method));
+      return new FieldPlan(
+        Kind.TRANSFORM,
+        Objects.requireNonNull(usingClassFqn),
+        Objects.requireNonNull(method),
+        null,
+        null
+      );
     }
   }
 
@@ -2092,14 +2119,21 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
         plans.put(sf.name(), FieldPlan.identity());
         continue;
       }
-      // (1b) Primitive ↔ its boxed wrapper (boolean↔Boolean, int↔Integer, …) → identity, so no
-      //      sub-bridge is derived (the primitive isn't a declared type and the wrapper isn't
-      //      telescope-recursable). The generated read auto-boxes on the forward direction (always
-      //      safe) and auto-unboxes on the backward direction; a null wrapper unboxes to an NPE
-      //      there, the same as the runtime's default PROPAGATE null strategy (the runtime's opt-in
-      //      null-defaulting strategy has no codegen equivalent).
+      // (1b) Primitive ↔ its boxed wrapper (boolean↔Boolean, int↔Integer, …). No sub-bridge is
+      //      derived (the primitive isn't a declared type and the wrapper isn't
+      // telescope-recursable).
+      //      The read auto-boxes when it writes the wrapper side and auto-unboxes when it writes
+      // the
+      //      primitive side; on the unbox direction a null wrapper null-coalesces to that
+      // primitive's
+      //      JLS default instead of NPE-ing, mirroring the runtime DeepMap.primitiveWrapperIso.
+      //      forward writes the target, backward writes the source — so the default applies to
+      //      whichever of those is the primitive (primitiveDefaultLiteral is empty for the
+      // wrapper).
       if (isPrimitiveWrapperPair(sf.type(), tf.type())) {
-        plans.put(sf.name(), FieldPlan.identity());
+        final var fwdNullDefault = primitiveDefaultLiteral(tf.type().getKind()).orElse(null);
+        final var bwdNullDefault = primitiveDefaultLiteral(sf.type().getKind()).orElse(null);
+        plans.put(sf.name(), FieldPlan.primWrapper(fwdNullDefault, bwdNullDefault));
         continue;
       }
       // (2) Container shape detection — both sides container of the same kind with element types
@@ -2288,6 +2322,9 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
     final var fwdElement = elementIdentity ? "e -> e" : sub + "::forward";
     return switch (plan.kind()) {
       case IDENTITY -> readExpr;
+      case PRIM_WRAPPER -> plan.fwdNullDefault() == null
+        ? readExpr
+        : "(" + readExpr + " == null ? " + plan.fwdNullDefault() + " : " + readExpr + ")";
       case RECURSE -> sub + ".forward(" + readExpr + ")";
       // LIST/SET/MAP_VALUES: when the element type needs a sub-bridge, delegate to a private static
       // helper emitted alongside this method (see emitContainerHelpers below). The helper inlines a
@@ -2320,6 +2357,9 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
     final var bwdElement = elementIdentity ? "e -> e" : sub + "::backward";
     return switch (plan.kind()) {
       case IDENTITY -> readExpr;
+      case PRIM_WRAPPER -> plan.bwdNullDefault() == null
+        ? readExpr
+        : "(" + readExpr + " == null ? " + plan.bwdNullDefault() + " : " + readExpr + ")";
       case RECURSE -> sub + ".backward(" + readExpr + ")";
       case LIST -> elementIdentity
         ? "(" + readExpr + " == null ? null : new ArrayList<>(" + readExpr + "))"
@@ -2503,8 +2543,10 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
   }
 
   // True when one of {a, b} is a primitive and the other is exactly its boxed wrapper (boolean ↔
-  // Boolean, int ↔ Integer, …). Order-independent. Lets field-bridge planning treat such pairs as
-  // identity (forward auto-boxes, backward auto-unboxes).
+  // Boolean, int ↔ Integer, …). Order-independent. Lets field-bridge planning route such pairs
+  // through the PRIM_WRAPPER plan: the box direction passes through, the unbox direction
+  // null-defaults a null wrapper to the primitive's JLS default (parity with the runtime
+  // primitiveWrapperIso).
   private boolean isPrimitiveWrapperPair(final TypeMirror a, final TypeMirror b) {
     return isBoxedOf(a, b) || isBoxedOf(b, a);
   }

--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
@@ -28,6 +28,7 @@ import javax.lang.model.element.Modifier;
 import javax.lang.model.element.NestingKind;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.PrimitiveType;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.ElementFilter;
@@ -155,6 +156,13 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
   // BridgeConfig.EMPTY at lookup time, same as the auto-recursed case in the eager path).
   private final Set<TypePair> deferredPairs = new LinkedHashSet<>();
   private final Map<TypePair, BridgeConfig> deferredConfigs = new HashMap<>();
+
+  // Sub-pairs that an enclosing lenient @Bridge referenced. A sub-pair carries no BridgeConfig of
+  // its own (it falls back to BridgeConfig.EMPTY, which is strict), so without this its bijection
+  // check would fail when the nested target has extra fields — even though the lenient parent
+  // intends those to default. generate() ORs this into the per-pair lenient flag so leniency
+  // propagates to every nesting level, matching the runtime mapperForward(...) behaviour.
+  private final Set<TypePair> lenientPairs = new HashSet<>();
 
   // Set true around the deferred drain in processingOver() so sub-pair discovery inside
   // generate(...) / generateSealed(...) / planFieldSubBridges(...) / planElementSubBridge(...)
@@ -1090,7 +1098,9 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
     final var writeStrategy = cfg.writeStrategy();
     final var rawConstants = cfg.constants();
     final var computes = cfg.computes();
-    final var lenient = cfg.lenient();
+    // A pair is lenient if its own config says so, or if an enclosing lenient @Bridge referenced it
+    // as a sub-pair (leniency propagates down the nesting).
+    final var lenient = cfg.lenient() || lenientPairs.contains(thisPair);
 
     // Validate every transform field is a real source field (drops would mask the validation).
     for (final var t : transforms.keySet()) {
@@ -1494,7 +1504,8 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
       viaMappers,
       pending,
       seen,
-      userDeclared
+      userDeclared,
+      lenient
     );
     if (fieldPlans == null) return;
 
@@ -2040,7 +2051,8 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
     final Map<String, String> viaMappers,
     final Deque<TypePair> pending,
     final Set<TypePair> seen,
-    final Set<TypePair> userDeclared
+    final Set<TypePair> userDeclared,
+    final boolean lenient
   ) {
     final var plans = new LinkedHashMap<String, FieldPlan>();
     for (final var sf : sourceFields) {
@@ -2066,6 +2078,14 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
       final var tf = fieldByName(targetFields, renames.getOrDefault(sf.name(), sf.name()));
       // (1) Same type → identity. Covers same-typed containers too (List<X>↔List<X> is identity).
       if (isSameType(sf.type(), tf.type())) {
+        plans.put(sf.name(), FieldPlan.identity());
+        continue;
+      }
+      // (1b) Primitive ↔ its boxed wrapper (boolean↔Boolean, int↔Integer, …) → identity. The
+      //      generated read auto-boxes on the forward direction and auto-unboxes on the backward
+      //      direction exactly as Java does, matching the runtime DeepMap's primitive/wrapper
+      //      handling. Neither side is a reflectable declared type, but no sub-bridge is needed.
+      if (isPrimitiveWrapperPair(sf.type(), tf.type())) {
         plans.put(sf.name(), FieldPlan.identity());
         continue;
       }
@@ -2160,6 +2180,9 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
           if (shouldDeferSubPair(subSourceEl, subTargetEl)) deferredPairs.add(subPair);
           else pending.add(subPair);
         }
+        // Leniency propagates: a lenient parent's nested sub-pair is itself lenient, so its
+        // bijection check is skipped and unmatched nested-target fields take JLS defaults.
+        if (lenient) lenientPairs.add(subPair);
         final var subBridgeName = bridgeClassName(subSourceEl, subTargetEl, userDeclared.contains(subPair));
         plans.put(sf.name(), FieldPlan.recurse(subBridgeName));
         continue;
@@ -2464,6 +2487,20 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
    */
   private boolean isSameType(final TypeMirror a, final TypeMirror b) {
     return processingEnv.getTypeUtils().isSameType(a, b);
+  }
+
+  // True when one of {a, b} is a primitive and the other is exactly its boxed wrapper (boolean ↔
+  // Boolean, int ↔ Integer, …). Order-independent. Lets field-bridge planning treat such pairs as
+  // identity, matching the runtime DeepMap autobox/unbox behaviour.
+  private boolean isPrimitiveWrapperPair(final TypeMirror a, final TypeMirror b) {
+    return isBoxedOf(a, b) || isBoxedOf(b, a);
+  }
+
+  // True when `prim` is a primitive and `boxed` is exactly its boxed wrapper type.
+  private boolean isBoxedOf(final TypeMirror prim, final TypeMirror boxed) {
+    if (!prim.getKind().isPrimitive() || !(boxed instanceof DeclaredType)) return false;
+    final var types = processingEnv.getTypeUtils();
+    return types.isSameType(types.boxedClass((PrimitiveType) prim).asType(), boxed);
   }
 
   /** Whether the declared type is a record/class telescope can recurse into. */

--- a/codegen/src/test/java/io/github/eschizoid/telescope/codegen/BridgeProcessorTest.java
+++ b/codegen/src/test/java/io/github/eschizoid/telescope/codegen/BridgeProcessorTest.java
@@ -3978,7 +3978,7 @@ class BridgeProcessorTest {
   }
 
   @Nested
-  @DisplayName("Primitive ↔ wrapper fields auto-bridge as identity (forward auto-box, backward unbox)")
+  @DisplayName("Primitive ↔ wrapper fields auto-bridge with box/unbox and backward null-default")
   class PrimitiveWrapperBridging {
 
     @Test
@@ -4006,8 +4006,8 @@ class BridgeProcessorTest {
       assertTrue(compilation.success(), () -> "compilation failed: " + compilation.errorMessages());
       final var generated = compilation.generated().get("demo.SrcBridge");
       assertNotNull(generated, () -> "SrcBridge not generated; saw " + compilation.generated().keySet());
-      // The primitive/wrapper field is treated as identity: forward auto-boxes, backward
-      // auto-unboxes.
+      // The primitive/wrapper field is handled by the PRIM_WRAPPER plan: forward auto-boxes,
+      // backward unboxes and null-defaults to the primitive's JLS default.
       assertTrue(generated.contains("locked"), generated);
     }
 

--- a/codegen/src/test/java/io/github/eschizoid/telescope/codegen/BridgeProcessorTest.java
+++ b/codegen/src/test/java/io/github/eschizoid/telescope/codegen/BridgeProcessorTest.java
@@ -3976,4 +3976,94 @@ class BridgeProcessorTest {
       );
     }
   }
+
+  @Nested
+  @DisplayName("Primitive ↔ wrapper fields auto-bridge as identity (codegen parity with runtime DeepMap)")
+  class PrimitiveWrapperBridging {
+
+    @Test
+    @DisplayName("a boolean field bridged to a Boolean field compiles and emits a bridge instead of erroring")
+    void primitiveToWrapperFieldAutoBridges() {
+      final var compilation = compile(
+        source(
+          "demo.Src",
+          """
+          package demo;
+          import io.github.eschizoid.telescope.annotations.Bridge;
+          @Bridge(demo.Dst.class)
+          public record Src(boolean locked, String name) {}
+          """
+        ),
+        source(
+          "demo.Dst",
+          """
+          package demo;
+          public record Dst(Boolean locked, String name) {}
+          """
+        )
+      );
+
+      assertTrue(compilation.success(), () -> "compilation failed: " + compilation.errorMessages());
+      final var generated = compilation.generated().get("demo.SrcBridge");
+      assertNotNull(generated, () -> "SrcBridge not generated; saw " + compilation.generated().keySet());
+      // The primitive/wrapper field is treated as identity: forward auto-boxes, backward
+      // auto-unboxes.
+      assertTrue(generated.contains("locked"), generated);
+    }
+  }
+
+  @Nested
+  @DisplayName("@Bridge(lenient = true) propagates leniency into nested sub-pairs")
+  class LenientNestedPropagation {
+
+    @Test
+    @DisplayName(
+      "a lenient parent whose nested target sub-type has an extra field compiles (sub-pair inherits lenient)"
+    )
+    void lenientPropagatesIntoNestedSubPair() {
+      final var compilation = compile(
+        source(
+          "demo.Outer",
+          """
+          package demo;
+          import io.github.eschizoid.telescope.annotations.Bridge;
+          @Bridge(value = demo.OuterBO.class, lenient = true)
+          public record Outer(demo.Inner inner) {}
+          """
+        ),
+        source(
+          "demo.Inner",
+          """
+          package demo;
+          public record Inner(String a) {}
+          """
+        ),
+        source(
+          "demo.OuterBO",
+          """
+          package demo;
+          public record OuterBO(demo.InnerBO inner) {}
+          """
+        ),
+        source(
+          "demo.InnerBO",
+          """
+          package demo;
+          public record InnerBO(String a, String extra) {}
+          """
+        )
+      );
+
+      assertTrue(compilation.success(), () -> "compilation failed: " + compilation.errorMessages());
+      assertNotNull(
+        compilation.generated().get("demo.OuterBridge"),
+        () -> "OuterBridge not generated; saw " + compilation.generated().keySet()
+      );
+      // The nested sub-bridge is emitted leniently: InnerBO's extra field has no source counterpart
+      // and is defaulted rather than failing the strict bijection. (Auto-recursed sub-pairs use the
+      // disambiguated <Source>To<Target>Bridge name.)
+      final var sub = compilation.generated().get("demo.InnerToInnerBOBridge");
+      assertNotNull(sub, () -> "Inner sub-bridge not generated; saw " + compilation.generated().keySet());
+    }
+  }
 }

--- a/codegen/src/test/java/io/github/eschizoid/telescope/codegen/BridgeProcessorTest.java
+++ b/codegen/src/test/java/io/github/eschizoid/telescope/codegen/BridgeProcessorTest.java
@@ -3978,7 +3978,7 @@ class BridgeProcessorTest {
   }
 
   @Nested
-  @DisplayName("Primitive ↔ wrapper fields auto-bridge as identity (codegen parity with runtime DeepMap)")
+  @DisplayName("Primitive ↔ wrapper fields auto-bridge as identity (forward auto-box, backward unbox)")
   class PrimitiveWrapperBridging {
 
     @Test
@@ -4009,6 +4009,37 @@ class BridgeProcessorTest {
       // The primitive/wrapper field is treated as identity: forward auto-boxes, backward
       // auto-unboxes.
       assertTrue(generated.contains("locked"), generated);
+    }
+
+    @Test
+    @DisplayName("the reverse order (Boolean source field, boolean target field) also auto-bridges")
+    void wrapperToPrimitiveFieldAutoBridges() {
+      // isPrimitiveWrapperPair is order-independent; the wrapper-on-source / primitive-on-target
+      // direction is a distinct code path and must compile too.
+      final var compilation = compile(
+        source(
+          "demo.WSrc",
+          """
+          package demo;
+          import io.github.eschizoid.telescope.annotations.Bridge;
+          @Bridge(demo.WDst.class)
+          public record WSrc(Integer count, String name) {}
+          """
+        ),
+        source(
+          "demo.WDst",
+          """
+          package demo;
+          public record WDst(int count, String name) {}
+          """
+        )
+      );
+
+      assertTrue(compilation.success(), () -> "compilation failed: " + compilation.errorMessages());
+      assertNotNull(
+        compilation.generated().get("demo.WSrcBridge"),
+        () -> "WSrcBridge not generated; saw " + compilation.generated().keySet()
+      );
     }
   }
 
@@ -4064,6 +4095,51 @@ class BridgeProcessorTest {
       // disambiguated <Source>To<Target>Bridge name.)
       final var sub = compilation.generated().get("demo.InnerToInnerBOBridge");
       assertNotNull(sub, () -> "Inner sub-bridge not generated; saw " + compilation.generated().keySet());
+    }
+
+    @Test
+    @DisplayName("a NON-lenient parent with an extra nested-target field still fails the nested bijection")
+    void nonLenientNestedMismatchStillErrors() {
+      // Same shape as above but WITHOUT lenient — the nested sub-pair must still be held to the
+      // strict bijection, proving the propagation didn't make every nested pair lenient.
+      final var compilation = compile(
+        source(
+          "demo.SOuter",
+          """
+          package demo;
+          import io.github.eschizoid.telescope.annotations.Bridge;
+          @Bridge(demo.SOuterBO.class)
+          public record SOuter(demo.SInner inner) {}
+          """
+        ),
+        source(
+          "demo.SInner",
+          """
+          package demo;
+          public record SInner(String a) {}
+          """
+        ),
+        source(
+          "demo.SOuterBO",
+          """
+          package demo;
+          public record SOuterBO(demo.SInnerBO inner) {}
+          """
+        ),
+        source(
+          "demo.SInnerBO",
+          """
+          package demo;
+          public record SInnerBO(String a, String extra) {}
+          """
+        )
+      );
+
+      assertFalse(compilation.success(), "a strict nested mismatch must still fail compilation");
+      assertTrue(
+        compilation.hasError("same field names"),
+        () -> "expected a nested bijection diagnostic; saw " + compilation.errorMessages()
+      );
     }
   }
 }

--- a/core/src/test/java/io/github/eschizoid/telescope/beans/BridgeCodegenTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/beans/BridgeCodegenTest.java
@@ -1,7 +1,6 @@
 package io.github.eschizoid.telescope.beans;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -106,14 +105,32 @@ class BridgeCodegenTest {
 
   @Test
   @DisplayName(
-    "primitive ↔ wrapper backward with a null wrapper unboxes to NPE (matches the runtime default null strategy)"
+    "primitive ↔ wrapper backward with a null wrapper null-defaults to the primitive's JLS default (parity with runtime primitiveWrapperIso)"
   )
-  void primitiveWrapperBackwardNullUnboxThrows() {
-    // The generated backward read is a bare unbox, so a null wrapper NPEs — the same as the runtime
-    // DeepMap's default PROPAGATE strategy. Pinned so the behaviour is characterised, not silent.
+  void primitiveWrapperBackwardNullUnboxDefaults() {
+    // A null wrapper on the backward (unbox) direction must coalesce to the primitive's JLS default
+    // (false / 0), not NPE — matching the runtime DeepMap primitiveWrapperIso, which null-defaults
+    // both directions of the box/unbox conversion.
     final var src = new BridgePrimRec(true, 7, "n");
-    assertThrows(NullPointerException.class, () ->
-      BridgePrimRecBridge.BRIDGE.set(src, new BridgePrimRecBO(null, 9, "m"))
-    );
+    final var back = BridgePrimRecBridge.BRIDGE.set(src, new BridgePrimRecBO(null, null, "m"));
+    assertEquals(false, back.locked());
+    assertEquals(0, back.count());
+    assertEquals("m", back.name());
+  }
+
+  @Test
+  @DisplayName(
+    "primitive ↔ wrapper forward with a null wrapper source null-defaults the primitive target (the other direction's wiring)"
+  )
+  void primitiveWrapperForwardNullDefaults() {
+    // Reverse orientation: wrapper source, primitive target — so the FORWARD (read) direction
+    // writes
+    // the primitive and must null-default a null wrapper source to false / 0, pinning the
+    // fwdNullDefault wiring at runtime (the backward test pins bwdNullDefault).
+    final var src = new BridgeWrapRec(null, null, "m");
+    final var bo = BridgeWrapRecBridge.BRIDGE.read(src);
+    assertEquals(false, bo.flag());
+    assertEquals(0, bo.num());
+    assertEquals("m", bo.name());
   }
 }

--- a/core/src/test/java/io/github/eschizoid/telescope/beans/BridgeCodegenTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/beans/BridgeCodegenTest.java
@@ -1,6 +1,7 @@
 package io.github.eschizoid.telescope.beans;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -83,5 +84,36 @@ class BridgeCodegenTest {
     final var back = BridgePojoABridge.BRIDGE.set(a, replacement);
     assertEquals("u2", back.getId());
     assertEquals("B@Y", back.getEmail());
+  }
+
+  @Test
+  @DisplayName("primitive ↔ wrapper fields: forward auto-boxes; backward unboxes a non-null wrapper")
+  void primitiveWrapperRoundTrip() {
+    final var src = new BridgePrimRec(true, 7, "n");
+
+    // forward: boolean → Boolean, int → Integer (auto-box, always safe).
+    final var bo = BridgePrimRecBridge.BRIDGE.read(src);
+    assertEquals(Boolean.TRUE, bo.locked());
+    assertEquals(Integer.valueOf(7), bo.count());
+    assertEquals("n", bo.name());
+
+    // backward: a non-null Boolean / Integer auto-unboxes back to the primitives.
+    final var back = BridgePrimRecBridge.BRIDGE.set(src, new BridgePrimRecBO(false, 9, "m"));
+    assertEquals(false, back.locked());
+    assertEquals(9, back.count());
+    assertEquals("m", back.name());
+  }
+
+  @Test
+  @DisplayName(
+    "primitive ↔ wrapper backward with a null wrapper unboxes to NPE (matches the runtime default null strategy)"
+  )
+  void primitiveWrapperBackwardNullUnboxThrows() {
+    // The generated backward read is a bare unbox, so a null wrapper NPEs — the same as the runtime
+    // DeepMap's default PROPAGATE strategy. Pinned so the behaviour is characterised, not silent.
+    final var src = new BridgePrimRec(true, 7, "n");
+    assertThrows(NullPointerException.class, () ->
+      BridgePrimRecBridge.BRIDGE.set(src, new BridgePrimRecBO(null, 9, "m"))
+    );
   }
 }

--- a/core/src/test/java/io/github/eschizoid/telescope/beans/BridgePrimRec.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/beans/BridgePrimRec.java
@@ -4,8 +4,8 @@ import io.github.eschizoid.telescope.annotations.Bridge;
 
 /**
  * Codegen fixture: record&harr;record bridge whose fields are primitives ({@code boolean}, {@code
- * int}) against the boxed wrappers on {@link BridgePrimRecBO}. Exercises the auto box/unbox
- * identity path in the generated bridge.
+ * int}) against the boxed wrappers on {@link BridgePrimRecBO}. Exercises the primitive↔wrapper
+ * box/unbox path (with backward null-defaulting) in the generated bridge.
  */
 @Bridge(BridgePrimRecBO.class)
 public record BridgePrimRec(boolean locked, int count, String name) {}

--- a/core/src/test/java/io/github/eschizoid/telescope/beans/BridgePrimRec.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/beans/BridgePrimRec.java
@@ -1,0 +1,11 @@
+package io.github.eschizoid.telescope.beans;
+
+import io.github.eschizoid.telescope.annotations.Bridge;
+
+/**
+ * Codegen fixture: record&harr;record bridge whose fields are primitives ({@code boolean}, {@code
+ * int}) against the boxed wrappers on {@link BridgePrimRecBO}. Exercises the auto box/unbox
+ * identity path in the generated bridge.
+ */
+@Bridge(BridgePrimRecBO.class)
+public record BridgePrimRec(boolean locked, int count, String name) {}

--- a/core/src/test/java/io/github/eschizoid/telescope/beans/BridgePrimRecBO.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/beans/BridgePrimRecBO.java
@@ -1,0 +1,4 @@
+package io.github.eschizoid.telescope.beans;
+
+/** Boxed-wrapper target for {@link BridgePrimRec} (Boolean / Integer against boolean / int). */
+public record BridgePrimRecBO(Boolean locked, Integer count, String name) {}

--- a/core/src/test/java/io/github/eschizoid/telescope/beans/BridgeWrapRec.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/beans/BridgeWrapRec.java
@@ -1,0 +1,12 @@
+package io.github.eschizoid.telescope.beans;
+
+import io.github.eschizoid.telescope.annotations.Bridge;
+
+/**
+ * Reverse-order codegen fixture: the source fields are the boxed wrappers and the target fields are
+ * the primitives (the mirror of {@link BridgePrimRec}). Exercises the forward null-default path —
+ * forward writes the primitive target, so a null wrapper source coalesces to the primitive's JLS
+ * default.
+ */
+@Bridge(BridgeWrapRecBO.class)
+public record BridgeWrapRec(Boolean flag, Integer num, String name) {}

--- a/core/src/test/java/io/github/eschizoid/telescope/beans/BridgeWrapRecBO.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/beans/BridgeWrapRecBO.java
@@ -1,0 +1,4 @@
+package io.github.eschizoid.telescope.beans;
+
+/** Primitive target for {@link BridgeWrapRec} (boolean / int against Boolean / Integer). */
+public record BridgeWrapRecBO(boolean flag, int num, String name) {}


### PR DESCRIPTION
## Problem

Two codegen `@Bridge` gaps where `BridgeProcessor` lags the already-fixed runtime path. Both are **compile-time errors** that block `@Bridge` on real adopter type pairs.

### 1. No primitive ↔ wrapper auto-bridge

```java
@Bridge(Dst.class)
public record Src(boolean locked, String name) {}
public record Dst(Boolean locked, String name) {}
```

```
@Bridge Src -> Dst: field 'locked' has incompatible types (boolean vs java.lang.Boolean)
and no auto-bridge could be derived.
```

The field-compatibility walk had no step for `PrimitiveType` ↔ its boxed `DeclaredType`: `isSameType` is false, it's not a container, not `Optional`, and a primitive isn't a reflectable `DeclaredType` — so it fell through to the error. The runtime `DeepMap` got this in 1.0.1 (`isPrimitiveWrapperPair`); codegen never did.

### 2. `@Bridge(lenient = true)` didn't propagate to nested sub-pairs

```java
public record Outer(Inner inner) {}     public record Inner(String a) {}
public record OuterBO(InnerBO inner) {} public record InnerBO(String a, String extra) {}  // extra: no source
```

A `lenient = true` top-level bridge still failed compilation on the nested `Inner → InnerBO` pair:

```
@Bridge: Inner and InnerBO must expose the same field names (a bijection).
Inner has [a], InnerBO has [a, extra].
```

The top-level lenient handling auto-fills drops/constants so the bijection passes, but enqueued sub-pairs carry no config → fall back to the strict `BridgeConfig.EMPTY`. The runtime `mapperForward(...)` skips the bijection at every nesting level; codegen only did at the top.

## Fix

1. **Primitive ↔ wrapper** — `planFields` gets a `(1b)` step: `if (isPrimitiveWrapperPair(sf, tf)) → FieldPlan.identity()`. `isPrimitiveWrapperPair` uses `Types.boxedClass` to test that one side is a primitive and the other its exact boxed wrapper. The generated read auto-boxes forward / auto-unboxes backward, like Java and the runtime path.

2. **Lenient propagation** — a `lenientPairs` set; when a lenient parent enqueues a sub-pair, the sub-pair is marked, and `generate()` ORs that into the per-pair lenient flag. Leniency now reaches every nesting level, so unmatched nested-target fields take JLS defaults.

## Tests

`BridgeProcessorTest` (ProcessorHarness): `boolean ↔ Boolean` field now compiles + emits a bridge; a lenient parent with an extra nested-target field now compiles + emits the lenient sub-bridge. Both were RED before the fix. Full `:codegen` / `:core` / `:lombok` suites green.

## Scope note — backward unbox

The primitive↔wrapper fix is plain identity (the adopter's proposed fix): forward auto-boxes (always safe), backward auto-*un*boxes — a **null** wrapper would NPE on the backward direction, where the runtime path null-defaults to the JLS default. This PR resolves the reported **compile** blocker and forward-direction parity; full backward-null-unbox parity (null wrapper → primitive JLS default in the generated backward read) would be a follow-up increment if wanted. Flagging for review.


---

**Update:** the backward-null-unbox boundary noted earlier is now **fixed** for full runtime parity. A new `PRIM_WRAPPER` `FieldPlan` kind null-coalesces the unbox direction to the primitive's JLS default (`null Boolean → false`, `null Integer → 0`), mirroring the runtime `DeepMap.primitiveWrapperIso` (which null-defaults both directions). The forward (box) direction stays a plain pass-through. Pinned by a runtime round-trip test that asserts the null-default rather than an NPE.
