### PR TITLE
feat(codegen): @FromMap — reflection-free Map→POJO converter generation

### DIFF
--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/AbstractTelescopeProcessor.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/AbstractTelescopeProcessor.java
@@ -51,10 +51,11 @@ public abstract class AbstractTelescopeProcessor extends AbstractProcessor {
   protected record Prop(String name, String getter, TypeMirror type) {}
 
   /**
-   * Emit a generated {@code public final} class: the package declaration, the single {@code
-   * io.github.eschizoid.telescope.Telescope} import, a one-line javadoc, and a private constructor,
-   * then {@code body} writes the members, then the closing brace. The package is derived from
-   * {@code qualifiedName}. An {@link IOException} is reported as a compile error on {@code origin}.
+   * Emit a generated {@code public final} class whose body references {@code Telescope}: the
+   * package declaration, the {@code io.github.eschizoid.telescope.Telescope} import, a one-line
+   * javadoc, and a private constructor, then {@code body} writes the members, then the closing
+   * brace. The package is derived from {@code qualifiedName}. An {@link IOException} is reported as
+   * a compile error on {@code origin}.
    */
   protected void writeClass(
     final String qualifiedName,
@@ -63,19 +64,20 @@ public abstract class AbstractTelescopeProcessor extends AbstractProcessor {
     final Element origin,
     final Consumer<PrintWriter> body
   ) {
-    writeClass(qualifiedName, simpleName, Set.of(), javadoc, origin, body);
+    writeClass(qualifiedName, simpleName, Set.of("io.github.eschizoid.telescope.Telescope"), javadoc, origin, body);
   }
 
   /**
-   * Same as {@link #writeClass(String, String, String, Element, Consumer)} but emits {@code
-   * extraImports} alongside the default {@code Telescope} import. Use this from a processor that
-   * needs additional {@code java.util.*} types in the body (e.g. {@code List}, {@code ArrayList})
-   * and would rather write simple names than FQNs.
+   * Same as {@link #writeClass(String, String, String, Element, Consumer)} but emits exactly the
+   * given {@code imports} — no implicit {@code Telescope}. A generator whose body references {@code
+   * Telescope} must include it in {@code imports}; one that doesn't (e.g. a {@code ForwardMapper}
+   * converter) omits it and gets no dead import. Use simple names in the body and list their FQNs
+   * here.
    */
   protected void writeClass(
     final String qualifiedName,
     final String simpleName,
-    final Set<String> extraImports,
+    final Set<String> imports,
     final String javadoc,
     final Element origin,
     final Consumer<PrintWriter> body
@@ -89,8 +91,7 @@ public abstract class AbstractTelescopeProcessor extends AbstractProcessor {
           out.println("package " + pkg + ";");
           out.println();
         }
-        out.println("import io.github.eschizoid.telescope.Telescope;");
-        final var sorted = new TreeSet<>(extraImports);
+        final var sorted = new TreeSet<>(imports);
         for (final var imp : sorted) out.println("import " + imp + ";");
         out.println();
         out.println("/** " + javadoc + " */");

--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
@@ -1636,6 +1636,7 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
     }
 
     final var imports = new TreeSet<>(importsFor(fieldPlans, sourceFields, targetFields, renames));
+    imports.add("io.github.eschizoid.telescope.Telescope");
     imports.add("io.github.eschizoid.telescope.conversion.BridgeFn");
     writeClass(
       qualifiedBridge,
@@ -1864,6 +1865,7 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
       qualifiedBridge,
       bridgeName,
       Set.of(
+        "io.github.eschizoid.telescope.Telescope",
         "io.github.eschizoid.telescope.conversion.BridgeFn",
         "io.github.eschizoid.telescope.conversion.Match",
         "java.util.function.Function"

--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/Coercion.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/Coercion.java
@@ -14,6 +14,8 @@ sealed interface Coercion
   permits
     Coercion.Cast,
     Coercion.Parse,
+    Coercion.BoolParse,
+    Coercion.CharParse,
     Coercion.EnumOf,
     Coercion.Nested,
     Coercion.Listed,
@@ -70,6 +72,60 @@ sealed interface Coercion
         "(String.valueOf(" +
         raw +
         "))"
+      );
+    }
+  }
+
+  /**
+   * {@code boolean}/{@code Boolean} target: take an existing {@code Boolean} directly, else parse a
+   * {@code String}, else the default ({@code false} for the primitive, {@code null} for the
+   * wrapper).
+   */
+  record BoolParse(String defaultLiteral) implements Coercion {
+    @Override
+    public String emit(final String raw, final int depth) {
+      final var v = "__b" + depth;
+      return (
+        raw +
+        " instanceof Boolean " +
+        v +
+        " ? " +
+        v +
+        " : " +
+        raw +
+        " == null ? " +
+        defaultLiteral +
+        " : Boolean.parseBoolean(String.valueOf(" +
+        raw +
+        "))"
+      );
+    }
+  }
+
+  /**
+   * {@code char}/{@code Character} target: take an existing {@code Character} directly, else the
+   * first char of the {@code String} form, else the default ({@code '\0'} primitive / {@code null}
+   * wrapper).
+   */
+  record CharParse(String defaultLiteral) implements Coercion {
+    @Override
+    public String emit(final String raw, final int depth) {
+      final var v = "__c" + depth;
+      return (
+        raw +
+        " instanceof Character " +
+        v +
+        " ? " +
+        v +
+        " : " +
+        raw +
+        " == null || String.valueOf(" +
+        raw +
+        ").isEmpty() ? " +
+        defaultLiteral +
+        " : String.valueOf(" +
+        raw +
+        ").charAt(0)"
       );
     }
   }

--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/Coercion.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/Coercion.java
@@ -1,13 +1,17 @@
 package io.github.eschizoid.telescope.codegen;
 
+import java.util.HashSet;
 import java.util.Optional;
+import java.util.Set;
 
 /**
  * A per-field coercion from a raw {@code Map} value expression to the target field's type, emitted
  * as a Java expression. The processor resolves each field's declared type to one of these, then
  * asks it to {@link #emit(String, int)} the conversion around the raw {@code map.get("key")}
- * expression. Sealed so each strategy is a distinct, independently testable shape; container
- * strategies compose recursively over their element coercion.
+ * expression and to {@link #imports()} the types it references — so the generated converter uses
+ * imports and simple names, not inline fully-qualified names. Sealed so each strategy is a
+ * distinct, independently testable shape; container strategies compose recursively over their
+ * element coercion.
  *
  * <p>{@code depth} disambiguates generated local/pattern variable names so nested containers (e.g.
  * {@code List<List<X>>}) don't shadow each other's lambda parameters.
@@ -34,6 +38,14 @@ sealed interface Coercion
   String emit(String raw, int depth);
 
   /**
+   * Fully-qualified names this coercion references, to be imported by the generated converter
+   * (simple names emitted).
+   */
+  default Set<String> imports() {
+    return Set.of();
+  }
+
+  /**
    * Whether the emitted expression performs an unchecked cast (so the enclosing method needs
    * {@code @SuppressWarnings}).
    */
@@ -50,14 +62,37 @@ sealed interface Coercion
     return Optional.empty();
   }
 
+  /** Simple name of a fully-qualified name (the segment after the last dot). */
+  static String simple(final String fqn) {
+    final var dot = fqn.lastIndexOf('.');
+    return dot < 0 ? fqn : fqn.substring(dot + 1);
+  }
+
+  /** Import set for a type — empty for {@code java.lang} (auto-imported), else the single FQN. */
+  static Set<String> importing(final String fqn) {
+    return fqn.startsWith("java.lang.") ? Set.of() : Set.of(fqn);
+  }
+
+  /** Union of a fixed import set with a child coercion's imports. */
+  static Set<String> with(final Set<String> own, final Coercion child) {
+    final var all = new HashSet<>(own);
+    all.addAll(child.imports());
+    return all;
+  }
+
   /**
    * Reference type (including {@code String}): a direct cast. A {@code null} raw casts to {@code
    * null}.
    */
-  record Cast(String typeName) implements Coercion {
+  record Cast(String fqn) implements Coercion {
     @Override
     public String emit(final String raw, final int depth) {
-      return "(" + typeName + ") " + raw;
+      return "(" + simple(fqn) + ") " + raw;
+    }
+
+    @Override
+    public Set<String> imports() {
+      return importing(fqn);
     }
   }
 
@@ -93,8 +128,8 @@ sealed interface Coercion
 
   /**
    * {@code boolean}/{@code Boolean} target: take an existing {@code Boolean} directly, else parse a
-   * {@code String}, else the default ({@code false} for the primitive, {@code null} for the
-   * wrapper).
+   * {@code String} ({@code Boolean.parseBoolean} — only {@code "true"} is truthy), else the
+   * default.
    */
   record BoolParse(String defaultLiteral) implements Coercion {
     @Override
@@ -119,19 +154,17 @@ sealed interface Coercion
 
   /**
    * {@code char}/{@code Character} target: take an existing {@code Character} directly, else the
-   * first char of the {@code String} form, else the default ({@code '\0'} primitive / {@code null}
-   * wrapper).
+   * first char of the {@code String} form, else the default.
    */
   record CharParse(String defaultLiteral) implements Coercion {
     @Override
     public String emit(final String raw, final int depth) {
-      final var v = "__c" + depth;
       return (
         raw +
-        " instanceof Character " +
-        v +
-        " ? " +
-        v +
+        " instanceof Character __c" +
+        depth +
+        " ? __c" +
+        depth +
         " : " +
         raw +
         " == null || String.valueOf(" +
@@ -149,14 +182,15 @@ sealed interface Coercion
    * Enum target: take an existing enum value directly, else map a {@code String} name via {@code
    * valueOf}.
    */
-  record EnumOf(String enumType) implements Coercion {
+  record EnumOf(String fqn) implements Coercion {
     @Override
     public String emit(final String raw, final int depth) {
+      final var type = simple(fqn);
       final var v = "__e" + depth;
       return (
         raw +
         " instanceof " +
-        enumType +
+        type +
         " " +
         v +
         " ? " +
@@ -164,11 +198,40 @@ sealed interface Coercion
         " : " +
         raw +
         " == null ? null : " +
-        enumType +
+        type +
         ".valueOf(String.valueOf(" +
         raw +
         "))"
       );
+    }
+
+    @Override
+    public Set<String> imports() {
+      return importing(fqn);
+    }
+  }
+
+  /**
+   * A JDK value type with a well-known String factory ({@code Instant.parse}, {@code
+   * UUID.fromString}, {@code new BigDecimal}, …): take an existing instance directly, else build it
+   * from the value's {@code String} form — the shape these arrive in from an untyped map.
+   */
+  record StringFactory(String fqn, String factory) implements Coercion {
+    @Override
+    public String emit(final String raw, final int depth) {
+      final var type = simple(fqn);
+      // factory is either a static method ("parse"/"fromString"/…) or "new" for a String
+      // constructor.
+      final var build = "new".equals(factory)
+        ? "new " + type + "(String.valueOf(" + raw + "))"
+        : type + "." + factory + "(String.valueOf(" + raw + "))";
+      final var v = "__sf" + depth;
+      return raw + " instanceof " + type + " " + v + " ? " + v + " : " + raw + " == null ? null : " + build;
+    }
+
+    @Override
+    public Set<String> imports() {
+      return importing(fqn);
     }
   }
 
@@ -176,10 +239,15 @@ sealed interface Coercion
    * Nested {@code @FromMap} target: a {@code null}-guarded recursion through its generated
    * converter.
    */
-  record Nested(String converterClass) implements Coercion {
+  record Nested(String converterFqn) implements Coercion {
     @Override
     public String emit(final String raw, final int depth) {
-      return raw + " == null ? null : " + converterClass + ".fromMap((Map<String, Object>) " + raw + ")";
+      return raw + " == null ? null : " + simple(converterFqn) + ".fromMap((Map<String, Object>) " + raw + ")";
+    }
+
+    @Override
+    public Set<String> imports() {
+      return importing(converterFqn);
     }
 
     @Override
@@ -189,14 +257,14 @@ sealed interface Coercion
   }
 
   /** {@code List<E>} target: stream each element through the element coercion into a fresh list. */
-  record Listed(Coercion element) implements Coercion {
+  record Listed(String elementType, Coercion element, Set<String> typeImports) implements Coercion {
     @Override
     public String emit(final String raw, final int depth) {
       final var list = "__l" + depth;
       final var el = "__el" + depth;
       return (
         raw +
-        " instanceof java.util.List<?> " +
+        " instanceof List<?> " +
         list +
         " ? " +
         list +
@@ -204,8 +272,17 @@ sealed interface Coercion
         el +
         " -> " +
         element.emit(el, depth + 1) +
-        ").collect(java.util.stream.Collectors.toList()) : java.util.List.of()"
+        ").collect(Collectors.toList()) : List.<" +
+        elementType +
+        ">of()"
       );
+    }
+
+    @Override
+    public Set<String> imports() {
+      final var all = with(Set.of("java.util.List", "java.util.stream.Collectors"), element);
+      all.addAll(typeImports);
+      return all;
     }
 
     @Override
@@ -220,14 +297,14 @@ sealed interface Coercion
   }
 
   /** {@code Set<E>} target: stream each element through the element coercion into a fresh set. */
-  record Setted(Coercion element) implements Coercion {
+  record Setted(String elementType, Coercion element, Set<String> typeImports) implements Coercion {
     @Override
     public String emit(final String raw, final int depth) {
       final var set = "__s" + depth;
       final var el = "__el" + depth;
       return (
         raw +
-        " instanceof java.util.Set<?> " +
+        " instanceof Set<?> " +
         set +
         " ? " +
         set +
@@ -235,8 +312,17 @@ sealed interface Coercion
         el +
         " -> " +
         element.emit(el, depth + 1) +
-        ").collect(java.util.stream.Collectors.toSet()) : java.util.Set.of()"
+        ").collect(Collectors.toSet()) : Set.<" +
+        elementType +
+        ">of()"
       );
+    }
+
+    @Override
+    public Set<String> imports() {
+      final var all = with(Set.of("java.util.Set", "java.util.stream.Collectors"), element);
+      all.addAll(typeImports);
+      return all;
     }
 
     @Override
@@ -257,7 +343,12 @@ sealed interface Coercion
   record OptionalOf(Coercion element) implements Coercion {
     @Override
     public String emit(final String raw, final int depth) {
-      return "java.util.Optional.ofNullable(" + element.emit(raw, depth) + ")";
+      return "Optional.ofNullable(" + element.emit(raw, depth) + ")";
+    }
+
+    @Override
+    public Set<String> imports() {
+      return with(Set.of("java.util.Optional"), element);
     }
 
     @Override
@@ -272,23 +363,34 @@ sealed interface Coercion
   }
 
   /**
-   * {@code Map<K, V>} target: coerce both key and value through their coercions into a fresh {@code
-   * LinkedHashMap}. Uses a put-accumulating collect (not {@code Collectors.toMap}) so a {@code
-   * null} value doesn't throw — matching the lenient spirit of {@code fromMap}.
+   * {@code Map<K, V>} target: coerce both key and value into a fresh {@code LinkedHashMap}. Uses a
+   * put-accumulating collect (not {@code Collectors.toMap}) so a {@code null} value doesn't throw —
+   * matching the lenient spirit of {@code fromMap}.
    */
-  record MapValues(Coercion key, Coercion value) implements Coercion {
+  record MapValues(
+    String keyType,
+    String valueType,
+    Coercion key,
+    Coercion value,
+    Set<String> typeImports
+  ) implements Coercion {
     @Override
     public String emit(final String raw, final int depth) {
       final var map = "__m" + depth;
       final var acc = "__acc" + depth;
       final var entry = "__et" + depth;
+      final var mapType = "Map<" + keyType + ", " + valueType + ">";
+      // Explicit <Map<K,V>> witness so the 3-arg collect types even when nested inside another
+      // container (javac can't otherwise infer the accumulator's element types there).
       return (
         raw +
-        " instanceof java.util.Map<?, ?> " +
+        " instanceof Map<?, ?> " +
         map +
         " ? " +
         map +
-        ".entrySet().stream().collect(java.util.LinkedHashMap::new, (" +
+        ".entrySet().stream().<" +
+        mapType +
+        ">collect(LinkedHashMap::new, (" +
         acc +
         ", " +
         entry +
@@ -298,8 +400,21 @@ sealed interface Coercion
         key.emit(entry + ".getKey()", depth + 1) +
         ", " +
         value.emit(entry + ".getValue()", depth + 1) +
-        "), java.util.LinkedHashMap::putAll) : java.util.Map.of()"
+        "), Map::putAll) : Map.<" +
+        keyType +
+        ", " +
+        valueType +
+        ">of()"
       );
+    }
+
+    @Override
+    public Set<String> imports() {
+      final var all = new HashSet<>(Set.of("java.util.Map", "java.util.LinkedHashMap"));
+      all.addAll(typeImports);
+      all.addAll(key.imports());
+      all.addAll(value.imports());
+      return all;
     }
 
     @Override
@@ -310,34 +425,6 @@ sealed interface Coercion
     @Override
     public Optional<String> firstUnsupported() {
       return key.firstUnsupported().or(value::firstUnsupported);
-    }
-  }
-
-  /**
-   * A JDK value type with a well-known String factory ({@code Instant.parse}, {@code
-   * UUID.fromString}, {@code new BigDecimal}, …): take an existing instance directly, else build it
-   * from the value's {@code String} form — the shape these arrive in from an untyped map.
-   */
-  record StringFactory(String typeName, String factory) implements Coercion {
-    @Override
-    public String emit(final String raw, final int depth) {
-      final var v = "__sf" + depth;
-      return (
-        raw +
-        " instanceof " +
-        typeName +
-        " " +
-        v +
-        " ? " +
-        v +
-        " : " +
-        raw +
-        " == null ? null : " +
-        factory +
-        "(String.valueOf(" +
-        raw +
-        "))"
-      );
     }
   }
 

--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/Coercion.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/Coercion.java
@@ -1,0 +1,203 @@
+package io.github.eschizoid.telescope.codegen;
+
+/**
+ * A per-field coercion from a raw {@code Map} value expression to the target field's type, emitted
+ * as a Java expression. The processor resolves each field's declared type (and any {@code @Extract}
+ * override) to one of these, then asks it to {@link #emit(String, int)} the conversion around the
+ * raw {@code map.get("key")} expression. Sealed so each strategy is a distinct, independently
+ * testable shape; container strategies compose recursively over their element coercion.
+ *
+ * <p>{@code depth} disambiguates generated local/pattern variable names so nested containers (e.g.
+ * {@code List<List<X>>}) don't shadow each other's lambda parameters.
+ */
+sealed interface Coercion
+  permits
+    Coercion.Cast,
+    Coercion.Parse,
+    Coercion.EnumOf,
+    Coercion.Nested,
+    Coercion.Listed,
+    Coercion.Setted,
+    Coercion.MapValues
+{
+  /**
+   * Emit a Java expression converting {@code raw} (an {@code Object}-typed expression) to the field
+   * type.
+   */
+  String emit(String raw, int depth);
+
+  /**
+   * Whether the emitted expression performs an unchecked cast (so the enclosing method needs
+   * {@code @SuppressWarnings}).
+   */
+  default boolean unchecked() {
+    return false;
+  }
+
+  /**
+   * Reference type (including {@code String}): a direct cast. A {@code null} raw casts to {@code
+   * null}.
+   */
+  record Cast(String typeName) implements Coercion {
+    @Override
+    public String emit(final String raw, final int depth) {
+      return "(" + typeName + ") " + raw;
+    }
+  }
+
+  /**
+   * {@code String}/{@code Number} to a primitive: take the {@code Number} directly when present,
+   * else parse a {@code String}, else fall back to the primitive's JLS default for an absent key.
+   */
+  record Parse(String narrowMethod, String parseMethod, String defaultLiteral) implements Coercion {
+    @Override
+    public String emit(final String raw, final int depth) {
+      final var v = "__n" + depth;
+      return (
+        raw +
+        " instanceof Number " +
+        v +
+        " ? " +
+        v +
+        "." +
+        narrowMethod +
+        "() : " +
+        raw +
+        " == null ? " +
+        defaultLiteral +
+        " : " +
+        parseMethod +
+        "(String.valueOf(" +
+        raw +
+        "))"
+      );
+    }
+  }
+
+  /**
+   * Enum target: take an existing enum value directly, else map a {@code String} name via {@code
+   * valueOf}.
+   */
+  record EnumOf(String enumType) implements Coercion {
+    @Override
+    public String emit(final String raw, final int depth) {
+      final var v = "__e" + depth;
+      return (
+        raw +
+        " instanceof " +
+        enumType +
+        " " +
+        v +
+        " ? " +
+        v +
+        " : " +
+        raw +
+        " == null ? null : " +
+        enumType +
+        ".valueOf(String.valueOf(" +
+        raw +
+        "))"
+      );
+    }
+  }
+
+  /**
+   * Nested {@code @FromMap} target: a {@code null}-guarded recursion through its generated
+   * converter.
+   */
+  record Nested(String converterClass) implements Coercion {
+    @Override
+    public String emit(final String raw, final int depth) {
+      return raw + " == null ? null : " + converterClass + ".fromMap((Map<String, Object>) " + raw + ")";
+    }
+
+    @Override
+    public boolean unchecked() {
+      return true;
+    }
+  }
+
+  /** {@code List<E>} target: stream each element through the element coercion into a fresh list. */
+  record Listed(Coercion element) implements Coercion {
+    @Override
+    public String emit(final String raw, final int depth) {
+      final var list = "__l" + depth;
+      final var el = "__el" + depth;
+      return (
+        raw +
+        " instanceof java.util.List<?> " +
+        list +
+        " ? " +
+        list +
+        ".stream().map(" +
+        el +
+        " -> " +
+        element.emit(el, depth + 1) +
+        ").collect(java.util.stream.Collectors.toList()) : java.util.List.of()"
+      );
+    }
+
+    @Override
+    public boolean unchecked() {
+      return element.unchecked();
+    }
+  }
+
+  /** {@code Set<E>} target: stream each element through the element coercion into a fresh set. */
+  record Setted(Coercion element) implements Coercion {
+    @Override
+    public String emit(final String raw, final int depth) {
+      final var set = "__s" + depth;
+      final var el = "__el" + depth;
+      return (
+        raw +
+        " instanceof java.util.Set<?> " +
+        set +
+        " ? " +
+        set +
+        ".stream().map(" +
+        el +
+        " -> " +
+        element.emit(el, depth + 1) +
+        ").collect(java.util.stream.Collectors.toSet()) : java.util.Set.of()"
+      );
+    }
+
+    @Override
+    public boolean unchecked() {
+      return element.unchecked();
+    }
+  }
+
+  /** {@code Map<K, V>} target: coerce each value through the value coercion, preserving keys. */
+  record MapValues(String keyType, Coercion value) implements Coercion {
+    @Override
+    public String emit(final String raw, final int depth) {
+      final var map = "__m" + depth;
+      final var entry = "__et" + depth;
+      return (
+        raw +
+        " instanceof java.util.Map<?, ?> " +
+        map +
+        " ? " +
+        map +
+        ".entrySet().stream().collect(java.util.stream.Collectors.toMap(" +
+        entry +
+        " -> (" +
+        keyType +
+        ") " +
+        entry +
+        ".getKey(), " +
+        entry +
+        " -> " +
+        value.emit(entry + ".getValue()", depth + 1) +
+        ")) : java.util.Map.of()"
+      );
+    }
+
+    @Override
+    public boolean unchecked() {
+      return true;
+    }
+  }
+}

--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/Coercion.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/Coercion.java
@@ -4,10 +4,10 @@ import java.util.Optional;
 
 /**
  * A per-field coercion from a raw {@code Map} value expression to the target field's type, emitted
- * as a Java expression. The processor resolves each field's declared type (and any {@code @Extract}
- * override) to one of these, then asks it to {@link #emit(String, int)} the conversion around the
- * raw {@code map.get("key")} expression. Sealed so each strategy is a distinct, independently
- * testable shape; container strategies compose recursively over their element coercion.
+ * as a Java expression. The processor resolves each field's declared type to one of these, then
+ * asks it to {@link #emit(String, int)} the conversion around the raw {@code map.get("key")}
+ * expression. Sealed so each strategy is a distinct, independently testable shape; container
+ * strategies compose recursively over their element coercion.
  *
  * <p>{@code depth} disambiguates generated local/pattern variable names so nested containers (e.g.
  * {@code List<List<X>>}) don't shadow each other's lambda parameters.
@@ -24,6 +24,7 @@ sealed interface Coercion
     Coercion.Setted,
     Coercion.MapValues,
     Coercion.OptionalOf,
+    Coercion.StringFactory,
     Coercion.Unsupported
 {
   /**
@@ -62,7 +63,8 @@ sealed interface Coercion
 
   /**
    * {@code String}/{@code Number} to a primitive: take the {@code Number} directly when present,
-   * else parse a {@code String}, else fall back to the primitive's JLS default for an absent key.
+   * else fall back to the primitive's JLS default when the key is absent, else parse the {@code
+   * String} form.
    */
   record Parse(String narrowMethod, String parseMethod, String defaultLiteral) implements Coercion {
     @Override
@@ -308,6 +310,34 @@ sealed interface Coercion
     @Override
     public Optional<String> firstUnsupported() {
       return key.firstUnsupported().or(value::firstUnsupported);
+    }
+  }
+
+  /**
+   * A JDK value type with a well-known String factory ({@code Instant.parse}, {@code
+   * UUID.fromString}, {@code new BigDecimal}, …): take an existing instance directly, else build it
+   * from the value's {@code String} form — the shape these arrive in from an untyped map.
+   */
+  record StringFactory(String typeName, String factory) implements Coercion {
+    @Override
+    public String emit(final String raw, final int depth) {
+      final var v = "__sf" + depth;
+      return (
+        raw +
+        " instanceof " +
+        typeName +
+        " " +
+        v +
+        " ? " +
+        v +
+        " : " +
+        raw +
+        " == null ? null : " +
+        factory +
+        "(String.valueOf(" +
+        raw +
+        "))"
+      );
     }
   }
 

--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/Coercion.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/Coercion.java
@@ -20,7 +20,8 @@ sealed interface Coercion
     Coercion.Nested,
     Coercion.Listed,
     Coercion.Setted,
-    Coercion.MapValues
+    Coercion.MapValues,
+    Coercion.OptionalOf
 {
   /**
    * Emit a Java expression converting {@code raw} (an {@code Object}-typed expression) to the field
@@ -225,11 +226,32 @@ sealed interface Coercion
     }
   }
 
-  /** {@code Map<K, V>} target: coerce each value through the value coercion, preserving keys. */
-  record MapValues(String keyType, Coercion value) implements Coercion {
+  /**
+   * {@code Optional<E>} target: wrap the (null-coalescing) element coercion in {@code
+   * Optional.ofNullable}.
+   */
+  record OptionalOf(Coercion element) implements Coercion {
+    @Override
+    public String emit(final String raw, final int depth) {
+      return "java.util.Optional.ofNullable(" + element.emit(raw, depth) + ")";
+    }
+
+    @Override
+    public boolean unchecked() {
+      return element.unchecked();
+    }
+  }
+
+  /**
+   * {@code Map<K, V>} target: coerce both key and value through their coercions into a fresh {@code
+   * LinkedHashMap}. Uses a put-accumulating collect (not {@code Collectors.toMap}) so a {@code
+   * null} value doesn't throw — matching the lenient spirit of {@code fromMap}.
+   */
+  record MapValues(Coercion key, Coercion value) implements Coercion {
     @Override
     public String emit(final String raw, final int depth) {
       final var map = "__m" + depth;
+      final var acc = "__acc" + depth;
       final var entry = "__et" + depth;
       return (
         raw +
@@ -237,17 +259,17 @@ sealed interface Coercion
         map +
         " ? " +
         map +
-        ".entrySet().stream().collect(java.util.stream.Collectors.toMap(" +
+        ".entrySet().stream().collect(java.util.LinkedHashMap::new, (" +
+        acc +
+        ", " +
         entry +
-        " -> (" +
-        keyType +
-        ") " +
-        entry +
-        ".getKey(), " +
-        entry +
-        " -> " +
+        ") -> " +
+        acc +
+        ".put(" +
+        key.emit(entry + ".getKey()", depth + 1) +
+        ", " +
         value.emit(entry + ".getValue()", depth + 1) +
-        ")) : java.util.Map.of()"
+        "), java.util.LinkedHashMap::putAll) : java.util.Map.of()"
       );
     }
 

--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/Coercion.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/Coercion.java
@@ -1,5 +1,7 @@
 package io.github.eschizoid.telescope.codegen;
 
+import java.util.Optional;
+
 /**
  * A per-field coercion from a raw {@code Map} value expression to the target field's type, emitted
  * as a Java expression. The processor resolves each field's declared type (and any {@code @Extract}
@@ -21,7 +23,8 @@ sealed interface Coercion
     Coercion.Listed,
     Coercion.Setted,
     Coercion.MapValues,
-    Coercion.OptionalOf
+    Coercion.OptionalOf,
+    Coercion.Unsupported
 {
   /**
    * Emit a Java expression converting {@code raw} (an {@code Object}-typed expression) to the field
@@ -35,6 +38,15 @@ sealed interface Coercion
    */
   default boolean unchecked() {
     return false;
+  }
+
+  /**
+   * The first {@link Unsupported} reason in this coercion tree (containers delegate to their
+   * element/value), or empty when the field is coercible. The processor turns a present reason into
+   * a compile error instead of emitting code that would {@code ClassCastException} at runtime.
+   */
+  default Optional<String> firstUnsupported() {
+    return Optional.empty();
   }
 
   /**
@@ -198,6 +210,11 @@ sealed interface Coercion
     public boolean unchecked() {
       return element.unchecked();
     }
+
+    @Override
+    public Optional<String> firstUnsupported() {
+      return element.firstUnsupported();
+    }
   }
 
   /** {@code Set<E>} target: stream each element through the element coercion into a fresh set. */
@@ -224,6 +241,11 @@ sealed interface Coercion
     public boolean unchecked() {
       return element.unchecked();
     }
+
+    @Override
+    public Optional<String> firstUnsupported() {
+      return element.firstUnsupported();
+    }
   }
 
   /**
@@ -239,6 +261,11 @@ sealed interface Coercion
     @Override
     public boolean unchecked() {
       return element.unchecked();
+    }
+
+    @Override
+    public Optional<String> firstUnsupported() {
+      return element.firstUnsupported();
     }
   }
 
@@ -276,6 +303,28 @@ sealed interface Coercion
     @Override
     public boolean unchecked() {
       return true;
+    }
+
+    @Override
+    public Optional<String> firstUnsupported() {
+      return key.firstUnsupported().or(value::firstUnsupported);
+    }
+  }
+
+  /**
+   * A field type {@code @FromMap} can't coerce (a nested object that isn't {@code @FromMap}, a
+   * collection subtype, a type variable). Never emitted — the processor reports {@link #reason} as
+   * a compile error and skips the converter, upholding "if it compiles, it runs".
+   */
+  record Unsupported(String reason) implements Coercion {
+    @Override
+    public String emit(final String raw, final int depth) {
+      throw new IllegalStateException("Unsupported coercion must not be emitted: " + reason);
+    }
+
+    @Override
+    public Optional<String> firstUnsupported() {
+      return Optional.of(reason);
     }
   }
 }

--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/Coercion.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/Coercion.java
@@ -68,6 +68,15 @@ sealed interface Coercion
     return dot < 0 ? fqn : fqn.substring(dot + 1);
   }
 
+  /**
+   * A generated local/pattern variable name, scoped by {@code depth} so nested containers don't
+   * shadow each other. The {@code __} prefix (avoiding any user identifier) lives here, in one
+   * place, rather than inlined per permit.
+   */
+  static String gensym(final String tag, final int depth) {
+    return "__" + tag + depth;
+  }
+
   /** Import set for a type — empty for {@code java.lang} (auto-imported), else the single FQN. */
   static Set<String> importing(final String fqn) {
     return fqn.startsWith("java.lang.") ? Set.of() : Set.of(fqn);
@@ -78,6 +87,40 @@ sealed interface Coercion
     final var all = new HashSet<>(own);
     all.addAll(child.imports());
     return all;
+  }
+
+  /**
+   * A type rendered to its simple-name source form ({@code Map<String, Address>}) together with the
+   * FQNs that form needs imported. Kept as one value so the rendered string and its imports can't
+   * drift apart — the container coercions thread it straight through to their type witnesses.
+   */
+  record RenderedType(String source, Set<String> imports) {}
+
+  /**
+   * How a JDK value type is rebuilt from its {@code String} form: a named static factory ({@code
+   * Instant.parse}, {@code UUID.fromString}, …) or the {@code String} constructor ({@code new
+   * BigDecimal(...)}). A sealed pair so {@link StringFactory} dispatches on the type, not a magic
+   * string.
+   */
+  sealed interface Factory permits Factory.Static, Factory.Ctor {
+    /** The build expression for {@code type} from the {@code String}-form {@code arg}. */
+    String build(String type, String arg);
+
+    /** Build via {@code Type.method(String)}. */
+    record Static(String method) implements Factory {
+      @Override
+      public String build(final String type, final String arg) {
+        return type + "." + method + "(" + arg + ")";
+      }
+    }
+
+    /** Build via {@code new Type(String)}. */
+    record Ctor() implements Factory {
+      @Override
+      public String build(final String type, final String arg) {
+        return "new " + type + "(" + arg + ")";
+      }
+    }
   }
 
   /**
@@ -104,7 +147,7 @@ sealed interface Coercion
   record Parse(String narrowMethod, String parseMethod, String defaultLiteral) implements Coercion {
     @Override
     public String emit(final String raw, final int depth) {
-      final var v = "__n" + depth;
+      final var v = gensym("n", depth);
       return (
         raw +
         " instanceof Number " +
@@ -134,7 +177,7 @@ sealed interface Coercion
   record BoolParse(String defaultLiteral) implements Coercion {
     @Override
     public String emit(final String raw, final int depth) {
-      final var v = "__b" + depth;
+      final var v = gensym("b", depth);
       return (
         raw +
         " instanceof Boolean " +
@@ -159,12 +202,13 @@ sealed interface Coercion
   record CharParse(String defaultLiteral) implements Coercion {
     @Override
     public String emit(final String raw, final int depth) {
+      final var v = gensym("c", depth);
       return (
         raw +
-        " instanceof Character __c" +
-        depth +
-        " ? __c" +
-        depth +
+        " instanceof Character " +
+        v +
+        " ? " +
+        v +
         " : " +
         raw +
         " == null || String.valueOf(" +
@@ -186,7 +230,7 @@ sealed interface Coercion
     @Override
     public String emit(final String raw, final int depth) {
       final var type = simple(fqn);
-      final var v = "__e" + depth;
+      final var v = gensym("e", depth);
       return (
         raw +
         " instanceof " +
@@ -216,16 +260,12 @@ sealed interface Coercion
    * UUID.fromString}, {@code new BigDecimal}, …): take an existing instance directly, else build it
    * from the value's {@code String} form — the shape these arrive in from an untyped map.
    */
-  record StringFactory(String fqn, String factory) implements Coercion {
+  record StringFactory(String fqn, Factory factory) implements Coercion {
     @Override
     public String emit(final String raw, final int depth) {
       final var type = simple(fqn);
-      // factory is either a static method ("parse"/"fromString"/…) or "new" for a String
-      // constructor.
-      final var build = "new".equals(factory)
-        ? "new " + type + "(String.valueOf(" + raw + "))"
-        : type + "." + factory + "(String.valueOf(" + raw + "))";
-      final var v = "__sf" + depth;
+      final var build = factory.build(type, "String.valueOf(" + raw + ")");
+      final var v = gensym("sf", depth);
       return raw + " instanceof " + type + " " + v + " ? " + v + " : " + raw + " == null ? null : " + build;
     }
 
@@ -257,11 +297,11 @@ sealed interface Coercion
   }
 
   /** {@code List<E>} target: stream each element through the element coercion into a fresh list. */
-  record Listed(String elementType, Coercion element, Set<String> typeImports) implements Coercion {
+  record Listed(RenderedType elementType, Coercion element) implements Coercion {
     @Override
     public String emit(final String raw, final int depth) {
-      final var list = "__l" + depth;
-      final var el = "__el" + depth;
+      final var list = gensym("l", depth);
+      final var el = gensym("el", depth);
       return (
         raw +
         " instanceof List<?> " +
@@ -273,7 +313,7 @@ sealed interface Coercion
         " -> " +
         element.emit(el, depth + 1) +
         ").collect(Collectors.toList()) : List.<" +
-        elementType +
+        elementType.source() +
         ">of()"
       );
     }
@@ -281,7 +321,7 @@ sealed interface Coercion
     @Override
     public Set<String> imports() {
       final var all = with(Set.of("java.util.List", "java.util.stream.Collectors"), element);
-      all.addAll(typeImports);
+      all.addAll(elementType.imports());
       return all;
     }
 
@@ -297,11 +337,11 @@ sealed interface Coercion
   }
 
   /** {@code Set<E>} target: stream each element through the element coercion into a fresh set. */
-  record Setted(String elementType, Coercion element, Set<String> typeImports) implements Coercion {
+  record Setted(RenderedType elementType, Coercion element) implements Coercion {
     @Override
     public String emit(final String raw, final int depth) {
-      final var set = "__s" + depth;
-      final var el = "__el" + depth;
+      final var set = gensym("s", depth);
+      final var el = gensym("el", depth);
       return (
         raw +
         " instanceof Set<?> " +
@@ -313,7 +353,7 @@ sealed interface Coercion
         " -> " +
         element.emit(el, depth + 1) +
         ").collect(Collectors.toSet()) : Set.<" +
-        elementType +
+        elementType.source() +
         ">of()"
       );
     }
@@ -321,7 +361,7 @@ sealed interface Coercion
     @Override
     public Set<String> imports() {
       final var all = with(Set.of("java.util.Set", "java.util.stream.Collectors"), element);
-      all.addAll(typeImports);
+      all.addAll(elementType.imports());
       return all;
     }
 
@@ -367,19 +407,13 @@ sealed interface Coercion
    * put-accumulating collect (not {@code Collectors.toMap}) so a {@code null} value doesn't throw —
    * matching the lenient spirit of {@code fromMap}.
    */
-  record MapValues(
-    String keyType,
-    String valueType,
-    Coercion key,
-    Coercion value,
-    Set<String> typeImports
-  ) implements Coercion {
+  record MapValues(RenderedType keyType, RenderedType valueType, Coercion key, Coercion value) implements Coercion {
     @Override
     public String emit(final String raw, final int depth) {
-      final var map = "__m" + depth;
-      final var acc = "__acc" + depth;
-      final var entry = "__et" + depth;
-      final var mapType = "Map<" + keyType + ", " + valueType + ">";
+      final var map = gensym("m", depth);
+      final var acc = gensym("acc", depth);
+      final var entry = gensym("et", depth);
+      final var mapType = "Map<" + keyType.source() + ", " + valueType.source() + ">";
       // Explicit <Map<K,V>> witness so the 3-arg collect types even when nested inside another
       // container (javac can't otherwise infer the accumulator's element types there).
       return (
@@ -401,9 +435,9 @@ sealed interface Coercion
         ", " +
         value.emit(entry + ".getValue()", depth + 1) +
         "), Map::putAll) : Map.<" +
-        keyType +
+        keyType.source() +
         ", " +
-        valueType +
+        valueType.source() +
         ">of()"
       );
     }
@@ -411,7 +445,8 @@ sealed interface Coercion
     @Override
     public Set<String> imports() {
       final var all = new HashSet<>(Set.of("java.util.Map", "java.util.LinkedHashMap"));
-      all.addAll(typeImports);
+      all.addAll(keyType.imports());
+      all.addAll(valueType.imports());
       all.addAll(key.imports());
       all.addAll(value.imports());
       return all;

--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/FromMapProcessor.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/FromMapProcessor.java
@@ -39,24 +39,26 @@ public final class FromMapProcessor extends AbstractTelescopeProcessor {
     "java.lang.CharSequence"
   );
 
-  // JDK value types that arrive as a String in an untyped map, mapped to the String factory that
-  // rebuilds them — a static method name, or "new" for a String constructor.
-  private static final Map<String, String> JDK_STRING_FACTORIES = Map.ofEntries(
-    Map.entry("java.time.Instant", "parse"),
-    Map.entry("java.time.LocalDate", "parse"),
-    Map.entry("java.time.LocalDateTime", "parse"),
-    Map.entry("java.time.LocalTime", "parse"),
-    Map.entry("java.time.OffsetDateTime", "parse"),
-    Map.entry("java.time.ZonedDateTime", "parse"),
-    Map.entry("java.time.Duration", "parse"),
-    Map.entry("java.time.Period", "parse"),
-    Map.entry("java.util.UUID", "fromString"),
-    Map.entry("java.math.BigDecimal", "new"),
-    Map.entry("java.math.BigInteger", "new"),
-    Map.entry("java.net.URI", "create"),
-    Map.entry("java.util.Currency", "getInstance"),
-    Map.entry("java.util.Locale", "forLanguageTag"),
-    Map.entry("java.util.regex.Pattern", "compile")
+  // JDK value types that arrive as a String in an untyped map, mapped to the factory that rebuilds
+  // them from that String — a named static method, or the String constructor.
+  private static final Coercion.Factory PARSE = new Coercion.Factory.Static("parse");
+  private static final Coercion.Factory CTOR = new Coercion.Factory.Ctor();
+  private static final Map<String, Coercion.Factory> JDK_STRING_FACTORIES = Map.ofEntries(
+    Map.entry("java.time.Instant", PARSE),
+    Map.entry("java.time.LocalDate", PARSE),
+    Map.entry("java.time.LocalDateTime", PARSE),
+    Map.entry("java.time.LocalTime", PARSE),
+    Map.entry("java.time.OffsetDateTime", PARSE),
+    Map.entry("java.time.ZonedDateTime", PARSE),
+    Map.entry("java.time.Duration", PARSE),
+    Map.entry("java.time.Period", PARSE),
+    Map.entry("java.util.UUID", new Coercion.Factory.Static("fromString")),
+    Map.entry("java.math.BigDecimal", CTOR),
+    Map.entry("java.math.BigInteger", CTOR),
+    Map.entry("java.net.URI", new Coercion.Factory.Static("create")),
+    Map.entry("java.util.Currency", new Coercion.Factory.Static("getInstance")),
+    Map.entry("java.util.Locale", new Coercion.Factory.Static("forLanguageTag")),
+    Map.entry("java.util.regex.Pattern", new Coercion.Factory.Static("compile"))
   );
 
   // @FromMap targets carrying a Lombok trigger are deferred to processingOver(): in round 1 Lombok
@@ -287,27 +289,21 @@ public final class FromMapProcessor extends AbstractTelescopeProcessor {
     if (hasAnnotation(element, ANNOTATION)) return new Coercion.Nested(boxedType(type) + "FromMap");
     final var listElement = singleArgOf(type, "java.util.List");
     if (listElement != null) {
-      final var imports = new HashSet<String>();
-      return new Coercion.Listed(renderType(listElement, imports), resolveCoercion(listElement), imports);
+      return new Coercion.Listed(renderType(listElement), resolveCoercion(listElement));
     }
     final var setElement = singleArgOf(type, "java.util.Set");
     if (setElement != null) {
-      final var imports = new HashSet<String>();
-      return new Coercion.Setted(renderType(setElement, imports), resolveCoercion(setElement), imports);
+      return new Coercion.Setted(renderType(setElement), resolveCoercion(setElement));
     }
     final var optElement = singleArgOf(type, "java.util.Optional");
     if (optElement != null) return new Coercion.OptionalOf(resolveCoercion(optElement));
     if (isErasure(type, "java.util.Map") && type.getTypeArguments().size() == 2) {
       final var args = type.getTypeArguments();
-      final var imports = new HashSet<String>();
-      final var keyType = renderType(args.get(0), imports);
-      final var valueType = renderType(args.get(1), imports);
       return new Coercion.MapValues(
-        keyType,
-        valueType,
+        renderType(args.get(0)),
+        renderType(args.get(1)),
         resolveCoercion(args.get(0)),
-        resolveCoercion(args.get(1)),
-        imports
+        resolveCoercion(args.get(1))
       );
     }
     final var fqn = boxedType(type);
@@ -353,18 +349,24 @@ public final class FromMapProcessor extends AbstractTelescopeProcessor {
    * Render a type as a simple-name source string ({@code Map<String, List<Address>>}), collecting
    * the FQNs to import. Used for the explicit type witnesses on the generated container collectors.
    */
-  private String renderType(final TypeMirror type, final Set<String> imports) {
-    if (type.getKind() != TypeKind.DECLARED) return Coercion.simple(boxedType(type));
+  private Coercion.RenderedType renderType(final TypeMirror type) {
+    if (type.getKind() != TypeKind.DECLARED) return new Coercion.RenderedType(
+      Coercion.simple(boxedType(type)),
+      Set.of()
+    );
     final var declared = (DeclaredType) type;
     final var raw = ((TypeElement) declared.asElement()).getQualifiedName().toString();
-    imports.addAll(Coercion.importing(raw));
+    final var imports = new HashSet<>(Coercion.importing(raw));
     final var args = declared.getTypeArguments();
-    if (args.isEmpty()) return Coercion.simple(raw);
-    final var rendered = args
-      .stream()
-      .map(a -> renderType(a, imports))
-      .collect(Collectors.joining(", "));
-    return Coercion.simple(raw) + "<" + rendered + ">";
+    if (args.isEmpty()) return new Coercion.RenderedType(Coercion.simple(raw), imports);
+    final var rendered = new StringBuilder();
+    for (final var arg : args) {
+      final var part = renderType(arg);
+      if (rendered.length() > 0) rendered.append(", ");
+      rendered.append(part.source());
+      imports.addAll(part.imports());
+    }
+    return new Coercion.RenderedType(Coercion.simple(raw) + "<" + rendered + ">", imports);
   }
 
   /**

--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/FromMapProcessor.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/FromMapProcessor.java
@@ -10,6 +10,7 @@ import javax.annotation.processing.RoundEnvironment;
 import javax.annotation.processing.SupportedAnnotationTypes;
 import javax.annotation.processing.SupportedSourceVersion;
 import javax.lang.model.SourceVersion;
+import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.DeclaredType;
@@ -29,6 +30,12 @@ public final class FromMapProcessor extends AbstractTelescopeProcessor {
 
   private static final String ANNOTATION = "io.github.eschizoid.telescope.annotations.FromMap";
 
+  // @FromMap targets carrying a Lombok trigger are deferred to processingOver(): in round 1 Lombok
+  // hasn't synthesized the getters/setters yet, so beanProperties() would see "no readable
+  // properties". By the final round Lombok is done patching. Cleared after the drain so a reused
+  // processor instance starts clean.
+  private final Set<TypeElement> pending = new LinkedHashSet<>();
+
   /** Public no-arg constructor for {@code ServiceLoader} discovery by the Java compiler. */
   public FromMapProcessor() {
     super();
@@ -39,15 +46,27 @@ public final class FromMapProcessor extends AbstractTelescopeProcessor {
     final var anno = processingEnv.getElementUtils().getTypeElement(ANNOTATION);
     if (anno == null) return false;
     for (final var element : roundEnv.getElementsAnnotatedWith(anno)) {
-      if (element.getKind() == ElementKind.RECORD) {
-        generateForRecord((TypeElement) element);
-      } else if (element.getKind() == ElementKind.CLASS) {
-        generateForBean((TypeElement) element);
+      if (!roundEnv.processingOver() && carriesLombokTrigger(element)) {
+        pending.add((TypeElement) element);
       } else {
-        error(element, "@FromMap is only supported on records and classes");
+        generate(element);
       }
     }
+    if (roundEnv.processingOver()) {
+      pending.forEach(this::generate);
+      pending.clear();
+    }
     return true;
+  }
+
+  private void generate(final Element element) {
+    if (element.getKind() == ElementKind.RECORD) {
+      generateForRecord((TypeElement) element);
+    } else if (element.getKind() == ElementKind.CLASS) {
+      generateForBean((TypeElement) element);
+    } else {
+      error(element, "@FromMap is only supported on records and classes");
+    }
   }
 
   private void generateForRecord(final TypeElement record) {

--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/FromMapProcessor.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/FromMapProcessor.java
@@ -1,6 +1,7 @@
 package io.github.eschizoid.telescope.codegen;
 
 import java.io.PrintWriter;
+import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
@@ -38,24 +39,24 @@ public final class FromMapProcessor extends AbstractTelescopeProcessor {
     "java.lang.CharSequence"
   );
 
-  // JDK value types that arrive as a String in an untyped map, with the factory that rebuilds them.
-  // Generated form: `raw instanceof T t ? t : raw == null ? null : <factory>(String.valueOf(raw))`.
+  // JDK value types that arrive as a String in an untyped map, mapped to the String factory that
+  // rebuilds them — a static method name, or "new" for a String constructor.
   private static final Map<String, String> JDK_STRING_FACTORIES = Map.ofEntries(
-    Map.entry("java.time.Instant", "java.time.Instant.parse"),
-    Map.entry("java.time.LocalDate", "java.time.LocalDate.parse"),
-    Map.entry("java.time.LocalDateTime", "java.time.LocalDateTime.parse"),
-    Map.entry("java.time.LocalTime", "java.time.LocalTime.parse"),
-    Map.entry("java.time.OffsetDateTime", "java.time.OffsetDateTime.parse"),
-    Map.entry("java.time.ZonedDateTime", "java.time.ZonedDateTime.parse"),
-    Map.entry("java.time.Duration", "java.time.Duration.parse"),
-    Map.entry("java.time.Period", "java.time.Period.parse"),
-    Map.entry("java.util.UUID", "java.util.UUID.fromString"),
-    Map.entry("java.math.BigDecimal", "new java.math.BigDecimal"),
-    Map.entry("java.math.BigInteger", "new java.math.BigInteger"),
-    Map.entry("java.net.URI", "java.net.URI.create"),
-    Map.entry("java.util.Currency", "java.util.Currency.getInstance"),
-    Map.entry("java.util.Locale", "java.util.Locale.forLanguageTag"),
-    Map.entry("java.util.regex.Pattern", "java.util.regex.Pattern.compile")
+    Map.entry("java.time.Instant", "parse"),
+    Map.entry("java.time.LocalDate", "parse"),
+    Map.entry("java.time.LocalDateTime", "parse"),
+    Map.entry("java.time.LocalTime", "parse"),
+    Map.entry("java.time.OffsetDateTime", "parse"),
+    Map.entry("java.time.ZonedDateTime", "parse"),
+    Map.entry("java.time.Duration", "parse"),
+    Map.entry("java.time.Period", "parse"),
+    Map.entry("java.util.UUID", "fromString"),
+    Map.entry("java.math.BigDecimal", "new"),
+    Map.entry("java.math.BigInteger", "new"),
+    Map.entry("java.net.URI", "create"),
+    Map.entry("java.util.Currency", "getInstance"),
+    Map.entry("java.util.Locale", "forLanguageTag"),
+    Map.entry("java.util.regex.Pattern", "compile")
   );
 
   // @FromMap targets carrying a Lombok trigger are deferred to processingOver(): in round 1 Lombok
@@ -107,8 +108,12 @@ public final class FromMapProcessor extends AbstractTelescopeProcessor {
     }
     if (!coercible) return;
     final var unchecked = coercions.stream().anyMatch(Coercion::unchecked);
+    final var imports = coercions
+      .stream()
+      .flatMap(c -> c.imports().stream())
+      .collect(Collectors.toSet());
 
-    emitConverter(record, unchecked, out -> {
+    emitConverter(record, unchecked, imports, out -> {
       final var args = IntStream.range(0, components.size())
         .mapToObj(i -> coercions.get(i).emit("map.get(\"" + components.get(i).getSimpleName() + "\")", 0))
         .collect(Collectors.joining(", "));
@@ -169,8 +174,12 @@ public final class FromMapProcessor extends AbstractTelescopeProcessor {
     }
     if (!coercible) return;
     final var unchecked = coercions.stream().anyMatch(Coercion::unchecked);
+    final var imports = coercions
+      .stream()
+      .flatMap(c -> c.imports().stream())
+      .collect(Collectors.toSet());
 
-    emitConverter(pojo, unchecked, out -> {
+    emitConverter(pojo, unchecked, imports, out -> {
       if (useBuilder) {
         out.print("    return " + name + ".builder()");
         for (var i = 0; i < props.size(); i++) {
@@ -196,7 +205,12 @@ public final class FromMapProcessor extends AbstractTelescopeProcessor {
    * Emit the shared {@code <X>FromMap} class shell — the fromMap method (body supplied) and
    * FROM_MAP constant.
    */
-  private void emitConverter(final TypeElement type, final boolean unchecked, final Consumer<PrintWriter> body) {
+  private void emitConverter(
+    final TypeElement type,
+    final boolean unchecked,
+    final Set<String> coercionImports,
+    final Consumer<PrintWriter> body
+  ) {
     final var pkg = processingEnv.getElementUtils().getPackageOf(type).getQualifiedName().toString();
     final var name = type.getSimpleName().toString();
     final var holder = name + "FromMap";
@@ -205,6 +219,10 @@ public final class FromMapProcessor extends AbstractTelescopeProcessor {
     final Set<String> imports = new LinkedHashSet<>();
     imports.add("java.util.Map");
     imports.add("io.github.eschizoid.telescope.conversion.ForwardMapper");
+    imports.addAll(coercionImports);
+    // The converter lives in the target's own package — no self-import needed for sibling
+    // converters.
+    imports.removeIf(fqn -> fqn.equals(pkg + "." + Coercion.simple(fqn)));
 
     final var javadoc = "Generated by telescope-codegen for @FromMap " + name + ".";
     writeClass(qualified, holder, imports, javadoc, type, out -> {
@@ -268,14 +286,29 @@ public final class FromMapProcessor extends AbstractTelescopeProcessor {
     if (element.getKind() == ElementKind.ENUM) return new Coercion.EnumOf(boxedType(type));
     if (hasAnnotation(element, ANNOTATION)) return new Coercion.Nested(boxedType(type) + "FromMap");
     final var listElement = singleArgOf(type, "java.util.List");
-    if (listElement != null) return new Coercion.Listed(resolveCoercion(listElement));
+    if (listElement != null) {
+      final var imports = new HashSet<String>();
+      return new Coercion.Listed(renderType(listElement, imports), resolveCoercion(listElement), imports);
+    }
     final var setElement = singleArgOf(type, "java.util.Set");
-    if (setElement != null) return new Coercion.Setted(resolveCoercion(setElement));
+    if (setElement != null) {
+      final var imports = new HashSet<String>();
+      return new Coercion.Setted(renderType(setElement, imports), resolveCoercion(setElement), imports);
+    }
     final var optElement = singleArgOf(type, "java.util.Optional");
     if (optElement != null) return new Coercion.OptionalOf(resolveCoercion(optElement));
     if (isErasure(type, "java.util.Map") && type.getTypeArguments().size() == 2) {
       final var args = type.getTypeArguments();
-      return new Coercion.MapValues(resolveCoercion(args.get(0)), resolveCoercion(args.get(1)));
+      final var imports = new HashSet<String>();
+      final var keyType = renderType(args.get(0), imports);
+      final var valueType = renderType(args.get(1), imports);
+      return new Coercion.MapValues(
+        keyType,
+        valueType,
+        resolveCoercion(args.get(0)),
+        resolveCoercion(args.get(1)),
+        imports
+      );
     }
     final var fqn = boxedType(type);
     // A collection/map SUBTYPE (ArrayList, TreeSet, HashMap, …) — codegen can't allocate the
@@ -314,6 +347,24 @@ public final class FromMapProcessor extends AbstractTelescopeProcessor {
     final var types = processingEnv.getTypeUtils();
     final var raw = processingEnv.getElementUtils().getTypeElement(rawFqn);
     return raw != null && types.isAssignable(types.erasure(type), types.erasure(raw.asType()));
+  }
+
+  /**
+   * Render a type as a simple-name source string ({@code Map<String, List<Address>>}), collecting
+   * the FQNs to import. Used for the explicit type witnesses on the generated container collectors.
+   */
+  private String renderType(final TypeMirror type, final Set<String> imports) {
+    if (type.getKind() != TypeKind.DECLARED) return Coercion.simple(boxedType(type));
+    final var declared = (DeclaredType) type;
+    final var raw = ((TypeElement) declared.asElement()).getQualifiedName().toString();
+    imports.addAll(Coercion.importing(raw));
+    final var args = declared.getTypeArguments();
+    if (args.isEmpty()) return Coercion.simple(raw);
+    final var rendered = args
+      .stream()
+      .map(a -> renderType(a, imports))
+      .collect(Collectors.joining(", "));
+    return Coercion.simple(raw) + "<" + rendered + ">";
   }
 
   /**

--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/FromMapProcessor.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/FromMapProcessor.java
@@ -1,0 +1,212 @@
+package io.github.eschizoid.telescope.codegen;
+
+import java.io.PrintWriter;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import javax.annotation.processing.RoundEnvironment;
+import javax.annotation.processing.SupportedAnnotationTypes;
+import javax.annotation.processing.SupportedSourceVersion;
+import javax.lang.model.SourceVersion;
+import javax.lang.model.element.ElementKind;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.TypeKind;
+import javax.lang.model.type.TypeMirror;
+
+/**
+ * Emits a reflection-free {@code <X>FromMap} converter for each {@code @FromMap} record or bean: a
+ * {@code static X fromMap(Map<String, Object>)} that rebuilds the target (record canonical
+ * constructor, or bean builder / no-arg-ctor + setters) with the map values coerced inline, plus a
+ * {@code FROM_MAP} {@code ForwardMapper} constant. No {@code SerializedLambda}, no reflection — the
+ * generated code is GraalVM native-image clean.
+ */
+@SupportedAnnotationTypes("io.github.eschizoid.telescope.annotations.FromMap")
+@SupportedSourceVersion(SourceVersion.RELEASE_17)
+public final class FromMapProcessor extends AbstractTelescopeProcessor {
+
+  private static final String ANNOTATION = "io.github.eschizoid.telescope.annotations.FromMap";
+
+  /** Public no-arg constructor for {@code ServiceLoader} discovery by the Java compiler. */
+  public FromMapProcessor() {
+    super();
+  }
+
+  @Override
+  public boolean process(final Set<? extends TypeElement> annotations, final RoundEnvironment roundEnv) {
+    final var anno = processingEnv.getElementUtils().getTypeElement(ANNOTATION);
+    if (anno == null) return false;
+    for (final var element : roundEnv.getElementsAnnotatedWith(anno)) {
+      if (element.getKind() == ElementKind.RECORD) {
+        generateForRecord((TypeElement) element);
+      } else if (element.getKind() == ElementKind.CLASS) {
+        generateForBean((TypeElement) element);
+      } else {
+        error(element, "@FromMap is only supported on records and classes");
+      }
+    }
+    return true;
+  }
+
+  private void generateForRecord(final TypeElement record) {
+    final var name = record.getSimpleName().toString();
+    final var components = record.getRecordComponents();
+    final var coercions = components
+      .stream()
+      .map(c -> resolveCoercion(c.asType()))
+      .toList();
+    final var unchecked = coercions.stream().anyMatch(Coercion::unchecked);
+
+    emitConverter(record, unchecked, out -> {
+      final var args = IntStream.range(0, components.size())
+        .mapToObj(i -> coercions.get(i).emit("map.get(\"" + components.get(i).getSimpleName() + "\")", 0))
+        .collect(Collectors.joining(", "));
+      out.println("    return new " + name + "(" + args + ");");
+    });
+  }
+
+  private void generateForBean(final TypeElement pojo) {
+    final var name = pojo.getSimpleName().toString();
+    final var props = beanProperties(pojo);
+    if (props.isEmpty()) {
+      error(pojo, "@FromMap: " + pojo.getQualifiedName() + " has no readable properties (getX()/isX())");
+      return;
+    }
+    final var builder = staticBuilderMethod(pojo);
+    final var builderType =
+      builder != null && builder.getReturnType().getKind() == TypeKind.DECLARED
+        ? (TypeElement) ((DeclaredType) builder.getReturnType()).asElement()
+        : null;
+    final var useBuilder = builderType != null && hasBuildMethod(builderType);
+    if (!useBuilder && !hasPublicNoArgConstructor(pojo)) {
+      error(
+        pojo,
+        "@FromMap: " +
+          pojo.getQualifiedName() +
+          " needs a static builder() or a public no-arg constructor with setters (field injection isn't " +
+          "available to generated code — use Telescope.ofBean for the runtime path)"
+      );
+      return;
+    }
+    final var setters = new String[props.size()];
+    for (var i = 0; i < props.size(); i++) {
+      setters[i] = useBuilder ? builderSetter(builderType, props.get(i).name()) : setterName(pojo, props.get(i).name());
+      if (setters[i] == null) {
+        error(
+          pojo,
+          "@FromMap: no " +
+            (useBuilder ? "builder method" : "setter") +
+            " for property '" +
+            props.get(i).name() +
+            "' on " +
+            pojo.getQualifiedName()
+        );
+        return;
+      }
+    }
+    final var coercions = props
+      .stream()
+      .map(p -> resolveCoercion(p.type()))
+      .toList();
+    final var unchecked = coercions.stream().anyMatch(Coercion::unchecked);
+
+    emitConverter(pojo, unchecked, out -> {
+      if (useBuilder) {
+        out.print("    return " + name + ".builder()");
+        for (var i = 0; i < props.size(); i++) {
+          out.print("." + setters[i] + "(" + valueOf(coercions.get(i), props.get(i).name()) + ")");
+        }
+        out.println(".build();");
+      } else {
+        out.println("    final var bean = new " + name + "();");
+        for (var i = 0; i < props.size(); i++) {
+          out.println("    bean." + setters[i] + "(" + valueOf(coercions.get(i), props.get(i).name()) + ");");
+        }
+        out.println("    return bean;");
+      }
+    });
+  }
+
+  /** The coerced value expression for a property whose map key is its name. */
+  private static String valueOf(final Coercion coercion, final String key) {
+    return coercion.emit("map.get(\"" + key + "\")", 0);
+  }
+
+  /**
+   * Emit the shared {@code <X>FromMap} class shell — the fromMap method (body supplied) and
+   * FROM_MAP constant.
+   */
+  private void emitConverter(final TypeElement type, final boolean unchecked, final Consumer<PrintWriter> body) {
+    final var pkg = processingEnv.getElementUtils().getPackageOf(type).getQualifiedName().toString();
+    final var name = type.getSimpleName().toString();
+    final var holder = name + "FromMap";
+    final var qualified = pkg.isEmpty() ? holder : pkg + "." + holder;
+
+    final Set<String> imports = new LinkedHashSet<>();
+    imports.add("java.util.Map");
+    imports.add("io.github.eschizoid.telescope.conversion.ForwardMapper");
+
+    final var javadoc = "Generated by telescope-codegen for @FromMap " + name + ".";
+    writeClass(qualified, holder, imports, javadoc, type, out -> {
+      if (unchecked) out.println("  @SuppressWarnings(\"unchecked\")");
+      out.println("  public static " + name + " fromMap(final Map<String, Object> map) {");
+      out.println("    if (map == null) return null;");
+      body.accept(out);
+      out.println("  }");
+      out.println();
+      // Map.class is a raw Class<Map>; create wants Class<Map<String, Object>> — same unchecked
+      // bridge the runtime Telescope.fromMap makes.
+      out.println("  @SuppressWarnings(\"unchecked\")");
+      out.println("  public static final ForwardMapper<Map<String, Object>, " + name + "> FROM_MAP =");
+      out.println("      ForwardMapper.create(" + holder + "::fromMap, Map.class, " + name + ".class);");
+    });
+  }
+
+  /** Map a target field type to the expression strategy that coerces a raw map value into it. */
+  private Coercion resolveCoercion(final TypeMirror type) {
+    return switch (type.getKind()) {
+      case INT -> new Coercion.Parse("intValue", "Integer.parseInt", "0");
+      case LONG -> new Coercion.Parse("longValue", "Long.parseLong", "0L");
+      case DOUBLE -> new Coercion.Parse("doubleValue", "Double.parseDouble", "0.0d");
+      case DECLARED -> declaredCoercion((DeclaredType) type);
+      default -> new Coercion.Cast(boxedType(type));
+    };
+  }
+
+  /**
+   * Coercion for a declared (reference) type: enum, nested @FromMap, List/Set/Map container, else a
+   * cast.
+   */
+  private Coercion declaredCoercion(final DeclaredType type) {
+    final var element = type.asElement();
+    if (element.getKind() == ElementKind.ENUM) return new Coercion.EnumOf(boxedType(type));
+    if (hasAnnotation(element, ANNOTATION)) return new Coercion.Nested(boxedType(type) + "FromMap");
+    final var listElement = singleArgOf(type, "java.util.List");
+    if (listElement != null) return new Coercion.Listed(resolveCoercion(listElement));
+    final var setElement = singleArgOf(type, "java.util.Set");
+    if (setElement != null) return new Coercion.Setted(resolveCoercion(setElement));
+    if (isErasure(type, "java.util.Map") && type.getTypeArguments().size() == 2) {
+      final var args = type.getTypeArguments();
+      return new Coercion.MapValues(boxedType(args.get(0)), resolveCoercion(args.get(1)));
+    }
+    return new Coercion.Cast(boxedType(type));
+  }
+
+  /**
+   * The sole type argument of {@code type} when its erasure is exactly {@code rawFqn}, else null.
+   */
+  private TypeMirror singleArgOf(final DeclaredType type, final String rawFqn) {
+    if (!isErasure(type, rawFqn)) return null;
+    final var args = type.getTypeArguments();
+    return args.size() == 1 ? args.get(0) : null;
+  }
+
+  /** Whether {@code type}'s erasure is exactly the raw type named {@code rawFqn}. */
+  private boolean isErasure(final DeclaredType type, final String rawFqn) {
+    final var types = processingEnv.getTypeUtils();
+    final var raw = processingEnv.getElementUtils().getTypeElement(rawFqn);
+    return raw != null && types.isSameType(types.erasure(type), types.erasure(raw.asType()));
+  }
+}

--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/FromMapProcessor.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/FromMapProcessor.java
@@ -2,6 +2,7 @@ package io.github.eschizoid.telescope.codegen;
 
 import java.io.PrintWriter;
 import java.util.LinkedHashSet;
+import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
@@ -30,6 +31,33 @@ public final class FromMapProcessor extends AbstractTelescopeProcessor {
 
   private static final String ANNOTATION = "io.github.eschizoid.telescope.annotations.FromMap";
 
+  // Reference types a raw map plausibly carries as themselves, so a direct cast is justified.
+  private static final Set<String> CAST_AS_IS = Set.of(
+    "java.lang.String",
+    "java.lang.Object",
+    "java.lang.CharSequence"
+  );
+
+  // JDK value types that arrive as a String in an untyped map, with the factory that rebuilds them.
+  // Generated form: `raw instanceof T t ? t : raw == null ? null : <factory>(String.valueOf(raw))`.
+  private static final Map<String, String> JDK_STRING_FACTORIES = Map.ofEntries(
+    Map.entry("java.time.Instant", "java.time.Instant.parse"),
+    Map.entry("java.time.LocalDate", "java.time.LocalDate.parse"),
+    Map.entry("java.time.LocalDateTime", "java.time.LocalDateTime.parse"),
+    Map.entry("java.time.LocalTime", "java.time.LocalTime.parse"),
+    Map.entry("java.time.OffsetDateTime", "java.time.OffsetDateTime.parse"),
+    Map.entry("java.time.ZonedDateTime", "java.time.ZonedDateTime.parse"),
+    Map.entry("java.time.Duration", "java.time.Duration.parse"),
+    Map.entry("java.time.Period", "java.time.Period.parse"),
+    Map.entry("java.util.UUID", "java.util.UUID.fromString"),
+    Map.entry("java.math.BigDecimal", "new java.math.BigDecimal"),
+    Map.entry("java.math.BigInteger", "new java.math.BigInteger"),
+    Map.entry("java.net.URI", "java.net.URI.create"),
+    Map.entry("java.util.Currency", "java.util.Currency.getInstance"),
+    Map.entry("java.util.Locale", "java.util.Locale.forLanguageTag"),
+    Map.entry("java.util.regex.Pattern", "java.util.regex.Pattern.compile")
+  );
+
   // @FromMap targets carrying a Lombok trigger are deferred to processingOver(): in round 1 Lombok
   // hasn't synthesized the getters/setters yet, so beanProperties() would see "no readable
   // properties". By the final round Lombok is done patching. Cleared after the drain so a reused
@@ -46,11 +74,8 @@ public final class FromMapProcessor extends AbstractTelescopeProcessor {
     final var anno = processingEnv.getElementUtils().getTypeElement(ANNOTATION);
     if (anno == null) return false;
     for (final var element : roundEnv.getElementsAnnotatedWith(anno)) {
-      if (!roundEnv.processingOver() && carriesLombokTrigger(element)) {
-        pending.add((TypeElement) element);
-      } else {
-        generate(element);
-      }
+      if (!roundEnv.processingOver() && carriesLombokTrigger(element)) pending.add((TypeElement) element);
+      else generate(element);
     }
     if (roundEnv.processingOver()) {
       pending.forEach(this::generate);
@@ -60,13 +85,9 @@ public final class FromMapProcessor extends AbstractTelescopeProcessor {
   }
 
   private void generate(final Element element) {
-    if (element.getKind() == ElementKind.RECORD) {
-      generateForRecord((TypeElement) element);
-    } else if (element.getKind() == ElementKind.CLASS) {
-      generateForBean((TypeElement) element);
-    } else {
-      error(element, "@FromMap is only supported on records and classes");
-    }
+    if (element.getKind() == ElementKind.RECORD) generateForRecord((TypeElement) element);
+    else if (element.getKind() == ElementKind.CLASS) generateForBean((TypeElement) element);
+    else error(element, "@FromMap is only supported on records and classes");
   }
 
   private void generateForRecord(final TypeElement record) {
@@ -264,8 +285,23 @@ public final class FromMapProcessor extends AbstractTelescopeProcessor {
         fqn + " is a collection subtype — declare the field as List/Set/Map/Optional so @FromMap can build it"
       );
     }
-    // JDK scalar reference types (String, Object, Instant, UUID, …) — cast and trust the map.
-    if (fqn.startsWith("java.") || fqn.startsWith("javax.")) return new Coercion.Cast(fqn);
+    // Reference types a map plausibly holds as-is — cast and trust the map.
+    if (CAST_AS_IS.contains(fqn)) return new Coercion.Cast(fqn);
+    // A JDK value type with a known String factory (Instant, UUID, BigDecimal, LocalDate, …) —
+    // build
+    // it from the String form it arrives in.
+    final var factory = JDK_STRING_FACTORIES.get(fqn);
+    if (factory != null) return new Coercion.StringFactory(fqn, factory);
+    // An unrecognized JDK type can't be built from a Map value — refuse rather than emit a cast
+    // that
+    // would CCE at runtime and defeat the "if it compiles, it runs" guard.
+    if (fqn.startsWith("java.") || fqn.startsWith("javax.")) {
+      return new Coercion.Unsupported(
+        fqn +
+          " can't be built from a Map value by @FromMap — use the runtime Telescope.fromMap with a " +
+          "custom extract(key, accessor, converter)"
+      );
+    }
     // A user type that isn't @FromMap would arrive as a nested Map and CCE — require the
     // annotation.
     return new Coercion.Unsupported(

--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/FromMapProcessor.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/FromMapProcessor.java
@@ -211,9 +211,11 @@ public final class FromMapProcessor extends AbstractTelescopeProcessor {
     if (listElement != null) return new Coercion.Listed(resolveCoercion(listElement));
     final var setElement = singleArgOf(type, "java.util.Set");
     if (setElement != null) return new Coercion.Setted(resolveCoercion(setElement));
+    final var optElement = singleArgOf(type, "java.util.Optional");
+    if (optElement != null) return new Coercion.OptionalOf(resolveCoercion(optElement));
     if (isErasure(type, "java.util.Map") && type.getTypeArguments().size() == 2) {
       final var args = type.getTypeArguments();
-      return new Coercion.MapValues(boxedType(args.get(0)), resolveCoercion(args.get(1)));
+      return new Coercion.MapValues(resolveCoercion(args.get(0)), resolveCoercion(args.get(1)));
     }
     return new Coercion.Cast(boxedType(type));
   }

--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/FromMapProcessor.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/FromMapProcessor.java
@@ -57,6 +57,15 @@ public final class FromMapProcessor extends AbstractTelescopeProcessor {
       .stream()
       .map(c -> resolveCoercion(c.asType()))
       .toList();
+    var coercible = true;
+    for (var i = 0; i < components.size(); i++) {
+      final var reason = coercions.get(i).firstUnsupported();
+      if (reason.isPresent()) {
+        error(components.get(i), "@FromMap: " + reason.get());
+        coercible = false;
+      }
+    }
+    if (!coercible) return;
     final var unchecked = coercions.stream().anyMatch(Coercion::unchecked);
 
     emitConverter(record, unchecked, out -> {
@@ -110,6 +119,15 @@ public final class FromMapProcessor extends AbstractTelescopeProcessor {
       .stream()
       .map(p -> resolveCoercion(p.type()))
       .toList();
+    var coercible = true;
+    for (var i = 0; i < props.size(); i++) {
+      final var reason = coercions.get(i).firstUnsupported();
+      if (reason.isPresent()) {
+        error(pojo, "@FromMap: property '" + props.get(i).name() + "' — " + reason.get());
+        coercible = false;
+      }
+    }
+    if (!coercible) return;
     final var unchecked = coercions.stream().anyMatch(Coercion::unchecked);
 
     emitConverter(pojo, unchecked, out -> {
@@ -176,7 +194,9 @@ public final class FromMapProcessor extends AbstractTelescopeProcessor {
       case BOOLEAN -> new Coercion.BoolParse("false");
       case CHAR -> new Coercion.CharParse("'\\0'");
       case DECLARED -> declaredCoercion((DeclaredType) type);
-      default -> new Coercion.Cast(boxedType(type));
+      default -> new Coercion.Unsupported(
+        type + " can't be coerced from a Map (type variable / array / unsupported kind)"
+      );
     };
   }
 
@@ -217,7 +237,28 @@ public final class FromMapProcessor extends AbstractTelescopeProcessor {
       final var args = type.getTypeArguments();
       return new Coercion.MapValues(resolveCoercion(args.get(0)), resolveCoercion(args.get(1)));
     }
-    return new Coercion.Cast(boxedType(type));
+    final var fqn = boxedType(type);
+    // A collection/map SUBTYPE (ArrayList, TreeSet, HashMap, …) — codegen can't allocate the
+    // concrete target; require the interface so the lift is well-defined.
+    if (assignableToRaw(type, "java.util.Collection") || assignableToRaw(type, "java.util.Map")) {
+      return new Coercion.Unsupported(
+        fqn + " is a collection subtype — declare the field as List/Set/Map/Optional so @FromMap can build it"
+      );
+    }
+    // JDK scalar reference types (String, Object, Instant, UUID, …) — cast and trust the map.
+    if (fqn.startsWith("java.") || fqn.startsWith("javax.")) return new Coercion.Cast(fqn);
+    // A user type that isn't @FromMap would arrive as a nested Map and CCE — require the
+    // annotation.
+    return new Coercion.Unsupported(
+      fqn + " is a nested object but isn't @FromMap — annotate " + fqn + " with @FromMap"
+    );
+  }
+
+  /** Whether {@code type} is assignable to the raw type named {@code rawFqn}. */
+  private boolean assignableToRaw(final DeclaredType type, final String rawFqn) {
+    final var types = processingEnv.getTypeUtils();
+    final var raw = processingEnv.getElementUtils().getTypeElement(rawFqn);
+    return raw != null && types.isAssignable(types.erasure(type), types.erasure(raw.asType()));
   }
 
   /**

--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/FromMapProcessor.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/FromMapProcessor.java
@@ -170,17 +170,41 @@ public final class FromMapProcessor extends AbstractTelescopeProcessor {
       case INT -> new Coercion.Parse("intValue", "Integer.parseInt", "0");
       case LONG -> new Coercion.Parse("longValue", "Long.parseLong", "0L");
       case DOUBLE -> new Coercion.Parse("doubleValue", "Double.parseDouble", "0.0d");
+      case FLOAT -> new Coercion.Parse("floatValue", "Float.parseFloat", "0.0f");
+      case SHORT -> new Coercion.Parse("shortValue", "Short.parseShort", "(short) 0");
+      case BYTE -> new Coercion.Parse("byteValue", "Byte.parseByte", "(byte) 0");
+      case BOOLEAN -> new Coercion.BoolParse("false");
+      case CHAR -> new Coercion.CharParse("'\\0'");
       case DECLARED -> declaredCoercion((DeclaredType) type);
       default -> new Coercion.Cast(boxedType(type));
     };
   }
 
   /**
-   * Coercion for a declared (reference) type: enum, nested @FromMap, List/Set/Map container, else a
-   * cast.
+   * Coercion for a boxed wrapper field (parse like its primitive, but null stays null), or null.
+   */
+  private Coercion boxedWrapperCoercion(final String fqn) {
+    return switch (fqn) {
+      case "java.lang.Integer" -> new Coercion.Parse("intValue", "Integer.parseInt", "null");
+      case "java.lang.Long" -> new Coercion.Parse("longValue", "Long.parseLong", "null");
+      case "java.lang.Double" -> new Coercion.Parse("doubleValue", "Double.parseDouble", "null");
+      case "java.lang.Float" -> new Coercion.Parse("floatValue", "Float.parseFloat", "null");
+      case "java.lang.Short" -> new Coercion.Parse("shortValue", "Short.parseShort", "null");
+      case "java.lang.Byte" -> new Coercion.Parse("byteValue", "Byte.parseByte", "null");
+      case "java.lang.Boolean" -> new Coercion.BoolParse("null");
+      case "java.lang.Character" -> new Coercion.CharParse("null");
+      default -> null;
+    };
+  }
+
+  /**
+   * Coercion for a declared (reference) type: boxed wrapper, enum, nested @FromMap, List/Set/Map
+   * container, else a cast.
    */
   private Coercion declaredCoercion(final DeclaredType type) {
     final var element = type.asElement();
+    final var boxed = boxedWrapperCoercion(boxedType(type));
+    if (boxed != null) return boxed;
     if (element.getKind() == ElementKind.ENUM) return new Coercion.EnumOf(boxedType(type));
     if (hasAnnotation(element, ANNOTATION)) return new Coercion.Nested(boxedType(type) + "FromMap");
     final var listElement = singleArgOf(type, "java.util.List");

--- a/codegen/src/main/java/module-info.java
+++ b/codegen/src/main/java/module-info.java
@@ -19,5 +19,6 @@ module io.github.eschizoid.telescope.codegen {
     with
       io.github.eschizoid.telescope.codegen.FocusProcessor,
       io.github.eschizoid.telescope.codegen.BeanFocusProcessor,
-      io.github.eschizoid.telescope.codegen.BridgeProcessor;
+      io.github.eschizoid.telescope.codegen.BridgeProcessor,
+      io.github.eschizoid.telescope.codegen.FromMapProcessor;
 }

--- a/codegen/src/main/resources/META-INF/services/javax.annotation.processing.Processor
+++ b/codegen/src/main/resources/META-INF/services/javax.annotation.processing.Processor
@@ -1,3 +1,4 @@
 io.github.eschizoid.telescope.codegen.FocusProcessor
 io.github.eschizoid.telescope.codegen.BridgeProcessor
 io.github.eschizoid.telescope.codegen.BeanFocusProcessor
+io.github.eschizoid.telescope.codegen.FromMapProcessor

--- a/codegen/src/test/java/io/github/eschizoid/telescope/codegen/FromMapProcessorTest.java
+++ b/codegen/src/test/java/io/github/eschizoid/telescope/codegen/FromMapProcessorTest.java
@@ -222,6 +222,24 @@ class FromMapProcessorTest {
     }
 
     @Test
+    @DisplayName("an unrecognized JDK type with no String factory is rejected with guidance")
+    void unknownJdkTypeRejected() {
+      final var compilation = compile(
+        source(
+          "demo.Doc",
+          """
+          package demo;
+          import io.github.eschizoid.telescope.annotations.FromMap;
+          @FromMap
+          public record Doc(java.io.File path) {}
+          """
+        )
+      );
+      assertFalse(compilation.success(), "a JDK type with no String factory must be rejected, not cast");
+      assertTrue(compilation.hasError("can't be built from a Map value"), () -> compilation.errorMessages().toString());
+    }
+
+    @Test
     @DisplayName("a collection subtype field (ArrayList<X>) is rejected — declare the interface")
     void collectionSubtypeRejected() {
       final var compilation = compile(

--- a/codegen/src/test/java/io/github/eschizoid/telescope/codegen/FromMapProcessorTest.java
+++ b/codegen/src/test/java/io/github/eschizoid/telescope/codegen/FromMapProcessorTest.java
@@ -1,0 +1,234 @@
+package io.github.eschizoid.telescope.codegen;
+
+import static io.github.eschizoid.telescope.codegen.ProcessorHarness.source;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.github.eschizoid.telescope.codegen.ProcessorHarness.Compilation;
+import javax.tools.JavaFileObject;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Drives {@link FromMapProcessor} through the shared {@link ProcessorHarness}. Asserts on the shape
+ * of the generated reflection-free {@code <X>FromMap} converter: a {@code fromMap(Map)} static
+ * method that rebuilds the target directly and a {@code FROM_MAP} ForwardMapper constant.
+ */
+class FromMapProcessorTest {
+
+  private static Compilation compile(final JavaFileObject... sources) {
+    return ProcessorHarness.compile(new FromMapProcessor(), sources);
+  }
+
+  @Nested
+  @DisplayName("Happy path — record target")
+  class RecordTarget {
+
+    @Test
+    @DisplayName("generates <X>FromMap with a fromMap(Map) method and a FROM_MAP ForwardMapper constant")
+    void generatesConverterClass() {
+      final var compilation = compile(
+        source(
+          "demo.User",
+          """
+          package demo;
+          import io.github.eschizoid.telescope.annotations.FromMap;
+          @FromMap
+          public record User(String name, int age) {}
+          """
+        )
+      );
+
+      assertTrue(compilation.success(), () -> "compilation failed: " + compilation.errorMessages());
+      final var generated = compilation.generated().get("demo.UserFromMap");
+      assertNotNull(generated, () -> "UserFromMap not generated; saw " + compilation.generated().keySet());
+
+      assertTrue(generated.contains("public final class UserFromMap"), generated);
+      assertTrue(generated.contains("public static User fromMap(final Map<String, Object> map)"), generated);
+      assertTrue(
+        generated.contains("public static final ForwardMapper<Map<String, Object>, User> FROM_MAP"),
+        generated
+      );
+      // Direct canonical-constructor rebuild — no reflection.
+      assertTrue(generated.contains("new User("), generated);
+      // String field: read the key by name.
+      assertTrue(generated.contains("map.get(\"name\")"), generated);
+    }
+
+    @Test
+    @DisplayName("enum field coerces a String name via Enum.valueOf (taking an existing enum value directly)")
+    void enumFieldCoercesViaValueOf() {
+      final var compilation = compile(
+        source(
+          "demo.Account",
+          """
+          package demo;
+          import io.github.eschizoid.telescope.annotations.FromMap;
+          @FromMap
+          public record Account(demo.Role role) {}
+          """
+        ),
+        source("demo.Role", "package demo; public enum Role { ADMIN, USER }")
+      );
+
+      assertTrue(compilation.success(), () -> "compilation failed: " + compilation.errorMessages());
+      final var generated = compilation.generated().get("demo.AccountFromMap");
+      assertNotNull(generated, () -> "AccountFromMap not generated; saw " + compilation.generated().keySet());
+      assertTrue(generated.contains("demo.Role.valueOf(String.valueOf(map.get(\"role\")))"), generated);
+      assertTrue(generated.contains("instanceof demo.Role"), generated);
+    }
+
+    @Test
+    @DisplayName("nested @FromMap field recurses through the nested type's generated converter")
+    void nestedFromMapFieldRecurses() {
+      final var compilation = compile(
+        source(
+          "demo.Profile",
+          """
+          package demo;
+          import io.github.eschizoid.telescope.annotations.FromMap;
+          @FromMap
+          public record Profile(String handle, demo.Address address) {}
+          """
+        ),
+        source(
+          "demo.Address",
+          """
+          package demo;
+          import io.github.eschizoid.telescope.annotations.FromMap;
+          @FromMap
+          public record Address(String city) {}
+          """
+        )
+      );
+
+      assertTrue(compilation.success(), () -> "compilation failed: " + compilation.errorMessages());
+      final var generated = compilation.generated().get("demo.ProfileFromMap");
+      assertNotNull(generated, () -> "ProfileFromMap not generated; saw " + compilation.generated().keySet());
+      // The nested input object recurses through the nested type's own generated converter.
+      assertTrue(generated.contains("demo.AddressFromMap.fromMap("), generated);
+    }
+
+    @Test
+    @DisplayName("List<@FromMap> field element-maps each entry through the element's generated converter")
+    void listOfNestedElementMaps() {
+      final var compilation = compile(
+        source(
+          "demo.Team",
+          """
+          package demo;
+          import io.github.eschizoid.telescope.annotations.FromMap;
+          import java.util.List;
+          @FromMap
+          public record Team(List<demo.Member> members) {}
+          """
+        ),
+        source(
+          "demo.Member",
+          """
+          package demo;
+          import io.github.eschizoid.telescope.annotations.FromMap;
+          @FromMap
+          public record Member(String name) {}
+          """
+        )
+      );
+
+      assertTrue(compilation.success(), () -> "compilation failed: " + compilation.errorMessages());
+      final var generated = compilation.generated().get("demo.TeamFromMap");
+      assertNotNull(generated, () -> "TeamFromMap not generated; saw " + compilation.generated().keySet());
+      // Each element streamed through the element type's own generated converter.
+      assertTrue(generated.contains(".stream()"), generated);
+      assertTrue(generated.contains("demo.MemberFromMap.fromMap("), generated);
+    }
+
+    @Test
+    @DisplayName("Set<E> field collects elements into a fresh set")
+    void setFieldCollectsToSet() {
+      final var compilation = compile(
+        source(
+          "demo.Labels",
+          """
+          package demo;
+          import io.github.eschizoid.telescope.annotations.FromMap;
+          import java.util.Set;
+          @FromMap
+          public record Labels(Set<String> tags) {}
+          """
+        )
+      );
+      assertTrue(compilation.success(), () -> "compilation failed: " + compilation.errorMessages());
+      final var generated = compilation.generated().get("demo.LabelsFromMap");
+      assertNotNull(generated, () -> "LabelsFromMap not generated; saw " + compilation.generated().keySet());
+      assertTrue(generated.contains("instanceof java.util.Set<?>"), generated);
+      assertTrue(generated.contains("toSet()"), generated);
+    }
+
+    @Test
+    @DisplayName("Map<K, @FromMap> field coerces values through their converter, preserving keys")
+    void mapFieldCoercesValues() {
+      final var compilation = compile(
+        source(
+          "demo.Registry",
+          """
+          package demo;
+          import io.github.eschizoid.telescope.annotations.FromMap;
+          import java.util.Map;
+          @FromMap
+          public record Registry(Map<String, demo.Address> byCity) {}
+          """
+        ),
+        source(
+          "demo.Address",
+          """
+          package demo;
+          import io.github.eschizoid.telescope.annotations.FromMap;
+          @FromMap
+          public record Address(String city) {}
+          """
+        )
+      );
+      assertTrue(compilation.success(), () -> "compilation failed: " + compilation.errorMessages());
+      final var generated = compilation.generated().get("demo.RegistryFromMap");
+      assertNotNull(generated, () -> "RegistryFromMap not generated; saw " + compilation.generated().keySet());
+      assertTrue(generated.contains("entrySet()"), generated);
+      assertTrue(generated.contains("demo.AddressFromMap.fromMap("), generated);
+    }
+  }
+
+  @Nested
+  @DisplayName("Bean target")
+  class BeanTarget {
+
+    @Test
+    @DisplayName("POJO with no-arg constructor + setters rebuilds via new + setX")
+    void pojoViaSetters() {
+      final var compilation = compile(
+        source(
+          "demo.UserBean",
+          """
+          package demo;
+          import io.github.eschizoid.telescope.annotations.FromMap;
+          @FromMap
+          public class UserBean {
+            private String name;
+            private int age;
+            public String getName() { return name; }
+            public void setName(final String name) { this.name = name; }
+            public int getAge() { return age; }
+            public void setAge(final int age) { this.age = age; }
+          }
+          """
+        )
+      );
+
+      assertTrue(compilation.success(), () -> "compilation failed: " + compilation.errorMessages());
+      final var generated = compilation.generated().get("demo.UserBeanFromMap");
+      assertNotNull(generated, () -> "UserBeanFromMap not generated; saw " + compilation.generated().keySet());
+      assertTrue(generated.contains("new UserBean()"), generated);
+      assertTrue(generated.contains(".setName("), generated);
+      assertTrue(generated.contains(".setAge("), generated);
+    }
+  }
+}

--- a/codegen/src/test/java/io/github/eschizoid/telescope/codegen/FromMapProcessorTest.java
+++ b/codegen/src/test/java/io/github/eschizoid/telescope/codegen/FromMapProcessorTest.java
@@ -76,8 +76,8 @@ class FromMapProcessorTest {
       assertTrue(compilation.success(), () -> "compilation failed: " + compilation.errorMessages());
       final var generated = compilation.generated().get("demo.AccountFromMap");
       assertNotNull(generated, () -> "AccountFromMap not generated; saw " + compilation.generated().keySet());
-      assertTrue(generated.contains("demo.Role.valueOf(String.valueOf(map.get(\"role\")))"), generated);
-      assertTrue(generated.contains("instanceof demo.Role"), generated);
+      assertTrue(generated.contains("Role.valueOf(String.valueOf(map.get(\"role\")))"), generated);
+      assertTrue(generated.contains("instanceof Role"), generated);
     }
 
     @Test
@@ -108,7 +108,7 @@ class FromMapProcessorTest {
       final var generated = compilation.generated().get("demo.ProfileFromMap");
       assertNotNull(generated, () -> "ProfileFromMap not generated; saw " + compilation.generated().keySet());
       // The nested input object recurses through the nested type's own generated converter.
-      assertTrue(generated.contains("demo.AddressFromMap.fromMap("), generated);
+      assertTrue(generated.contains("AddressFromMap.fromMap("), generated);
     }
 
     @Test
@@ -141,7 +141,7 @@ class FromMapProcessorTest {
       assertNotNull(generated, () -> "TeamFromMap not generated; saw " + compilation.generated().keySet());
       // Each element streamed through the element type's own generated converter.
       assertTrue(generated.contains(".stream()"), generated);
-      assertTrue(generated.contains("demo.MemberFromMap.fromMap("), generated);
+      assertTrue(generated.contains("MemberFromMap.fromMap("), generated);
     }
 
     @Test
@@ -162,7 +162,7 @@ class FromMapProcessorTest {
       assertTrue(compilation.success(), () -> "compilation failed: " + compilation.errorMessages());
       final var generated = compilation.generated().get("demo.LabelsFromMap");
       assertNotNull(generated, () -> "LabelsFromMap not generated; saw " + compilation.generated().keySet());
-      assertTrue(generated.contains("instanceof java.util.Set<?>"), generated);
+      assertTrue(generated.contains("instanceof Set<?>"), generated);
       assertTrue(generated.contains("toSet()"), generated);
     }
 
@@ -194,7 +194,7 @@ class FromMapProcessorTest {
       final var generated = compilation.generated().get("demo.RegistryFromMap");
       assertNotNull(generated, () -> "RegistryFromMap not generated; saw " + compilation.generated().keySet());
       assertTrue(generated.contains("entrySet()"), generated);
-      assertTrue(generated.contains("demo.AddressFromMap.fromMap("), generated);
+      assertTrue(generated.contains("AddressFromMap.fromMap("), generated);
     }
   }
 

--- a/codegen/src/test/java/io/github/eschizoid/telescope/codegen/FromMapProcessorTest.java
+++ b/codegen/src/test/java/io/github/eschizoid/telescope/codegen/FromMapProcessorTest.java
@@ -1,6 +1,7 @@
 package io.github.eschizoid.telescope.codegen;
 
 import static io.github.eschizoid.telescope.codegen.ProcessorHarness.source;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -194,6 +195,48 @@ class FromMapProcessorTest {
       assertNotNull(generated, () -> "RegistryFromMap not generated; saw " + compilation.generated().keySet());
       assertTrue(generated.contains("entrySet()"), generated);
       assertTrue(generated.contains("demo.AddressFromMap.fromMap("), generated);
+    }
+  }
+
+  @Nested
+  @DisplayName("Rejections — fail at compile, not at runtime")
+  class Rejections {
+
+    @Test
+    @DisplayName("a nested object field whose type isn't @FromMap is a compile error, not a runtime CCE")
+    void nonFromMapNestedFieldRejected() {
+      final var compilation = compile(
+        source(
+          "demo.Order",
+          """
+          package demo;
+          import io.github.eschizoid.telescope.annotations.FromMap;
+          @FromMap
+          public record Order(demo.Customer customer) {}
+          """
+        ),
+        source("demo.Customer", "package demo; public record Customer(String name) {}")
+      );
+      assertFalse(compilation.success(), "a non-@FromMap nested object must be rejected");
+      assertTrue(compilation.hasError("isn't @FromMap"), () -> compilation.errorMessages().toString());
+    }
+
+    @Test
+    @DisplayName("a collection subtype field (ArrayList<X>) is rejected — declare the interface")
+    void collectionSubtypeRejected() {
+      final var compilation = compile(
+        source(
+          "demo.Holder",
+          """
+          package demo;
+          import io.github.eschizoid.telescope.annotations.FromMap;
+          @FromMap
+          public record Holder(java.util.ArrayList<String> items) {}
+          """
+        )
+      );
+      assertFalse(compilation.success(), "a collection subtype must be rejected");
+      assertTrue(compilation.hasError("collection subtype"), () -> compilation.errorMessages().toString());
     }
   }
 

--- a/core/src/main/java/io/github/eschizoid/telescope/annotations/FromMap.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/annotations/FromMap.java
@@ -20,9 +20,13 @@ import java.lang.annotation.Target;
  * native-image clean by construction.
  *
  * <p>The map key for each field is the field name, and the value is coerced to the field's type by
- * the standard rules: {@code String} as-is, {@code String}/{@code Number} to a primitive, a {@code
- * String} enum name to the enum, a nested {@code Map} to a nested {@code @FromMap} type, and {@code
- * List}/{@code Set}/{@code Map} element-mapped. An absent key takes the field's JLS default.
+ * the standard rules: {@code String} as-is, {@code String}/{@code Number} to a primitive or
+ * wrapper, a {@code String} enum name to the enum, a {@code String}-carried JDK value type ({@code
+ * Instant}, {@code UUID}, {@code BigDecimal}, {@code LocalDate}, …) via its String factory, a
+ * nested {@code Map} to a nested {@code @FromMap} type, and {@code List}/{@code Set}/{@code
+ * Map}/{@code Optional} element-mapped. An absent key takes the field's JLS default. A field type
+ * that can't be coerced (a non-{@code @FromMap} nested object, a collection subtype) is a compile
+ * error, not a runtime failure.
  *
  * <pre>{@code
  * @FromMap

--- a/core/src/main/java/io/github/eschizoid/telescope/annotations/FromMap.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/annotations/FromMap.java
@@ -28,6 +28,11 @@ import java.lang.annotation.Target;
  * that can't be coerced (a non-{@code @FromMap} nested object, a collection subtype) is a compile
  * error, not a runtime failure.
  *
+ * <p>Coercion is lenient, matching the runtime {@code fromMap}: a wrong-shaped value for a
+ * container field yields an empty collection, only {@code "true"} is truthy for a boolean, a
+ * multi-character String for a {@code char} takes the first character, and a non-numeric String for
+ * a numeric field throws {@code NumberFormatException}.
+ *
  * <pre>{@code
  * @FromMap
  * record User(String name, int age, Role role, Address address) {}

--- a/core/src/main/java/io/github/eschizoid/telescope/annotations/FromMap.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/annotations/FromMap.java
@@ -1,0 +1,43 @@
+package io.github.eschizoid.telescope.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marks a record or JavaBeans-style POJO for reflection-free {@code Map<String, Object>} ingestion.
+ * The {@code telescope-codegen} processor emits a sibling {@code <X>FromMap} class with a {@code
+ * public static X fromMap(Map<String, Object>)} method and a {@code public static final
+ * ForwardMapper<Map<String, Object>, X> FROM_MAP} constant — a direct canonical-constructor (or
+ * builder/setter) rebuild with the map values coerced inline.
+ *
+ * <p>This is the generated-code sibling of the runtime {@link
+ * io.github.eschizoid.telescope.Telescope#fromMap(Class,
+ * io.github.eschizoid.telescope.mapping.MapExtractStep...)}. Where the runtime form recovers field
+ * names from method references via {@code SerializedLambda} (and so can't run in a GraalVM native
+ * image), the generated form embeds the field names at compile time and uses no reflection — it is
+ * native-image clean by construction.
+ *
+ * <p>By convention the map key for each field is the field name, and the value is coerced to the
+ * field's type by the standard rules: {@code String} as-is, {@code String}/{@code Number} to a
+ * primitive, a {@code String} enum name to the enum, a nested {@code Map} to a nested
+ * {@code @FromMap} type, and a {@code List} element-mapped. Override a key or supply a custom
+ * converter with {@link Extract}.
+ *
+ * <pre>{@code
+ * @FromMap
+ * record User(String name, int age, Role role, Address address) {}
+ *
+ * // Generated alongside:
+ * //   public final class UserFromMap {
+ * //     public static User fromMap(Map<String, Object> map) { ... }
+ * //     public static final ForwardMapper<Map<String, Object>, User> FROM_MAP = ...;
+ * //   }
+ *
+ * User u = UserFromMap.fromMap(graphqlInput);   // no reflection
+ * }</pre>
+ */
+@Retention(RetentionPolicy.SOURCE)
+@Target(ElementType.TYPE)
+public @interface FromMap {}

--- a/core/src/main/java/io/github/eschizoid/telescope/annotations/FromMap.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/annotations/FromMap.java
@@ -19,11 +19,10 @@ import java.lang.annotation.Target;
  * image), the generated form embeds the field names at compile time and uses no reflection — it is
  * native-image clean by construction.
  *
- * <p>By convention the map key for each field is the field name, and the value is coerced to the
- * field's type by the standard rules: {@code String} as-is, {@code String}/{@code Number} to a
- * primitive, a {@code String} enum name to the enum, a nested {@code Map} to a nested
- * {@code @FromMap} type, and a {@code List} element-mapped. Override a key or supply a custom
- * converter with {@link Extract}.
+ * <p>The map key for each field is the field name, and the value is coerced to the field's type by
+ * the standard rules: {@code String} as-is, {@code String}/{@code Number} to a primitive, a {@code
+ * String} enum name to the enum, a nested {@code Map} to a nested {@code @FromMap} type, and {@code
+ * List}/{@code Set}/{@code Map} element-mapped. An absent key takes the field's JLS default.
  *
  * <pre>{@code
  * @FromMap

--- a/core/src/test/java/io/github/eschizoid/telescope/frommap/FmAddress.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/frommap/FmAddress.java
@@ -1,0 +1,6 @@
+package io.github.eschizoid.telescope.frommap;
+
+import io.github.eschizoid.telescope.annotations.FromMap;
+
+@FromMap
+public record FmAddress(String city, String zip) {}

--- a/core/src/test/java/io/github/eschizoid/telescope/frommap/FmBean.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/frommap/FmBean.java
@@ -1,0 +1,27 @@
+package io.github.eschizoid.telescope.frommap;
+
+import io.github.eschizoid.telescope.annotations.FromMap;
+
+/** Bean target: no-arg constructor + setters. */
+@FromMap
+public class FmBean {
+
+  private String label;
+  private int count;
+
+  public String getLabel() {
+    return label;
+  }
+
+  public void setLabel(final String label) {
+    this.label = label;
+  }
+
+  public int getCount() {
+    return count;
+  }
+
+  public void setCount(final int count) {
+    this.count = count;
+  }
+}

--- a/core/src/test/java/io/github/eschizoid/telescope/frommap/FmExtras.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/frommap/FmExtras.java
@@ -1,0 +1,11 @@
+package io.github.eschizoid.telescope.frommap;
+
+import io.github.eschizoid.telescope.annotations.FromMap;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Optional field (C), a Map with non-String keys (E), and a plain Map for the null-value test (D).
+ */
+@FromMap
+public record FmExtras(Optional<FmAddress> maybeHq, Map<Integer, String> byCode, Map<String, String> notes) {}

--- a/core/src/test/java/io/github/eschizoid/telescope/frommap/FmExtras.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/frommap/FmExtras.java
@@ -4,8 +4,6 @@ import io.github.eschizoid.telescope.annotations.FromMap;
 import java.util.Map;
 import java.util.Optional;
 
-/**
- * Optional field (C), a Map with non-String keys (E), and a plain Map for the null-value test (D).
- */
+/** An Optional field, a Map with non-String keys, and a plain Map for the null-value test. */
 @FromMap
 public record FmExtras(Optional<FmAddress> maybeHq, Map<Integer, String> byCode, Map<String, String> notes) {}

--- a/core/src/test/java/io/github/eschizoid/telescope/frommap/FmJdk.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/frommap/FmJdk.java
@@ -1,0 +1,14 @@
+package io.github.eschizoid.telescope.frommap;
+
+import io.github.eschizoid.telescope.annotations.FromMap;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.UUID;
+
+/**
+ * JDK value types carried as Strings — Instant/UUID/BigDecimal/LocalDate via their String
+ * factories.
+ */
+@FromMap
+public record FmJdk(Instant ts, UUID id, BigDecimal amount, LocalDate day) {}

--- a/core/src/test/java/io/github/eschizoid/telescope/frommap/FmNested.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/frommap/FmNested.java
@@ -1,0 +1,14 @@
+package io.github.eschizoid.telescope.frommap;
+
+import io.github.eschizoid.telescope.annotations.FromMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/** Deeply nested containers: Map-of-List-of-@FromMap, List-of-Map, and Optional-of-List. */
+@FromMap
+public record FmNested(
+  Map<String, List<FmAddress>> byTeam,
+  List<Map<String, String>> rows,
+  Optional<List<FmAddress>> maybe
+) {}

--- a/core/src/test/java/io/github/eschizoid/telescope/frommap/FmRole.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/frommap/FmRole.java
@@ -1,0 +1,6 @@
+package io.github.eschizoid.telescope.frommap;
+
+public enum FmRole {
+  ADMIN,
+  USER,
+}

--- a/core/src/test/java/io/github/eschizoid/telescope/frommap/FmScalars.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/frommap/FmScalars.java
@@ -1,0 +1,15 @@
+package io.github.eschizoid.telescope.frommap;
+
+import io.github.eschizoid.telescope.annotations.FromMap;
+
+/** Every primitive + a couple of boxed wrappers, to pin the parse/null behavior. */
+@FromMap
+public record FmScalars(
+  boolean active,
+  float ratio,
+  short small,
+  byte tiny,
+  char letter,
+  Integer boxedInt,
+  Boolean boxedBool
+) {}

--- a/core/src/test/java/io/github/eschizoid/telescope/frommap/FmTeam.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/frommap/FmTeam.java
@@ -1,0 +1,21 @@
+package io.github.eschizoid.telescope.frommap;
+
+import io.github.eschizoid.telescope.annotations.FromMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Kitchen-sink record: String, primitive-from-String, enum, nested, List<nested>, Set<String>,
+ * Map<String,nested>.
+ */
+@FromMap
+public record FmTeam(
+  String name,
+  int size,
+  FmRole role,
+  FmAddress hq,
+  List<FmAddress> sites,
+  Set<String> tags,
+  Map<String, FmAddress> byCity
+) {}

--- a/core/src/test/java/io/github/eschizoid/telescope/frommap/FromMapCodegenTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/frommap/FromMapCodegenTest.java
@@ -146,6 +146,28 @@ class FromMapCodegenTest {
   }
 
   @Test
+  @DisplayName("deeply nested containers: Map<String, List<@FromMap>> and List<Map<String, String>> compose")
+  void deeplyNestedContainers() {
+    final var r = FmNestedFromMap.fromMap(
+      Map.of(
+        "byTeam",
+        Map.of("alpha", List.of(Map.of("city", "NYC", "zip", "10001"), Map.of("city", "LA", "zip", "90001"))),
+        "rows",
+        List.of(Map.of("k", "v"), Map.of("x", "y")),
+        "maybe",
+        List.of(Map.of("city", "SF", "zip", "94107"))
+      )
+    );
+    // Map<String, List<FmAddress>> — value list element-bridged through AddressFromMap.
+    assertEquals(List.of(new FmAddress("NYC", "10001"), new FmAddress("LA", "90001")), r.byTeam().get("alpha"));
+    // List<Map<String, String>> — element maps coerced.
+    assertEquals("v", r.rows().get(0).get("k"));
+    assertEquals("y", r.rows().get(1).get("x"));
+    // Optional<List<FmAddress>> — element list bridged inside the Optional.
+    assertEquals(Optional.of(List.of(new FmAddress("SF", "94107"))), r.maybe());
+  }
+
+  @Test
   @DisplayName("bean: rebuilds via no-arg constructor + setters")
   void beanViaSetters() {
     final var bean = FmBeanFromMap.fromMap(Map.of("label", "widget", "count", 7));

--- a/core/src/test/java/io/github/eschizoid/telescope/frommap/FromMapCodegenTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/frommap/FromMapCodegenTest.java
@@ -1,0 +1,76 @@
+package io.github.eschizoid.telescope.frommap;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Compiles AND runs the {@code @FromMap}-generated converters (the {@code FromMapProcessorTest}
+ * harness only asserts on generated text). The {@code <X>FromMap} classes referenced here are
+ * generated at test-compile time by {@code telescope-codegen}; if generation produced non-compiling
+ * code, this test would not compile. Proves every coercion + both rebuild strategies end-to-end.
+ */
+class FromMapCodegenTest {
+
+  @Test
+  @DisplayName("record: String, primitive-from-String, enum, nested, List<nested>, Set<String>, Map<String,nested>")
+  void recordAllCoercions() {
+    final var input = Map.of(
+      "name",
+      "Platform",
+      "size",
+      "5", // String → int
+      "role",
+      "ADMIN", // String → enum
+      "hq",
+      Map.of("city", "New York", "zip", "10001"), // nested Map → FmAddress
+      "sites",
+      List.of(Map.of("city", "Austin", "zip", "73301")), // List<Map> → List<FmAddress>
+      "tags",
+      Set.of("java", "native"), // Set<String>
+      "byCity",
+      Map.of("sf", Map.of("city", "San Francisco", "zip", "94107")) // Map<String, Map> → Map<String, FmAddress>
+    );
+
+    final var team = FmTeamFromMap.fromMap(input);
+
+    assertEquals("Platform", team.name());
+    assertEquals(5, team.size());
+    assertEquals(FmRole.ADMIN, team.role());
+    assertEquals(new FmAddress("New York", "10001"), team.hq());
+    assertEquals(List.of(new FmAddress("Austin", "73301")), team.sites());
+    assertEquals(Set.of("java", "native"), team.tags());
+    assertEquals(new FmAddress("San Francisco", "94107"), team.byCity().get("sf"));
+  }
+
+  @Test
+  @DisplayName("record: an absent primitive key takes the JLS default; an absent reference key is null")
+  void recordAbsentKeys() {
+    final var team = FmTeamFromMap.fromMap(Map.of("name", "Bare"));
+    assertEquals("Bare", team.name());
+    assertEquals(0, team.size()); // absent int → 0
+    assertNull(team.role()); // absent reference → null
+    assertTrue(team.sites().isEmpty()); // absent List → empty
+  }
+
+  @Test
+  @DisplayName("bean: rebuilds via no-arg constructor + setters")
+  void beanViaSetters() {
+    final var bean = FmBeanFromMap.fromMap(Map.of("label", "widget", "count", 7));
+    assertEquals("widget", bean.getLabel());
+    assertEquals(7, bean.getCount());
+  }
+
+  @Test
+  @DisplayName("a null source map converts to null, not a throw")
+  void nullSourceMap() {
+    assertNull(FmTeamFromMap.fromMap(null));
+    assertNull(FmBeanFromMap.fromMap(null));
+  }
+}

--- a/core/src/test/java/io/github/eschizoid/telescope/frommap/FromMapCodegenTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/frommap/FromMapCodegenTest.java
@@ -125,6 +125,27 @@ class FromMapCodegenTest {
   }
 
   @Test
+  @DisplayName("JDK value types (Instant/UUID/BigDecimal/LocalDate) parse from their String forms")
+  void jdkValueTypesParseFromStrings() {
+    final var r = FmJdkFromMap.fromMap(
+      Map.of(
+        "ts",
+        "2026-06-24T00:00:00Z",
+        "id",
+        "123e4567-e89b-12d3-a456-426614174000",
+        "amount",
+        "19.99",
+        "day",
+        "2026-06-24"
+      )
+    );
+    assertEquals(java.time.Instant.parse("2026-06-24T00:00:00Z"), r.ts());
+    assertEquals(java.util.UUID.fromString("123e4567-e89b-12d3-a456-426614174000"), r.id());
+    assertEquals(new java.math.BigDecimal("19.99"), r.amount());
+    assertEquals(java.time.LocalDate.parse("2026-06-24"), r.day());
+  }
+
+  @Test
   @DisplayName("bean: rebuilds via no-arg constructor + setters")
   void beanViaSetters() {
     final var bean = FmBeanFromMap.fromMap(Map.of("label", "widget", "count", 7));

--- a/core/src/test/java/io/github/eschizoid/telescope/frommap/FromMapCodegenTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/frommap/FromMapCodegenTest.java
@@ -1,6 +1,7 @@
 package io.github.eschizoid.telescope.frommap;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -57,6 +58,44 @@ class FromMapCodegenTest {
     assertEquals(0, team.size()); // absent int → 0
     assertNull(team.role()); // absent reference → null
     assertTrue(team.sites().isEmpty()); // absent List → empty
+  }
+
+  @Test
+  @DisplayName("every primitive parses from a String; boxed wrappers parse too; absent keys default")
+  void scalarsParseFromStrings() {
+    final var full = FmScalarsFromMap.fromMap(
+      Map.of(
+        "active",
+        "true",
+        "ratio",
+        "1.5",
+        "small",
+        "7",
+        "tiny",
+        "3",
+        "letter",
+        "X",
+        "boxedInt",
+        "42",
+        "boxedBool",
+        "false"
+      )
+    );
+    assertTrue(full.active());
+    assertEquals(1.5f, full.ratio());
+    assertEquals((short) 7, full.small());
+    assertEquals((byte) 3, full.tiny());
+    assertEquals('X', full.letter());
+    assertEquals(Integer.valueOf(42), full.boxedInt());
+    assertEquals(Boolean.FALSE, full.boxedBool());
+
+    // Absent keys: primitives take JLS defaults (no NPE on unbox), boxed wrappers stay null.
+    final var bare = FmScalarsFromMap.fromMap(Map.of());
+    assertFalse(bare.active());
+    assertEquals(0.0f, bare.ratio());
+    assertEquals('\0', bare.letter());
+    assertNull(bare.boxedInt());
+    assertNull(bare.boxedBool());
   }
 
   @Test

--- a/core/src/test/java/io/github/eschizoid/telescope/frommap/FromMapCodegenTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/frommap/FromMapCodegenTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -96,6 +97,31 @@ class FromMapCodegenTest {
     assertEquals('\0', bare.letter());
     assertNull(bare.boxedInt());
     assertNull(bare.boxedBool());
+  }
+
+  @Test
+  @DisplayName("Optional field wraps the coerced element; Map coerces non-String keys")
+  void optionalAndMapKeyCoercions() {
+    final var present = FmExtrasFromMap.fromMap(
+      Map.of("maybeHq", Map.of("city", "NYC", "zip", "10001"), "byCode", Map.of(1, "a"), "notes", Map.of("k", "v"))
+    );
+    assertEquals(Optional.of(new FmAddress("NYC", "10001")), present.maybeHq());
+    assertEquals("a", present.byCode().get(1)); // Integer key coerced through the key coercion
+    assertEquals("v", present.notes().get("k"));
+
+    final var absent = FmExtrasFromMap.fromMap(Map.of());
+    assertEquals(Optional.empty(), absent.maybeHq()); // absent Optional → empty, not null
+  }
+
+  @Test
+  @DisplayName("Map with a null value doesn't throw (lenient accumulation, not Collectors.toMap)")
+  void mapToleratesNullValue() {
+    final var notes = new java.util.HashMap<String, Object>();
+    notes.put("k", null);
+    final var source = new java.util.HashMap<String, Object>();
+    source.put("notes", notes);
+    final var result = FmExtrasFromMap.fromMap(source); // would NPE under Collectors.toMap
+    assertNull(result.notes().get("k"));
   }
 
   @Test

--- a/docs/adr/0010-frommap-codegen.md
+++ b/docs/adr/0010-frommap-codegen.md
@@ -1,0 +1,76 @@
+# ADR-0010: `@FromMap` codegen for reflection-free, native-image-clean `Map<String, Object>` ingestion
+
+**Status:** Accepted — shipping in the `@FromMap` codegen PR · **Date:** 2026-06-24
+
+## Context
+
+ADR-0008 added the runtime `Telescope.fromMap(Class<T>, MapExtractStep...)` factory for untyped `Map<String, Object>`
+sources. It works on the JVM, but it recovers each field name from its `User::name` method reference via
+`SerializedLambda` (reflective `writeReplace` + `setAccessible`) — and that is the one machinery GraalVM native image
+cannot run: native-image does not synthesize `writeReplace` on non-serializable lambdas, so the runtime `fromMap` path
+**builds but dies at runtime** with `NoSuchMethodException: …$$Lambda/…writeReplace()`, even after native-image
+auto-registers ~1,000 reflection entries.
+
+This is exactly where the untyped-source use case bites hardest. An adopter building a GraalVM-native GraphQL service
+hits it directly: every graphql-java argument arrives as a `String`, primitive, enum name, or nested `Map`, and the
+usual `Jackson.convertValue` conversion is reflection-heavy and a chore to register for native image — the burden a
+library shouldn't dump on its users. The runtime `fromMap` doesn't help here because it is itself reflection-bound.
+
+ADR-0004 already established that telescope keeps a runtime tier and a codegen tier as **separate strategies**, and
+ADR-0006 established the codegen↔runtime contract (a generated sibling class surfacing a public constant). The Map→POJO
+case had a runtime tier (ADR-0008) but no codegen tier. This ADR adds it.
+
+## Decision
+
+Add a `@FromMap` annotation (records and JavaBeans) processed by `FromMapProcessor`, emitting a sibling `<X>FromMap`
+class with a `public static X fromMap(Map<String, Object>)` method and a
+`public static final ForwardMapper<Map<String, Object>, X> FROM_MAP` constant. The method rebuilds the target directly —
+record canonical constructor, or bean builder / no-arg-ctor + setters — with each map value coerced inline. No
+`SerializedLambda`, no `LambdaMetafactory`, no reflection: the generated code is native-image clean by construction.
+
+Load-bearing design points:
+
+- **Per-field coercion is a sealed `Coercion` model** (`Cast`/`Parse`/`BoolParse`/`CharParse`/`EnumOf`/`Nested`/
+  `Listed`/`Setted`/`MapValues`/`OptionalOf`/`StringFactory`/`Unsupported`). Each emits a Java expression; container
+  strategies compose recursively over their element coercion, so arbitrarily nested shapes
+  (`Map<String, List<@FromMap>>`, `Optional<List<X>>`) work. Generated container collectors and empty fallbacks carry
+  explicit type witnesses (`.<Map<K,V>>collect`, `List.<E>of()`) so they type-check at any nesting depth.
+
+- **The lattice surface is `FROM_MAP`, a `Getter`-backed `ForwardMapper`; the generated body is direct.** Map→POJO is
+  forward-only (no faithful inverse), so the correct lattice member is `Getter` (the read-only weakening), which
+  `ForwardMapper` wraps. The generated converter lives in the consumer's package, which JPMS does not let see
+  `internal.optics.*` (qualified-exported to `:core` only) — so the direct rebuild body is _forced_, not a shortcut, and
+  the public `ForwardMapper` constant is the maximal reachable lattice surface. This mirrors how `@Bridge` exposes
+  `Telescope.bridge(...)` with a direct rebuild body (ADR-0006).
+
+- **Uncoercible fields are compile errors, not runtime failures.** A nested object whose type isn't `@FromMap`, a
+  collection subtype (`ArrayList<X>`), a type variable, or an unrecognized JDK type carry no defensible cast, so the
+  processor reports a guiding error and skips the converter — upholding "if it compiles, it runs."
+
+- **Known String-carried JDK value types are supported** (`Instant`/`LocalDate`/`UUID`/`BigDecimal`/`URI`/… via their
+  String factory), since an untyped map carries these as Strings. Unrecognized JDK types are rejected with a pointer to
+  the runtime `fromMap` + a custom `extract` converter.
+
+- **Lombok `@Data`/`@Value`/`@Builder` targets are round-deferred** to `processingOver()`, so the synthesized accessors
+  are visible — the same pattern the other telescope processors use for Lombok.
+
+- **Coercion is lenient, matching the runtime `fromMap`** (ADR-0008): absent key → JLS default; wrong-shaped container
+  value → empty collection; only `"true"` is truthy; a non-numeric numeric value throws.
+
+The `@Extract`-style per-field converter override is deferred until an adopter needs it — the convention + standard
+coercions cover the motivating cases.
+
+## Consequences
+
+- **A GraalVM-native service can do Map→POJO with zero reflection config.** Consumed via the `FROM_MAP` constant (or a
+  direct `XFromMap.fromMap(...)` call), the generated converter native-images `--no-fallback` with no hand-written
+  `reflect-config.json`. The native A/B is the rationale in one line: the runtime `fromMap` dies on `writeReplace`; the
+  generated converter just works.
+
+- **The two-strategy split (ADR-0004) is complete for the Map→POJO case.** JVM code keeps the ergonomic runtime
+  `fromMap`; native (or hot-loop) code annotates with `@FromMap` and gets the reflection-free sibling. Both return the
+  same `ForwardMapper`-shaped value.
+
+- **`@FromMap` is a secondary capability, not a new identity.** Map→POJO ingestion is an untyped-source concern adjacent
+  to telescope's typed-optics core; it earns its place by closing a native-image gap MapStruct also leaves open, not by
+  redefining what telescope is.

--- a/docs/adr/0010-frommap-codegen.md
+++ b/docs/adr/0010-frommap-codegen.md
@@ -40,8 +40,10 @@ Load-bearing design points:
   forward-only (no faithful inverse), so the correct lattice member is `Getter` (the read-only weakening), which
   `ForwardMapper` wraps. The generated converter lives in the consumer's package, which JPMS does not let see
   `internal.optics.*` (qualified-exported to `:core` only) — so the direct rebuild body is _forced_, not a shortcut, and
-  the public `ForwardMapper` constant is the maximal reachable lattice surface. This mirrors how `@Bridge` exposes
-  `Telescope.bridge(...)` with a direct rebuild body (ADR-0006).
+  the public `ForwardMapper` constant is the maximal reachable lattice surface. This follows how `@Bridge` surfaces a
+  public lattice constant over a direct rebuild body (ADR-0006); `@Bridge` emits a bidirectional `Telescope<A, B>`
+  because a bridge has a faithful inverse, whereas Map→POJO does not, so `@FromMap` emits the forward-only
+  `ForwardMapper`.
 
 - **Uncoercible fields are compile errors, not runtime failures.** A nested object whose type isn't `@FromMap`, a
   collection subtype (`ArrayList<X>`), a type variable, or an unrecognized JDK type carry no defensible cast, so the

--- a/lombok/src/test/java/io/github/eschizoid/telescope/codegen/lombok/FromMapLombokDeferralTest.java
+++ b/lombok/src/test/java/io/github/eschizoid/telescope/codegen/lombok/FromMapLombokDeferralTest.java
@@ -1,0 +1,28 @@
+package io.github.eschizoid.telescope.codegen.lombok;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies @FromMap on a Lombok @Data bean. The generated FromMapDataUserFromMap is emitted in the
+ * final processing round (after Lombok synthesizes accessors), so it's loaded reflectively here and
+ * run end-to-end: a String "30" must coerce to int 30 through the generated setter rebuild.
+ */
+class FromMapLombokDeferralTest {
+
+  @Test
+  @DisplayName("@FromMap on a Lombok @Data bean generates a working converter (round-deferred)")
+  void lombokDataBeanGetsFromMapConverter() throws Exception {
+    final var converter = Class.forName("io.github.eschizoid.telescope.codegen.lombok.fixtures.FromMapDataUserFromMap");
+    final var fromMap = converter.getMethod("fromMap", Map.class);
+
+    final var user = fromMap.invoke(null, Map.of("name", "Alice", "age", "30"));
+    assertNotNull(user, "FromMapDataUserFromMap.fromMap returned null");
+    assertEquals("Alice", user.getClass().getMethod("getName").invoke(user));
+    assertEquals(30, user.getClass().getMethod("getAge").invoke(user));
+  }
+}

--- a/lombok/src/test/java/io/github/eschizoid/telescope/codegen/lombok/fixtures/FromMapDataUser.java
+++ b/lombok/src/test/java/io/github/eschizoid/telescope/codegen/lombok/fixtures/FromMapDataUser.java
@@ -1,0 +1,21 @@
+package io.github.eschizoid.telescope.codegen.lombok.fixtures;
+
+import io.github.eschizoid.telescope.annotations.FromMap;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Fixture: a Lombok {@code @Data} bean also marked {@code @FromMap}. FromMapProcessor must defer to
+ * processingOver() so Lombok's synthesized getters/setters are visible — otherwise beanProperties()
+ * sees "no readable properties".
+ */
+@FromMap
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class FromMapDataUser {
+
+  private String name;
+  private int age;
+}


### PR DESCRIPTION
## `@FromMap` — reflection-free `Map<String,Object> → POJO` codegen

The generated-code sibling of the runtime `Telescope.fromMap`, built for **GraalVM native image**.

`@FromMap` on a record or bean makes `FromMapProcessor` emit a sibling `<X>FromMap`:
- `public static X fromMap(Map<String,Object>)` — direct canonical-constructor (record) or builder / no-arg-ctor+setters (bean) rebuild, with map values coerced inline
- `public static final ForwardMapper<Map<String,Object>, X> FROM_MAP`

No `SerializedLambda`, no `LambdaMetafactory`, no reflection — **native-image clean by construction**. (The runtime `fromMap` recovers field names via `SerializedLambda`, which dies at runtime in a native image — see the companion examples PR for the A/B.)

### Coercions (sealed `Coercion`)
| Field type | Strategy |
|---|---|
| reference / `String` | `Cast` |
| primitive | `Parse` (`String`/`Number` → primitive, JLS default on absent key) |
| enum | `EnumOf` (`String` name → `valueOf`) |
| nested `@FromMap` | `Nested` (recurse its converter) |
| `List`/`Set`/`Map` | `Listed`/`Setted`/`MapValues` — compose recursively to arbitrary depth, depth-uniquified to avoid lambda shadowing |

Absent keys take the JLS default; a null source map returns null — matching the runtime `fromMap` contract.

### Tests
- `FromMapProcessorTest` — asserts the generated text (records, beans, every coercion)
- `FromMapCodegenTest` (`:core`) — **compiles and runs** the generated converters end-to-end (every coercion, both rebuild strategies, absent-key defaults, null-source)

SPI + `module-info` registered. Lattice note: `FROM_MAP` is a `ForwardMapper`, backed by the lattice's `Getter` (forward-only — `Map→POJO` has no faithful `Iso` inverse), same as the runtime tier.
