### PR TITLE
fix(codegen): @Bridge element-bridges user-defined Collection/Map subtype fields

### DIFF
--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
@@ -1992,6 +1992,16 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
    *       {@code Y}; bridge the element and unwrap on forward / wrap on backward.
    *   <li>{@code NULLABLE_TO_OPTIONAL} — mirror direction.
    * </ul>
+   *
+   * <p>This flat record now carries several components that are live only for a subset of {@link
+   * Kind}s (the container-impl and raw-container fields for LIST/SET/MAP_VALUES, the null-default
+   * fields for PRIM_WRAPPER, the qualifier for TRANSFORM) — the per-variant validity matrix lives
+   * in the field comments, not the type. That is acceptable for this private, single-file plan
+   * object, but it is the binding constraint now: do NOT add a further variant-specific component
+   * to this flat shape. The next container/variant feature should first convert this to a sealed
+   * hierarchy (a Container variant carrying kind/sub/impls/raw, separate PrimWrapper / Recurse /
+   * Transform / Identity variants) so the compiler enforces the matrix the comments currently
+   * describe.
    */
   private record FieldPlan(
     Kind kind,
@@ -2012,7 +2022,17 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
     // recomputes its allocation from the field types directly). Mirrors DeepMap's allocation
     // table.
     String fwdContainerImpl,
-    String bwdContainerImpl
+    String bwdContainerImpl,
+    // LIST/SET/MAP_VALUES only: true when the field is a raw (non-generic) Collection/Map subtype
+    // on
+    // at least one side (e.g. `class ImageUrls extends ArrayList<ImageUrl>`, or a generic
+    // interface
+    // paired with such a subtype). The element type lives in the supertype, the subtype is
+    // allocated
+    // via its no-arg constructor (subclasses don't inherit the JDK copy ctor), so these route to
+    // the
+    // self-contained raw helpers instead of the generic copy-ctor inline path.
+    boolean rawContainer
   ) {
     enum Kind {
       IDENTITY,
@@ -2028,13 +2048,29 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
     }
 
     static FieldPlan identity() {
-      return new FieldPlan(Kind.IDENTITY, null, null, null, null, null, null);
+      return new FieldPlan(Kind.IDENTITY, null, null, null, null, null, null, false);
     }
 
     // Attach the concrete-impl class names for a LIST/SET/MAP_VALUES plan — the classes the inline
     // identity-element copy allocates for the forward (target) and backward (source) outputs.
     FieldPlan withContainerImpls(final String fwdImpl, final String bwdImpl) {
-      return new FieldPlan(kind, subBridgeName, qualifierMethod, fwdNullDefault, bwdNullDefault, fwdImpl, bwdImpl);
+      return new FieldPlan(
+        kind,
+        subBridgeName,
+        qualifierMethod,
+        fwdNullDefault,
+        bwdNullDefault,
+        fwdImpl,
+        bwdImpl,
+        false
+      );
+    }
+
+    // Mark a LIST/SET/MAP_VALUES plan as a raw (non-generic) Collection/Map subtype container, so
+    // applyForward/applyBackward route to the self-contained raw helpers (no-arg ctor + addAll /
+    // element loop) rather than the generic copy-ctor inline path.
+    static FieldPlan rawContainer(final Kind kind, final String subBridgeName) {
+      return new FieldPlan(kind, Objects.requireNonNull(subBridgeName), null, null, null, null, null, true);
     }
 
     // Primitive ↔ boxed wrapper. The direction that writes the primitive side null-coalesces a null
@@ -2042,15 +2078,15 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
     // (null is a legal wrapper value). Exactly one of the two defaults is non-null for any given
     // pair. Matches the runtime DeepMap.primitiveWrapperIso.
     static FieldPlan primWrapper(final String fwdNullDefault, final String bwdNullDefault) {
-      return new FieldPlan(Kind.PRIM_WRAPPER, null, null, fwdNullDefault, bwdNullDefault, null, null);
+      return new FieldPlan(Kind.PRIM_WRAPPER, null, null, fwdNullDefault, bwdNullDefault, null, null, false);
     }
 
     static FieldPlan recurse(final String subBridgeName) {
-      return new FieldPlan(Kind.RECURSE, Objects.requireNonNull(subBridgeName), null, null, null, null, null);
+      return new FieldPlan(Kind.RECURSE, Objects.requireNonNull(subBridgeName), null, null, null, null, null, false);
     }
 
     static FieldPlan ofKind(final Kind kind, final String subBridgeName) {
-      return new FieldPlan(kind, Objects.requireNonNull(subBridgeName), null, null, null, null, null);
+      return new FieldPlan(kind, Objects.requireNonNull(subBridgeName), null, null, null, null, null, false);
     }
 
     // Qualifier-dispatch TRANSFORM variant: the `using` class hosts a named static method, NOT a
@@ -2064,7 +2100,8 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
         null,
         null,
         null,
-        null
+        null,
+        false
       );
     }
   }
@@ -2098,6 +2135,55 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
       return new ContainerShape(FieldPlan.Kind.MAP_VALUES, args.get(1), args.get(0));
     }
     return null;
+  }
+
+  // The container shape of a RAW (non-generic) Collection/Map subtype — a field declared as `class
+  // ImageUrls extends ArrayList<ImageUrl>` whose own type-argument list is empty, so the element
+  // type lives in the supertype. Returns null for a generic container (handled by
+  // containerShapeOf),
+  // a raw use of a generic type with no concrete supertype element, or a non-container. Optional is
+  // final and cannot be subtyped, so it has no raw form.
+  private ContainerShape rawContainerShapeOf(final TypeMirror type) {
+    if (!(type instanceof DeclaredType dt) || !dt.getTypeArguments().isEmpty()) return null;
+    if (assignableToRaw(type, "java.util.List")) {
+      final var args = containerViewArgs(type, "java.util.List");
+      return args.size() == 1 ? new ContainerShape(FieldPlan.Kind.LIST, args.get(0), null) : null;
+    }
+    if (assignableToRaw(type, "java.util.Set")) {
+      final var args = containerViewArgs(type, "java.util.Set");
+      return args.size() == 1 ? new ContainerShape(FieldPlan.Kind.SET, args.get(0), null) : null;
+    }
+    if (assignableToRaw(type, "java.util.Map")) {
+      final var args = containerViewArgs(type, "java.util.Map");
+      return args.size() == 2 ? new ContainerShape(FieldPlan.Kind.MAP_VALUES, args.get(1), args.get(0)) : null;
+    }
+    return null;
+  }
+
+  // The type arguments of `type`'s view as the JDK container `rawFqn` (e.g. the `<ImageUrl>` of the
+  // `java.util.List` supertype of `class ImageUrls extends ArrayList<ImageUrl>`). Walks the
+  // supertype graph until it finds the declared supertype whose erasure is exactly `rawFqn` and
+  // carries concrete type arguments. Returns an empty list when there is no such concrete view
+  // (e.g. a raw use of a generic type, where the args are unresolved type variables).
+  private List<? extends TypeMirror> containerViewArgs(final TypeMirror type, final String rawFqn) {
+    final var types = processingEnv.getTypeUtils();
+    final var rawEl = processingEnv.getElementUtils().getTypeElement(rawFqn);
+    if (rawEl == null) return List.of();
+    final var rawErasure = types.erasure(rawEl.asType());
+    final Deque<TypeMirror> queue = new ArrayDeque<>();
+    final Set<String> seen = new HashSet<>();
+    queue.add(type);
+    while (!queue.isEmpty()) {
+      final var t = queue.poll();
+      if (t instanceof DeclaredType dt && dt.asElement() instanceof TypeElement te) {
+        if (!seen.add(te.getQualifiedName().toString())) continue;
+        if (types.isSameType(types.erasure(t), rawErasure) && !dt.getTypeArguments().isEmpty()) {
+          return dt.getTypeArguments();
+        }
+      }
+      queue.addAll(types.directSupertypes(t));
+    }
+    return List.of();
   }
 
   // True when `type`'s erasure is assignable to the raw interface named by `rawFqn`.
@@ -2268,6 +2354,70 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
         plans.put(sf.name(), withImpls);
         continue;
       }
+      // (2-raw) Raw Collection/Map subtype container — at least one side is a non-generic subtype
+      //     (`class ImageUrls extends ArrayList<ImageUrl>`), possibly paired with a generic
+      //     container on the other. The element lives in the supertype; the subtype is allocated
+      // via
+      //     its no-arg ctor + element loop. Falls back to the generic shape when a side is already
+      // a
+      //     parameterized container (the mixed `List<X>` ↔ `Wrap` case).
+      final var srcRaw = srcShape != null ? srcShape : rawContainerShapeOf(sf.type());
+      final var tgtRaw = tgtShape != null ? tgtShape : rawContainerShapeOf(tf.type());
+      if (srcRaw != null && tgtRaw != null && srcRaw.kind() == tgtRaw.kind()) {
+        if (srcRaw.kind() == FieldPlan.Kind.MAP_VALUES && !isSameType(srcRaw.keyType(), tgtRaw.keyType())) {
+          error(
+            source,
+            "@Bridge " +
+              source.getSimpleName() +
+              " -> " +
+              target.getSimpleName() +
+              ": field '" +
+              sf.name() +
+              "' has incompatible Map key types — " +
+              srcRaw.keyType() +
+              " vs " +
+              tgtRaw.keyType() +
+              ". Map key types must match exactly; codegen preserves source keys."
+          );
+          return null;
+        }
+        // The raw helper allocates each side's concrete container via its no-arg constructor. A
+        // subtype that hides it (`class Wrap extends ArrayList<X> { Wrap(int cap) {} }`) would make
+        // the generated `new Wrap()` fail in the consumer's build with a raw javac error; reject it
+        // here with a telescope-authored diagnostic instead.
+        final var badAlloc = firstNonAllocatableContainer(sf.type(), tf.type(), srcRaw.kind());
+        if (badAlloc != null) {
+          error(
+            source,
+            "@Bridge " +
+              source.getSimpleName() +
+              " -> " +
+              target.getSimpleName() +
+              ": field '" +
+              sf.name() +
+              "' container type '" +
+              badAlloc +
+              "' has no public no-arg constructor — codegen allocates it directly. Add a no-arg " +
+              "constructor, or use the runtime mapper with an explicit row for this field."
+          );
+          return null;
+        }
+        final var subPlan = planElementSubBridge(
+          source,
+          target,
+          sf.name(),
+          srcRaw.elementType(),
+          tgtRaw.elementType(),
+          srcRaw.kind(),
+          pending,
+          seen,
+          userDeclared,
+          lenient
+        );
+        if (subPlan == null) return null;
+        plans.put(sf.name(), FieldPlan.rawContainer(subPlan.kind(), subPlan.subBridgeName()));
+        continue;
+      }
       // (3) Cross-paradigm Optional↔nullable bridge — one side has Optional<X>, the other has
       //     plain (possibly null) X. Element side must be reflectable to bridge.
       if (srcShape != null && srcShape.kind() == FieldPlan.Kind.OPTIONAL && tgtShape == null) {
@@ -2427,6 +2577,10 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
   }
 
   private String applyForward(final String fieldName, final FieldPlan plan, final String readExpr) {
+    // Raw Collection/Map subtype containers always route to their self-contained helper (no-arg
+    // ctor
+    // + addAll / element loop); the inline copy-ctor below is invalid for a non-generic subtype.
+    if (plan.rawContainer()) return "__fwd_" + fieldName + "(" + readExpr + ")";
     final var sub = plan.subBridgeName();
     final boolean elementIdentity = IDENTITY_ELEMENT_SENTINEL.equals(sub);
     final var fwdElement = elementIdentity ? "e -> e" : sub + "::forward";
@@ -2486,6 +2640,7 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
   }
 
   private String applyBackward(final String fieldName, final FieldPlan plan, final String readExpr) {
+    if (plan.rawContainer()) return "__bwd_" + fieldName + "(" + readExpr + ")";
     final var sub = plan.subBridgeName();
     final boolean elementIdentity = IDENTITY_ELEMENT_SENTINEL.equals(sub);
     final var bwdElement = elementIdentity ? "e -> e" : sub + "::backward";
@@ -2551,6 +2706,8 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
     final var imports = new TreeSet<String>();
     for (final var entry : fieldPlans.entrySet()) {
       final var plan = entry.getValue();
+      // Raw-container helpers render every type by fully-qualified name, so they need no imports.
+      if (plan.rawContainer()) continue;
       switch (plan.kind()) {
         // A container field needs both the declared raw of each side (the helper return / param
         // types and the inline copy) and the concrete impl each side allocates. For the common
@@ -2589,9 +2746,16 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
     for (final var entry : fieldPlans.entrySet()) {
       final var fieldName = entry.getKey();
       final var plan = entry.getValue();
-      if (IDENTITY_ELEMENT_SENTINEL.equals(plan.subBridgeName())) continue;
       final var srcType = fieldByName(sourceFields, fieldName).type();
       final var tgtType = fieldByName(targetFields, renames.getOrDefault(fieldName, fieldName)).type();
+      // Raw Collection/Map subtype containers get the self-contained helper even for identity
+      // elements (the inline copy-ctor path is invalid for a non-generic subtype).
+      if (plan.rawContainer()) {
+        emitRawContainerHelper(out, "__fwd_" + fieldName, srcType, tgtType, plan, "forward");
+        emitRawContainerHelper(out, "__bwd_" + fieldName, tgtType, srcType, plan, "backward");
+        continue;
+      }
+      if (IDENTITY_ELEMENT_SENTINEL.equals(plan.subBridgeName())) continue;
       switch (plan.kind()) {
         case LIST -> {
           emitListHelper(out, "__fwd_" + fieldName, srcType, tgtType, plan.subBridgeName(), "forward");
@@ -2609,6 +2773,77 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
         }
       }
     }
+  }
+
+  // Emit one direction of a raw Collection/Map subtype container helper. Every type is rendered
+  // fully-qualified (no imports needed). The output collection is allocated via its no-arg
+  // constructor (a Collection/Map subtype does not inherit the JDK copy constructor) and filled by
+  // addAll/putAll for an identity element or an element-bridging loop otherwise.
+  private void emitRawContainerHelper(
+    final PrintWriter out,
+    final String name,
+    final TypeMirror srcContainer,
+    final TypeMirror tgtContainer,
+    final FieldPlan plan,
+    final String direction
+  ) {
+    final var identity = IDENTITY_ELEMENT_SENTINEL.equals(plan.subBridgeName());
+    final var sub = plan.subBridgeName();
+    out.println();
+    out.println("  private static " + tgtContainer + " " + name + "(final " + srcContainer + " src) {");
+    out.println("    if (src == null) return null;");
+    out.println("    final var out = " + rawAllocExpr(tgtContainer, plan.kind()) + ";");
+    if (plan.kind() == FieldPlan.Kind.MAP_VALUES) {
+      if (identity) {
+        out.println("    out.putAll(src);");
+      } else {
+        out.println(
+          "    for (final var e : src.entrySet()) out.put(e.getKey(), " + sub + "." + direction + "(e.getValue()));"
+        );
+      }
+    } else if (identity) {
+      out.println("    out.addAll(src);");
+    } else {
+      out.println("    for (final var x : src) out.add(" + sub + "." + direction + "(x));");
+    }
+    out.println("    return out;");
+    out.println("  }");
+  }
+
+  // The first of the two raw-container fields whose concrete allocation class lacks a public no-arg
+  // constructor (the generated `new <impl>()` would not compile), or null when both are
+  // allocatable.
+  // The JDK default impls (ArrayList / LinkedHashSet / HashMap) always qualify; only a user subtype
+  // can hide its no-arg ctor.
+  private String firstNonAllocatableContainer(
+    final TypeMirror srcContainer,
+    final TypeMirror tgtContainer,
+    final FieldPlan.Kind kind
+  ) {
+    for (final var container : List.of(srcContainer, tgtContainer)) {
+      final var implFqn = concreteImplFqn(container, kind);
+      final var implEl = processingEnv.getElementUtils().getTypeElement(implFqn);
+      if (implEl != null && !hasPublicNoArgConstructor(implEl)) return implFqn;
+    }
+    return null;
+  }
+
+  // Allocation expression for a raw-container output: the target's concrete class (the subtype
+  // itself
+  // when instantiable, else the interface's default impl), with a diamond only when that class is
+  // generic. A non-generic subtype (`class ImageUrls extends ArrayList<ImageUrl>`) takes no type
+  // arguments; the default impl for a generic interface field takes the field's element args.
+  private String rawAllocExpr(final TypeMirror container, final FieldPlan.Kind kind) {
+    final var implFqn = concreteImplFqn(container, kind);
+    final var implEl = processingEnv.getElementUtils().getTypeElement(implFqn);
+    final var generic = implEl != null && !implEl.getTypeParameters().isEmpty();
+    if (!generic) return "new " + implFqn + "()";
+    if (kind == FieldPlan.Kind.MAP_VALUES) {
+      final var args = containerViewArgs(container, "java.util.Map");
+      return "new " + implFqn + "<" + args.get(0) + ", " + args.get(1) + ">()";
+    }
+    final var args = containerViewArgs(container, kind == FieldPlan.Kind.SET ? "java.util.Set" : "java.util.List");
+    return "new " + implFqn + "<" + args.get(0) + ">()";
   }
 
   private void emitListHelper(
@@ -2780,12 +3015,24 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
     if (kind != ElementKind.RECORD && kind != ElementKind.CLASS) return false;
     // Filter out boxed scalars / String / common JDK types we don't want to recurse into.
     final var fq = te.getQualifiedName().toString();
-    return (
-      !fq.startsWith("java.lang.") &&
-      !fq.startsWith("java.time.") &&
-      !fq.startsWith("java.util.") &&
-      !fq.startsWith("java.math.")
-    );
+    if (
+      fq.startsWith("java.lang.") ||
+      fq.startsWith("java.time.") ||
+      fq.startsWith("java.util.") ||
+      fq.startsWith("java.math.")
+    ) {
+      return false;
+    }
+    // A user-package subtype of a JDK Collection/Map (e.g. `class ImageUrls extends
+    // ArrayList<ImageUrl>`) clears the prefix filter but must NOT be bean-introspected: ArrayList's
+    // synthesized `isEmpty()` reads as a property `empty` with no `setEmpty`, producing a
+    // misleading
+    // "no setter for 'empty'" error. Same-kind subtype pairs are element-bridged by the (2-raw)
+    // container branch before reaching here; this exclusion is the backstop for the pairs that
+    // branch can't claim (a kind mismatch like List-subtype vs Set-subtype, or a Collection/Map
+    // subtype opposite a non-container), so they fall to the accurate "no auto-bridge could be
+    // derived" diagnostic instead of the bean-introspection crash.
+    return !assignableToRaw(dt, "java.util.Collection") && !assignableToRaw(dt, "java.util.Map");
   }
 
   // Read field `f` from `var`: `var.f()` for a record, `var.getF()` / `var.isF()` for a POJO.

--- a/codegen/src/test/java/io/github/eschizoid/telescope/codegen/BridgeProcessorTest.java
+++ b/codegen/src/test/java/io/github/eschizoid/telescope/codegen/BridgeProcessorTest.java
@@ -335,6 +335,458 @@ class BridgeProcessorTest {
 
     @Test
     @DisplayName(
+      "a user-defined raw collection-subtype field (class Wrap extends ArrayList<Elem>) element-bridges into a fresh target wrapper"
+    )
+    void rawCollectionSubtypeFieldElementBridges() {
+      // The adopter shape: a custom collection wrapper `class Wrap extends ArrayList<Elem>` whose
+      // own
+      // type-argument list is empty (the element lives in the supertype). The element pair is a
+      // distinct, bridgeable record pair (SrcElem -> DstElem), so the field must element-bridge
+      // into
+      // a fresh target wrapper allocated via its no-arg constructor (subclasses don't inherit
+      // ArrayList's copy constructor), not be bean-introspected.
+      final var compilation = compile(
+        source(
+          "demo.RawOrder",
+          """
+          package demo;
+          import io.github.eschizoid.telescope.annotations.Bridge;
+          @Bridge(demo.RawOrderDto.class)
+          public record RawOrder(demo.SrcWrap items) {}
+          """
+        ),
+        source(
+          "demo.SrcWrap",
+          """
+          package demo;
+          import java.util.ArrayList;
+          public class SrcWrap extends ArrayList<demo.SrcElem> {}
+          """
+        ),
+        source(
+          "demo.SrcElem",
+          """
+          package demo;
+          public record SrcElem(String sku) {}
+          """
+        ),
+        source(
+          "demo.RawOrderDto",
+          """
+          package demo;
+          public record RawOrderDto(demo.DstWrap items) {}
+          """
+        ),
+        source(
+          "demo.DstWrap",
+          """
+          package demo;
+          import java.util.ArrayList;
+          public class DstWrap extends ArrayList<demo.DstElem> {}
+          """
+        ),
+        source(
+          "demo.DstElem",
+          """
+          package demo;
+          public record DstElem(String sku) {}
+          """
+        )
+      );
+
+      assertTrue(compilation.success(), () -> "compilation failed: " + compilation.errorMessages());
+      final var bridge = compilation.generated().get("demo.RawOrderBridge");
+      assertNotNull(bridge);
+      // A sub-bridge is generated for the distinct element pair, and the forward copy allocates a
+      // fresh target wrapper via its no-arg ctor (raw type, no diamond — the subtype is
+      // non-generic).
+      assertNotNull(compilation.generated().get("demo.SrcElemToDstElemBridge"));
+      assertTrue(bridge.contains("new demo.DstWrap()"), bridge);
+      assertTrue(bridge.contains("SrcElemToDstElemBridge.forward(x)"), bridge);
+      // backward allocates a fresh source wrapper the same way.
+      assertTrue(bridge.contains("new demo.SrcWrap()"), bridge);
+      assertTrue(bridge.contains("SrcElemToDstElemBridge.backward(x)"), bridge);
+    }
+
+    @Test
+    @DisplayName("raw collection-subtype with identity elements copies via addAll into a fresh wrapper (no sub-bridge)")
+    void rawCollectionSubtypeIdentityElementCopiesViaAddAll() {
+      final var compilation = compile(
+        source(
+          "demo.IdOrder",
+          """
+          package demo;
+          import io.github.eschizoid.telescope.annotations.Bridge;
+          @Bridge(demo.IdOrderDto.class)
+          public record IdOrder(demo.SrcTags tags) {}
+          """
+        ),
+        source(
+          "demo.SrcTags",
+          """
+          package demo;
+          import java.util.ArrayList;
+          public class SrcTags extends ArrayList<String> {}
+          """
+        ),
+        source(
+          "demo.IdOrderDto",
+          """
+          package demo;
+          public record IdOrderDto(demo.DstTags tags) {}
+          """
+        ),
+        source(
+          "demo.DstTags",
+          """
+          package demo;
+          import java.util.ArrayList;
+          public class DstTags extends ArrayList<String> {}
+          """
+        )
+      );
+
+      assertTrue(compilation.success(), () -> "compilation failed: " + compilation.errorMessages());
+      final var bridge = compilation.generated().get("demo.IdOrderBridge");
+      assertNotNull(bridge);
+      // Same element type → no sub-bridge, a verbatim addAll into a fresh target wrapper.
+      assertNull(compilation.generated().get("demo.StringToStringBridge"));
+      assertTrue(bridge.contains("new demo.DstTags()"), bridge);
+      assertTrue(bridge.contains("out.addAll(src)"), bridge);
+    }
+
+    @Test
+    @DisplayName("raw Set-subtype element-bridges into a fresh target set")
+    void rawSetSubtypeElementBridges() {
+      final var compilation = compile(
+        source(
+          "demo.SetOrder",
+          """
+          package demo;
+          import io.github.eschizoid.telescope.annotations.Bridge;
+          @Bridge(demo.SetOrderDto.class)
+          public record SetOrder(demo.SrcSet items) {}
+          """
+        ),
+        source(
+          "demo.SrcSet",
+          """
+          package demo;
+          import java.util.HashSet;
+          public class SrcSet extends HashSet<demo.SElem> {}
+          """
+        ),
+        source("demo.SElem", "package demo; public record SElem(String v) {}"),
+        source(
+          "demo.SetOrderDto",
+          """
+          package demo;
+          public record SetOrderDto(demo.DstSet items) {}
+          """
+        ),
+        source(
+          "demo.DstSet",
+          """
+          package demo;
+          import java.util.HashSet;
+          public class DstSet extends HashSet<demo.DElem> {}
+          """
+        ),
+        source("demo.DElem", "package demo; public record DElem(String v) {}")
+      );
+
+      assertTrue(compilation.success(), () -> "compilation failed: " + compilation.errorMessages());
+      final var bridge = compilation.generated().get("demo.SetOrderBridge");
+      assertNotNull(bridge);
+      assertNotNull(compilation.generated().get("demo.SElemToDElemBridge"));
+      assertTrue(bridge.contains("new demo.DstSet()"), bridge);
+      assertTrue(bridge.contains("SElemToDElemBridge.forward(x)"), bridge);
+    }
+
+    @Test
+    @DisplayName("raw Map-subtype element-bridges values, preserves keys, into a fresh target map")
+    void rawMapSubtypeElementBridgesValues() {
+      final var compilation = compile(
+        source(
+          "demo.MapOrder",
+          """
+          package demo;
+          import io.github.eschizoid.telescope.annotations.Bridge;
+          @Bridge(demo.MapOrderDto.class)
+          public record MapOrder(demo.SrcMeta meta) {}
+          """
+        ),
+        source(
+          "demo.SrcMeta",
+          """
+          package demo;
+          import java.util.HashMap;
+          public class SrcMeta extends HashMap<String, demo.MSElem> {}
+          """
+        ),
+        source("demo.MSElem", "package demo; public record MSElem(String v) {}"),
+        source(
+          "demo.MapOrderDto",
+          """
+          package demo;
+          public record MapOrderDto(demo.DstMeta meta) {}
+          """
+        ),
+        source(
+          "demo.DstMeta",
+          """
+          package demo;
+          import java.util.HashMap;
+          public class DstMeta extends HashMap<String, demo.MDElem> {}
+          """
+        ),
+        source("demo.MDElem", "package demo; public record MDElem(String v) {}")
+      );
+
+      assertTrue(compilation.success(), () -> "compilation failed: " + compilation.errorMessages());
+      final var bridge = compilation.generated().get("demo.MapOrderBridge");
+      assertNotNull(bridge);
+      assertNotNull(compilation.generated().get("demo.MSElemToMDElemBridge"));
+      assertTrue(bridge.contains("new demo.DstMeta()"), bridge);
+      assertTrue(bridge.contains("out.put(e.getKey(), MSElemToMDElemBridge.forward(e.getValue()))"), bridge);
+    }
+
+    @Test
+    @DisplayName("lenient propagates through the raw container branch to a non-bijection element pair")
+    void rawCollectionSubtypeLenientPropagatesToElement() {
+      // The adopter's reported shape carried lenient = true. Leniency must thread through the
+      // raw-container branch into the element sub-pair, so a non-bijection element pair (the target
+      // element has an extra field) compiles instead of failing the bijection check.
+      final var compilation = compile(
+        source(
+          "demo.LenOrder",
+          """
+          package demo;
+          import io.github.eschizoid.telescope.annotations.Bridge;
+          @Bridge(value = demo.LenOrderDto.class, lenient = true)
+          public record LenOrder(demo.LenSrcWrap items) {}
+          """
+        ),
+        source(
+          "demo.LenSrcWrap",
+          """
+          package demo;
+          import java.util.ArrayList;
+          public class LenSrcWrap extends ArrayList<demo.LenSrcElem> {}
+          """
+        ),
+        source("demo.LenSrcElem", "package demo; public record LenSrcElem(String a) {}"),
+        source(
+          "demo.LenOrderDto",
+          """
+          package demo;
+          public record LenOrderDto(demo.LenDstWrap items) {}
+          """
+        ),
+        source(
+          "demo.LenDstWrap",
+          """
+          package demo;
+          import java.util.ArrayList;
+          public class LenDstWrap extends ArrayList<demo.LenDstElem> {}
+          """
+        ),
+        source("demo.LenDstElem", "package demo; public record LenDstElem(String a, String extra) {}")
+      );
+
+      assertTrue(
+        compilation.success(),
+        () -> "lenient should propagate into the element pair: " + compilation.errorMessages()
+      );
+      assertNotNull(compilation.generated().get("demo.LenSrcElemToLenDstElemBridge"));
+    }
+
+    @Test
+    @DisplayName(
+      "mixed generic↔raw: List<X> ↔ raw ArrayList subtype element-bridges, backward allocates the interface default"
+    )
+    void mixedGenericAndRawCollectionElementBridges() {
+      final var compilation = compile(
+        source(
+          "demo.MixOrder",
+          """
+          package demo;
+          import io.github.eschizoid.telescope.annotations.Bridge;
+          import java.util.List;
+          @Bridge(demo.MixOrderDto.class)
+          public record MixOrder(List<demo.MixSrc> items) {}
+          """
+        ),
+        source("demo.MixSrc", "package demo; public record MixSrc(String v) {}"),
+        source(
+          "demo.MixOrderDto",
+          """
+          package demo;
+          public record MixOrderDto(demo.MixWrap items) {}
+          """
+        ),
+        source(
+          "demo.MixWrap",
+          """
+          package demo;
+          import java.util.ArrayList;
+          public class MixWrap extends ArrayList<demo.MixDst> {}
+          """
+        ),
+        source("demo.MixDst", "package demo; public record MixDst(String v) {}")
+      );
+
+      assertTrue(compilation.success(), () -> "compilation failed: " + compilation.errorMessages());
+      final var bridge = compilation.generated().get("demo.MixOrderBridge");
+      assertNotNull(bridge);
+      assertNotNull(compilation.generated().get("demo.MixSrcToMixDstBridge"));
+      // forward allocates the concrete subtype; backward allocates the interface's default impl.
+      assertTrue(bridge.contains("new demo.MixWrap()"), bridge);
+      assertTrue(bridge.contains("new java.util.ArrayList<demo.MixSrc>()"), bridge);
+    }
+
+    @Test
+    @DisplayName("mixed generic↔raw Map: Map<K, V> ↔ raw HashMap subtype, backward allocates the two-arg default impl")
+    void mixedGenericAndRawMapElementBridges() {
+      final var compilation = compile(
+        source(
+          "demo.MMixOrder",
+          """
+          package demo;
+          import io.github.eschizoid.telescope.annotations.Bridge;
+          import java.util.Map;
+          @Bridge(demo.MMixOrderDto.class)
+          public record MMixOrder(Map<String, demo.MMixSrc> meta) {}
+          """
+        ),
+        source("demo.MMixSrc", "package demo; public record MMixSrc(String v) {}"),
+        source(
+          "demo.MMixOrderDto",
+          """
+          package demo;
+          public record MMixOrderDto(demo.MMixWrap meta) {}
+          """
+        ),
+        source(
+          "demo.MMixWrap",
+          """
+          package demo;
+          import java.util.HashMap;
+          public class MMixWrap extends HashMap<String, demo.MMixDst> {}
+          """
+        ),
+        source("demo.MMixDst", "package demo; public record MMixDst(String v) {}")
+      );
+
+      assertTrue(compilation.success(), () -> "compilation failed: " + compilation.errorMessages());
+      final var bridge = compilation.generated().get("demo.MMixOrderBridge");
+      assertNotNull(bridge);
+      assertNotNull(compilation.generated().get("demo.MMixSrcToMMixDstBridge"));
+      // forward allocates the concrete subtype; backward allocates the Map interface's two-arg
+      // default.
+      assertTrue(bridge.contains("new demo.MMixWrap()"), bridge);
+      assertTrue(bridge.contains("new java.util.HashMap<java.lang.String, demo.MMixSrc>()"), bridge);
+    }
+
+    @Test
+    @DisplayName("a raw collection subtype with no public no-arg constructor is rejected with a telescope diagnostic")
+    void rawCollectionSubtypeWithoutNoArgCtorIsRejected() {
+      // The raw helper allocates `new Wrap()`; a subtype that hides the no-arg ctor would fail in
+      // the
+      // consumer's build with a raw javac error. The processor rejects it up front instead.
+      final var compilation = compile(
+        source(
+          "demo.CtorSrc",
+          """
+          package demo;
+          import io.github.eschizoid.telescope.annotations.Bridge;
+          @Bridge(demo.CtorDst.class)
+          public record CtorSrc(demo.CtorSrcWrap items) {}
+          """
+        ),
+        source(
+          "demo.CtorSrcWrap",
+          """
+          package demo;
+          import java.util.ArrayList;
+          public class CtorSrcWrap extends ArrayList<String> {}
+          """
+        ),
+        source(
+          "demo.CtorDst",
+          """
+          package demo;
+          public record CtorDst(demo.NoCtorWrap items) {}
+          """
+        ),
+        source(
+          "demo.NoCtorWrap",
+          """
+          package demo;
+          import java.util.ArrayList;
+          public class NoCtorWrap extends ArrayList<String> {
+            public NoCtorWrap(final int capacity) {
+              super(capacity);
+            }
+          }
+          """
+        )
+      );
+
+      assertFalse(compilation.success(), "a ctor-less container subtype should be rejected");
+      assertTrue(
+        compilation.hasError("no public no-arg constructor"),
+        () -> "expected the no-arg-ctor diagnostic; saw " + compilation.errorMessages()
+      );
+    }
+
+    @Test
+    @DisplayName("raw Map-subtype pair with mismatched key types is an error")
+    void rawMapSubtypeKeyMismatchIsRejected() {
+      final var compilation = compile(
+        source(
+          "demo.KSrc",
+          """
+          package demo;
+          import io.github.eschizoid.telescope.annotations.Bridge;
+          @Bridge(demo.KDst.class)
+          public record KSrc(demo.KSrcMap meta) {}
+          """
+        ),
+        source(
+          "demo.KSrcMap",
+          """
+          package demo;
+          import java.util.HashMap;
+          public class KSrcMap extends HashMap<String, String> {}
+          """
+        ),
+        source(
+          "demo.KDst",
+          """
+          package demo;
+          public record KDst(demo.KDstMap meta) {}
+          """
+        ),
+        source(
+          "demo.KDstMap",
+          """
+          package demo;
+          import java.util.HashMap;
+          public class KDstMap extends HashMap<Integer, String> {}
+          """
+        )
+      );
+
+      assertFalse(compilation.success(), "a raw Map-subtype pair with mismatched keys should fail");
+      assertTrue(
+        compilation.hasError("Map key types must match exactly"),
+        () -> "expected the key-type diagnostic; saw " + compilation.errorMessages()
+      );
+    }
+
+    @Test
+    @DisplayName(
       "identity element, concrete List subtype: List<String> ↔ LinkedList<String> emits an inline copy into each side's concrete class"
     )
     void identityElementConcreteListEmitsInlineConcreteCopy() {
@@ -779,6 +1231,116 @@ class BridgeProcessorTest {
       assertTrue(
         compilation.hasError("@Bridge is only supported on top-level types"),
         () -> "expected top-level diagnostic; saw " + compilation.errorMessages()
+      );
+    }
+
+    @Test
+    @DisplayName(
+      "a kind-mismatched Collection-subtype pair (List subtype vs Set subtype) is not bean-introspected — clean diagnostic, not 'no setter for empty'"
+    )
+    void kindMismatchedCollectionSubtypesAreNotBeanIntrospected() {
+      // Same-kind Collection/Map subtype pairs are element-bridged (see DeepRecursion). A
+      // kind-mismatched pair (List subtype vs Set subtype) cannot be — but both still clear the
+      // qualified-name prefix filter, so without the guard the planner would recurse into one as a
+      // bean and surface ArrayList's synthesized `isEmpty()` → property `empty` → no `setEmpty` →
+      // the
+      // misleading "no setter for 'empty'" error. The isReflectableDeclared exclusion makes it fall
+      // to the accurate "no auto-bridge" diagnostic instead.
+      final var compilation = compile(
+        source(
+          "demo.Src",
+          """
+          package demo;
+          import io.github.eschizoid.telescope.annotations.Bridge;
+          @Bridge(demo.Dst.class)
+          public record Src(demo.SrcList items) {}
+          """
+        ),
+        source(
+          "demo.SrcList",
+          """
+          package demo;
+          import java.util.ArrayList;
+          public class SrcList extends ArrayList<String> {}
+          """
+        ),
+        source(
+          "demo.Dst",
+          """
+          package demo;
+          public record Dst(demo.DstSet items) {}
+          """
+        ),
+        source(
+          "demo.DstSet",
+          """
+          package demo;
+          import java.util.HashSet;
+          public class DstSet extends HashSet<String> {}
+          """
+        )
+      );
+
+      assertFalse(compilation.success(), "a kind-mismatched Collection-subtype pair should fail");
+      assertFalse(
+        compilation.hasError("no setter for 'empty'"),
+        () -> "must not leak the bean-introspection error; saw " + compilation.errorMessages()
+      );
+      assertTrue(
+        compilation.hasError("no auto-bridge could be derived"),
+        () -> "expected the clean no-auto-bridge diagnostic; saw " + compilation.errorMessages()
+      );
+    }
+
+    @Test
+    @DisplayName("a kind-mismatched Map-subtype pair (Map subtype vs List subtype) is not bean-introspected either")
+    void kindMismatchedMapSubtypeIsNotBeanIntrospected() {
+      // Map subtype vs List subtype — kind mismatch, not element-bridgeable. Pins the
+      // `java.util.Map` clause of the isReflectableDeclared exclusion guarding the HashMap `empty`
+      // crash.
+      final var compilation = compile(
+        source(
+          "demo.MSrc",
+          """
+          package demo;
+          import io.github.eschizoid.telescope.annotations.Bridge;
+          @Bridge(demo.MDst.class)
+          public record MSrc(demo.SrcMap meta) {}
+          """
+        ),
+        source(
+          "demo.SrcMap",
+          """
+          package demo;
+          import java.util.HashMap;
+          public class SrcMap extends HashMap<String, String> {}
+          """
+        ),
+        source(
+          "demo.MDst",
+          """
+          package demo;
+          public record MDst(demo.DstList meta) {}
+          """
+        ),
+        source(
+          "demo.DstList",
+          """
+          package demo;
+          import java.util.ArrayList;
+          public class DstList extends ArrayList<String> {}
+          """
+        )
+      );
+
+      assertFalse(compilation.success(), "a kind-mismatched Map-subtype pair should fail");
+      assertFalse(
+        compilation.hasError("no setter for 'empty'"),
+        () -> "must not leak the bean-introspection error; saw " + compilation.errorMessages()
+      );
+      assertTrue(
+        compilation.hasError("no auto-bridge could be derived"),
+        () -> "expected the clean no-auto-bridge diagnostic; saw " + compilation.errorMessages()
       );
     }
 
@@ -3781,6 +4343,85 @@ class BridgeProcessorTest {
         bridge.contains("Telescope<modela.UserEntity, modelb.UserDto>"),
         () -> "BRIDGE constant should be typed Telescope<Source, Target> referencing both modules; saw:\n" + bridge
       );
+    }
+
+    @Test
+    @DisplayName("adopter shape: carrier + lenient + sibling @Rename + a raw collection-subtype field, all together")
+    void carrierLenientRenameWithRawCollectionField() {
+      // Faithful reproduction of the reported scenario: a carrier @Bridge with lenient = true and a
+      // @Rename on a scalar sibling, where the bean target also nests a custom collection wrapper
+      // (`class Wrap extends ArrayList<Elem>`). All four dimensions must coexist: the raw container
+      // field element-bridges, the rename applies, and leniency lets the extra target field
+      // default.
+      final var compilation = compile(
+        source(
+          "modela.DocDbDetails",
+          """
+          package modela;
+          public class DocDbDetails {
+            private modela.SrcUrls imageUrls;
+            private String icVerificationExt;
+            public modela.SrcUrls getImageUrls() { return imageUrls; }
+            public void setImageUrls(final modela.SrcUrls v) { this.imageUrls = v; }
+            public String getIcVerificationExt() { return icVerificationExt; }
+            public void setIcVerificationExt(final String v) { this.icVerificationExt = v; }
+          }
+          """
+        ),
+        source(
+          "modela.SrcUrls",
+          "package modela; import java.util.ArrayList; public class SrcUrls extends ArrayList<modela.SrcUrl> {}"
+        ),
+        source("modela.SrcUrl", "package modela; public record SrcUrl(String url) {}"),
+        source(
+          "modelb.DocBoDetails",
+          """
+          package modelb;
+          public class DocBoDetails {
+            private modelb.DstUrls imageUrls;
+            private String vendorExtendedResult;
+            private String extra;
+            public modelb.DstUrls getImageUrls() { return imageUrls; }
+            public void setImageUrls(final modelb.DstUrls v) { this.imageUrls = v; }
+            public String getVendorExtendedResult() { return vendorExtendedResult; }
+            public void setVendorExtendedResult(final String v) { this.vendorExtendedResult = v; }
+            public String getExtra() { return extra; }
+            public void setExtra(final String v) { this.extra = v; }
+          }
+          """
+        ),
+        source(
+          "modelb.DstUrls",
+          "package modelb; import java.util.ArrayList; public class DstUrls extends ArrayList<modelb.DstUrl> {}"
+        ),
+        source("modelb.DstUrl", "package modelb; public record DstUrl(String url) {}"),
+        source(
+          "carrier.IdentificationBridgeDef",
+          """
+          package carrier;
+          import io.github.eschizoid.telescope.annotations.Bridge;
+          import io.github.eschizoid.telescope.annotations.Rename;
+          @Bridge(
+            source = modela.DocDbDetails.class,
+            target = modelb.DocBoDetails.class,
+            lenient = true,
+            renames = { @Rename(source = "icVerificationExt", target = "vendorExtendedResult") })
+          public class IdentificationBridgeDef {}
+          """
+        )
+      );
+
+      assertTrue(
+        compilation.success(),
+        () -> "the adopter's full shape should compile; saw " + compilation.errorMessages()
+      );
+      final var bridge = compilation.generated().get("carrier.IdentificationBridgeDefBridge");
+      assertNotNull(bridge);
+      // The raw collection field element-bridges through a generated element sub-bridge...
+      assertNotNull(compilation.generated().get("modela.SrcUrlToDstUrlBridge"));
+      assertTrue(bridge.contains("new modelb.DstUrls()"), bridge);
+      // ...and the misleading bean-introspection error never appears.
+      assertFalse(compilation.hasError("no setter for 'empty'"), () -> compilation.errorMessages().toString());
     }
 
     @Test

--- a/core/src/test/java/io/github/eschizoid/telescope/CustomWrapperDstUrl.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/CustomWrapperDstUrl.java
@@ -1,0 +1,4 @@
+package io.github.eschizoid.telescope;
+
+/** target element record. */
+public record CustomWrapperDstUrl(String url) {}

--- a/core/src/test/java/io/github/eschizoid/telescope/CustomWrapperDstUrls.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/CustomWrapperDstUrls.java
@@ -1,0 +1,11 @@
+package io.github.eschizoid.telescope;
+
+import java.io.Serial;
+import java.util.ArrayList;
+
+/** distinct custom collection wrapper on the target side. */
+public class CustomWrapperDstUrls extends ArrayList<CustomWrapperDstUrl> {
+
+  @Serial
+  private static final long serialVersionUID = 1L;
+}

--- a/core/src/test/java/io/github/eschizoid/telescope/CustomWrapperSource.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/CustomWrapperSource.java
@@ -1,0 +1,37 @@
+package io.github.eschizoid.telescope;
+
+import io.github.eschizoid.telescope.annotations.Bridge;
+import io.github.eschizoid.telescope.annotations.Rename;
+
+/**
+ * faithful reproduction of the reported scenario: a @Data-style bean whose nested field is a custom
+ * collection wrapper ({@code class CustomWrapperSrcUrls extends ArrayList<CustomWrapperSrcUrl>}),
+ * bridged with {@code lenient = true} and a {@code @Rename} on a scalar sibling. Before the fix the
+ * processor bean-introspected the wrapper and failed with "no setter for 'empty'".
+ */
+@Bridge(
+  value = CustomWrapperTarget.class,
+  lenient = true,
+  renames = { @Rename(source = "icVerificationExt", target = "vendorExtendedResult") }
+)
+public class CustomWrapperSource {
+
+  private CustomWrapperSrcUrls imageUrls;
+  private String icVerificationExt;
+
+  public CustomWrapperSrcUrls getImageUrls() {
+    return imageUrls;
+  }
+
+  public void setImageUrls(final CustomWrapperSrcUrls imageUrls) {
+    this.imageUrls = imageUrls;
+  }
+
+  public String getIcVerificationExt() {
+    return icVerificationExt;
+  }
+
+  public void setIcVerificationExt(final String icVerificationExt) {
+    this.icVerificationExt = icVerificationExt;
+  }
+}

--- a/core/src/test/java/io/github/eschizoid/telescope/CustomWrapperSrcUrl.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/CustomWrapperSrcUrl.java
@@ -1,0 +1,4 @@
+package io.github.eschizoid.telescope;
+
+/** source element record (distinct from the target element). */
+public record CustomWrapperSrcUrl(String url) {}

--- a/core/src/test/java/io/github/eschizoid/telescope/CustomWrapperSrcUrls.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/CustomWrapperSrcUrls.java
@@ -1,0 +1,11 @@
+package io.github.eschizoid.telescope;
+
+import java.io.Serial;
+import java.util.ArrayList;
+
+/** custom collection wrapper on the source side (the legacy-codebase shape). */
+public class CustomWrapperSrcUrls extends ArrayList<CustomWrapperSrcUrl> {
+
+  @Serial
+  private static final long serialVersionUID = 1L;
+}

--- a/core/src/test/java/io/github/eschizoid/telescope/CustomWrapperTarget.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/CustomWrapperTarget.java
@@ -1,0 +1,33 @@
+package io.github.eschizoid.telescope;
+
+/** target bean: distinct wrapper, renamed scalar, plus an extra field leniency defaults. */
+public class CustomWrapperTarget {
+
+  private CustomWrapperDstUrls imageUrls;
+  private String vendorExtendedResult;
+  private String extra;
+
+  public CustomWrapperDstUrls getImageUrls() {
+    return imageUrls;
+  }
+
+  public void setImageUrls(final CustomWrapperDstUrls imageUrls) {
+    this.imageUrls = imageUrls;
+  }
+
+  public String getVendorExtendedResult() {
+    return vendorExtendedResult;
+  }
+
+  public void setVendorExtendedResult(final String vendorExtendedResult) {
+    this.vendorExtendedResult = vendorExtendedResult;
+  }
+
+  public String getExtra() {
+    return extra;
+  }
+
+  public void setExtra(final String extra) {
+    this.extra = extra;
+  }
+}

--- a/core/src/test/java/io/github/eschizoid/telescope/MapperBuilderTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/MapperBuilderTest.java
@@ -2,9 +2,7 @@ package io.github.eschizoid.telescope;
 
 import static io.github.eschizoid.telescope.mapping.Mapping.constant;
 import static io.github.eschizoid.telescope.mapping.Mapping.to;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotSame;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 
 import io.github.eschizoid.telescope.mapping.MapStep;
 import org.junit.jupiter.api.DisplayName;
@@ -193,7 +191,7 @@ class MapperBuilderTest {
       };
 
       final var ex = assertThrows(NullPointerException.class, () -> builder.inherit(withNullSlot));
-      assertEquals(true, ex.getMessage().contains("rows[1]"), "NPE message names the failing index");
+      assertTrue(ex.getMessage().contains("rows[1]"), "NPE message names the failing index");
     }
 
     @Test
@@ -204,7 +202,7 @@ class MapperBuilderTest {
       final var ex = assertThrows(NullPointerException.class, () ->
         builder.add(to(Entity::createdAt, Dto::createdAt), null)
       );
-      assertEquals(true, ex.getMessage().contains("rows[1]"), "NPE message names the failing index");
+      assertTrue(ex.getMessage().contains("rows[1]"), "NPE message names the failing index");
     }
 
     @Test

--- a/core/src/test/java/io/github/eschizoid/telescope/MappingWhenTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/MappingWhenTest.java
@@ -5,9 +5,7 @@ import static io.github.eschizoid.telescope.mapping.Mapping.constant;
 import static io.github.eschizoid.telescope.mapping.Mapping.to;
 import static io.github.eschizoid.telescope.mapping.Mapping.when;
 import static io.github.eschizoid.telescope.mapping.Mapping.zip;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 
 import io.github.eschizoid.telescope.mapping.Mapping;
 import java.util.List;
@@ -441,9 +439,9 @@ class MappingWhenTest {
         when((java.util.function.Predicate<Src>) s -> true, to(Src::name, Dst::name))
       );
       final var msg = ex.getMessage();
-      assertEquals(true, msg.contains("toOrElse"), "error suggests the field-level alternative");
-      assertEquals(true, msg.contains("telescope-based"), "error names the supported shape");
-      assertEquals(true, msg.contains("SameTypedTo"), "error names the rejected kind");
+      assertTrue(msg.contains("toOrElse"), "error suggests the field-level alternative");
+      assertTrue(msg.contains("telescope-based"), "error names the supported shape");
+      assertTrue(msg.contains("SameTypedTo"), "error names the rejected kind");
       assertEquals(
         true,
         msg.contains("name → name"),
@@ -458,27 +456,24 @@ class MappingWhenTest {
         when((java.util.function.Predicate<Src>) s -> true, Mapping.toOneWay(Src::name, Dst::name, String::toUpperCase))
       );
       final var msg = ex.getMessage();
-      assertEquals(true, msg.contains("Mapping.toOneWay"), "error names the forward-only construct");
+      assertTrue(msg.contains("Mapping.toOneWay"), "error names the forward-only construct");
       assertEquals(
         true,
         msg.contains("fold the predicate"),
         "error suggests inlining the predicate into the forward function"
       );
-      assertEquals(true, msg.contains("ForwardOnlyTransformTo"), "error names the rejected kind");
+      assertTrue(msg.contains("ForwardOnlyTransformTo"), "error names the rejected kind");
     }
 
     @Test
     @DisplayName("nested Conditional rejected — combine via Predicate#and/or instead")
     void rejectsNestedConditional() {
       final var emailTel = Telescope.of(Dst.class).field(Dst::name);
-      final Mapping<Src, Dst> inner = when(
-        (java.util.function.Predicate<Src>) s -> s.name() != null,
-        to(Src::name, emailTel)
-      );
+      final Mapping<Src, Dst> inner = when(s -> s.name() != null, to(Src::name, emailTel));
       final var ex = assertThrows(IllegalArgumentException.class, () ->
         when((java.util.function.Predicate<Src>) s -> true, inner)
       );
-      assertEquals(true, ex.getMessage().contains("does not nest"), "error explains nesting is rejected");
+      assertTrue(ex.getMessage().contains("does not nest"), "error explains nesting is rejected");
     }
 
     @Test

--- a/core/src/test/java/io/github/eschizoid/telescope/MigrationRegressionTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/MigrationRegressionTest.java
@@ -4,6 +4,7 @@ import static io.github.eschizoid.telescope.mapping.WriteHint.writeBeans;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -2659,5 +2660,46 @@ class MigrationRegressionTest {
      * probe's target-mismatch rejection branch.
      */
     public record SiblingTarget(String id, int score) {}
+  }
+
+  @Nested
+  @DisplayName("@Bridge codegen — custom collection-wrapper field")
+  class BridgeCustomCollectionWrapper {
+
+    @Test
+    @DisplayName(
+      "the full reported shape — bean parent, lenient, sibling rename, a custom ArrayList wrapper field with distinct elements — bridges end-to-end"
+    )
+    void adopterShapeBridgesEndToEnd() {
+      // Before the fix the @Bridge processor bean-introspected the custom collection wrapper and
+      // failed with "no setter for 'empty'". It now element-bridges the wrapper's contents while
+      // the
+      // lenient flag and the sibling rename apply alongside. This runs the generated codegen bridge
+      // —
+      // the reflection-free path the adopter used.
+      final var src = new CustomWrapperSource();
+      final var urls = new CustomWrapperSrcUrls();
+      urls.add(new CustomWrapperSrcUrl("a"));
+      urls.add(new CustomWrapperSrcUrl("b"));
+      src.setImageUrls(urls);
+      src.setIcVerificationExt("ext-1");
+
+      final var dst = CustomWrapperSourceBridge.BRIDGE.read(src);
+
+      // 1. The custom wrapper's elements are converted (not verbatim-copied) into a fresh target
+      //    wrapper of the declared subtype.
+      assertInstanceOf(CustomWrapperDstUrls.class, dst.getImageUrls(), "target's custom wrapper class is allocated");
+      assertEquals(List.of(new CustomWrapperDstUrl("a"), new CustomWrapperDstUrl("b")), dst.getImageUrls());
+      // 2. The sibling rename applied.
+      assertEquals("ext-1", dst.getVendorExtendedResult());
+      // 3. Leniency defaulted the unmatched target field instead of failing the bijection check.
+      assertNull(dst.getExtra());
+
+      // 4. Backward round-trips into a fresh source wrapper with the elements bridged back.
+      final var back = CustomWrapperSourceBridge.BRIDGE.set(src, dst);
+      assertInstanceOf(CustomWrapperSrcUrls.class, back.getImageUrls());
+      assertEquals(new CustomWrapperSrcUrl("a"), back.getImageUrls().get(0));
+      assertEquals("ext-1", back.getIcVerificationExt());
+    }
   }
 }

--- a/core/src/test/java/io/github/eschizoid/telescope/NullStrategyTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/NullStrategyTest.java
@@ -5,9 +5,7 @@ import static io.github.eschizoid.telescope.mapping.Mapping.toOrElse;
 import static io.github.eschizoid.telescope.mapping.NullHint.NullStrategy.DEFAULT;
 import static io.github.eschizoid.telescope.mapping.NullHint.NullStrategy.PROPAGATE;
 import static io.github.eschizoid.telescope.mapping.NullHint.nullSourceValues;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.List;
 import java.util.Map;
@@ -204,7 +202,7 @@ class NullStrategyTest {
       final var ex = assertThrows(IllegalArgumentException.class, () ->
         Telescope.mapper(Src.class, Dst.class, nullSourceValues(DEFAULT), nullSourceValues(PROPAGATE))
       );
-      assertEquals(true, ex.getMessage().contains("Duplicate nullSourceValues"));
+      assertTrue(ex.getMessage().contains("Duplicate nullSourceValues"));
     }
   }
 

--- a/core/src/test/java/io/github/eschizoid/telescope/TelescopeFromMapTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/TelescopeFromMapTest.java
@@ -1,11 +1,7 @@
 package io.github.eschizoid.telescope;
 
 import static io.github.eschizoid.telescope.mapping.MapExtractStep.extract;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -195,8 +191,8 @@ class TelescopeFromMapTest {
           extract("k2", CaseListRequest::bookingType, Object::toString)
         )
       );
-      assertEquals(true, ex.getMessage().contains("duplicate extract row"), () -> ex.getMessage());
-      assertEquals(true, ex.getMessage().contains("bookingType"), () -> ex.getMessage());
+      assertTrue(ex.getMessage().contains("duplicate extract row"), ex::getMessage);
+      assertTrue(ex.getMessage().contains("bookingType"), ex::getMessage);
     }
 
     @Test

--- a/core/src/test/java/io/github/eschizoid/telescope/TelescopeLatticeHooksTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/TelescopeLatticeHooksTest.java
@@ -83,7 +83,7 @@ class TelescopeLatticeHooksTest {
         .field(User::email)
         .before(String::toLowerCase);
 
-      final var normalize = Telescope.<Team>all(over(emailsNormalised, e -> "MIXED@X.COM"));
+      final var normalize = Telescope.all(over(emailsNormalised, e -> "MIXED@X.COM"));
       final var team = new Team("eng", List.of(new User("a@x"), new User("b@x")));
 
       assertEquals(

--- a/core/src/test/java/io/github/eschizoid/telescope/TelescopeMappingTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/TelescopeMappingTest.java
@@ -2,8 +2,7 @@ package io.github.eschizoid.telescope;
 
 import static io.github.eschizoid.telescope.mapping.Mapping.to;
 import static io.github.eschizoid.telescope.mapping.Mapping.zip;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 
 import io.github.eschizoid.telescope.mapping.Mapping;
 import java.util.List;
@@ -104,8 +103,8 @@ class TelescopeMappingTest {
       // .then(...). This must behave identically to
       // Telescope.of(B.class).field(B::inner).field(...)
       // when fed into Mapping.to — same routing, same forward / backward result.
-      final var codegenStyleTgt = Telescope.<B, Inner>lens(B::inner, (s, v) -> new B(s.label(), v)).then(
-        Telescope.<Inner, String>lens(Inner::code, (s, v) -> new Inner(v))
+      final var codegenStyleTgt = Telescope.lens(B::inner, (s, v) -> new B(s.label(), v)).then(
+        Telescope.lens(Inner::code, (s, v) -> new Inner(v))
       );
 
       final var mapper = Telescope.mapper(A.class, B.class, to(A::label, codegenStyleTgt));
@@ -118,8 +117,8 @@ class TelescopeMappingTest {
     @Test
     @DisplayName("codegen-style nested-source telescope works with Mapping.to(Telescope, Accessor)")
     void codegenStyleNestedSourceWorks() {
-      final var codegenStyleSrc = Telescope.<A, Inner>lens(A::inner, (s, v) -> new A(s.label(), v)).then(
-        Telescope.<Inner, String>lens(Inner::code, (s, v) -> new Inner(v))
+      final var codegenStyleSrc = Telescope.lens(A::inner, (s, v) -> new A(s.label(), v)).then(
+        Telescope.lens(Inner::code, (s, v) -> new Inner(v))
       );
 
       final var mapper = Telescope.mapper(A.class, B.class, to(codegenStyleSrc, B::label));
@@ -345,7 +344,7 @@ class TelescopeMappingTest {
       final var mapper = Telescope.mapper(
         SrcWrap.class,
         TgtWrap.class,
-        Mapping.<SrcWrap, TgtWrap, List<Item>, List<Item>>to(
+        Mapping.to(
           SrcWrap::items,
           TgtWrap::items,
           xs -> xs.stream().limit(2).toList(), // shrink to 2
@@ -360,7 +359,7 @@ class TelescopeMappingTest {
       final var ex = assertThrows(IllegalStateException.class, () ->
         mapper.forward(new SrcWrap("t", List.of(new Item("x"), new Item("y"), new Item("z"))))
       );
-      assertEquals(true, ex.getMessage().contains("cardinality must match"));
+      assertTrue(ex.getMessage().contains("cardinality must match"));
     }
   }
 }

--- a/core/src/test/java/io/github/eschizoid/telescope/TypedContainerPathTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/TypedContainerPathTest.java
@@ -1,18 +1,12 @@
 package io.github.eschizoid.telescope;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 import io.github.eschizoid.telescope.Telescope.ListTelescope;
 import io.github.eschizoid.telescope.Telescope.MapTelescope;
 import io.github.eschizoid.telescope.Telescope.OptionalTelescope;
 import io.github.eschizoid.telescope.Telescope.SetTelescope;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Collectors;
+import java.util.*;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -101,7 +95,7 @@ class TypedContainerPathTest {
       final Telescope<TagSet, Set<Tag>> raw = Telescope.of(TagSet.class).field(TagSet::tags);
       final SetTelescope<TagSet, Tag> promoted = Telescope.asSet(raw);
       final var src = new TagSet("alice", new LinkedHashSet<>(List.of(new Tag("a"))));
-      assertEquals(Set.of(new Tag("a")), promoted.each().toList(src).stream().collect(Collectors.toSet()));
+      assertEquals(Set.of(new Tag("a")), new HashSet<>(promoted.each().toList(src)));
     }
   }
 
@@ -262,8 +256,8 @@ class TypedContainerPathTest {
     @DisplayName("null source passes through to null (preserved by the assembleIso null-wrap)")
     void nullPassThrough() {
       final var mapper = Telescope.mapper(SrcRec.class, TgtRec.class);
-      assertTrue(mapper.read(null) == null);
-      assertTrue(mapper.backward(null) == null);
+      assertNull(mapper.read(null));
+      assertNull(mapper.backward(null));
     }
   }
 }

--- a/core/src/test/java/io/github/eschizoid/telescope/beans/BridgeCodegenTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/beans/BridgeCodegenTest.java
@@ -279,6 +279,85 @@ class BridgeCodegenTest {
 
   @Test
   @DisplayName(
+    "raw collection-subtype field (class Wrap extends ArrayList<Elem>) element-bridges end-to-end into a fresh target wrapper"
+  )
+  void rawCollectionSubtypeBridgesEndToEnd() {
+    // The adopter's shape: a custom ArrayList wrapper whose distinct element record needs bridging.
+    // Proves the generated raw-container helper actually runs — converts each element through the
+    // sub-bridge and lands them in a freshly-allocated target wrapper (no-arg ctor + add).
+    final var src = new RawColSrcWrap();
+    src.add(new RawColSrcElem("a"));
+    src.add(new RawColSrcElem("b"));
+
+    final var dst = RawColParentBridge.BRIDGE.read(new RawColParent(src));
+    assertInstanceOf(RawColDstWrap.class, dst.items(), "target's custom wrapper class is allocated");
+    assertEquals(2, dst.items().size());
+    assertEquals(new RawColDstElem("a"), dst.items().get(0));
+    assertEquals(new RawColDstElem("b"), dst.items().get(1));
+
+    // Backward round-trips into a fresh source wrapper.
+    final var back = RawColParentBridge.BRIDGE.set(new RawColParent(src), dst);
+    assertInstanceOf(RawColSrcWrap.class, back.items());
+    assertEquals(new RawColSrcElem("a"), back.items().get(0));
+  }
+
+  @Test
+  @DisplayName(
+    "raw collection-subtype field on a BEAN parent (setter rebuild) element-bridges end-to-end — the adopter's @Data shape"
+  )
+  void rawCollectionSubtypeOnBeanParentBridgesEndToEnd() {
+    // The adopter's parent was a @Data bean, not a record: the rebuild routes the raw helper's
+    // output
+    // through the target's setter (out.setItems(__fwd_items(...))) rather than a constructor arg.
+    // Proves the raw container helper composes with the bean (no-arg ctor + setters) rebuild path.
+    final var srcItems = new RawColSrcWrap();
+    srcItems.add(new RawColSrcElem("a"));
+    final var src = new RawColBeanSrc();
+    src.setItems(srcItems);
+
+    final var dst = RawColBeanSrcBridge.BRIDGE.read(src);
+    assertInstanceOf(RawColDstWrap.class, dst.getItems());
+    assertEquals(new RawColDstElem("a"), dst.getItems().get(0));
+  }
+
+  @Test
+  @DisplayName(
+    "raw Map-subtype field (class Wrap extends HashMap<K, Elem>) element-bridges values, preserves keys, end-to-end"
+  )
+  void rawMapSubtypeBridgesEndToEnd() {
+    // Distinct emit path from the List case: entrySet/put + a two-type-arg allocation. Proves the
+    // generated raw-map helper runs — bridges each value through the sub-bridge, keeps keys, into a
+    // freshly-allocated target wrapper.
+    final var src = new RawMapSrcWrap();
+    src.put("k1", new RawColSrcElem("a"));
+    src.put("k2", new RawColSrcElem("b"));
+
+    final var dst = RawMapParentBridge.BRIDGE.read(new RawMapParent(src));
+    assertInstanceOf(RawMapDstWrap.class, dst.byKey(), "target's custom map wrapper class is allocated");
+    assertEquals(new RawColDstElem("a"), dst.byKey().get("k1"));
+    assertEquals(new RawColDstElem("b"), dst.byKey().get("k2"));
+
+    final var back = RawMapParentBridge.BRIDGE.set(new RawMapParent(src), dst);
+    assertInstanceOf(RawMapSrcWrap.class, back.byKey());
+    assertEquals(new RawColSrcElem("a"), back.byKey().get("k1"));
+  }
+
+  @Test
+  @DisplayName("raw collection-subtype with identity elements copies verbatim end-to-end (addAll path)")
+  void rawCollectionSubtypeIdentityElementCopiesEndToEnd() {
+    // The identity-element branch (out.addAll(src), no sub-bridge) — a distinct emit path the
+    // distinct-element e2e never executes. Same element type on both sides.
+    final var src = new IdTagsSrc();
+    src.add("x");
+    src.add("y");
+
+    final var dst = IdTagsParentBridge.BRIDGE.read(new IdTagsParent(src));
+    assertInstanceOf(IdTagsDst.class, dst.tags());
+    assertEquals(Arrays.asList("x", "y"), dst.tags());
+  }
+
+  @Test
+  @DisplayName(
     "bare Map<K,V> default: codegen and the runtime reflective mapper allocate the SAME concrete class (HashMap) — cross-strategy parity on the interface-family default"
   )
   void bareMapDefaultMatchesRuntimeConcreteClass() {

--- a/core/src/test/java/io/github/eschizoid/telescope/beans/IdTagsDst.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/beans/IdTagsDst.java
@@ -1,0 +1,11 @@
+package io.github.eschizoid.telescope.beans;
+
+import java.io.Serial;
+import java.util.ArrayList;
+
+/** Distinct target wrapper, same String element → identity copy via addAll. */
+public class IdTagsDst extends ArrayList<String> {
+
+  @Serial
+  private static final long serialVersionUID = 1L;
+}

--- a/core/src/test/java/io/github/eschizoid/telescope/beans/IdTagsParent.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/beans/IdTagsParent.java
@@ -1,0 +1,7 @@
+package io.github.eschizoid.telescope.beans;
+
+import io.github.eschizoid.telescope.annotations.Bridge;
+
+/** Source for the identity-element raw-subtype e2e: same element type both sides (String). */
+@Bridge(IdTagsParentDst.class)
+public record IdTagsParent(IdTagsSrc tags) {}

--- a/core/src/test/java/io/github/eschizoid/telescope/beans/IdTagsParentDst.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/beans/IdTagsParentDst.java
@@ -1,0 +1,4 @@
+package io.github.eschizoid.telescope.beans;
+
+/** Target with a distinct wrapper class but the same String element — the addAll path. */
+public record IdTagsParentDst(IdTagsDst tags) {}

--- a/core/src/test/java/io/github/eschizoid/telescope/beans/IdTagsSrc.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/beans/IdTagsSrc.java
@@ -1,0 +1,11 @@
+package io.github.eschizoid.telescope.beans;
+
+import java.io.Serial;
+import java.util.ArrayList;
+
+/** Source wrapper with String elements. */
+public class IdTagsSrc extends ArrayList<String> {
+
+  @Serial
+  private static final long serialVersionUID = 1L;
+}

--- a/core/src/test/java/io/github/eschizoid/telescope/beans/RawColBeanDst.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/beans/RawColBeanDst.java
@@ -1,0 +1,15 @@
+package io.github.eschizoid.telescope.beans;
+
+/** Bean target rebuilt via no-arg ctor + setters, holding a distinct raw collection wrapper. */
+public class RawColBeanDst {
+
+  private RawColDstWrap items;
+
+  public RawColDstWrap getItems() {
+    return items;
+  }
+
+  public void setItems(final RawColDstWrap items) {
+    this.items = items;
+  }
+}

--- a/core/src/test/java/io/github/eschizoid/telescope/beans/RawColBeanSrc.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/beans/RawColBeanSrc.java
@@ -1,0 +1,20 @@
+package io.github.eschizoid.telescope.beans;
+
+import io.github.eschizoid.telescope.annotations.Bridge;
+
+/**
+ * Bean (getter/setter) parent holding a raw collection-subtype field — the adopter's @Data shape.
+ */
+@Bridge(RawColBeanDst.class)
+public class RawColBeanSrc {
+
+  private RawColSrcWrap items;
+
+  public RawColSrcWrap getItems() {
+    return items;
+  }
+
+  public void setItems(final RawColSrcWrap items) {
+    this.items = items;
+  }
+}

--- a/core/src/test/java/io/github/eschizoid/telescope/beans/RawColDstElem.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/beans/RawColDstElem.java
@@ -1,0 +1,4 @@
+package io.github.eschizoid.telescope.beans;
+
+/** Distinct target element record (same component → bridgeable). */
+public record RawColDstElem(String sku) {}

--- a/core/src/test/java/io/github/eschizoid/telescope/beans/RawColDstWrap.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/beans/RawColDstWrap.java
@@ -1,0 +1,11 @@
+package io.github.eschizoid.telescope.beans;
+
+import java.io.Serial;
+import java.util.ArrayList;
+
+/** Target-side custom collection wrapper. */
+public class RawColDstWrap extends ArrayList<RawColDstElem> {
+
+  @Serial
+  private static final long serialVersionUID = 1L;
+}

--- a/core/src/test/java/io/github/eschizoid/telescope/beans/RawColParent.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/beans/RawColParent.java
@@ -1,0 +1,7 @@
+package io.github.eschizoid.telescope.beans;
+
+import io.github.eschizoid.telescope.annotations.Bridge;
+
+/** Source for the raw collection-subtype end-to-end test: a custom ArrayList wrapper field. */
+@Bridge(RawColParentDst.class)
+public record RawColParent(RawColSrcWrap items) {}

--- a/core/src/test/java/io/github/eschizoid/telescope/beans/RawColParentDst.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/beans/RawColParentDst.java
@@ -1,0 +1,4 @@
+package io.github.eschizoid.telescope.beans;
+
+/** Target with a distinct custom ArrayList wrapper whose element is a distinct record. */
+public record RawColParentDst(RawColDstWrap items) {}

--- a/core/src/test/java/io/github/eschizoid/telescope/beans/RawColSrcElem.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/beans/RawColSrcElem.java
@@ -1,0 +1,4 @@
+package io.github.eschizoid.telescope.beans;
+
+/** Distinct source element record. */
+public record RawColSrcElem(String sku) {}

--- a/core/src/test/java/io/github/eschizoid/telescope/beans/RawColSrcWrap.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/beans/RawColSrcWrap.java
@@ -1,0 +1,11 @@
+package io.github.eschizoid.telescope.beans;
+
+import java.io.Serial;
+import java.util.ArrayList;
+
+/** Custom collection wrapper — the legacy-codebase shape the adopter hit. */
+public class RawColSrcWrap extends ArrayList<RawColSrcElem> {
+
+  @Serial
+  private static final long serialVersionUID = 1L;
+}

--- a/core/src/test/java/io/github/eschizoid/telescope/beans/RawMapDstWrap.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/beans/RawMapDstWrap.java
@@ -1,0 +1,11 @@
+package io.github.eschizoid.telescope.beans;
+
+import java.io.Serial;
+import java.util.HashMap;
+
+/** Target-side custom map wrapper; value record is distinct (bridgeable). */
+public class RawMapDstWrap extends HashMap<String, RawColDstElem> {
+
+  @Serial
+  private static final long serialVersionUID = 1L;
+}

--- a/core/src/test/java/io/github/eschizoid/telescope/beans/RawMapParent.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/beans/RawMapParent.java
@@ -1,0 +1,7 @@
+package io.github.eschizoid.telescope.beans;
+
+import io.github.eschizoid.telescope.annotations.Bridge;
+
+/** Source for the raw Map-subtype end-to-end test: a custom HashMap wrapper field. */
+@Bridge(RawMapParentDst.class)
+public record RawMapParent(RawMapSrcWrap byKey) {}

--- a/core/src/test/java/io/github/eschizoid/telescope/beans/RawMapParentDst.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/beans/RawMapParentDst.java
@@ -1,0 +1,4 @@
+package io.github.eschizoid.telescope.beans;
+
+/** Target with a distinct custom HashMap wrapper whose value is a distinct record. */
+public record RawMapParentDst(RawMapDstWrap byKey) {}

--- a/core/src/test/java/io/github/eschizoid/telescope/beans/RawMapSrcWrap.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/beans/RawMapSrcWrap.java
@@ -1,0 +1,11 @@
+package io.github.eschizoid.telescope.beans;
+
+import java.io.Serial;
+import java.util.HashMap;
+
+/** Custom map wrapper — the legacy-codebase shape. */
+public class RawMapSrcWrap extends HashMap<String, RawColSrcElem> {
+
+  @Serial
+  private static final long serialVersionUID = 1L;
+}


### PR DESCRIPTION
## `@Bridge` element-bridges user-defined Collection/Map subtype fields

Adopter Round 7 (their #19). A nested field typed as a custom collection wrapper — `class ImageUrls extends ArrayList<ImageUrl>`, common in legacy codebases — used to be bean-introspected by the `@Bridge` processor: ArrayList's synthesized `isEmpty()` reads as a property `empty` with no `setEmpty`, so the build failed with the misleading **`...ImageUrlsBO has a no-arg constructor but no setter for 'empty'`**.

Codegen now bridges these fields properly instead of crashing.

### How

A `(2-raw)` branch in the field planner detects a same-kind Collection/Map subtype on either side — `raw↔raw` or a generic interface paired with a subtype (the mixed `List<X>` ↔ `Wrap` case) — walks the supertype graph to extract the element/key type (the subtype's own type-argument list is empty; the element lives in `extends ArrayList<Elem>`), and recurses on the element pair via the existing `planElementSubBridge`. Self-contained raw helpers allocate a fresh target wrapper through its **no-arg constructor** (a subclass doesn't inherit `ArrayList(Collection)`) and fill it with `addAll`/`putAll` for an identity element or an element-bridging loop otherwise. List, Set, and Map are all covered.

This goes **beyond the runtime**, whose `collectionCopyIso` does a verbatim `addAll` with no per-element bridging — a footgun for distinct element types (`ImageUrlDBO` → `ImageUrlBO`) rather than a working conversion. Codegen actually converts the elements.

The `isReflectableDeclared` Collection/Map exclusion remains as the **backstop** for the pairs `(2-raw)` can't claim — a kind mismatch (List-subtype vs Set-subtype) or a subtype opposite a non-container — turning the old `no setter for 'empty'` crash into the accurate `no auto-bridge could be derived` diagnostic.

### Isolation

The generic container path shipped in #186 stays **byte-identical**: `FieldPlan` gains a `rawContainer` flag (existing factories pass `false`), and `applyForward`/`applyBackward`/`emitContainerHelpers`/`importsFor` short-circuit raw plans before the generic logic. Detection reuses the `assignableToRaw` helper from #186.

### Tests

- Harness (generated-source): List/Set/Map distinct-element bridging, List identity-element (`addAll`, no sub-bridge), mixed generic↔raw (forward subtype + backward interface default), `lenient = true` propagation into the element pair (the adopter's exact flag), and two kind-mismatch backstops.
- Runtime end-to-end (`:core`, loads + runs the generated bridge): List element-bridging both directions, Map values-bridged/keys-preserved both directions, identity-element `addAll`.
- Reviewer fleet (correctness / regression / test-coverage) converged clean; the flagged Map-runtime / identity-runtime / lenient gaps are closed here.

### Notes for reviewers

- **Intentional FQN rendering in the raw helpers.** The raw-container helpers render every type fully-qualified (and `importsFor` skips raw plans), unlike the generic #186 helpers which use simple names + imports. This is deliberate: a raw subtype's element type can live in a package the import-collection block wasn't built to discover, so FQN output is always-correct and self-contained. Please don't "unify" it back onto the simpleName+import path — that reintroduces the import-discovery gap.
- **Ctor-less subtype.** A Collection/Map subtype that hides its no-arg constructor is rejected up front with a telescope-authored diagnostic ("no accessible no-arg constructor"), rather than emitting `new Wrap()` that fails later in the consumer's build.
- **`FieldPlan` shape.** The 8th component (`rawContainer` flag) is the pragmatic call for this isolated extension; a `// next variant → sealed refactor first` line-in-the-sand is recorded on the record so the boolean-vs-sealed decision isn't re-litigated.
