### PR TITLE
fix(codegen): three more runtime-parity fixes (primitive setter, null element, container subtypes)

### DIFF
--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/AbstractTelescopeProcessor.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/AbstractTelescopeProcessor.java
@@ -1201,14 +1201,14 @@ public abstract class AbstractTelescopeProcessor extends AbstractProcessor {
     if (useBuilder) {
       final var sb = new StringBuilder("(p, v) -> " + pojoName + ".builder()");
       for (var i = 0; i < all.size(); i++) {
-        final var arg = all.get(i).name().equals(target.name()) ? "v" : offPathRead(all.get(i));
+        final var arg = all.get(i).name().equals(target.name()) ? focusedArg(target) : offPathRead(all.get(i));
         sb.append(".").append(setters[i]).append("(").append(arg).append(")");
       }
       return sb.append(".build()").toString();
     }
     final var sb = new StringBuilder("(p, v) -> { final var c = new " + pojoName + "(); ");
     for (var i = 0; i < all.size(); i++) {
-      final var arg = all.get(i).name().equals(target.name()) ? "v" : offPathRead(all.get(i));
+      final var arg = all.get(i).name().equals(target.name()) ? focusedArg(target) : offPathRead(all.get(i));
       sb.append("c.").append(setters[i]).append("(").append(arg).append("); ");
     }
     return sb.append("return c; }").toString();
@@ -1228,6 +1228,19 @@ public abstract class AbstractTelescopeProcessor extends AbstractProcessor {
   private static String offPathRead(final Prop p) {
     final var def = primitiveDefaultLiteral(p.type().getKind()).orElse("null");
     return "(p == null ? " + def + " : p." + p.getter() + "())";
+  }
+
+  /**
+   * The "write the focused value into its setter" expression. The focused setter receives the
+   * incoming value {@code v}; for a primitive-typed setter a null {@code v} coalesces to the
+   * primitive's JLS default rather than NPE-ing on the implicit unbox — matching the runtime {@code
+   * SettersWriter}, which skips null on primitive setters so the field keeps its JLS default. A
+   * reference-typed setter passes {@code v} through (null is a legal reference value).
+   */
+  private static String focusedArg(final Prop target) {
+    return primitiveDefaultLiteral(target.type().getKind())
+      .map(def -> "(v == null ? " + def + " : v)")
+      .orElse("v");
   }
 
   /**

--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
@@ -1635,7 +1635,7 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
       }
     }
 
-    final var imports = new TreeSet<>(importsFor(fieldPlans));
+    final var imports = new TreeSet<>(importsFor(fieldPlans, sourceFields, targetFields, renames));
     imports.add("io.github.eschizoid.telescope.conversion.BridgeFn");
     writeClass(
       qualifiedBridge,
@@ -2002,7 +2002,17 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
     // when that direction writes the wrapper side (which tolerates null). Mirrors the runtime
     // primitiveWrapperIso's fwdDefault / bwdDefault.
     String fwdNullDefault,
-    String bwdNullDefault
+    String bwdNullDefault,
+    // LIST/SET/MAP_VALUES only: the simple name of the concrete collection/map class to allocate
+    // for
+    // the forward (target) and backward (source) outputs, used by the inline identity-element
+    // copy
+    // in applyForward/applyBackward. Null for non-container kinds (the element-bridging helper
+    // path
+    // recomputes its allocation from the field types directly). Mirrors DeepMap's allocation
+    // table.
+    String fwdContainerImpl,
+    String bwdContainerImpl
   ) {
     enum Kind {
       IDENTITY,
@@ -2018,7 +2028,13 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
     }
 
     static FieldPlan identity() {
-      return new FieldPlan(Kind.IDENTITY, null, null, null, null);
+      return new FieldPlan(Kind.IDENTITY, null, null, null, null, null, null);
+    }
+
+    // Attach the concrete-impl class names for a LIST/SET/MAP_VALUES plan — the classes the inline
+    // identity-element copy allocates for the forward (target) and backward (source) outputs.
+    FieldPlan withContainerImpls(final String fwdImpl, final String bwdImpl) {
+      return new FieldPlan(kind, subBridgeName, qualifierMethod, fwdNullDefault, bwdNullDefault, fwdImpl, bwdImpl);
     }
 
     // Primitive ↔ boxed wrapper. The direction that writes the primitive side null-coalesces a null
@@ -2026,15 +2042,15 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
     // (null is a legal wrapper value). Exactly one of the two defaults is non-null for any given
     // pair. Matches the runtime DeepMap.primitiveWrapperIso.
     static FieldPlan primWrapper(final String fwdNullDefault, final String bwdNullDefault) {
-      return new FieldPlan(Kind.PRIM_WRAPPER, null, null, fwdNullDefault, bwdNullDefault);
+      return new FieldPlan(Kind.PRIM_WRAPPER, null, null, fwdNullDefault, bwdNullDefault, null, null);
     }
 
     static FieldPlan recurse(final String subBridgeName) {
-      return new FieldPlan(Kind.RECURSE, Objects.requireNonNull(subBridgeName), null, null, null);
+      return new FieldPlan(Kind.RECURSE, Objects.requireNonNull(subBridgeName), null, null, null, null, null);
     }
 
     static FieldPlan ofKind(final Kind kind, final String subBridgeName) {
-      return new FieldPlan(kind, Objects.requireNonNull(subBridgeName), null, null, null);
+      return new FieldPlan(kind, Objects.requireNonNull(subBridgeName), null, null, null, null, null);
     }
 
     // Qualifier-dispatch TRANSFORM variant: the `using` class hosts a named static method, NOT a
@@ -2046,6 +2062,8 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
         Objects.requireNonNull(usingClassFqn),
         Objects.requireNonNull(method),
         null,
+        null,
+        null,
         null
       );
     }
@@ -2056,24 +2074,82 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
    * non-Map shapes; the keyType on a Map is validated to match across the source/target pair so the
    * lift preserves keys identically.
    */
-  private record ContainerShape(FieldPlan.Kind kind, TypeMirror elementType, TypeMirror keyType) {
-    static ContainerShape of(final TypeMirror type) {
-      if (!(type instanceof DeclaredType dt)) return null;
-      final var el = dt.asElement();
-      if (!(el instanceof TypeElement te)) return null;
-      final var args = dt.getTypeArguments();
-      return switch (te.getQualifiedName().toString()) {
-        case "java.util.List" -> args.size() == 1 ? new ContainerShape(FieldPlan.Kind.LIST, args.get(0), null) : null;
-        case "java.util.Set" -> args.size() == 1 ? new ContainerShape(FieldPlan.Kind.SET, args.get(0), null) : null;
-        case "java.util.Optional" -> args.size() == 1
-          ? new ContainerShape(FieldPlan.Kind.OPTIONAL, args.get(0), null)
-          : null;
-        case "java.util.Map" -> args.size() == 2
-          ? new ContainerShape(FieldPlan.Kind.MAP_VALUES, args.get(1), args.get(0))
-          : null;
-        default -> null;
-      };
+  private record ContainerShape(FieldPlan.Kind kind, TypeMirror elementType, TypeMirror keyType) {}
+
+  // The container shape of a type, accepting any List/Set/Map SUBTYPE (ArrayList, TreeSet,
+  // LinkedHashMap, …) — not just the exact interface — via erasure assignability, matching the
+  // runtime ContainerShape's isAssignableFrom check. Optional is final, so it stays an exact match.
+  // The declared type's type arguments give the element (and key) types; a raw subtype with no type
+  // arguments (e.g. `class Names extends ArrayList<String>`) is not handled here (returns null),
+  // same as before.
+  private ContainerShape containerShapeOf(final TypeMirror type) {
+    if (!(type instanceof DeclaredType dt)) return null;
+    final var args = dt.getTypeArguments();
+    if (assignableToRaw(type, "java.util.Optional")) {
+      return args.size() == 1 ? new ContainerShape(FieldPlan.Kind.OPTIONAL, args.get(0), null) : null;
     }
+    if (args.size() == 1 && assignableToRaw(type, "java.util.List")) {
+      return new ContainerShape(FieldPlan.Kind.LIST, args.get(0), null);
+    }
+    if (args.size() == 1 && assignableToRaw(type, "java.util.Set")) {
+      return new ContainerShape(FieldPlan.Kind.SET, args.get(0), null);
+    }
+    if (args.size() == 2 && assignableToRaw(type, "java.util.Map")) {
+      return new ContainerShape(FieldPlan.Kind.MAP_VALUES, args.get(1), args.get(0));
+    }
+    return null;
+  }
+
+  // True when `type`'s erasure is assignable to the raw interface named by `rawFqn`.
+  private boolean assignableToRaw(final TypeMirror type, final String rawFqn) {
+    final var types = processingEnv.getTypeUtils();
+    final var raw = processingEnv.getElementUtils().getTypeElement(rawFqn);
+    if (raw == null) return false;
+    return types.isAssignable(types.erasure(type), types.erasure(raw.asType()));
+  }
+
+  // FQN of a container's declared raw class (e.g. java.util.List, java.util.LinkedList) — the type
+  // a
+  // helper must declare as its return so the rebuild assigns it to the target field directly.
+  private static String containerRawFqn(final TypeMirror container) {
+    return ((TypeElement) ((DeclaredType) container).asElement()).getQualifiedName().toString();
+  }
+
+  // FQN of the concrete, instantiable class to allocate for a container field of the given declared
+  // type — the declared subtype itself when it is an instantiable class (ArrayList, TreeSet,
+  // LinkedHashMap, …), else the default impl for the interface family (List → ArrayList, Set →
+  // LinkedHashSet, Map → LinkedHashMap). Mirrors the runtime DeepMap allocation table.
+  private static String concreteImplFqn(final TypeMirror container, final FieldPlan.Kind kind) {
+    final var el = (TypeElement) ((DeclaredType) container).asElement();
+    if (el.getKind() == ElementKind.CLASS && !el.getModifiers().contains(Modifier.ABSTRACT)) {
+      return el.getQualifiedName().toString();
+    }
+    return switch (kind) {
+      case LIST -> "java.util.ArrayList";
+      case SET -> "java.util.LinkedHashSet";
+      case MAP_VALUES -> "java.util.LinkedHashMap";
+      default -> throw new IllegalStateException("not a collection/map kind: " + kind);
+    };
+  }
+
+  private static String simpleName(final String fqn) {
+    final var dot = fqn.lastIndexOf('.');
+    return dot < 0 ? fqn : fqn.substring(dot + 1);
+  }
+
+  // Whether the impl class exposes a capacity-presizing (int) constructor. The default impls do; an
+  // arbitrary concrete subtype (LinkedList, TreeSet, TreeMap, …) may not, so it is filled via the
+  // no-arg constructor instead.
+  private static boolean hasPresizeCtor(final String implFqn) {
+    return switch (implFqn) {
+      case
+        "java.util.ArrayList",
+        "java.util.HashSet",
+        "java.util.LinkedHashSet",
+        "java.util.HashMap",
+        "java.util.LinkedHashMap" -> true;
+      default -> false;
+    };
   }
 
   /**
@@ -2142,8 +2218,8 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
       }
       // (2) Container shape detection — both sides container of the same kind with element types
       //     that need their own sub-bridge. List/Set/Optional/Map values, key-equal Map.
-      final var srcShape = ContainerShape.of(sf.type());
-      final var tgtShape = ContainerShape.of(tf.type());
+      final var srcShape = containerShapeOf(sf.type());
+      final var tgtShape = containerShapeOf(tf.type());
       if (srcShape != null && tgtShape != null && srcShape.kind() == tgtShape.kind()) {
         if (srcShape.kind() == FieldPlan.Kind.MAP_VALUES && !isSameType(srcShape.keyType(), tgtShape.keyType())) {
           error(
@@ -2175,7 +2251,17 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
           lenient
         );
         if (subPlan == null) return null;
-        plans.put(sf.name(), subPlan);
+        // Attach the concrete-impl class the inline identity-element copy allocates: the target's
+        // class on forward, the source's on backward — so a field typed as a concrete subtype
+        // (LinkedList, TreeSet, …) is rebuilt as that class, not the default impl.
+        final var withImpls = switch (subPlan.kind()) {
+          case LIST, SET, MAP_VALUES -> subPlan.withContainerImpls(
+            simpleName(concreteImplFqn(tf.type(), subPlan.kind())),
+            simpleName(concreteImplFqn(sf.type(), subPlan.kind()))
+          );
+          default -> subPlan;
+        };
+        plans.put(sf.name(), withImpls);
         continue;
       }
       // (3) Cross-paradigm Optional↔nullable bridge — one side has Optional<X>, the other has
@@ -2342,14 +2428,14 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
       // dispatch site. When the element type is identity (same on both sides), a defensive copy is
       // sufficient and we emit it inline.
       case LIST -> elementIdentity
-        ? "(" + readExpr + " == null ? null : new ArrayList<>(" + readExpr + "))"
+        ? "(" + readExpr + " == null ? null : new " + plan.fwdContainerImpl() + "<>(" + readExpr + "))"
         : "__fwd_" + fieldName + "(" + readExpr + ")";
       case SET -> elementIdentity
-        ? "(" + readExpr + " == null ? null : new LinkedHashSet<>(" + readExpr + "))"
+        ? "(" + readExpr + " == null ? null : new " + plan.fwdContainerImpl() + "<>(" + readExpr + "))"
         : "__fwd_" + fieldName + "(" + readExpr + ")";
       case OPTIONAL -> "(" + readExpr + " == null ? null : " + readExpr + ".map(" + fwdElement + "))";
       case MAP_VALUES -> elementIdentity
-        ? "(" + readExpr + " == null ? null : new LinkedHashMap<>(" + readExpr + "))"
+        ? "(" + readExpr + " == null ? null : new " + plan.fwdContainerImpl() + "<>(" + readExpr + "))"
         : "__fwd_" + fieldName + "(" + readExpr + ")";
       case OPTIONAL_TO_NULLABLE -> "(" +
       readExpr +
@@ -2378,14 +2464,14 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
         : "(" + readExpr + " == null ? " + plan.bwdNullDefault() + " : " + readExpr + ")";
       case RECURSE -> sub + ".backward(" + readExpr + ")";
       case LIST -> elementIdentity
-        ? "(" + readExpr + " == null ? null : new ArrayList<>(" + readExpr + "))"
+        ? "(" + readExpr + " == null ? null : new " + plan.bwdContainerImpl() + "<>(" + readExpr + "))"
         : "__bwd_" + fieldName + "(" + readExpr + ")";
       case SET -> elementIdentity
-        ? "(" + readExpr + " == null ? null : new LinkedHashSet<>(" + readExpr + "))"
+        ? "(" + readExpr + " == null ? null : new " + plan.bwdContainerImpl() + "<>(" + readExpr + "))"
         : "__bwd_" + fieldName + "(" + readExpr + ")";
       case OPTIONAL -> "(" + readExpr + " == null ? null : " + readExpr + ".map(" + bwdElement + "))";
       case MAP_VALUES -> elementIdentity
-        ? "(" + readExpr + " == null ? null : new LinkedHashMap<>(" + readExpr + "))"
+        ? "(" + readExpr + " == null ? null : new " + plan.bwdContainerImpl() + "<>(" + readExpr + "))"
         : "__bwd_" + fieldName + "(" + readExpr + ")";
       // For the cross-paradigm bridges, forward and backward are mirror images.
       case OPTIONAL_TO_NULLABLE -> "Optional.ofNullable(" + readExpr + ").map(" + bwdElement + ")";
@@ -2406,21 +2492,27 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
    * Set, String, Element, java.util.function.Consumer)} so the emitted file has clean imports
    * instead of FQNs in the body.
    */
-  private Set<String> importsFor(final Map<String, FieldPlan> fieldPlans) {
+  private Set<String> importsFor(
+    final Map<String, FieldPlan> fieldPlans,
+    final List<Field> sourceFields,
+    final List<Field> targetFields,
+    final Map<String, String> renames
+  ) {
     final var imports = new TreeSet<String>();
-    for (final var plan : fieldPlans.values()) {
+    for (final var entry : fieldPlans.entrySet()) {
+      final var plan = entry.getValue();
       switch (plan.kind()) {
-        case LIST -> {
-          imports.add("java.util.List");
-          imports.add("java.util.ArrayList");
-        }
-        case SET -> {
-          imports.add("java.util.Set");
-          imports.add("java.util.LinkedHashSet");
-        }
-        case MAP_VALUES -> {
-          imports.add("java.util.Map");
-          imports.add("java.util.LinkedHashMap");
+        // A container field needs both the declared raw of each side (the helper return / param
+        // types and the inline copy) and the concrete impl each side allocates. For the common
+        // interface-typed field this is {List, ArrayList} etc., unchanged; a concrete subtype adds
+        // its own class (LinkedList, TreeSet, …).
+        case LIST, SET, MAP_VALUES -> {
+          final var srcType = fieldByName(sourceFields, entry.getKey()).type();
+          final var tgtType = fieldByName(targetFields, renames.getOrDefault(entry.getKey(), entry.getKey())).type();
+          for (final var t : List.of(srcType, tgtType)) {
+            imports.add(containerRawFqn(t));
+            imports.add(concreteImplFqn(t, plan.kind()));
+          }
         }
         case OPTIONAL_TO_NULLABLE, NULLABLE_TO_OPTIONAL -> imports.add("java.util.Optional");
         default -> {
@@ -2479,10 +2571,27 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
   ) {
     final var srcElement = ((DeclaredType) srcContainer).getTypeArguments().get(0);
     final var tgtElement = ((DeclaredType) tgtContainer).getTypeArguments().get(0);
+    final var returnRaw = simpleName(containerRawFqn(tgtContainer));
+    final var paramRaw = simpleName(containerRawFqn(srcContainer));
+    final var implFqn = concreteImplFqn(tgtContainer, FieldPlan.Kind.LIST);
+    final var alloc =
+      "new " + simpleName(implFqn) + "<" + tgtElement + ">" + (hasPresizeCtor(implFqn) ? "(src.size())" : "()");
     out.println();
-    out.println("  private static List<" + tgtElement + "> " + name + "(final List<" + srcElement + "> src) {");
+    out.println(
+      "  private static " +
+        returnRaw +
+        "<" +
+        tgtElement +
+        "> " +
+        name +
+        "(final " +
+        paramRaw +
+        "<" +
+        srcElement +
+        "> src) {"
+    );
     out.println("    if (src == null) return null;");
-    out.println("    final var out = new ArrayList<" + tgtElement + ">(src.size());");
+    out.println("    final var out = " + alloc + ";");
     out.println("    for (final var x : src) out.add(" + subBridge + "." + direction + "(x));");
     out.println("    return out;");
     out.println("  }");
@@ -2498,10 +2607,27 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
   ) {
     final var srcElement = ((DeclaredType) srcContainer).getTypeArguments().get(0);
     final var tgtElement = ((DeclaredType) tgtContainer).getTypeArguments().get(0);
+    final var returnRaw = simpleName(containerRawFqn(tgtContainer));
+    final var paramRaw = simpleName(containerRawFqn(srcContainer));
+    final var implFqn = concreteImplFqn(tgtContainer, FieldPlan.Kind.SET);
+    final var alloc =
+      "new " + simpleName(implFqn) + "<" + tgtElement + ">" + (hasPresizeCtor(implFqn) ? "(src.size())" : "()");
     out.println();
-    out.println("  private static Set<" + tgtElement + "> " + name + "(final Set<" + srcElement + "> src) {");
+    out.println(
+      "  private static " +
+        returnRaw +
+        "<" +
+        tgtElement +
+        "> " +
+        name +
+        "(final " +
+        paramRaw +
+        "<" +
+        srcElement +
+        "> src) {"
+    );
     out.println("    if (src == null) return null;");
-    out.println("    final var out = new LinkedHashSet<" + tgtElement + ">(src.size());");
+    out.println("    final var out = " + alloc + ";");
     out.println("    for (final var x : src) out.add(" + subBridge + "." + direction + "(x));");
     out.println("    return out;");
     out.println("  }");
@@ -2520,22 +2646,38 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
     final var keyType = srcArgs.get(0);
     final var srcValue = srcArgs.get(1);
     final var tgtValue = tgtArgs.get(1);
+    final var returnRaw = simpleName(containerRawFqn(tgtContainer));
+    final var paramRaw = simpleName(containerRawFqn(srcContainer));
+    final var implFqn = concreteImplFqn(tgtContainer, FieldPlan.Kind.MAP_VALUES);
+    final var alloc =
+      "new " +
+      simpleName(implFqn) +
+      "<" +
+      keyType +
+      ", " +
+      tgtValue +
+      ">" +
+      (hasPresizeCtor(implFqn) ? "(src.size())" : "()");
     out.println();
     out.println(
-      "  private static Map<" +
+      "  private static " +
+        returnRaw +
+        "<" +
         keyType +
         ", " +
         tgtValue +
         "> " +
         name +
-        "(final Map<" +
+        "(final " +
+        paramRaw +
+        "<" +
         keyType +
         ", " +
         srcValue +
         "> src) {"
     );
     out.println("    if (src == null) return null;");
-    out.println("    final var out = new LinkedHashMap<" + keyType + ", " + tgtValue + ">(src.size());");
+    out.println("    final var out = " + alloc + ";");
     out.println(
       "    for (final var e : src.entrySet()) out.put(e.getKey(), " + subBridge + "." + direction + "(e.getValue()));"
     );

--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
@@ -2117,8 +2117,12 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
 
   // FQN of the concrete, instantiable class to allocate for a container field of the given declared
   // type — the declared subtype itself when it is an instantiable class (ArrayList, TreeSet,
-  // LinkedHashMap, …), else the default impl for the interface family (List → ArrayList, Set →
-  // LinkedHashSet, Map → LinkedHashMap). Mirrors the runtime DeepMap allocation table.
+  // TreeMap, …), else the default impl for the interface family. The interface-family defaults
+  // match
+  // the runtime DeepMap allocators for the bare interface raws: List → ArrayList
+  // (listAllocatorFor),
+  // Set → LinkedHashSet (setAllocatorFor), Map → HashMap (mapAllocatorFor), so codegen and the
+  // reflective path produce the same runtime class for an interface-typed field.
   private static String concreteImplFqn(final TypeMirror container, final FieldPlan.Kind kind) {
     final var el = (TypeElement) ((DeclaredType) container).asElement();
     if (el.getKind() == ElementKind.CLASS && !el.getModifiers().contains(Modifier.ABSTRACT)) {
@@ -2127,7 +2131,7 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
     return switch (kind) {
       case LIST -> "java.util.ArrayList";
       case SET -> "java.util.LinkedHashSet";
-      case MAP_VALUES -> "java.util.LinkedHashMap";
+      case MAP_VALUES -> "java.util.HashMap";
       default -> throw new IllegalStateException("not a collection/map kind: " + kind);
     };
   }
@@ -2412,6 +2416,16 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
   /** Sentinel sub-bridge name meaning "the element passes through unchanged". */
   private static final String IDENTITY_ELEMENT_SENTINEL = "__IDENTITY__";
 
+  // The concrete-impl class the inline identity-element copy allocates. Non-null for any
+  // LIST/SET/MAP_VALUES plan (attached at planning via withContainerImpls); this guard turns a
+  // future
+  // desync — a container plan reaching emit without its impls — into a loud processor failure
+  // rather
+  // than emitting `new null<>(...)`.
+  private static String requireImpl(final String impl, final String fieldName) {
+    return Objects.requireNonNull(impl, "container impl not attached for field '" + fieldName + "'");
+  }
+
   private String applyForward(final String fieldName, final FieldPlan plan, final String readExpr) {
     final var sub = plan.subBridgeName();
     final boolean elementIdentity = IDENTITY_ELEMENT_SENTINEL.equals(sub);
@@ -2428,14 +2442,32 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
       // dispatch site. When the element type is identity (same on both sides), a defensive copy is
       // sufficient and we emit it inline.
       case LIST -> elementIdentity
-        ? "(" + readExpr + " == null ? null : new " + plan.fwdContainerImpl() + "<>(" + readExpr + "))"
+        ? "(" +
+          readExpr +
+          " == null ? null : new " +
+          requireImpl(plan.fwdContainerImpl(), fieldName) +
+          "<>(" +
+          readExpr +
+          "))"
         : "__fwd_" + fieldName + "(" + readExpr + ")";
       case SET -> elementIdentity
-        ? "(" + readExpr + " == null ? null : new " + plan.fwdContainerImpl() + "<>(" + readExpr + "))"
+        ? "(" +
+          readExpr +
+          " == null ? null : new " +
+          requireImpl(plan.fwdContainerImpl(), fieldName) +
+          "<>(" +
+          readExpr +
+          "))"
         : "__fwd_" + fieldName + "(" + readExpr + ")";
       case OPTIONAL -> "(" + readExpr + " == null ? null : " + readExpr + ".map(" + fwdElement + "))";
       case MAP_VALUES -> elementIdentity
-        ? "(" + readExpr + " == null ? null : new " + plan.fwdContainerImpl() + "<>(" + readExpr + "))"
+        ? "(" +
+          readExpr +
+          " == null ? null : new " +
+          requireImpl(plan.fwdContainerImpl(), fieldName) +
+          "<>(" +
+          readExpr +
+          "))"
         : "__fwd_" + fieldName + "(" + readExpr + ")";
       case OPTIONAL_TO_NULLABLE -> "(" +
       readExpr +
@@ -2464,14 +2496,32 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
         : "(" + readExpr + " == null ? " + plan.bwdNullDefault() + " : " + readExpr + ")";
       case RECURSE -> sub + ".backward(" + readExpr + ")";
       case LIST -> elementIdentity
-        ? "(" + readExpr + " == null ? null : new " + plan.bwdContainerImpl() + "<>(" + readExpr + "))"
+        ? "(" +
+          readExpr +
+          " == null ? null : new " +
+          requireImpl(plan.bwdContainerImpl(), fieldName) +
+          "<>(" +
+          readExpr +
+          "))"
         : "__bwd_" + fieldName + "(" + readExpr + ")";
       case SET -> elementIdentity
-        ? "(" + readExpr + " == null ? null : new " + plan.bwdContainerImpl() + "<>(" + readExpr + "))"
+        ? "(" +
+          readExpr +
+          " == null ? null : new " +
+          requireImpl(plan.bwdContainerImpl(), fieldName) +
+          "<>(" +
+          readExpr +
+          "))"
         : "__bwd_" + fieldName + "(" + readExpr + ")";
       case OPTIONAL -> "(" + readExpr + " == null ? null : " + readExpr + ".map(" + bwdElement + "))";
       case MAP_VALUES -> elementIdentity
-        ? "(" + readExpr + " == null ? null : new " + plan.bwdContainerImpl() + "<>(" + readExpr + "))"
+        ? "(" +
+          readExpr +
+          " == null ? null : new " +
+          requireImpl(plan.bwdContainerImpl(), fieldName) +
+          "<>(" +
+          readExpr +
+          "))"
         : "__bwd_" + fieldName + "(" + readExpr + ")";
       // For the cross-paradigm bridges, forward and backward are mirror images.
       case OPTIONAL_TO_NULLABLE -> "Optional.ofNullable(" + readExpr + ").map(" + bwdElement + ")";

--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
@@ -1686,10 +1686,14 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
         // shared one anonymous Iso class body across every bridge, going megamorphic on
         // Function::apply as more bridges were loaded.
         out.println("  public static " + targetFq + " forward(final " + sourceFq + " s) {");
+        // Null in -> null out, matching the runtime structural Iso. Also lets a null container
+        // element (subBridge.forward(null) in the container helpers) pass through as null.
+        out.println("    if (s == null) return null;");
         emitMethodBody(out, forwardBody);
         out.println("  }");
         out.println();
         out.println("  public static " + sourceFq + " backward(final " + targetFq + " t) {");
+        out.println("    if (t == null) return null;");
         emitMethodBody(out, backwardBody);
         out.println("  }");
         out.println();

--- a/codegen/src/test/java/io/github/eschizoid/telescope/codegen/BridgeProcessorTest.java
+++ b/codegen/src/test/java/io/github/eschizoid/telescope/codegen/BridgeProcessorTest.java
@@ -283,6 +283,57 @@ class BridgeProcessorTest {
     }
 
     @Test
+    @DisplayName(
+      "a field declared as a concrete List subtype (LinkedList<Y>) auto-lifts and the helper allocates that concrete class"
+    )
+    void concreteListSubtypeFieldAllocatesTargetClass() {
+      // The runtime ContainerShape accepts any List subtype via isAssignableFrom and allocates the
+      // target's concrete class; codegen must match — a field typed LinkedList<Y> should auto-lift
+      // (not error) and the forward helper should new LinkedList<Y>, not the default ArrayList.
+      final var compilation = compile(
+        source(
+          "demo.LLOrder",
+          """
+          package demo;
+          import io.github.eschizoid.telescope.annotations.Bridge;
+          import java.util.List;
+          @Bridge(demo.LLOrderDto.class)
+          public record LLOrder(List<demo.LLItem> items) {}
+          """
+        ),
+        source(
+          "demo.LLItem",
+          """
+          package demo;
+          public record LLItem(String sku) {}
+          """
+        ),
+        source(
+          "demo.LLOrderDto",
+          """
+          package demo;
+          import java.util.LinkedList;
+          public record LLOrderDto(LinkedList<demo.LLItemDto> items) {}
+          """
+        ),
+        source(
+          "demo.LLItemDto",
+          """
+          package demo;
+          public record LLItemDto(String sku) {}
+          """
+        )
+      );
+
+      assertTrue(compilation.success(), () -> "compilation failed: " + compilation.errorMessages());
+      final var bridge = compilation.generated().get("demo.LLOrderBridge");
+      assertNotNull(bridge);
+      // P5: the forward helper writes the target's concrete class (LinkedList), not the default
+      // ArrayList, and its return type is the target's declared concrete type.
+      assertTrue(bridge.contains("new LinkedList<demo.LLItemDto>"), bridge);
+    }
+
+    @Test
     @DisplayName("Set<X> ↔ Set<Y> auto-lifts via a for-loop helper into a pre-sized LinkedHashSet")
     void setContainerAutoLifts() {
       final var compilation = compile(

--- a/codegen/src/test/java/io/github/eschizoid/telescope/codegen/BridgeProcessorTest.java
+++ b/codegen/src/test/java/io/github/eschizoid/telescope/codegen/BridgeProcessorTest.java
@@ -334,6 +334,108 @@ class BridgeProcessorTest {
     }
 
     @Test
+    @DisplayName(
+      "identity element, concrete List subtype: List<String> ↔ LinkedList<String> emits an inline copy into each side's concrete class"
+    )
+    void identityElementConcreteListEmitsInlineConcreteCopy() {
+      final var compilation = compile(
+        source(
+          "demo.ILOrder",
+          """
+          package demo;
+          import io.github.eschizoid.telescope.annotations.Bridge;
+          import java.util.List;
+          @Bridge(demo.ILOrderDto.class)
+          public record ILOrder(List<String> tags) {}
+          """
+        ),
+        source(
+          "demo.ILOrderDto",
+          """
+          package demo;
+          import java.util.LinkedList;
+          public record ILOrderDto(LinkedList<String> tags) {}
+          """
+        )
+      );
+
+      assertTrue(compilation.success(), () -> "compilation failed: " + compilation.errorMessages());
+      final var bridge = compilation.generated().get("demo.ILOrderBridge");
+      assertNotNull(bridge);
+      // Identity element → no helper; an inline copy into the target's LinkedList (forward) and the
+      // source's default ArrayList (backward).
+      assertTrue(bridge.contains("new LinkedList<>("), bridge);
+      assertTrue(bridge.contains("new ArrayList<>("), bridge);
+    }
+
+    @Test
+    @DisplayName(
+      "identity element, concrete Set subtype: Set<String> ↔ TreeSet<String> emits an inline copy into each side's concrete class"
+    )
+    void identityElementConcreteSetEmitsInlineConcreteCopy() {
+      final var compilation = compile(
+        source(
+          "demo.ISOrder",
+          """
+          package demo;
+          import io.github.eschizoid.telescope.annotations.Bridge;
+          import java.util.Set;
+          @Bridge(demo.ISOrderDto.class)
+          public record ISOrder(Set<String> tags) {}
+          """
+        ),
+        source(
+          "demo.ISOrderDto",
+          """
+          package demo;
+          import java.util.TreeSet;
+          public record ISOrderDto(TreeSet<String> tags) {}
+          """
+        )
+      );
+
+      assertTrue(compilation.success(), () -> "compilation failed: " + compilation.errorMessages());
+      final var bridge = compilation.generated().get("demo.ISOrderBridge");
+      assertNotNull(bridge);
+      assertTrue(bridge.contains("new TreeSet<>("), bridge);
+      assertTrue(bridge.contains("new LinkedHashSet<>("), bridge);
+    }
+
+    @Test
+    @DisplayName(
+      "identity value, concrete Map subtype: Map<String, String> ↔ TreeMap<String, String> emits an inline copy into each side's concrete class"
+    )
+    void identityValueConcreteMapEmitsInlineConcreteCopy() {
+      final var compilation = compile(
+        source(
+          "demo.IMOrder",
+          """
+          package demo;
+          import io.github.eschizoid.telescope.annotations.Bridge;
+          import java.util.Map;
+          @Bridge(demo.IMOrderDto.class)
+          public record IMOrder(Map<String, String> byKey) {}
+          """
+        ),
+        source(
+          "demo.IMOrderDto",
+          """
+          package demo;
+          import java.util.TreeMap;
+          public record IMOrderDto(TreeMap<String, String> byKey) {}
+          """
+        )
+      );
+
+      assertTrue(compilation.success(), () -> "compilation failed: " + compilation.errorMessages());
+      final var bridge = compilation.generated().get("demo.IMOrderBridge");
+      assertNotNull(bridge);
+      // Forward into the target TreeMap; backward into the source's default HashMap.
+      assertTrue(bridge.contains("new TreeMap<>("), bridge);
+      assertTrue(bridge.contains("new HashMap<>("), bridge);
+    }
+
+    @Test
     @DisplayName("Set<X> ↔ Set<Y> auto-lifts via a for-loop helper into a pre-sized LinkedHashSet")
     void setContainerAutoLifts() {
       final var compilation = compile(

--- a/codegen/src/test/java/io/github/eschizoid/telescope/codegen/BridgeProcessorTest.java
+++ b/codegen/src/test/java/io/github/eschizoid/telescope/codegen/BridgeProcessorTest.java
@@ -328,7 +328,7 @@ class BridgeProcessorTest {
       assertTrue(compilation.success(), () -> "compilation failed: " + compilation.errorMessages());
       final var bridge = compilation.generated().get("demo.LLOrderBridge");
       assertNotNull(bridge);
-      // P5: the forward helper writes the target's concrete class (LinkedList), not the default
+      // The forward helper writes the target's concrete class (LinkedList), not the default
       // ArrayList, and its return type is the target's declared concrete type.
       assertTrue(bridge.contains("new LinkedList<demo.LLItemDto>"), bridge);
     }
@@ -479,9 +479,9 @@ class BridgeProcessorTest {
       assertNotNull(cart);
       assertTrue(cart.contains("__fwd_items(s.items())"), cart);
       assertTrue(cart.contains("__bwd_items(t.items())"), cart);
-      assertTrue(cart.contains("import java.util.LinkedHashMap;"), cart);
+      assertTrue(cart.contains("import java.util.HashMap;"), cart);
       assertTrue(cart.contains("import java.util.Map;"), cart);
-      assertTrue(cart.contains("new LinkedHashMap<java.lang.String, demo.LineItemDto>(src.size())"), cart);
+      assertTrue(cart.contains("new HashMap<java.lang.String, demo.LineItemDto>(src.size())"), cart);
       assertTrue(cart.contains("LineItemToLineItemDtoBridge.forward(e.getValue())"), cart);
       assertTrue(cart.contains("LineItemToLineItemDtoBridge.backward(e.getValue())"), cart);
     }

--- a/core/src/main/java/io/github/eschizoid/telescope/DeepMap.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/DeepMap.java
@@ -1340,7 +1340,8 @@ public final class DeepMap {
    * Map-level lift that writes into the target's concrete raw class. Mirror of {@link
    * #liftListIntoTargetRaw} for Maps. Preserves source keys verbatim (matches {@link
    * Iso#liftMapValues}); the calling site already ensured the key classes match. Falls back to
-   * {@link LinkedHashMap} when the raw class is the {@link Map} interface itself.
+   * {@link HashMap} when the raw class is the {@link Map} interface itself (see {@link
+   * #mapAllocatorFor}).
    */
   @SuppressWarnings({ "unchecked", "rawtypes" })
   private static Iso<?, ?> liftMapIntoTargetRaw(

--- a/core/src/test/java/io/github/eschizoid/telescope/MigrationRegressionTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/MigrationRegressionTest.java
@@ -2452,6 +2452,22 @@ class MigrationRegressionTest {
       final var rec = assertDoesNotThrow(() -> mapper.forward(src));
       assertEquals(0, rec.attemptCount()); // JLS default for int
     }
+
+    @Test
+    @DisplayName(
+      "setting a primitive @BeanFocus lens to null coalesces to the JLS default instead of NPE (parity with SettersWriter)"
+    )
+    void setPrimitiveBeanFocusLensToNullUsesJlsDefault() {
+      // The generated holder lens rebuild writes the focused value straight into the setter. For a
+      // primitive setter a null focus must coalesce to the JLS default rather than NPE on the
+      // implicit unbox — matching the runtime SettersWriter, which skips null on primitive setters
+      // so the field keeps its JLS default.
+      final var bean = new PrimitiveIntTarget();
+      bean.setAttemptCount(5);
+      final var path = Telescope.ofBean(PrimitiveIntTarget.class).field(PrimitiveIntTarget::getAttemptCount);
+      final var updated = assertDoesNotThrow(() -> path.set(bean, null));
+      assertEquals(0, updated.getAttemptCount());
+    }
   }
 
   @Nested

--- a/core/src/test/java/io/github/eschizoid/telescope/beans/BareMapDst.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/beans/BareMapDst.java
@@ -1,0 +1,6 @@
+package io.github.eschizoid.telescope.beans;
+
+import java.util.Map;
+
+/** Target with a bare Map<K,V> field; values bridge OptElem -> OptElemBO. */
+public record BareMapDst(Map<String, OptElemBO> byKey) {}

--- a/core/src/test/java/io/github/eschizoid/telescope/beans/BareMapSrc.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/beans/BareMapSrc.java
@@ -1,0 +1,8 @@
+package io.github.eschizoid.telescope.beans;
+
+import io.github.eschizoid.telescope.annotations.Bridge;
+import java.util.Map;
+
+/** Source with a bare Map<K,V> field — exercises the interface-family default allocation. */
+@Bridge(BareMapDst.class)
+public record BareMapSrc(Map<String, OptElem> byKey) {}

--- a/core/src/test/java/io/github/eschizoid/telescope/beans/BridgeCodegenTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/beans/BridgeCodegenTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.util.Arrays;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -240,7 +241,9 @@ class BridgeCodegenTest {
     "concrete Set subtype: a TreeSet<String> target is rebuilt as a TreeSet via the no-presize copy constructor"
   )
   void concreteSetSubtypeRebuildsAsTreeSet() {
-    final var src = new SetIdSrc(new TreeSet<>(Arrays.asList("b", "a", "c")));
+    // Seed an insertion-ordered (unsorted) source so the [a, b, c] result proves the TreeSet's sort
+    // is active, independent of the instanceof check.
+    final var src = new SetIdSrc(new LinkedHashSet<>(Arrays.asList("b", "a", "c")));
     final var dst = SetIdSrcBridge.BRIDGE.read(src);
     assertInstanceOf(TreeSet.class, dst.tags(), "target's declared TreeSet class is preserved");
     assertEquals(Arrays.asList("a", "b", "c"), List.copyOf(dst.tags()));

--- a/core/src/test/java/io/github/eschizoid/telescope/beans/BridgeCodegenTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/beans/BridgeCodegenTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
+import java.util.Arrays;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -179,5 +180,18 @@ class BridgeCodegenTest {
     // Forward and a present round-trip still work.
     final var fwd = NtoOSrcBridge.BRIDGE.read(new NtoOSrc(new OptElem("y")));
     assertEquals(Optional.of(new OptElemBO("y")), fwd.maybe());
+  }
+
+  @Test
+  @DisplayName(
+    "container bridge: a null element passes through as null instead of NPE (parity with the runtime element Iso)"
+  )
+  void containerNullElementPassesThrough() {
+    // A null element inside a bridged List must map to null, not NPE on subBridge.forward(null).
+    final var src = new ElemListSrc(Arrays.asList(new OptElem("a"), null));
+    final var dst = assertDoesNotThrow(() -> ElemListSrcBridge.BRIDGE.read(src));
+    assertEquals(2, dst.items().size());
+    assertEquals(new OptElemBO("a"), dst.items().get(0));
+    assertNull(dst.items().get(1), "null element bridges to null");
   }
 }

--- a/core/src/test/java/io/github/eschizoid/telescope/beans/BridgeCodegenTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/beans/BridgeCodegenTest.java
@@ -5,7 +5,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
+import io.github.eschizoid.telescope.Telescope;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.LinkedList;
@@ -273,5 +275,28 @@ class BridgeCodegenTest {
     final var back = BwdConcreteSrcBridge.BRIDGE.set(src, dst);
     assertInstanceOf(LinkedList.class, back.tags(), "backward rebuild lands in the source's concrete class");
     assertEquals(Arrays.asList("x", "y"), back.tags());
+  }
+
+  @Test
+  @DisplayName(
+    "bare Map<K,V> default: codegen and the runtime reflective mapper allocate the SAME concrete class (HashMap) — cross-strategy parity on the interface-family default"
+  )
+  void bareMapDefaultMatchesRuntimeConcreteClass() {
+    final Map<String, OptElem> in = new LinkedHashMap<>();
+    in.put("k", new OptElem("a"));
+
+    // Same record pair, two strategies: the codegen @Bridge and the runtime reflective deep-map.
+    final var viaCodegen = BareMapSrcBridge.BRIDGE.read(new BareMapSrc(in));
+    final var viaRuntime = Telescope.mapper(BareMapSrc.class, BareMapDst.class).forward(new BareMapSrc(in));
+
+    // Both must land on the runtime allocator's bare-Map default (HashMap), or an adopter switching
+    // strategies gets a different runtime class for the same field — the seam this audit closes.
+    assertEquals(HashMap.class, viaCodegen.byKey().getClass(), "codegen allocates the runtime default impl");
+    assertEquals(
+      viaRuntime.byKey().getClass(),
+      viaCodegen.byKey().getClass(),
+      "codegen and runtime allocate the same concrete class"
+    );
+    assertEquals(new OptElemBO("a"), viaCodegen.byKey().get("k"));
   }
 }

--- a/core/src/test/java/io/github/eschizoid/telescope/beans/BridgeCodegenTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/beans/BridgeCodegenTest.java
@@ -6,8 +6,13 @@ import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.util.Arrays;
+import java.util.LinkedHashMap;
 import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.TreeMap;
+import java.util.TreeSet;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -195,6 +200,14 @@ class BridgeCodegenTest {
     assertEquals(2, dst.items().size());
     assertEquals(new OptElemBO("a"), dst.items().get(0));
     assertNull(dst.items().get(1), "null element bridges to null");
+
+    // The backward direction shares the same per-element guard: a null element survives set(...).
+    final var back = assertDoesNotThrow(() ->
+      ElemListSrcBridge.BRIDGE.set(src, new ElemListDst(Arrays.asList(new OptElemBO("a"), null)))
+    );
+    assertEquals(2, back.items().size());
+    assertEquals(new OptElem("a"), back.items().get(0));
+    assertNull(back.items().get(1), "null element bridges backward to null");
   }
 
   @Test
@@ -220,5 +233,42 @@ class BridgeCodegenTest {
     final var dst = IdListSrcBridge.BRIDGE.read(src);
     assertInstanceOf(LinkedList.class, dst.tags(), "identity-element copy lands in the target's concrete class");
     assertEquals(Arrays.asList("x", "y"), dst.tags());
+  }
+
+  @Test
+  @DisplayName(
+    "concrete Set subtype: a TreeSet<String> target is rebuilt as a TreeSet via the no-presize copy constructor"
+  )
+  void concreteSetSubtypeRebuildsAsTreeSet() {
+    final var src = new SetIdSrc(new TreeSet<>(Arrays.asList("b", "a", "c")));
+    final var dst = SetIdSrcBridge.BRIDGE.read(src);
+    assertInstanceOf(TreeSet.class, dst.tags(), "target's declared TreeSet class is preserved");
+    assertEquals(Arrays.asList("a", "b", "c"), List.copyOf(dst.tags()));
+  }
+
+  @Test
+  @DisplayName(
+    "concrete Map subtype: a TreeMap<String, Y> target bridges values element-wise and is rebuilt as a TreeMap"
+  )
+  void concreteMapSubtypeRebuildsAsTreeMap() {
+    final Map<String, OptElem> in = new LinkedHashMap<>();
+    in.put("k1", new OptElem("a"));
+    in.put("k2", new OptElem("b"));
+    final var dst = MapBrSrcBridge.BRIDGE.read(new MapBrSrc(in));
+    assertInstanceOf(TreeMap.class, dst.byKey(), "target's declared TreeMap class is preserved");
+    assertEquals(new OptElemBO("a"), dst.byKey().get("k1"));
+    assertEquals(new OptElemBO("b"), dst.byKey().get("k2"));
+  }
+
+  @Test
+  @DisplayName(
+    "backward concrete container: a LinkedList<String> source field is rebuilt as a LinkedList on the backward pass"
+  )
+  void backwardConcreteContainerRebuildsAsSourceClass() {
+    final var src = new BwdConcreteSrc(new LinkedList<>(Arrays.asList("x", "y")));
+    final var dst = BwdConcreteSrcBridge.BRIDGE.read(src);
+    final var back = BwdConcreteSrcBridge.BRIDGE.set(src, dst);
+    assertInstanceOf(LinkedList.class, back.tags(), "backward rebuild lands in the source's concrete class");
+    assertEquals(Arrays.asList("x", "y"), back.tags());
   }
 }

--- a/core/src/test/java/io/github/eschizoid/telescope/beans/BridgeCodegenTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/beans/BridgeCodegenTest.java
@@ -2,9 +2,11 @@ package io.github.eschizoid.telescope.beans;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.util.Arrays;
+import java.util.LinkedList;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -193,5 +195,30 @@ class BridgeCodegenTest {
     assertEquals(2, dst.items().size());
     assertEquals(new OptElemBO("a"), dst.items().get(0));
     assertNull(dst.items().get(1), "null element bridges to null");
+  }
+
+  @Test
+  @DisplayName(
+    "concrete container subtype: a LinkedList<Y> target field is bridged element-wise and rebuilt as a LinkedList, not the default ArrayList (parity with the runtime container allocation table)"
+  )
+  void concreteListSubtypeRebuildsAsTargetClass() {
+    final var src = new ConcreteListSrc(Arrays.asList(new OptElem("a"), new OptElem("b")));
+    final var dst = ConcreteListSrcBridge.BRIDGE.read(src);
+    assertInstanceOf(LinkedList.class, dst.items(), "target's declared concrete class is preserved");
+    assertEquals(Arrays.asList(new OptElemBO("a"), new OptElemBO("b")), dst.items());
+
+    final var back = ConcreteListSrcBridge.BRIDGE.set(src, dst);
+    assertEquals(Arrays.asList(new OptElem("a"), new OptElem("b")), back.items());
+  }
+
+  @Test
+  @DisplayName(
+    "concrete container subtype with identity elements: a List<String> ↔ LinkedList<String> copies inline into the target's concrete class"
+  )
+  void concreteListSubtypeIdentityElementCopiesIntoTargetClass() {
+    final var src = new IdListSrc(Arrays.asList("x", "y"));
+    final var dst = IdListSrcBridge.BRIDGE.read(src);
+    assertInstanceOf(LinkedList.class, dst.tags(), "identity-element copy lands in the target's concrete class");
+    assertEquals(Arrays.asList("x", "y"), dst.tags());
   }
 }

--- a/core/src/test/java/io/github/eschizoid/telescope/beans/BwdConcreteDst.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/beans/BwdConcreteDst.java
@@ -1,0 +1,6 @@
+package io.github.eschizoid.telescope.beans;
+
+import java.util.List;
+
+/** Target declared as the List interface; the forward rebuild lands in the default ArrayList. */
+public record BwdConcreteDst(List<String> tags) {}

--- a/core/src/test/java/io/github/eschizoid/telescope/beans/BwdConcreteSrc.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/beans/BwdConcreteSrc.java
@@ -1,0 +1,8 @@
+package io.github.eschizoid.telescope.beans;
+
+import io.github.eschizoid.telescope.annotations.Bridge;
+import java.util.LinkedList;
+
+/** Source declared as a concrete LinkedList, so the BACKWARD rebuild must allocate a LinkedList. */
+@Bridge(BwdConcreteDst.class)
+public record BwdConcreteSrc(LinkedList<String> tags) {}

--- a/core/src/test/java/io/github/eschizoid/telescope/beans/ConcreteListDst.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/beans/ConcreteListDst.java
@@ -1,0 +1,8 @@
+package io.github.eschizoid.telescope.beans;
+
+import java.util.LinkedList;
+
+/**
+ * Target with a concrete LinkedList field whose element needs an OptElem -> OptElemBO sub-bridge.
+ */
+public record ConcreteListDst(LinkedList<OptElemBO> items) {}

--- a/core/src/test/java/io/github/eschizoid/telescope/beans/ConcreteListSrc.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/beans/ConcreteListSrc.java
@@ -1,0 +1,8 @@
+package io.github.eschizoid.telescope.beans;
+
+import io.github.eschizoid.telescope.annotations.Bridge;
+import java.util.List;
+
+/** Source for the concrete-container parity test: a List source bridged to a LinkedList target. */
+@Bridge(ConcreteListDst.class)
+public record ConcreteListSrc(List<OptElem> items) {}

--- a/core/src/test/java/io/github/eschizoid/telescope/beans/ElemListDst.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/beans/ElemListDst.java
@@ -1,0 +1,6 @@
+package io.github.eschizoid.telescope.beans;
+
+import java.util.List;
+
+/** Element-list bridge target for {@link ElemListSrc}. */
+public record ElemListDst(List<OptElemBO> items) {}

--- a/core/src/test/java/io/github/eschizoid/telescope/beans/ElemListSrc.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/beans/ElemListSrc.java
@@ -1,0 +1,12 @@
+package io.github.eschizoid.telescope.beans;
+
+import io.github.eschizoid.telescope.annotations.Bridge;
+import java.util.List;
+
+/**
+ * Codegen fixture with a {@code List<OptElem>} bridged to {@code List<OptElemBO>}. Exercises the
+ * generated container helper's null-element handling: a null element inside the list must bridge to
+ * null rather than NPE on {@code subBridge.forward(null)}, matching the runtime element Iso.
+ */
+@Bridge(ElemListDst.class)
+public record ElemListSrc(List<OptElem> items) {}

--- a/core/src/test/java/io/github/eschizoid/telescope/beans/IdListDst.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/beans/IdListDst.java
@@ -1,0 +1,9 @@
+package io.github.eschizoid.telescope.beans;
+
+import java.util.LinkedList;
+
+/**
+ * Target with a concrete LinkedList field whose element passes through unchanged (String ->
+ * String).
+ */
+public record IdListDst(LinkedList<String> tags) {}

--- a/core/src/test/java/io/github/eschizoid/telescope/beans/IdListSrc.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/beans/IdListSrc.java
@@ -1,0 +1,11 @@
+package io.github.eschizoid.telescope.beans;
+
+import io.github.eschizoid.telescope.annotations.Bridge;
+import java.util.List;
+
+/**
+ * Source for the identity-element concrete-container path: List<String> bridged to
+ * LinkedList<String>.
+ */
+@Bridge(IdListDst.class)
+public record IdListSrc(List<String> tags) {}

--- a/core/src/test/java/io/github/eschizoid/telescope/beans/MapBrDst.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/beans/MapBrDst.java
@@ -1,0 +1,6 @@
+package io.github.eschizoid.telescope.beans;
+
+import java.util.TreeMap;
+
+/** Target with a concrete TreeMap field; values bridge OptElem -> OptElemBO, keys preserved. */
+public record MapBrDst(TreeMap<String, OptElemBO> byKey) {}

--- a/core/src/test/java/io/github/eschizoid/telescope/beans/MapBrSrc.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/beans/MapBrSrc.java
@@ -1,0 +1,8 @@
+package io.github.eschizoid.telescope.beans;
+
+import io.github.eschizoid.telescope.annotations.Bridge;
+import java.util.Map;
+
+/** Source for the MAP concrete-subtype path: a Map source whose values need a sub-bridge. */
+@Bridge(MapBrDst.class)
+public record MapBrSrc(Map<String, OptElem> byKey) {}

--- a/core/src/test/java/io/github/eschizoid/telescope/beans/SetIdDst.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/beans/SetIdDst.java
@@ -1,0 +1,6 @@
+package io.github.eschizoid.telescope.beans;
+
+import java.util.TreeSet;
+
+/** Target with a concrete TreeSet field; element passes through (String -> String, Comparable). */
+public record SetIdDst(TreeSet<String> tags) {}

--- a/core/src/test/java/io/github/eschizoid/telescope/beans/SetIdSrc.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/beans/SetIdSrc.java
@@ -1,0 +1,8 @@
+package io.github.eschizoid.telescope.beans;
+
+import io.github.eschizoid.telescope.annotations.Bridge;
+import java.util.Set;
+
+/** Source for the SET concrete-subtype path: a Set source bridged to a TreeSet target. */
+@Bridge(SetIdDst.class)
+public record SetIdSrc(Set<String> tags) {}


### PR DESCRIPTION
## Codegen ↔ runtime parity — three more gaps from the proactive audit

Continues the parity sweep (#184, #185). Each fix closes a place where the `@Focus`/`@BeanFocus`/`@Bridge` codegen path shipped a narrower behaviour than the reflective runtime, found by reading the runtime capabilities against the generated output rather than waiting for a report. Every fix is TDD'd (RED proving the gap, GREEN locking the parity).

### Focused primitive setter null-coalesces (was: NPE)

The generated `@BeanFocus` rebuild wrote the focused value straight into its setter, so setting a primitive lens to `null` (`ofBean(T).field(T::getCount).set(bean, null)`) NPE'd on the implicit unbox. A `focusedArg` helper now coalesces a null focus to the primitive's JLS default; reference setters still pass `null` through. Matches the runtime `SettersWriter`, which skips null on primitive setters.

### Null container element passes through (was: NPE)

A `null` element inside a bridged container called `subBridge.forward(null)`, and the generated `forward`/`backward` had no null-source guard, so it NPE'd on the first field read. Both now start with `if (s == null) return null` — null in, null out, matching the runtime structural `Iso` and hardening the directly-callable `BRIDGE_FN` against a null argument too.

### Container subtypes accepted and rebuilt as the declared concrete class (was: rejected)

`@Bridge` container detection exact-string-matched `java.util.List`/`Set`/`Map`, rejecting a field declared as `ArrayList<X>`/`LinkedList<Y>`/`TreeSet<Z>` even though the runtime `ContainerShape` accepts any subtype via `isAssignableFrom`. Detection now uses erasure assignability (Optional stays exact — it's final). Accepting a concrete subtype forces the rebuild to allocate that exact class (an `ArrayList<Y>` helper can't satisfy a `LinkedList<Y>` constructor parameter), so the element-bridging helpers and the inline identity-element copy allocate the target's declared concrete class — the class itself when instantiable, else the interface's default impl (`List`→`ArrayList`, `Set`→`LinkedHashSet`, `Map`→`LinkedHashMap`) — mirroring the runtime `DeepMap` allocation table, presizing only when the impl has a capacity constructor.

## Tests

- `MigrationRegressionTest`: primitive `@BeanFocus` lens set to null → JLS default.
- `BridgeCodegenTest`: null container element passes through; `LinkedList<Y>` target rebuilt as a `LinkedList` (both the element-bridging and identity-element-copy paths) and round-trips.
- `BridgeProcessorTest`: a `LinkedList<Y>` field auto-lifts and the helper allocates the concrete class.
- Full `:codegen` / `:core` / `:lombok` suites green.
