### PR TITLE
fix(codegen): three runtime-parity fixes (record construct null-guard, lenient container propagation, Optional null-guard)

### DIFF
--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
@@ -2167,7 +2167,8 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
           srcShape.kind(),
           pending,
           seen,
-          userDeclared
+          userDeclared,
+          lenient
         );
         if (subPlan == null) return null;
         plans.put(sf.name(), subPlan);
@@ -2185,7 +2186,8 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
           FieldPlan.Kind.OPTIONAL_TO_NULLABLE,
           pending,
           seen,
-          userDeclared
+          userDeclared,
+          lenient
         );
         if (subPlan == null) return null;
         plans.put(sf.name(), subPlan);
@@ -2201,7 +2203,8 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
           FieldPlan.Kind.NULLABLE_TO_OPTIONAL,
           pending,
           seen,
-          userDeclared
+          userDeclared,
+          lenient
         );
         if (subPlan == null) return null;
         plans.put(sf.name(), subPlan);
@@ -2269,7 +2272,8 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
     final FieldPlan.Kind kind,
     final Deque<TypePair> pending,
     final Set<TypePair> seen,
-    final Set<TypePair> userDeclared
+    final Set<TypePair> userDeclared,
+    final boolean lenient
   ) {
     if (isSameType(srcElement, tgtElement)) {
       // Container kind matters (lift), but no sub-bridge — the element passes through. Use a
@@ -2293,6 +2297,8 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
         if (shouldDeferSubPair(subSourceEl, subTargetEl)) deferredPairs.add(subPair);
         else pending.add(subPair);
       }
+      // Leniency propagates into the element pair too, matching the scalar sub-pair path.
+      if (lenient) lenientPairs.add(subPair);
       final var subBridgeName = bridgeClassName(subSourceEl, subTargetEl, userDeclared.contains(subPair));
       return FieldPlan.ofKind(kind, subBridgeName);
     }
@@ -2337,11 +2343,17 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
       case SET -> elementIdentity
         ? "(" + readExpr + " == null ? null : new LinkedHashSet<>(" + readExpr + "))"
         : "__fwd_" + fieldName + "(" + readExpr + ")";
-      case OPTIONAL -> readExpr + ".map(" + fwdElement + ")";
+      case OPTIONAL -> "(" + readExpr + " == null ? null : " + readExpr + ".map(" + fwdElement + "))";
       case MAP_VALUES -> elementIdentity
         ? "(" + readExpr + " == null ? null : new LinkedHashMap<>(" + readExpr + "))"
         : "__fwd_" + fieldName + "(" + readExpr + ")";
-      case OPTIONAL_TO_NULLABLE -> readExpr + ".map(" + fwdElement + ").orElse(null)";
+      case OPTIONAL_TO_NULLABLE -> "(" +
+      readExpr +
+      " == null ? null : " +
+      readExpr +
+      ".map(" +
+      fwdElement +
+      ").orElse(null))";
       case NULLABLE_TO_OPTIONAL -> "Optional.ofNullable(" + readExpr + ").map(" + fwdElement + ")";
       // Qualifier dispatch: emit a direct {@code UsingClass.methodName(value)} call. Otherwise
       // dispatch through the {@code __tx_<field>} BridgeFn singleton instance (legacy shape).
@@ -2367,13 +2379,19 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
       case SET -> elementIdentity
         ? "(" + readExpr + " == null ? null : new LinkedHashSet<>(" + readExpr + "))"
         : "__bwd_" + fieldName + "(" + readExpr + ")";
-      case OPTIONAL -> readExpr + ".map(" + bwdElement + ")";
+      case OPTIONAL -> "(" + readExpr + " == null ? null : " + readExpr + ".map(" + bwdElement + "))";
       case MAP_VALUES -> elementIdentity
         ? "(" + readExpr + " == null ? null : new LinkedHashMap<>(" + readExpr + "))"
         : "__bwd_" + fieldName + "(" + readExpr + ")";
       // For the cross-paradigm bridges, forward and backward are mirror images.
       case OPTIONAL_TO_NULLABLE -> "Optional.ofNullable(" + readExpr + ").map(" + bwdElement + ")";
-      case NULLABLE_TO_OPTIONAL -> readExpr + ".map(" + bwdElement + ").orElse(null)";
+      case NULLABLE_TO_OPTIONAL -> "(" +
+      readExpr +
+      " == null ? null : " +
+      readExpr +
+      ".map(" +
+      bwdElement +
+      ").orElse(null))";
       case TRANSFORM -> "__tx_" + fieldName + ".backward(" + readExpr + ")";
     };
   }

--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/FocusProcessor.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/FocusProcessor.java
@@ -201,7 +201,18 @@ public final class FocusProcessor extends AbstractTelescopeProcessor {
       final var comp = components.get(i);
       final var compName = comp.getSimpleName().toString();
       final var castType = shortenStdImports(boxedType(comp.asType()));
-      out.print("(" + castType + ") values.apply(\"" + compName + "\")");
+      final var apply = "values.apply(\"" + compName + "\")";
+      // A primitive component null-guards with an instanceof-default so a null boxed value takes
+      // the
+      // JLS default instead of NPE-ing on the canonical-constructor unbox — same guard the bean
+      // construct emits via valueExprForProp. The pattern variable is named per-component because
+      // all
+      // arguments live in one `new R(...)` expression, so a shared name could collide.
+      final var pv = "__v_" + compName;
+      final var arg = primitiveDefaultLiteral(comp.asType().getKind())
+        .map(def -> apply + " instanceof " + castType + " " + pv + " ? " + pv + " : " + def)
+        .orElseGet(() -> "(" + castType + ") " + apply);
+      out.print(arg);
       if (i < components.size() - 1) out.print(", ");
     }
     out.println(");");

--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/FocusProcessor.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/FocusProcessor.java
@@ -185,9 +185,10 @@ public final class FocusProcessor extends AbstractTelescopeProcessor {
   }
 
   // Emit a `public static <Record> construct(Function<String, Object> values)` that calls the
-  // canonical constructor directly with cast-pulled values — the runtime hybrid dispatch in
-  // MetadataHolderProbe / Reflective#structuralIso routes here, bypassing the reflective
-  // Records.construct path for annotated records.
+  // canonical constructor directly: a reference component is a plain cast, a primitive component is
+  // pulled through an instanceof-default null-guard (so a null boxed value takes the JLS default
+  // instead of NPE-ing on the unbox). The runtime hybrid dispatch in MetadataHolderProbe /
+  // Reflective#structuralIso routes here, bypassing the reflective Records.construct path.
   private void emitRecordConstruct(
     final PrintWriter out,
     final String recordName,

--- a/codegen/src/test/java/io/github/eschizoid/telescope/codegen/BridgeProcessorTest.java
+++ b/codegen/src/test/java/io/github/eschizoid/telescope/codegen/BridgeProcessorTest.java
@@ -467,9 +467,16 @@ class BridgeProcessorTest {
       assertTrue(compilation.success(), () -> "compilation failed: " + compilation.errorMessages());
       final var order = compilation.generated().get("demo.OrderBridge");
       assertNotNull(order);
-      // Forward: Optional<Address>.map(AddressBridge::forward).orElse(null)
-      assertTrue(order.contains("s.giftWrap().map(AddressToAddressEntityBridge::forward).orElse(null)"), order);
-      // Backward: Optional.ofNullable(...).map(AddressBridge::backward)
+      // Forward (OPTIONAL_TO_NULLABLE) reads the source Optional, so it null-guards the reference
+      // before .map(...), matching the runtime Iso.liftOptionalToNullable (ox == null ? null :
+      // ...).
+      assertTrue(
+        order.contains(
+          "(s.giftWrap() == null ? null : s.giftWrap().map(AddressToAddressEntityBridge::forward).orElse(null))"
+        ),
+        order
+      );
+      // Backward: Optional.ofNullable(...) is already null-safe on the plain target value.
       assertTrue(order.contains("import java.util.Optional;"), order);
       assertTrue(
         order.contains("Optional.ofNullable(t.giftWrap()).map(AddressToAddressEntityBridge::backward)"),
@@ -4139,6 +4146,54 @@ class BridgeProcessorTest {
       assertTrue(
         compilation.hasError("same field names"),
         () -> "expected a nested bijection diagnostic; saw " + compilation.errorMessages()
+      );
+    }
+
+    @Test
+    @DisplayName(
+      "lenient propagates into a CONTAINER-ELEMENT sub-pair (List<Elem> whose element target has an extra field compiles)"
+    )
+    void lenientPropagatesIntoContainerElementSubPair() {
+      // The runtime treats every nested auto-recursed pair as lenient, including container element
+      // pairs. Codegen previously only propagated lenient into scalar sub-pairs; a List<Elem> whose
+      // element sub-bridge has a field mismatch must now also inherit the parent's leniency.
+      final var compilation = compile(
+        source(
+          "demo.LOuter",
+          """
+          package demo;
+          import io.github.eschizoid.telescope.annotations.Bridge;
+          @Bridge(value = demo.LOuterBO.class, lenient = true)
+          public record LOuter(java.util.List<demo.LElem> items) {}
+          """
+        ),
+        source(
+          "demo.LElem",
+          """
+          package demo;
+          public record LElem(String a) {}
+          """
+        ),
+        source(
+          "demo.LOuterBO",
+          """
+          package demo;
+          public record LOuterBO(java.util.List<demo.LElemBO> items) {}
+          """
+        ),
+        source(
+          "demo.LElemBO",
+          """
+          package demo;
+          public record LElemBO(String a, String extra) {}
+          """
+        )
+      );
+
+      assertTrue(compilation.success(), () -> "compilation failed: " + compilation.errorMessages());
+      assertNotNull(
+        compilation.generated().get("demo.LElemToLElemBOBridge"),
+        () -> "element sub-bridge not generated; saw " + compilation.generated().keySet()
       );
     }
   }

--- a/codegen/src/test/java/io/github/eschizoid/telescope/codegen/BridgeProcessorTest.java
+++ b/codegen/src/test/java/io/github/eschizoid/telescope/codegen/BridgeProcessorTest.java
@@ -373,8 +373,16 @@ class BridgeProcessorTest {
       assertTrue(compilation.success(), () -> "compilation failed: " + compilation.errorMessages());
       final var user = compilation.generated().get("demo.UserBridge");
       assertNotNull(user);
-      assertTrue(user.contains("s.profile().map(ProfileToProfileDtoBridge::forward)"), user);
-      assertTrue(user.contains("t.profile().map(ProfileToProfileDtoBridge::backward)"), user);
+      // Both directions null-guard the Optional reference before .map(...), matching the runtime
+      // Iso.liftOptional (ox == null ? null : ox.map(...)).
+      assertTrue(
+        user.contains("(s.profile() == null ? null : s.profile().map(ProfileToProfileDtoBridge::forward))"),
+        user
+      );
+      assertTrue(
+        user.contains("(t.profile() == null ? null : t.profile().map(ProfileToProfileDtoBridge::backward))"),
+        user
+      );
     }
 
     @Test

--- a/codegen/src/test/java/io/github/eschizoid/telescope/codegen/FocusProcessorTest.java
+++ b/codegen/src/test/java/io/github/eschizoid/telescope/codegen/FocusProcessorTest.java
@@ -616,12 +616,15 @@ class FocusProcessorTest {
       // construct() signature: public static Person construct(final Function<String, Object>
       // values)
       assertTrue(holder.contains("public static Person construct(final Function<String, Object> values)"), holder);
-      // The body must call the canonical constructor with per-component casts pulled from
-      // values.apply(...). Primitives surface as their boxed equivalents (the auto-unbox happens
-      // implicitly at the canonical-ctor call site).
+      // The body must call the canonical constructor with per-component values pulled from
+      // values.apply(...). Reference components use a plain cast; primitive components null-guard
+      // with an instanceof-default so a null boxed value takes the JLS default instead of NPE-ing
+      // on
+      // the canonical-ctor unbox (per-component pattern variable to avoid collisions in the single
+      // `new R(...)` expression).
       assertTrue(holder.contains("return new Person("), holder);
       assertTrue(holder.contains("(String) values.apply(\"name\")"), holder);
-      assertTrue(holder.contains("(Integer) values.apply(\"age\")"), holder);
+      assertTrue(holder.contains("values.apply(\"age\") instanceof Integer __v_age ? __v_age : 0"), holder);
       // Function import has to be in the holder's import block — extra import collected by
       // emitMetadataHolder, alongside any java.util container imports.
       assertTrue(holder.contains("import java.util.function.Function;"), holder);

--- a/core/src/test/java/io/github/eschizoid/telescope/MigrationRegressionTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/MigrationRegressionTest.java
@@ -34,6 +34,7 @@ import io.github.eschizoid.telescope.focus.OptionalTargetBean;
 import io.github.eschizoid.telescope.focus.PlainChainLeaf;
 import io.github.eschizoid.telescope.focus.PlainChainMid;
 import io.github.eschizoid.telescope.focus.PlainChainOuter;
+import io.github.eschizoid.telescope.focus.PrimitiveIntRecord;
 import io.github.eschizoid.telescope.focus.PrimitiveIntTarget;
 import io.github.eschizoid.telescope.focus.WriteChainLeaf;
 import io.github.eschizoid.telescope.focus.WriteChainMid;
@@ -2432,6 +2433,24 @@ class MigrationRegressionTest {
       // src.attemptCount left null
       final var dto = assertDoesNotThrow(() -> mapper.forward(src));
       assertEquals(0, dto.getAttemptCount()); // JLS default for int
+    }
+
+    @Test
+    @DisplayName("forward(source) with null boxed Integer to @Focus RECORD primitive int component uses JLS default")
+    void nullBoxedToPrimitiveRecordComponentUsesJlsDefault() {
+      // Record sibling of the bean case: the generated record holder's construct(Function) rebuilds
+      // via the canonical constructor, so a null boxed value bound to a primitive component must
+      // take the JLS default rather than NPE-ing on the implicit unbox. The bean construct guards
+      // this via valueExprForProp; the record construct must too.
+      final var mapper = Telescope.mapperForward(
+        NullableIntegerSource.class,
+        PrimitiveIntRecord.class,
+        Mapping.to(NullableIntegerSource::getAttemptCount, PrimitiveIntRecord::attemptCount)
+      );
+      final var src = new NullableIntegerSource();
+      // src.attemptCount left null
+      final var rec = assertDoesNotThrow(() -> mapper.forward(src));
+      assertEquals(0, rec.attemptCount()); // JLS default for int
     }
   }
 

--- a/core/src/test/java/io/github/eschizoid/telescope/beans/BridgeCodegenTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/beans/BridgeCodegenTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
+import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -148,7 +149,7 @@ class BridgeCodegenTest {
     assertNull(dstForward.maybe(), "null Optional source bridges forward to null, not NPE");
 
     final var srcBackward = assertDoesNotThrow(() ->
-      OptSrcBridge.BRIDGE.set(new OptSrc(java.util.Optional.empty()), new OptDst(null))
+      OptSrcBridge.BRIDGE.set(new OptSrc(Optional.empty()), new OptDst(null))
     );
     assertNull(srcBackward.maybe(), "null Optional target bridges backward to null, not NPE");
   }
@@ -156,10 +157,27 @@ class BridgeCodegenTest {
   @Test
   @DisplayName("Optional bridge: a present Optional round-trips through the element sub-bridge")
   void optionalPresentRoundTrips() {
-    final var src = new OptSrc(java.util.Optional.of(new OptElem("x")));
+    final var src = new OptSrc(Optional.of(new OptElem("x")));
     final var dst = OptSrcBridge.BRIDGE.read(src);
-    assertEquals(java.util.Optional.of(new OptElemBO("x")), dst.maybe());
+    assertEquals(Optional.of(new OptElemBO("x")), dst.maybe());
     final var back = OptSrcBridge.BRIDGE.set(src, dst);
-    assertEquals(java.util.Optional.of(new OptElem("x")), back.maybe());
+    assertEquals(Optional.of(new OptElem("x")), back.maybe());
+  }
+
+  @Test
+  @DisplayName(
+    "nullable→Optional bridge: a null Optional target reference passes through backward as null instead of NPE"
+  )
+  void nullableToOptionalBackwardNullGuard() {
+    // NtoOSrc.maybe is a plain (nullable) OptElem; NtoODst.maybe is Optional<OptElemBO>. The
+    // backward
+    // (set) direction reads the TARGET Optional, so a null Optional reference there must not NPE on
+    // the generated .map(...) — exercising the NULLABLE_TO_OPTIONAL backward guard.
+    final var back = assertDoesNotThrow(() -> NtoOSrcBridge.BRIDGE.set(new NtoOSrc(null), new NtoODst(null)));
+    assertNull(back.maybe(), "null Optional target bridges backward to a null source field, not NPE");
+
+    // Forward and a present round-trip still work.
+    final var fwd = NtoOSrcBridge.BRIDGE.read(new NtoOSrc(new OptElem("y")));
+    assertEquals(Optional.of(new OptElemBO("y")), fwd.maybe());
   }
 }

--- a/core/src/test/java/io/github/eschizoid/telescope/beans/BridgeCodegenTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/beans/BridgeCodegenTest.java
@@ -1,6 +1,8 @@
 package io.github.eschizoid.telescope.beans;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -132,5 +134,32 @@ class BridgeCodegenTest {
     assertEquals(false, bo.flag());
     assertEquals(0, bo.num());
     assertEquals("m", bo.name());
+  }
+
+  @Test
+  @DisplayName(
+    "Optional bridge: a null Optional reference passes through as null instead of NPE (parity with Iso.liftOptional)"
+  )
+  void optionalNullReferencePassesThrough() {
+    // A null Optional field reference (not Optional.empty()) must not NPE on the generated
+    // .map(...).
+    // The runtime liftOptional guards `ox == null ? null`; the codegen must match both directions.
+    final var dstForward = assertDoesNotThrow(() -> OptSrcBridge.BRIDGE.read(new OptSrc(null)));
+    assertNull(dstForward.maybe(), "null Optional source bridges forward to null, not NPE");
+
+    final var srcBackward = assertDoesNotThrow(() ->
+      OptSrcBridge.BRIDGE.set(new OptSrc(java.util.Optional.empty()), new OptDst(null))
+    );
+    assertNull(srcBackward.maybe(), "null Optional target bridges backward to null, not NPE");
+  }
+
+  @Test
+  @DisplayName("Optional bridge: a present Optional round-trips through the element sub-bridge")
+  void optionalPresentRoundTrips() {
+    final var src = new OptSrc(java.util.Optional.of(new OptElem("x")));
+    final var dst = OptSrcBridge.BRIDGE.read(src);
+    assertEquals(java.util.Optional.of(new OptElemBO("x")), dst.maybe());
+    final var back = OptSrcBridge.BRIDGE.set(src, dst);
+    assertEquals(java.util.Optional.of(new OptElem("x")), back.maybe());
   }
 }

--- a/core/src/test/java/io/github/eschizoid/telescope/beans/NtoODst.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/beans/NtoODst.java
@@ -1,0 +1,6 @@
+package io.github.eschizoid.telescope.beans;
+
+import java.util.Optional;
+
+/** Optional-typed target for {@link NtoOSrc} (nullable source field → Optional target field). */
+public record NtoODst(Optional<OptElemBO> maybe) {}

--- a/core/src/test/java/io/github/eschizoid/telescope/beans/NtoOSrc.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/beans/NtoOSrc.java
@@ -1,0 +1,12 @@
+package io.github.eschizoid.telescope.beans;
+
+import io.github.eschizoid.telescope.annotations.Bridge;
+
+/**
+ * Codegen fixture with a plain (nullable) {@link OptElem} field bridged to an {@code
+ * Optional<OptElemBO>} target — the reverse orientation of {@link OptSrc}. Exercises the
+ * NULLABLE_TO_OPTIONAL backward lift, which reads the target Optional and must null-guard a null
+ * Optional reference before {@code .map(...)}.
+ */
+@Bridge(NtoODst.class)
+public record NtoOSrc(OptElem maybe) {}

--- a/core/src/test/java/io/github/eschizoid/telescope/beans/OptDst.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/beans/OptDst.java
@@ -1,0 +1,6 @@
+package io.github.eschizoid.telescope.beans;
+
+import java.util.Optional;
+
+/** Optional-bridge target for {@link OptSrc}. */
+public record OptDst(Optional<OptElemBO> maybe) {}

--- a/core/src/test/java/io/github/eschizoid/telescope/beans/OptElem.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/beans/OptElem.java
@@ -1,0 +1,4 @@
+package io.github.eschizoid.telescope.beans;
+
+/** Element type for the Optional-bridge fixtures. */
+public record OptElem(String a) {}

--- a/core/src/test/java/io/github/eschizoid/telescope/beans/OptElemBO.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/beans/OptElemBO.java
@@ -1,0 +1,6 @@
+package io.github.eschizoid.telescope.beans;
+
+/**
+ * Distinct element target for {@link OptElem}, so Optional&lt;OptElem&gt; bridges via a sub-bridge.
+ */
+public record OptElemBO(String a) {}

--- a/core/src/test/java/io/github/eschizoid/telescope/beans/OptSrc.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/beans/OptSrc.java
@@ -1,0 +1,13 @@
+package io.github.eschizoid.telescope.beans;
+
+import io.github.eschizoid.telescope.annotations.Bridge;
+import java.util.Optional;
+
+/**
+ * Codegen fixture with an {@code Optional<OptElem>} component bridged to {@code
+ * Optional<OptElemBO>}. Exercises the generated Optional lift's null-guard: a null Optional
+ * reference must pass through as null rather than NPE on {@code .map(...)}, matching the runtime
+ * {@code Iso.liftOptional}.
+ */
+@Bridge(OptDst.class)
+public record OptSrc(Optional<OptElem> maybe) {}

--- a/core/src/test/java/io/github/eschizoid/telescope/focus/PrimitiveIntRecord.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/focus/PrimitiveIntRecord.java
@@ -1,0 +1,12 @@
+package io.github.eschizoid.telescope.focus;
+
+import io.github.eschizoid.telescope.annotations.Focus;
+
+/**
+ * {@code @Focus} record with a primitive {@code int} component — the record sibling of {@link
+ * PrimitiveIntTarget}. Pairs with a nullable boxed-{@code Integer} source to exercise the generated
+ * record holder's {@code construct(Function)} null-guard: a null boxed value bound to a primitive
+ * component must take the JLS default rather than NPE-ing on the canonical-ctor unbox.
+ */
+@Focus
+public record PrimitiveIntRecord(int attemptCount) {}


### PR DESCRIPTION
## What

Three codegen-vs-runtime **parity fixes** from a proactive audit (the same fault line as the recently-fixed null-intermediate / primitive-wrapper / lenient bugs): the generated code shipped a *narrower* behavior than the reflective runtime path. Each is RED→GREEN.

### 1. `@Focus` record `construct()` doesn't null-guard primitive components
The record sibling of the already-shipped **bean** `construct()` guard. `FocusProcessor.emitRecordConstruct` emitted a bare `(Integer) values.apply("count")` → canonical-ctor unbox NPE on a null boxed value. Now mirrors the bean `valueExprForProp`: `values.apply("count") instanceof Integer __v_count ? __v_count : 0` (per-component pattern variable, since all args live in one `new R(...)` expression). A null boxed value takes the JLS default. *(Verified gap — the bean got this in v1.0.4, the record never did.)*

### 2. `@Bridge(lenient = true)` doesn't propagate into container-element sub-pairs
`lenientPairs` propagation was only wired into the **scalar** sub-pair path; `planElementSubBridge` (List/Set/Map/Optional element pairs) enqueued without marking lenient, so a lenient parent's `List<Elem>` with an element-target field mismatch still failed the strict bijection. Now threads `lenient` through and marks the element pair — matching the runtime's lenient-on-every-nested-pair. **Sealed-permit cases are deliberately left alone**: each permit case is a *required user-declared* `@Bridge` with its own config, so propagating the root's flag would override the user's explicit per-case choice (unlike the auto-generated element pairs, which have no config).

### 3. `@Bridge` Optional lifts NPE on a null Optional reference
The `OPTIONAL` / `OPTIONAL_TO_NULLABLE` / `NULLABLE_TO_OPTIONAL` emit called `.map(...)` directly on a possibly-null Optional `readExpr`. A null Optional field reference (not `Optional.empty()`) NPE'd; the runtime `Iso.liftOptional` guards `ox == null ? null`. Now null-guards the reference before `.map(...)` in all four `.map`-on-Optional directions.

## Tests
- **P1:** `MigrationRegressionTest` — record sibling of the bean Bug-12 test (null boxed Integer → `@Focus` record primitive int → 0, not NPE), via `mapperForward`. `FocusProcessorTest` source assertion updated to the guarded shape.
- **P2:** `BridgeProcessorTest` — lenient `List<Elem>` with an extra element-target field now compiles + emits the element sub-bridge; the non-lenient negative guard still errors.
- **P3:** `BridgeCodegenTest` — runtime: null `Optional` reference → null both directions (was NPE), present `Optional` round-trips; `BridgeProcessorTest` cross-paradigm source assertion strengthened to pin the guard.

Full `:codegen`/`:core`/`:lombok` suites green. These are the first three (verified) of seven gaps the audit logged; gaps 4–7 (agent-flagged, lower severity) are next to triage.
