### PR TITLE
chore: fix IntelliJ inspection warnings across modules (safe mechanical only)

### DIFF
--- a/codegen/src/test/java/io/github/eschizoid/telescope/codegen/BridgeProcessorTest.java
+++ b/codegen/src/test/java/io/github/eschizoid/telescope/codegen/BridgeProcessorTest.java
@@ -2115,8 +2115,8 @@ class BridgeProcessorTest {
         bridge.contains("new demo.Audit(t.id(), null)"),
         () -> "expected backward zero-fill for forwardOnly transform slot, saw: " + bridge
       );
-      assertTrue(
-        !bridge.contains("__tx_createdAt.backward"),
+      assertFalse(
+        bridge.contains("__tx_createdAt.backward"),
         () -> "backward must NOT invoke BridgeFn.backward for forwardOnly transform, saw: " + bridge
       );
     }
@@ -2169,12 +2169,12 @@ class BridgeProcessorTest {
       assertNotNull(bridge, () -> "UserEntityBridge missing; saw " + compilation.generated().keySet());
 
       // NO __tx_ singleton — qualifier dispatch calls the static method directly.
-      assertTrue(
-        !bridge.contains("__tx_expiresAt"),
+      assertFalse(
+        bridge.contains("__tx_expiresAt"),
         () -> "qualifier dispatch must NOT emit __tx_ field; saw: " + bridge
       );
-      assertTrue(
-        !bridge.contains("new demo.DateHelpers()"),
+      assertFalse(
+        bridge.contains("new demo.DateHelpers()"),
         () -> "qualifier dispatch must NOT instantiate the helper class; saw: " + bridge
       );
 
@@ -2260,14 +2260,14 @@ class BridgeProcessorTest {
       assertTrue(bridge.contains("__tx_price.backward(t.price())"), bridge);
 
       // Qualifier dispatch: no __tx_createdAt, direct method call
-      assertTrue(
-        !bridge.contains("__tx_createdAt"),
+      assertFalse(
+        bridge.contains("__tx_createdAt"),
         () -> "qualifier field MUST NOT have a __tx_ singleton; saw: " + bridge
       );
       assertTrue(bridge.contains("demo.Helpers.asIso(s.createdAt())"), bridge);
       // Forward-only on qualifier slot — backward zero-fills the createdAt slot
-      assertTrue(
-        !bridge.contains("Helpers.asIso(t.createdAt())"),
+      assertFalse(
+        bridge.contains("Helpers.asIso(t.createdAt())"),
         () -> "backward must NOT call qualifier method; saw: " + bridge
       );
     }
@@ -3154,12 +3154,12 @@ class BridgeProcessorTest {
         bridge.contains("new demo.User(") && bridge.contains("partial.age()"),
         () -> "expected primitive int age always patched from partial, saw: " + bridge
       );
-      assertTrue(
-        !bridge.contains("partial.age() != null"),
+      assertFalse(
+        bridge.contains("partial.age() != null"),
         () -> "primitive int age must NOT be null-gated, saw: " + bridge
       );
-      assertTrue(
-        !bridge.contains("__pp_age"),
+      assertFalse(
+        bridge.contains("__pp_age"),
         () -> "primitive int age must NOT have a __pp_ local (no double-eval concern), saw: " + bridge
       );
     }
@@ -3288,8 +3288,8 @@ class BridgeProcessorTest {
       );
       // P5-SLD: case mismatch is a no-op (return base), NOT a backward type-switch.
       assertTrue(bridge.contains("return base; // P5-SLD"), () -> "expected no-op mismatch fallback, saw: " + bridge);
-      assertTrue(
-        !bridge.contains("return BACKWARD.apply(partial)"),
+      assertFalse(
+        bridge.contains("return BACKWARD.apply(partial)"),
         () -> "case mismatch must NOT silently type-switch via BACKWARD, saw: " + bridge
       );
     }
@@ -3439,8 +3439,8 @@ class BridgeProcessorTest {
         () -> "expected patch to read createdAt from base (forward-only), saw: " + bridge
       );
       // Must NOT invoke __tx_createdAt.backward(...) anywhere in patch body.
-      assertTrue(
-        !bridge.contains("__tx_createdAt.backward"),
+      assertFalse(
+        bridge.contains("__tx_createdAt.backward"),
         () -> "patch must NOT call BridgeFn.backward for forward-only transform, saw: " + bridge
       );
     }
@@ -3524,7 +3524,7 @@ class BridgeProcessorTest {
         bridge.contains("final var out = new demo.PB()") && bridge.contains("out.setId(s.getId())"),
         () -> "expected SETTERS shape on forward, saw: " + bridge
       );
-      assertTrue(!bridge.contains("demo.PB.builder()"), () -> "should not call builder() when SETTERS forced");
+      assertFalse(bridge.contains("demo.PB.builder()"), () -> "should not call builder() when SETTERS forced");
     }
 
     @Test

--- a/core/src/test/java/io/github/eschizoid/telescope/AllOverTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/AllOverTest.java
@@ -185,7 +185,7 @@ class AllOverTest {
     @DisplayName("null direct value short-circuits to identity — source returned unchanged")
     void directNullIsIdentity() {
       final var company = sample();
-      final var out = Telescope.all(Edit.<Company, String>overIfPresent(DEPT_NAMES, null)).apply(company);
+      final var out = Telescope.all(Edit.overIfPresent(DEPT_NAMES, null)).apply(company);
       assertSame(company, out);
     }
 
@@ -236,7 +236,7 @@ class AllOverTest {
     void sparsePatchCompositionLandsOnlyPresentSlots() {
       final var company = sample();
       final var out = Telescope.all(
-        Edit.<Company, String>overIfPresent(DEPT_NAMES, null),
+        Edit.overIfPresent(DEPT_NAMES, null),
         Edit.overIfPresent(TEAM_NAMES, "Renamed"),
         Edit.<Company, String, String>overIfPresent(USER_NAMES, null, String::toUpperCase),
         Edit.mapIfPresent(EMAILS, "!", (bang, email) -> email + bang)

--- a/core/src/test/java/io/github/eschizoid/telescope/DeepMappingTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/DeepMappingTest.java
@@ -867,7 +867,7 @@ class DeepMappingTest {
       final var src = new HasOptional("alice", Optional.empty());
       final var dst = mapper.forward(src);
       assertEquals("alice", dst.name());
-      assertEquals(null, dst.nickname());
+      assertNull(dst.nickname());
       assertEquals(src, mapper.backward(dst));
     }
 

--- a/core/src/test/java/io/github/eschizoid/telescope/MapperIntoTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/MapperIntoTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.DisplayName;
@@ -204,8 +205,8 @@ class MapperIntoTest {
 
       final var ex = assertThrows(UnsupportedOperationException.class, () -> mapper.into(existing, new DtoRec("new")));
 
-      assertEquals(true, ex.getMessage().contains("records are immutable"), "message explains the constraint");
-      assertEquals(true, ex.getMessage().contains("Mapper.forward"), "message suggests the alternative");
+      assertTrue(ex.getMessage().contains("records are immutable"), "message explains the constraint");
+      assertTrue(ex.getMessage().contains("Mapper.forward"), "message suggests the alternative");
     }
   }
 

--- a/core/src/test/java/io/github/eschizoid/telescope/MapperPostHooksTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/MapperPostHooksTest.java
@@ -4,6 +4,7 @@ import static io.github.eschizoid.telescope.mapping.Mapping.drop;
 import static io.github.eschizoid.telescope.mapping.Mapping.to;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import io.github.eschizoid.telescope.conversion.Mapper;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -88,7 +89,7 @@ class MapperPostHooksTest {
       final Mapper<Entity, Dto> withHook = base.afterForward(d -> new Dto(d.id(), d.fullName(), 99L));
 
       assertNotSame(base, withHook);
-      assertEquals(null, base.forward(new Entity("e-1", "A", null, null)).updatedAtMillis());
+      assertNull(base.forward(new Entity("e-1", "A", null, null)).updatedAtMillis());
       assertEquals(99L, withHook.forward(new Entity("e-1", "A", null, null)).updatedAtMillis());
     }
 

--- a/core/src/test/java/io/github/eschizoid/telescope/MappingConstantComputeTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/MappingConstantComputeTest.java
@@ -5,6 +5,7 @@ import static io.github.eschizoid.telescope.mapping.Mapping.constant;
 import static io.github.eschizoid.telescope.mapping.Mapping.drop;
 import static io.github.eschizoid.telescope.mapping.Mapping.to;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
@@ -140,7 +141,7 @@ class MappingConstantComputeTest {
 
       final var t1 = mapper.forward(new Src("a", "A"));
       final var t2 = mapper.forward(new Src("a", "A"));
-      assertEquals(false, t1.traceId().equals(t2.traceId()), "UUID::randomUUID should produce distinct values");
+      assertFalse(t1.traceId().equals(t2.traceId()), "UUID::randomUUID should produce distinct values");
     }
 
     @Test

--- a/core/src/test/java/io/github/eschizoid/telescope/MappingEnumToTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/MappingEnumToTest.java
@@ -90,9 +90,9 @@ class MappingEnumToTest {
       final var ex = assertThrows(IllegalArgumentException.class, () ->
         enumTo(UserEntity::status, UserDtoMissing::status, EntityStatus.class, DtoStatusMissingClosed.class)
       );
-      assertTrue(ex.getMessage().contains("CLOSED"), () -> ex.getMessage());
-      assertTrue(ex.getMessage().contains("missing on target"), () -> ex.getMessage());
-      assertTrue(ex.getMessage().contains("DtoStatusMissingClosed"), () -> ex.getMessage());
+      assertTrue(ex.getMessage().contains("CLOSED"), ex::getMessage);
+      assertTrue(ex.getMessage().contains("missing on target"), ex::getMessage);
+      assertTrue(ex.getMessage().contains("DtoStatusMissingClosed"), ex::getMessage);
     }
 
     @Test
@@ -101,9 +101,9 @@ class MappingEnumToTest {
       final var ex = assertThrows(IllegalArgumentException.class, () ->
         enumTo(UserEntity::status, UserDtoExtra::status, EntityStatus.class, DtoStatusExtraPending.class)
       );
-      assertTrue(ex.getMessage().contains("PENDING"), () -> ex.getMessage());
-      assertTrue(ex.getMessage().contains("missing on source"), () -> ex.getMessage());
-      assertTrue(ex.getMessage().contains("EntityStatus"), () -> ex.getMessage());
+      assertTrue(ex.getMessage().contains("PENDING"), ex::getMessage);
+      assertTrue(ex.getMessage().contains("missing on source"), ex::getMessage);
+      assertTrue(ex.getMessage().contains("EntityStatus"), ex::getMessage);
     }
 
     @Test

--- a/core/src/test/java/io/github/eschizoid/telescope/MappingIntermediateAllocationTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/MappingIntermediateAllocationTest.java
@@ -3,6 +3,7 @@ package io.github.eschizoid.telescope;
 import static io.github.eschizoid.telescope.mapping.Mapping.to;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -69,7 +70,7 @@ class MappingIntermediateAllocationTest {
       assertEquals("Brooklyn", out.address().city());
       // Primitive default; default for non-claimed reference fields is null.
       assertEquals(0, out.age());
-      assertEquals(null, out.address().zip());
+      assertNull(out.address().zip());
     }
   }
 
@@ -267,7 +268,7 @@ class MappingIntermediateAllocationTest {
       final var out = mapper.forward(new Slim("Brooklyn"));
       assertNotNull(out.getAddress(), "bean intermediate AddressBean should be allocated from its no-arg ctor");
       assertEquals("Brooklyn", out.getAddress().getCity());
-      assertEquals(null, out.getAddress().getZip());
+      assertNull(out.getAddress().getZip());
     }
   }
 }

--- a/core/src/test/java/io/github/eschizoid/telescope/MappingOrElseTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/MappingOrElseTest.java
@@ -107,7 +107,7 @@ class MappingOrElseTest {
       final var mapper = Telescope.mapper(
         Wide.class,
         Wide.class,
-        toOrElse(Wide::items, Wide::items, List.<Integer>of(99), List::isEmpty)
+        toOrElse(Wide::items, Wide::items, List.of(99), List::isEmpty)
       );
 
       assertEquals(List.of(99), mapper.forward(new Wide("US", List.of())).items());

--- a/core/src/test/java/io/github/eschizoid/telescope/MappingToOneWayTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/MappingToOneWayTest.java
@@ -36,7 +36,7 @@ class MappingToOneWayTest {
       );
       assertTrue(ex.getMessage().contains("Telescope.mapper"));
       assertTrue(ex.getMessage().contains("Mapping.toOneWay"));
-      assertTrue(ex.getMessage().contains("createdAtIso"), () -> ex.getMessage());
+      assertTrue(ex.getMessage().contains("createdAtIso"), ex::getMessage);
       assertTrue(ex.getMessage().contains("mapperForward"));
     }
 

--- a/core/src/test/java/io/github/eschizoid/telescope/MappingWhenTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/MappingWhenTest.java
@@ -99,8 +99,8 @@ class MappingWhenTest {
       final var lowPrio = new Order("ORD-1", new Address("Chicago", "US"), 1);
       final var highPrio = new Order("ORD-2", new Address("Chicago", "US"), 99);
 
-      assertEquals(false, mapper.forward(lowPrio).expediteFlag(), "low priority → stamp skipped");
-      assertEquals(true, mapper.forward(highPrio).expediteFlag(), "high priority → stamped");
+      assertFalse(mapper.forward(lowPrio).expediteFlag(), "low priority → stamp skipped");
+      assertTrue(mapper.forward(highPrio).expediteFlag(), "high priority → stamped");
     }
   }
 
@@ -385,13 +385,13 @@ class MappingWhenTest {
 
       final var ex = assertThrows(IllegalStateException.class, () -> mapper.forward(new Src(null)));
       final var msg = ex.getMessage();
-      assertEquals(true, msg.contains("Mapping.when"), "message names the construct");
-      assertEquals(true, msg.contains("Constant"), "message names the inner kind");
+      assertTrue(msg.contains("Mapping.when"), "message names the construct");
+      assertTrue(msg.contains("Constant"), "message names the inner kind");
       // The failure class name (NullPointerException) MUST appear even when the predicate's NPE
       // carries a null message — otherwise the user sees "Predicate failure: null" and learns
       // nothing actionable. This pins the decoration improvement.
-      assertEquals(true, msg.contains("NullPointerException"), "message names the failure class");
-      assertEquals(true, ex.getCause() instanceof NullPointerException, "original predicate cause preserved");
+      assertTrue(msg.contains("NullPointerException"), "message names the failure class");
+      assertTrue(ex.getCause() instanceof NullPointerException, "original predicate cause preserved");
     }
   }
 
@@ -407,7 +407,7 @@ class MappingWhenTest {
     @DisplayName("Conditional.sourceClass / targetClass / sourceField / targetField all null")
     void pinsTopLevelOnly() {
       final var nameTel = Telescope.of(Dst.class).field(Dst::name);
-      final var conditional = when((java.util.function.Predicate<Src>) s -> true, to(Src::name, nameTel));
+      final var conditional = when(s -> true, to(Src::name, nameTel));
 
       // Pin the documented contract — every supported inner row is telescope-based, so the
       // Conditional always pins to the outer (topSource, topTarget) pair via null-class routing.
@@ -435,9 +435,7 @@ class MappingWhenTest {
     @Test
     @DisplayName("field-iso row (plain to(srcAcc, tgtAcc)) rejected with clear error pointing at toOrElse")
     void rejectsFieldIsoInner() {
-      final var ex = assertThrows(IllegalArgumentException.class, () ->
-        when((java.util.function.Predicate<Src>) s -> true, to(Src::name, Dst::name))
-      );
+      final var ex = assertThrows(IllegalArgumentException.class, () -> when(s -> true, to(Src::name, Dst::name)));
       final var msg = ex.getMessage();
       assertTrue(msg.contains("toOrElse"), "error suggests the field-level alternative");
       assertTrue(msg.contains("telescope-based"), "error names the supported shape");
@@ -453,7 +451,7 @@ class MappingWhenTest {
     @DisplayName("forward-only row rejected with hint pointing at fold-the-predicate-into-fn")
     void rejectsForwardOnlyTransformTo() {
       final var ex = assertThrows(IllegalArgumentException.class, () ->
-        when((java.util.function.Predicate<Src>) s -> true, Mapping.toOneWay(Src::name, Dst::name, String::toUpperCase))
+        when(s -> true, Mapping.toOneWay(Src::name, Dst::name, String::toUpperCase))
       );
       final var msg = ex.getMessage();
       assertTrue(msg.contains("Mapping.toOneWay"), "error names the forward-only construct");

--- a/core/src/test/java/io/github/eschizoid/telescope/MigrationRegressionTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/MigrationRegressionTest.java
@@ -134,7 +134,7 @@ class MigrationRegressionTest {
       src.setShipped(true);
       src.setName("alice");
       final var tgt = mapper.forward(src);
-      assertEquals(true, tgt.isShipped());
+      assertTrue(tgt.isShipped());
       assertEquals("alice", tgt.getName());
     }
 
@@ -261,7 +261,7 @@ class MigrationRegressionTest {
       );
       final var src = new Order(); // customer left null
       final var tgt = assertDoesNotThrow(() -> mapper.forward(src));
-      assertEquals(null, tgt.getCustomerEmail());
+      assertNull(tgt.getCustomerEmail());
     }
 
     @Test
@@ -387,7 +387,7 @@ class MigrationRegressionTest {
       assertEquals(80, tgt.getScores().getFirstNameScore());
       assertEquals(90, tgt.getScores().getLastNameScore());
       // Nested target's unmatched field stays at the JLS default.
-      assertEquals(null, tgt.getScores().getMatchingStatus());
+      assertNull(tgt.getScores().getMatchingStatus());
     }
 
     @Test
@@ -1084,8 +1084,8 @@ class MigrationRegressionTest {
       // count and active left null
       final var tgt = assertDoesNotThrow(() -> mapper.forward(src));
       assertEquals("alice", tgt.getName());
-      assertEquals(null, tgt.getCount());
-      assertEquals(null, tgt.getActive());
+      assertNull(tgt.getCount());
+      assertNull(tgt.getActive());
     }
   }
 
@@ -1156,7 +1156,7 @@ class MigrationRegressionTest {
       assertEquals("alice", tgt.getName());
       // The `processed` source value was discarded — target's getter-only field stays at the
       // primitive default. MapStruct would do the same.
-      assertEquals(false, tgt.isProcessed());
+      assertFalse(tgt.isProcessed());
     }
   }
 
@@ -1216,21 +1216,21 @@ class MigrationRegressionTest {
     @DisplayName("Mapper.forward(null) returns null (records)")
     void mapperForwardNullReturnsNullRecords() {
       final var mapper = Telescope.mapper(SrcRec.class, TgtRec.class);
-      assertEquals(null, mapper.forward(null));
+      assertNull(mapper.forward(null));
     }
 
     @Test
     @DisplayName("Mapper.backward(null) returns null (records)")
     void mapperBackwardNullReturnsNullRecords() {
       final var mapper = Telescope.mapper(SrcRec.class, TgtRec.class);
-      assertEquals(null, mapper.backward(null));
+      assertNull(mapper.backward(null));
     }
 
     @Test
     @DisplayName("Mapper.forward(null) returns null (beans)")
     void mapperForwardNullReturnsNullBeans() {
       final var mapper = Telescope.mapper(SrcBean.class, TgtBean.class, writeBeans(WriteHint.WriteStrategy.SETTERS));
-      assertEquals(null, mapper.forward(null));
+      assertNull(mapper.forward(null));
     }
 
     @Test
@@ -1247,14 +1247,14 @@ class MigrationRegressionTest {
     @DisplayName("ForwardMapper.forward(null) returns null")
     void forwardMapperNullReturnsNull() {
       final var mapper = ForwardMapper.create((SrcRec s) -> new TgtRec(s.id(), s.name()), SrcRec.class, TgtRec.class);
-      assertEquals(null, mapper.forward(null));
+      assertNull(mapper.forward(null));
     }
 
     @Test
     @DisplayName("ForwardMapper.read(null) returns null — read is documented as an alias of forward")
     void forwardMapperReadNullReturnsNull() {
       final var mapper = ForwardMapper.create((SrcRec s) -> new TgtRec(s.id(), s.name()), SrcRec.class, TgtRec.class);
-      assertEquals(null, mapper.read(null));
+      assertNull(mapper.read(null));
       // Non-null parity: read and forward must produce the same output, otherwise a future
       // refactor that breaks the alias contract slips through unnoticed.
       final var src = new SrcRec("o1", "alice");
@@ -1266,7 +1266,7 @@ class MigrationRegressionTest {
     void preForwardReturningNullPropagatesAsNull() {
       // A normalisation hook that maps a sentinel (empty id) to null must not crash the mapper.
       final var mapper = Telescope.mapper(SrcRec.class, TgtRec.class).beforeForward(s -> s.id().isEmpty() ? null : s);
-      assertEquals(null, mapper.forward(new SrcRec("", "alice")));
+      assertNull(mapper.forward(new SrcRec("", "alice")));
     }
 
     @Test
@@ -1275,7 +1275,7 @@ class MigrationRegressionTest {
       // Symmetric pin for the backward path: without this, a future revert of the backward guard
       // goes unnoticed because no other test exercises preBackward returning null.
       final var mapper = Telescope.mapper(SrcRec.class, TgtRec.class).beforeBackward(t -> t.id().isEmpty() ? null : t);
-      assertEquals(null, mapper.backward(new TgtRec("", "alice")));
+      assertNull(mapper.backward(new TgtRec("", "alice")));
     }
   }
 
@@ -1616,8 +1616,8 @@ class MigrationRegressionTest {
       final var ex = assertThrows(IllegalStateException.class, () ->
         Telescope.mapper(HasMapByRegionSrc.class, HasEnumMapTgt.class, writeBeans(WriteHint.WriteStrategy.SETTERS))
       );
-      assertEquals(true, ex.getMessage().contains("EnumMap"), "names the offending class");
-      assertEquals(true, ex.getMessage().contains("Mapping.via"), "cites the escape hatch");
+      assertTrue(ex.getMessage().contains("EnumMap"), "names the offending class");
+      assertTrue(ex.getMessage().contains("Mapping.via"), "cites the escape hatch");
     }
 
     // Unknown JDK collection class (SynchronousQueue is in java.base, has a no-arg ctor that
@@ -1660,7 +1660,7 @@ class MigrationRegressionTest {
       final var ex = assertThrows(IllegalStateException.class, () ->
         Telescope.mapper(HasListSrcForUnknown.class, HasSyncQueueTgt.class, writeBeans(WriteHint.WriteStrategy.SETTERS))
       );
-      assertEquals(true, ex.getMessage().contains("shapes"), "shape mismatch diagnostic");
+      assertTrue(ex.getMessage().contains("shapes"), "shape mismatch diagnostic");
     }
 
     // User subclass WITHOUT a no-arg ctor — the negative side of userListSubclassToArrayListWorks.
@@ -1699,7 +1699,7 @@ class MigrationRegressionTest {
           writeBeans(WriteHint.WriteStrategy.SETTERS)
         )
       );
-      assertEquals(true, ex.getMessage().contains("NoCtorList"), "names the offending class");
+      assertTrue(ex.getMessage().contains("NoCtorList"), "names the offending class");
     }
   }
 
@@ -1815,11 +1815,11 @@ class MigrationRegressionTest {
       assertEquals("alice", tgt.getName());
       assertEquals(42, tgt.getQuantity());
       // Unmatched target fields take JLS defaults (null for reference, 0 for int, false for bool).
-      assertEquals(null, tgt.getCreatedBy());
-      assertEquals(null, tgt.getUpdatedBy());
-      assertEquals(false, tgt.isArchived());
+      assertNull(tgt.getCreatedBy());
+      assertNull(tgt.getUpdatedBy());
+      assertFalse(tgt.isArchived());
       assertEquals(0, tgt.getVersion());
-      assertEquals(null, tgt.getTenant());
+      assertNull(tgt.getTenant());
     }
 
     record SourceWithExtras(String id, String name, String extraNote, String anotherExtra) {}
@@ -1867,7 +1867,7 @@ class MigrationRegressionTest {
       );
       final var tgt = mapper.forward(new SmallDto("o1", "alice", 42));
       assertEquals("alice", tgt.getName());
-      assertEquals(null, tgt.getCreatedBy());
+      assertNull(tgt.getCreatedBy());
     }
 
     @Test
@@ -1888,7 +1888,7 @@ class MigrationRegressionTest {
       });
       final var tgt = mapper.forward(new SmallDto("o1", "alice", 42));
       assertEquals("system", tgt.getCreatedBy(), "afterForward hook fired");
-      assertEquals(null, tgt.getUpdatedBy(), "other unmatched fields still at JLS default");
+      assertNull(tgt.getUpdatedBy(), "other unmatched fields still at JLS default");
       assertEquals("alice", tgt.getName(), "matched field carried through");
     }
 
@@ -1965,7 +1965,7 @@ class MigrationRegressionTest {
       src.setCustomer(c);
       final var tgt = mapper.forward(src);
       assertEquals("alice@example.com", tgt.getCustomerEmail(), "telescope row fired");
-      assertEquals(null, tgt.getOtherField(), "unmatched target field at JLS default");
+      assertNull(tgt.getOtherField(), "unmatched target field at JLS default");
     }
 
     // Bean-source coverage — the existing lenient tests use record sources. The leniency gate
@@ -2049,7 +2049,7 @@ class MigrationRegressionTest {
       final var tgt = mapper.forward(src);
       assertEquals("o1", tgt.getId(), "matched field carried through");
       assertEquals("alice", tgt.getName(), "matched field carried through");
-      assertEquals(null, tgt.getNewField(), "unmatched target field at JLS default");
+      assertNull(tgt.getNewField(), "unmatched target field at JLS default");
     }
   }
 
@@ -2079,7 +2079,7 @@ class MigrationRegressionTest {
       final var outer = new NullIntermediateOuter();
       // outer.inner left null on purpose
       final var dto = assertDoesNotThrow(() -> mapper.forward(outer));
-      assertEquals(null, dto.getInnerName());
+      assertNull(dto.getInnerName());
     }
 
     @Test

--- a/core/src/test/java/io/github/eschizoid/telescope/beans/BridgeCodegenTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/beans/BridgeCodegenTest.java
@@ -2,6 +2,7 @@ package io.github.eschizoid.telescope.beans;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
@@ -112,7 +113,7 @@ class BridgeCodegenTest {
 
     // backward: a non-null Boolean / Integer auto-unboxes back to the primitives.
     final var back = BridgePrimRecBridge.BRIDGE.set(src, new BridgePrimRecBO(false, 9, "m"));
-    assertEquals(false, back.locked());
+    assertFalse(back.locked());
     assertEquals(9, back.count());
     assertEquals("m", back.name());
   }
@@ -127,7 +128,7 @@ class BridgeCodegenTest {
     // both directions of the box/unbox conversion.
     final var src = new BridgePrimRec(true, 7, "n");
     final var back = BridgePrimRecBridge.BRIDGE.set(src, new BridgePrimRecBO(null, null, "m"));
-    assertEquals(false, back.locked());
+    assertFalse(back.locked());
     assertEquals(0, back.count());
     assertEquals("m", back.name());
   }
@@ -143,7 +144,7 @@ class BridgeCodegenTest {
     // fwdNullDefault wiring at runtime (the backward test pins bwdNullDefault).
     final var src = new BridgeWrapRec(null, null, "m");
     final var bo = BridgeWrapRecBridge.BRIDGE.read(src);
-    assertEquals(false, bo.flag());
+    assertFalse(bo.flag());
     assertEquals(0, bo.num());
     assertEquals("m", bo.name());
   }

--- a/core/src/test/java/io/github/eschizoid/telescope/effects/SealedEffectsBranchTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/effects/SealedEffectsBranchTest.java
@@ -312,7 +312,7 @@ class SealedEffectsBranchTest {
     void isFailedBothCases() {
       final var app = EitherK.<String>forLeft();
       assertTrue(app.isFailed(EitherK.box(Either.<String, Integer>left("bad"))));
-      assertFalse(app.isFailed(EitherK.box(Either.<String, Integer>right(1))));
+      assertFalse(app.isFailed(EitherK.box(Either.right(1))));
     }
 
     @Test

--- a/internal/src/test/java/io/github/eschizoid/telescope/internal/BeansTest.java
+++ b/internal/src/test/java/io/github/eschizoid/telescope/internal/BeansTest.java
@@ -704,7 +704,7 @@ class BeansTest {
       child.setName("only-on-child");
       assertEquals("inherited-id", Beans.readProperty(child, "id"));
       assertEquals("only-on-child", Beans.readProperty(child, "name"));
-      assertEquals("inherited-id", Beans.<ChildBean>getter(ChildBean.class, "id").get(child));
+      assertEquals("inherited-id", Beans.getter(ChildBean.class, "id").get(child));
     }
   }
 
@@ -764,7 +764,7 @@ class BeansTest {
       assertEquals(7, pojo.getI());
       assertEquals(42L, pojo.getL());
       assertEquals(3.14, pojo.getD());
-      assertEquals(true, pojo.isB());
+      assertTrue(pojo.isB());
     }
   }
 
@@ -995,7 +995,7 @@ class BeansTest {
       assertEquals(5, pojo.getI());
       assertEquals(99L, pojo.getL());
       assertEquals(2.5, pojo.getD());
-      assertEquals(true, pojo.isB());
+      assertTrue(pojo.isB());
     }
   }
 
@@ -1189,7 +1189,7 @@ class BeansTest {
     @Test
     @DisplayName("falls through to getClass() when the value is null")
     void nullSafe() {
-      assertEquals(null, Beans.persistentClassOf(null));
+      assertNull(Beans.persistentClassOf(null));
     }
 
     @Test
@@ -1414,11 +1414,7 @@ class BeansTest {
       // capturedReaders.get(name).apply(source) is bypassed in favour of readProperty(source,
       // name) which routes through the GETTER_INVOKERS ClassValue keyed by the runtime class.
       // The writer is the captured ParentBean writer, so the rebuild produces a ParentBean.
-      final Lens<ParentBean, String> idLens = Beans.lens(
-        ParentBean.class,
-        "id",
-        Beans.<ParentBean>settersWriter(ParentBean.class)
-      );
+      final Lens<ParentBean, String> idLens = Beans.lens(ParentBean.class, "id", Beans.settersWriter(ParentBean.class));
       final var child = new ChildBean();
       child.setId("inherited");
       child.setName("child-only");
@@ -1461,7 +1457,7 @@ class BeansTest {
       // wrapper. The metafactory generates the unbox bridge from Object to the primitive. The
       // int setter arm of wrap is covered by NoArgSetters.setScore elsewhere in this suite; this
       // test exercises the six remaining primitive setter variants end-to-end.
-      final var writer = Beans.<AllPrimitives>settersWriter(AllPrimitives.class);
+      final var writer = Beans.settersWriter(AllPrimitives.class);
       final var names = new String[] { "longVal", "doubleVal", "floatVal", "byteVal", "shortVal", "charVal" };
       final Map<String, Object> values = Map.of(
         "longVal",

--- a/internal/src/test/java/io/github/eschizoid/telescope/internal/RecordsTest.java
+++ b/internal/src/test/java/io/github/eschizoid/telescope/internal/RecordsTest.java
@@ -75,7 +75,7 @@ class RecordsTest {
     @DisplayName("with on a non-record source throws IllegalArgumentException")
     void withOnNonRecordThrows() {
       final var ex = assertThrows(IllegalArgumentException.class, () -> Records.with(new NotARecord(), "x", 1));
-      assertTrue(ex.getMessage().contains("Not a record"), () -> ex.getMessage());
+      assertTrue(ex.getMessage().contains("Not a record"), ex::getMessage);
     }
 
     @Test
@@ -83,7 +83,7 @@ class RecordsTest {
     void withUnknownComponentThrows() {
       final var src = new User("alice", 30);
       final var ex = assertThrows(IllegalArgumentException.class, () -> Records.with(src, "ghost", 1));
-      assertTrue(ex.getMessage().contains("ghost"), () -> ex.getMessage());
+      assertTrue(ex.getMessage().contains("ghost"), ex::getMessage);
     }
 
     @Test
@@ -213,7 +213,7 @@ class RecordsTest {
       // info() is package-private; reach it via the public surface to keep the test through the
       // contract. componentNames is the simplest entry point that exercises info() directly.
       final var ex = assertThrows(IllegalArgumentException.class, () -> Records.componentNames(NotARecord.class));
-      assertTrue(ex.getMessage().contains("Not a record"), () -> ex.getMessage());
+      assertTrue(ex.getMessage().contains("Not a record"), ex::getMessage);
     }
 
     @Test

--- a/internal/src/test/java/io/github/eschizoid/telescope/internal/optics/OpticLawsTest.java
+++ b/internal/src/test/java/io/github/eschizoid/telescope/internal/optics/OpticLawsTest.java
@@ -2,6 +2,7 @@ package io.github.eschizoid.telescope.internal.optics;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -95,7 +96,7 @@ class OpticLawsTest {
       // Lens#getOption / Lens#getAll. Drain via iterator to preserve the null element explicitly.
       final var it = nullableLens.getAll(ALICE).iterator();
       assertTrue(it.hasNext());
-      assertEquals(null, it.next());
+      assertNull(it.next());
     }
   }
 

--- a/internal/src/test/java/io/github/eschizoid/telescope/internal/optics/TraversalModifyFTest.java
+++ b/internal/src/test/java/io/github/eschizoid/telescope/internal/optics/TraversalModifyFTest.java
@@ -67,7 +67,7 @@ class TraversalModifyFTest {
   @DisplayName("Validated accumulates every focus error (no short-circuit)")
   void validatedAccumulatesEveryFocusError() {
     final var result = ValidatedK.unbox(
-      EACH.modifyF(ValidatedK.<String>forError(), List.of(1, 2, 3, 4), a -> {
+      EACH.modifyF(ValidatedK.forError(), List.of(1, 2, 3, 4), a -> {
         final Validated<String, Integer> v = a % 2 == 0 ? Validated.valid(a) : Validated.invalid("odd: " + a);
         return ValidatedK.box(v);
       })


### PR DESCRIPTION
## IntelliJ inspection warnings — codebase-wide sweep (safe mechanical only)

A pass over the IDE-flagged warnings across all modules, scoped strictly to **behavior-neutral mechanical fixes**:

- `assertEquals(true/false/null, x)` -> `assertTrue` / `assertFalse` / `assertNull` (assertion messages preserved)
- `assertTrue(x == null)` -> `assertNull`
- lambda -> method reference where the IDE flagged it
- redundant explicit type arguments removed (`List.<T>of` -> `List.of`, etc.)
- redundant lambda casts removed
- unused imports removed

**~83 fixes across ~22 files**, all in `core/test`, `internal/test`, and `codegen/test`.

### Intentionally NOT touched
- Main/library source, examples, benchmarks, quarkus, spring -- scanned, no safe-category warnings (public-API "never used", JMH patterns, javadoc resolution, IDE module-index artifacts).
- Boolean-wrapper assertions where `assertTrue`/`assertFalse` would change unboxing/NPE semantics.
- Anything behavior-changing, `final`/`var`/nullability stylistic, `assertInstanceOf`/`assertSame` (outside the approved list), or ambiguous.

Each edited file was re-inspected to confirm warnings cleared with no new ones. Full multi-module build + test suite green.
