### PR TITLE
bench(fieldByName): dispatch baseline (measured, parked)

### DIFF
--- a/benchmarks/src/jmh/java/io/github/eschizoid/telescope/benchmarks/FieldByNameBenchmark.java
+++ b/benchmarks/src/jmh/java/io/github/eschizoid/telescope/benchmarks/FieldByNameBenchmark.java
@@ -1,0 +1,135 @@
+package io.github.eschizoid.telescope.benchmarks;
+
+import io.github.eschizoid.telescope.Telescope;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.infra.Blackhole;
+
+/**
+ * RED baseline for the {@code fieldByName} dispatch-table pre-resolution work.
+ *
+ * <p>Contrasts the runtime-checked string-keyed {@code fieldByName(...)} lens against the typed
+ * {@code .field(Accessor)} lens, with the lens built once in {@code @Setup} and traversed in the
+ * hot loop (the real usage). The string-keyed lens is class-erased at build, so {@code
+ * Beans.fieldLens} re-resolves on every traversal — {@code get} routes through {@code readProperty}
+ * (a {@code ClassValue.get} + map lookup per call), and {@code set} re-walks {@code propertyNames}
+ * + {@code autoWriter} and re-reads every sibling via {@code readProperty} per call. The typed lens
+ * knows the concrete class at build ({@code implClassOf(getter)}) and captures the accessor/writer
+ * once.
+ *
+ * <p>The gap here is the headroom a per-lens last-class memo on the {@code fieldByName} path could
+ * close; this benchmark exists to size it before any change to {@code Beans.fieldLens}.
+ */
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+public class FieldByNameBenchmark {
+
+  /** Six-field POJO so the {@code set} path's per-call sibling re-reads are visible. */
+  public static final class Wide6 {
+
+    private String a;
+    private String b;
+    private String c;
+    private String d;
+    private String e;
+    private String f;
+
+    public String getA() {
+      return a;
+    }
+
+    public String getB() {
+      return b;
+    }
+
+    public String getC() {
+      return c;
+    }
+
+    public String getD() {
+      return d;
+    }
+
+    public String getE() {
+      return e;
+    }
+
+    public String getF() {
+      return f;
+    }
+
+    public void setA(final String a) {
+      this.a = a;
+    }
+
+    public void setB(final String b) {
+      this.b = b;
+    }
+
+    public void setC(final String c) {
+      this.c = c;
+    }
+
+    public void setD(final String d) {
+      this.d = d;
+    }
+
+    public void setE(final String e) {
+      this.e = e;
+    }
+
+    public void setF(final String f) {
+      this.f = f;
+    }
+  }
+
+  private Wide6 pojo;
+  private Telescope<Wide6, String> byName;
+  private Telescope<Wide6, String> typed;
+
+  @Setup
+  public void setup() {
+    pojo = new Wide6();
+    pojo.setA("A");
+    pojo.setB("B");
+    pojo.setC("C");
+    pojo.setD("D");
+    pojo.setE("E");
+    pojo.setF("F");
+
+    // Both lenses are built ONCE here; the benchmark times only traversal.
+    byName = Telescope.ofBean(Wide6.class).fieldByName("c");
+    typed = Telescope.ofBean(Wide6.class).field(Wide6::getC);
+  }
+
+  // ---- get: string-keyed (re-resolves) vs typed (captured) ------------------------------------
+
+  @Benchmark
+  public void fieldByName_get(final Blackhole bh) {
+    bh.consume(byName.read(pojo));
+  }
+
+  @Benchmark
+  public void typedField_get(final Blackhole bh) {
+    bh.consume(typed.read(pojo));
+  }
+
+  // ---- set: string-keyed (re-resolves writer + reads all siblings) vs typed (captured) --------
+
+  @Benchmark
+  public void fieldByName_set(final Blackhole bh) {
+    bh.consume(byName.set(pojo, "x"));
+  }
+
+  @Benchmark
+  public void typedField_set(final Blackhole bh) {
+    bh.consume(typed.set(pojo, "x"));
+  }
+}


### PR DESCRIPTION
## `fieldByName` dispatch baseline — measured, parked

Benchmark-only. No production change. This records the baseline that decided *not* to optimize the string-keyed lens path.

The runtime-checked `fieldByName(String)` lens is class-erased at build, so `Beans.fieldLens` re-resolves on every traversal — `get` routes through `readProperty` (a `ClassValue.get` + map lookup per call); `set` re-walks `propertyNames` + `autoWriter` and re-reads every sibling via `readProperty`. The typed `.field(Accessor)` lens knows the concrete class at build (`implClassOf(getter)`) and captures the accessor/writer once. This benchmark builds each lens once and traverses it hot, to size the re-resolution tax.

Measured (CI, 3 forks × 30 iters, JDK 25):

| Op | `fieldByName` (re-resolves) | `.field` (captured) | tax |
|---|---|---|---|
| `get` | 70.94 | 52.72 | +18.2 ns (+35%) |
| `set` | 232.10 | 173.21 | +58.9 ns (+34%) |

**Decision: parked.** A per-lens last-class memo would close that ~34% gap, but:
- it lands only on the escape hatch (`fieldByName`/`fromMap`), not the common typed path,
- even the fast typed path is ~53ns/get and ~173ns/set — the cost is dominated by the DSL terminal + immutable bean copy, which the memo can't touch, so the user's experience barely moves, and
- it turns a stateless lens stateful for a secondary-surface win, with no evidence of a hot-loop consumer.

The wider conclusion of the dispatch investigation (#187): the LMF substrate is already excellent (~1.4 ns captured dispatch), so there's no large runtime-dispatch win — codegen remains the hot-path answer. Kept here as the recorded baseline + the harness for a future revisit, whose trigger is a real adopter reporting `fieldByName`/`fromMap` in a hot loop.
