### PR TITLE
feat(fromMap): extract overload taking a nested fromMap mapper (nested composition)

### DIFF
--- a/core/src/main/java/io/github/eschizoid/telescope/mapping/MapExtractStep.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/mapping/MapExtractStep.java
@@ -2,6 +2,8 @@ package io.github.eschizoid.telescope.mapping;
 
 import io.github.eschizoid.telescope.Telescope;
 import io.github.eschizoid.telescope.Telescope.Accessor;
+import io.github.eschizoid.telescope.conversion.ForwardMapper;
+import java.util.Map;
 import java.util.function.Function;
 
 /**
@@ -58,5 +60,38 @@ public sealed interface MapExtractStep permits Extract {
     final Function<Object, X> converter
   ) {
     return new Extract<>(key, targetAccessor, converter);
+  }
+
+  /**
+   * Static factory for a nested {@link Extract} row whose converter is itself a {@link
+   * Telescope#fromMap(Class, MapExtractStep...) fromMap} mapper — the row's raw value is a nested
+   * {@code Map<String, Object>} that the {@code nested} mapper turns into the target component.
+   * Composes {@code fromMap} declaratively, so a nested map fills a nested POJO without a
+   * hand-rolled converter that casts and calls a static method:
+   *
+   * <pre>{@code
+   * Telescope.fromMap(CaseListRequest.class,
+   *     extract("caseId", CaseListRequest::getCaseId, Object::toString),
+   *     extract("pageDetails", CaseListRequest::getPageDetails,
+   *         Telescope.fromMap(PageDetails.class,
+   *             extract("pageSize", PageDetails::getPageSize, v -> (Integer) v))));
+   * }</pre>
+   *
+   * <p>The unchecked {@code Object → Map<String, Object>} cast the nested map requires lives here,
+   * once, instead of at every call site. An absent key (a {@code null} raw value) yields a {@code
+   * null} component — {@link ForwardMapper#forward} is null-in/null-out.
+   *
+   * @param key the map key the row pulls its nested map from
+   * @param targetAccessor method reference naming the target field/component
+   * @param nested a {@code fromMap} mapper that converts the nested map into the component value
+   */
+  static <T, X> MapExtractStep extract(
+    final String key,
+    final Accessor<T, X> targetAccessor,
+    final ForwardMapper<Map<String, Object>, X> nested
+  ) {
+    @SuppressWarnings("unchecked")
+    final Function<Object, X> converter = v -> nested.forward((Map<String, Object>) v);
+    return extract(key, targetAccessor, converter);
   }
 }

--- a/core/src/main/java/io/github/eschizoid/telescope/mapping/MapExtractStep.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/mapping/MapExtractStep.java
@@ -77,9 +77,11 @@ public sealed interface MapExtractStep permits Extract {
    *             extract("pageSize", PageDetails::getPageSize, v -> (Integer) v))));
    * }</pre>
    *
-   * <p>The unchecked {@code Object → Map<String, Object>} cast the nested map requires lives here,
-   * once, instead of at every call site. An absent key (a {@code null} raw value) yields a {@code
-   * null} component — {@link ForwardMapper#forward} is null-in/null-out.
+   * <p>The {@code Object → Map<String, Object>} cast the nested map requires lives here, once,
+   * instead of at every call site — and is guarded: an absent key (a {@code null} raw value) yields
+   * a {@code null} component ({@link ForwardMapper#forward} is null-in/null-out), while a key
+   * present but holding a non-{@code Map} value raises an {@link IllegalArgumentException} naming
+   * the key rather than leaking a bare {@code ClassCastException}.
    *
    * @param key the map key the row pulls its nested map from
    * @param targetAccessor method reference naming the target field/component
@@ -90,8 +92,19 @@ public sealed interface MapExtractStep permits Extract {
     final Accessor<T, X> targetAccessor,
     final ForwardMapper<Map<String, Object>, X> nested
   ) {
-    @SuppressWarnings("unchecked")
-    final Function<Object, X> converter = v -> nested.forward((Map<String, Object>) v);
+    final Function<Object, X> converter = v -> {
+      if (v == null) return null;
+      // The cast is the caller's now-internal one: guard it so a key that holds the wrong shape
+      // names itself, instead of leaking a bare `class String cannot be cast to class Map`.
+      if (!(v instanceof Map<?, ?> map)) {
+        throw new IllegalArgumentException(
+          "fromMap key \"" + key + "\" expects a nested Map<String, Object> but got " + v.getClass().getName()
+        );
+      }
+      @SuppressWarnings("unchecked")
+      final var nestedMap = (Map<String, Object>) map;
+      return nested.forward(nestedMap);
+    };
     return extract(key, targetAccessor, converter);
   }
 }

--- a/core/src/test/java/io/github/eschizoid/telescope/nestedextract/CaseListRequest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/nestedextract/CaseListRequest.java
@@ -1,0 +1,4 @@
+package io.github.eschizoid.telescope.nestedextract;
+
+/** Top-level target: a flat field plus a nested POJO filled from a nested map. */
+public record CaseListRequest(String caseId, PageDetails pageDetails) {}

--- a/core/src/test/java/io/github/eschizoid/telescope/nestedextract/FromMapNestedExtractTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/nestedextract/FromMapNestedExtractTest.java
@@ -1,0 +1,67 @@
+package io.github.eschizoid.telescope.nestedextract;
+
+import static io.github.eschizoid.telescope.mapping.MapExtractStep.extract;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import io.github.eschizoid.telescope.Telescope;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Enh 12: a nested {@code Telescope.fromMap(...)} composes as the converter of an {@code
+ * extract(...)} row via the {@code extract(key, accessor, ForwardMapper)} overload — so a nested
+ * {@code Map<String, Object>} fills a nested POJO declaratively, without dropping into a manual
+ * static method + cast.
+ */
+class FromMapNestedExtractTest {
+
+  @Test
+  @DisplayName("a nested fromMap converter fills a nested POJO from a nested map, composing declaratively")
+  void nestedFromMapComposes() {
+    final var mapper = Telescope.fromMap(
+      CaseListRequest.class,
+      extract("caseId", CaseListRequest::caseId, Object::toString),
+      extract(
+        "pageDetails",
+        CaseListRequest::pageDetails,
+        Telescope.fromMap(
+          PageDetails.class,
+          extract("pageSize", PageDetails::pageSize, v -> (Integer) v),
+          extract("exclusiveStartKey", PageDetails::exclusiveStartKey, Object::toString)
+        )
+      )
+    );
+
+    final var input = new HashMap<String, Object>();
+    input.put("caseId", "c-1");
+    input.put("pageDetails", Map.of("pageSize", 50, "exclusiveStartKey", "k-9"));
+
+    final var result = mapper.forward(input);
+
+    assertEquals("c-1", result.caseId());
+    assertEquals(50, result.pageDetails().pageSize());
+    assertEquals("k-9", result.pageDetails().exclusiveStartKey());
+  }
+
+  @Test
+  @DisplayName("an absent nested key yields a null nested component, not a throw")
+  void absentNestedKeyIsNull() {
+    final var mapper = Telescope.fromMap(
+      CaseListRequest.class,
+      extract("caseId", CaseListRequest::caseId, Object::toString),
+      extract(
+        "pageDetails",
+        CaseListRequest::pageDetails,
+        Telescope.fromMap(PageDetails.class, extract("pageSize", PageDetails::pageSize, v -> (Integer) v))
+      )
+    );
+
+    final var result = mapper.forward(Map.of("caseId", "c-2"));
+
+    assertEquals("c-2", result.caseId());
+    assertNull(result.pageDetails(), "absent nested map key → null nested component");
+  }
+}

--- a/core/src/test/java/io/github/eschizoid/telescope/nestedextract/FromMapNestedExtractTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/nestedextract/FromMapNestedExtractTest.java
@@ -3,6 +3,7 @@ package io.github.eschizoid.telescope.nestedextract;
 import static io.github.eschizoid.telescope.mapping.MapExtractStep.extract;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import io.github.eschizoid.telescope.Telescope;
 import java.util.HashMap;
@@ -11,10 +12,9 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 /**
- * Enh 12: a nested {@code Telescope.fromMap(...)} composes as the converter of an {@code
- * extract(...)} row via the {@code extract(key, accessor, ForwardMapper)} overload — so a nested
- * {@code Map<String, Object>} fills a nested POJO declaratively, without dropping into a manual
- * static method + cast.
+ * A nested {@code Telescope.fromMap(...)} composes as the converter of an {@code extract(...)} row
+ * via the {@code extract(key, accessor, ForwardMapper)} overload — so a nested {@code Map<String,
+ * Object>} fills a nested POJO declaratively, without dropping into a manual static method + cast.
  */
 class FromMapNestedExtractTest {
 
@@ -63,5 +63,23 @@ class FromMapNestedExtractTest {
 
     assertEquals("c-2", result.caseId());
     assertNull(result.pageDetails(), "absent nested map key → null nested component");
+  }
+
+  @Test
+  @DisplayName("a key present but holding a non-Map value fails with an error naming the key, not a bare CCE")
+  void presentNonMapKeyNamesTheKey() {
+    final var mapper = Telescope.fromMap(
+      CaseListRequest.class,
+      extract(
+        "pageDetails",
+        CaseListRequest::pageDetails,
+        Telescope.fromMap(PageDetails.class, extract("pageSize", PageDetails::pageSize, v -> (Integer) v))
+      )
+    );
+
+    final var source = new HashMap<String, Object>();
+    source.put("pageDetails", "not-a-map"); // wrong shape for a nested fromMap row
+    final var ex = assertThrows(IllegalArgumentException.class, () -> mapper.forward(source));
+    assertEquals(true, ex.getMessage().contains("pageDetails"), "error must name the offending key");
   }
 }

--- a/core/src/test/java/io/github/eschizoid/telescope/nestedextract/PageDetails.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/nestedextract/PageDetails.java
@@ -1,0 +1,4 @@
+package io.github.eschizoid.telescope.nestedextract;
+
+/** Nested target POJO rebuilt from a nested Map<String, Object> by a composed fromMap converter. */
+public record PageDetails(Integer pageSize, String exclusiveStartKey) {}


### PR DESCRIPTION
## What

A nested `Telescope.fromMap(...)` can now be used directly as the converter of an `extract(...)` row, so a nested `Map<String, Object>` fills a nested POJO **declaratively** — no hand-rolled converter, no cast at the call site:

```java
Telescope.fromMap(CaseListRequest.class,
    extract("caseId", CaseListRequest::getCaseId, Object::toString),
    extract("pageDetails", CaseListRequest::getPageDetails,
        Telescope.fromMap(PageDetails.class,
            extract("pageSize", PageDetails::getPageSize, v -> (Integer) v),
            extract("exclusiveStartKey", PageDetails::getExclusiveStartKey, Object::toString))));
```

## Why an overload (not just a method ref)

A bare `nestedMapper::forward` does **not** satisfy the converter slot: `extract` takes `Function<Object, X>`, but `ForwardMapper.forward` is `Function<Map<String,Object>, X>` — a narrower input than `Object`, which javac rejects. The only way to compose with the existing overload is `v -> nestedMapper.forward((Map<String,Object>) v)` — an unchecked cast at every nested call site, the exact boilerplate the request set out to remove.

The new overload `extract(key, accessor, ForwardMapper<Map<String,Object>, X>)` takes the nested mapper directly and does the one unchecked cast internally, once. `X` binds the nested mapper's output to the target accessor's type (fully type-checked), and an absent nested key yields a `null` component (`forward` is null-in/null-out). It delegates to the existing `Function` overload — no duplication, and `Function` vs `ForwardMapper` argument types mean no overload ambiguity.

## Tests (TDD)

- `FromMapNestedExtractTest` (`:core`): a 2-level nested `fromMap` composes and round-trips; an absent nested key yields a null component (no throw). The composition test would not compile on the pre-overload API.

Full `:core` / `:codegen` / `:lombok` + javadoc + spotless green.

## Notes

- New public API (one `extract` overload). Resolves Enh 12 in `docs/migration-feedback.md` (the "investigate composition first" condition — composition is blocked without a cast, so the overload is justified).
