### PR TITLE
fix(core): resolve same-typed to(src, tgt) renames through autoIso (P1 bidirectional Mapper CCE)

### DIFF
--- a/core/src/main/java/io/github/eschizoid/telescope/DeepMap.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/DeepMap.java
@@ -490,18 +490,30 @@ public final class DeepMap {
         // sync (typically same-typed copies of the same column), and the test pin makes the
         // last-row-wins behaviour explicit so silent ambiguity is impossible.
         claimedSrc.add(srcField);
+        final var srcType = srcRefl.genericType(source, srcField);
         final var tgtType = tgtRefl.genericType(target, tgtField);
-        final var rawRowIso = fieldIsoOf(row, srcRefl.genericType(source, srcField), tgtType);
-        // SameTypedTo rows are pure identity at the leaf — wrap with default-on-null when the
-        // mapper's null strategy is DEFAULT so an unset source field lands as the type default
-        // instead of null. Other field-iso rows (TypedTransformTo, ForwardOnlyTransformTo, Via)
-        // carry user-supplied forward functions and are explicitly NOT wrapped — the user already
-        // decided how their lambda handles null. This precedence rule lets toOrElse(...) (a
-        // TypedTransformTo) and explicit transforms win over the global hint without any extra
-        // marker on the row, which is the simplest "per-row beats per-mapper" semantics.
-        final var rowIso = (nullStrategy == NullHint.NullStrategy.DEFAULT && row instanceof SameTypedTo<?, ?, ?>)
-          ? wrapDefaultOnNull(rawRowIso, tgtType)
-          : rawRowIso;
+        // A same-typed to(src, tgt) carries no conversion — it resolves exactly like an
+        // auto-matched (here possibly renamed) field, so route it through autoIso. One tested place
+        // then supplies identity / null-safe primitive-wrapper / container lifting and the same
+        // default-on-null wrapping and "incompatible shapes" rejection the auto path gives. This
+        // also closes the LUB-inference hole: javac infers the shared type parameter as the
+        // least-upper-bound of the two accessors, so to(Integer-getter, String-getter) compiles and
+        // would otherwise identity-pass an Integer into a String setter (ClassCastException at
+        // construct). Rows that DO carry user forward/backward functions keep their own leaf Iso.
+        final var rowIso =
+          row instanceof SameTypedTo<?, ?, ?>
+            ? autoIso(
+                srcType,
+                tgtType,
+                srcField + " → " + tgtField,
+                overrides,
+                beanRefl,
+                cache,
+                nullStrategy,
+                cyclicPairs,
+                inProgress
+              )
+            : fieldIsoOf(row, srcType, tgtType);
         final var step = new FieldStep(srcField, tgtField, rowIso);
         byTargetName.put(tgtField, step);
         bySourceName.put(srcField, step);
@@ -1031,7 +1043,8 @@ public final class DeepMap {
         srcType.getTypeName() +
         " vs " +
         tgtType.getTypeName() +
-        ". Shapes must match: same scalar, both records/beans, or both same-kind container."
+        ". Shapes must match: same scalar, both records/beans, or both same-kind container. For " +
+        "differing scalar types, add a to(src, tgt, forward, backward) row to supply the conversion."
     );
   }
 
@@ -1070,7 +1083,12 @@ public final class DeepMap {
     // Inline the contributed leaf-level Iso for each row variant. Reading the public components
     // directly keeps Iso (internal) out of the mapping types' public signatures — so the mapping
     // types stay portable across packages without needing @SuppressWarnings("exports").
-    if (row instanceof SameTypedTo<?, ?, ?>) return Iso.identity();
+    // SameTypedTo carries no conversion; populateIso resolves it through autoIso (identity /
+    // primitive-wrapper / container lifting / incompatible-shape rejection), so it must not reach
+    // here. The guard surfaces a routing regression with a clear class name, like the rows below.
+    if (row instanceof SameTypedTo<?, ?, ?>) throw new IllegalStateException(
+      "SameTypedTo row should be resolved via autoIso, not fieldIsoOf"
+    );
     if (row instanceof TypedTransformTo<?, ?, ?, ?> r) return Iso.of((Function) r.forward(), (Function) r.backward());
     if (row instanceof ForwardOnlyTransformTo<?, ?, ?, ?> r) {
       // DEAD-BRANCH-DEFENSIVE: this throwingBackward lambda is unreachable via the public API.

--- a/core/src/test/java/io/github/eschizoid/telescope/MigrationRegressionTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/MigrationRegressionTest.java
@@ -2702,4 +2702,82 @@ class MigrationRegressionTest {
       assertEquals("ext-1", back.getIcVerificationExt());
     }
   }
+
+  @Nested
+  @DisplayName("Bidirectional Mapper — a same-typed to(src, tgt) rename with mismatched leaf types fails fast")
+  class BidirectionalRenameLeafTypeMismatch {
+
+    // Source carries an Integer; the target carries a String under a different name — the adopter's
+    // docUpdateAttempts → numberOfAttempts shape.
+    public static class AttemptsSource {
+
+      private Integer docUpdateAttempts;
+
+      public Integer getDocUpdateAttempts() {
+        return docUpdateAttempts;
+      }
+
+      public void setDocUpdateAttempts(final Integer docUpdateAttempts) {
+        this.docUpdateAttempts = docUpdateAttempts;
+      }
+    }
+
+    public static class AttemptsTarget {
+
+      private String numberOfAttempts;
+
+      public String getNumberOfAttempts() {
+        return numberOfAttempts;
+      }
+
+      public void setNumberOfAttempts(final String numberOfAttempts) {
+        this.numberOfAttempts = numberOfAttempts;
+      }
+    }
+
+    @Test
+    @DisplayName(
+      "2-arg to(Integer-getter, String-getter) rename is rejected at build, not a runtime ClassCastException"
+    )
+    void mismatchedSameTypedRenameRejectedAtBuild() {
+      // The feedback reports a runtime ClassCastException (Integer cannot be cast to String) at
+      // SettersWriter.construct: javac infers the shared type of the 2-arg to() as the LUB, so it
+      // compiles and then identity-passes the Integer into the String setter. The fix routes the
+      // same-typed row through autoIso, turning it into a build-time rejection that names the
+      // fields
+      // and points to the converting 4-arg form.
+      final var ex = assertThrows(IllegalStateException.class, () ->
+        Telescope.mapperBuilder(AttemptsSource.class, AttemptsTarget.class)
+          .add(Mapping.to(AttemptsSource::getDocUpdateAttempts, AttemptsTarget::getNumberOfAttempts))
+          .build()
+      );
+      assertTrue(ex.getMessage().contains("docUpdateAttempts"), ex.getMessage());
+      assertTrue(ex.getMessage().contains("numberOfAttempts"), ex.getMessage());
+      assertTrue(ex.getMessage().contains("to(src, tgt, forward, backward)"), ex.getMessage());
+    }
+
+    @Test
+    @DisplayName("the documented fix — 4-arg to(src, tgt, forward, backward) — round-trips the renamed field")
+    void fourArgTransformRoundTrips() {
+      final var mapper = Telescope.mapperBuilder(AttemptsSource.class, AttemptsTarget.class)
+        .add(
+          Mapping.to(
+            AttemptsSource::getDocUpdateAttempts,
+            AttemptsTarget::getNumberOfAttempts,
+            i -> i == null ? null : String.valueOf(i),
+            s -> s == null ? null : Integer.parseInt(s)
+          )
+        )
+        .build();
+
+      final var src = new AttemptsSource();
+      src.setDocUpdateAttempts(7);
+
+      final var dto = mapper.forward(src);
+      assertEquals("7", dto.getNumberOfAttempts());
+
+      final var back = mapper.backward(dto);
+      assertEquals(Integer.valueOf(7), back.getDocUpdateAttempts());
+    }
+  }
 }

--- a/core/src/test/java/io/github/eschizoid/telescope/MigrationRegressionTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/MigrationRegressionTest.java
@@ -2735,6 +2735,70 @@ class MigrationRegressionTest {
       }
     }
 
+    // Multi-field variant: a valid same-name row and a valid rename surround the one mismatched
+    // rename, so the build sees the bad row among good ones (strict bijection covers every field).
+    public static class MultiRowSource {
+
+      private String documentId;
+      private Integer docUpdateAttempts;
+      private String sourceSystem;
+
+      public String getDocumentId() {
+        return documentId;
+      }
+
+      public void setDocumentId(final String documentId) {
+        this.documentId = documentId;
+      }
+
+      public Integer getDocUpdateAttempts() {
+        return docUpdateAttempts;
+      }
+
+      public void setDocUpdateAttempts(final Integer docUpdateAttempts) {
+        this.docUpdateAttempts = docUpdateAttempts;
+      }
+
+      public String getSourceSystem() {
+        return sourceSystem;
+      }
+
+      public void setSourceSystem(final String sourceSystem) {
+        this.sourceSystem = sourceSystem;
+      }
+    }
+
+    public static class MultiRowTarget {
+
+      private String documentId;
+      private String numberOfAttempts;
+      private String origin;
+
+      public String getDocumentId() {
+        return documentId;
+      }
+
+      public void setDocumentId(final String documentId) {
+        this.documentId = documentId;
+      }
+
+      public String getNumberOfAttempts() {
+        return numberOfAttempts;
+      }
+
+      public void setNumberOfAttempts(final String numberOfAttempts) {
+        this.numberOfAttempts = numberOfAttempts;
+      }
+
+      public String getOrigin() {
+        return origin;
+      }
+
+      public void setOrigin(final String origin) {
+        this.origin = origin;
+      }
+    }
+
     @Test
     @DisplayName(
       "2-arg to(Integer-getter, String-getter) rename is rejected at build, not a runtime ClassCastException"
@@ -2778,6 +2842,25 @@ class MigrationRegressionTest {
 
       final var back = mapper.backward(dto);
       assertEquals(Integer.valueOf(7), back.getDocUpdateAttempts());
+    }
+
+    @Test
+    @DisplayName("a mismatched rename buried among valid rows still fails fast and names the offending row")
+    void mismatchedRenameAmongValidRowsAttributedCorrectly() {
+      // The realistic shape: many valid rows and one bad rename. The build must reject and point at
+      // the mismatched fields, not at one of the valid same-type rows.
+      final var ex = assertThrows(IllegalStateException.class, () ->
+        Telescope.mapperBuilder(MultiRowSource.class, MultiRowTarget.class)
+          .add(Mapping.to(MultiRowSource::getDocumentId, MultiRowTarget::getDocumentId))
+          .add(Mapping.to(MultiRowSource::getDocUpdateAttempts, MultiRowTarget::getNumberOfAttempts))
+          .add(Mapping.to(MultiRowSource::getSourceSystem, MultiRowTarget::getOrigin))
+          .build()
+      );
+      assertTrue(ex.getMessage().contains("docUpdateAttempts"), ex.getMessage());
+      assertTrue(ex.getMessage().contains("numberOfAttempts"), ex.getMessage());
+      assertFalse(ex.getMessage().contains("documentId"), ex.getMessage());
+      assertFalse(ex.getMessage().contains("sourceSystem"), ex.getMessage());
+      assertFalse(ex.getMessage().contains("origin"), ex.getMessage());
     }
   }
 }

--- a/core/src/test/java/io/github/eschizoid/telescope/bidirmapper/BfDocSrc.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/bidirmapper/BfDocSrc.java
@@ -3,7 +3,8 @@ package io.github.eschizoid.telescope.bidirmapper;
 import io.github.eschizoid.telescope.annotations.BeanFocus;
 
 /**
- * @BeanFocus source: routes the mapper construct through generated FieldOptics.
+ * Source annotated with {@code @BeanFocus}: routes the mapper construct through generated
+ * FieldOptics.
  */
 @BeanFocus
 public class BfDocSrc {

--- a/core/src/test/java/io/github/eschizoid/telescope/bidirmapper/BfDocSrc.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/bidirmapper/BfDocSrc.java
@@ -1,0 +1,20 @@
+package io.github.eschizoid.telescope.bidirmapper;
+
+import io.github.eschizoid.telescope.annotations.BeanFocus;
+
+/**
+ * @BeanFocus source: routes the mapper construct through generated FieldOptics.
+ */
+@BeanFocus
+public class BfDocSrc {
+
+  private Integer docUpdateAttempts;
+
+  public Integer getDocUpdateAttempts() {
+    return docUpdateAttempts;
+  }
+
+  public void setDocUpdateAttempts(final Integer v) {
+    this.docUpdateAttempts = v;
+  }
+}

--- a/core/src/test/java/io/github/eschizoid/telescope/bidirmapper/BfDocTgt.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/bidirmapper/BfDocTgt.java
@@ -1,0 +1,17 @@
+package io.github.eschizoid.telescope.bidirmapper;
+
+import io.github.eschizoid.telescope.annotations.BeanFocus;
+
+@BeanFocus
+public class BfDocTgt {
+
+  private String numberOfAttempts;
+
+  public String getNumberOfAttempts() {
+    return numberOfAttempts;
+  }
+
+  public void setNumberOfAttempts(final String v) {
+    this.numberOfAttempts = v;
+  }
+}

--- a/core/src/test/java/io/github/eschizoid/telescope/bidirmapper/BidirMapperTypedTransformTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/bidirmapper/BidirMapperTypedTransformTest.java
@@ -15,8 +15,8 @@ import org.junit.jupiter.api.Test;
 class BidirMapperTypedTransformTest {
 
   @Test
-  @DisplayName("forward applies the explicit String→Integer transform before the Integer setter")
-  void forwardAppliesTypedTransform() {
+  @DisplayName("the explicit String↔Integer transform applies on both the forward and backward setters")
+  void transformAppliesBothDirections() {
     final var mapper = Telescope.mapperBuilder(GovtIndex.class, IdDetails.class)
       .add(
         Mapping.to(
@@ -29,7 +29,7 @@ class BidirMapperTypedTransformTest {
       .build();
 
     final var out = mapper.forward(new GovtIndex("42"));
-
     assertEquals(Integer.valueOf(42), out.getSorId());
+    assertEquals("42", mapper.backward(out).getSorId());
   }
 }

--- a/core/src/test/java/io/github/eschizoid/telescope/bidirmapper/BidirMapperTypedTransformTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/bidirmapper/BidirMapperTypedTransformTest.java
@@ -1,0 +1,35 @@
+package io.github.eschizoid.telescope.bidirmapper;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.github.eschizoid.telescope.Telescope;
+import io.github.eschizoid.telescope.mapping.Mapping;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * A bidirectional Mapper with an explicit typed-transform row must apply the conversion before the
+ * target setter, instead of passing the source-typed value through to a mismatched setter (which
+ * CCEs).
+ */
+class BidirMapperTypedTransformTest {
+
+  @Test
+  @DisplayName("forward applies the explicit String→Integer transform before the Integer setter")
+  void forwardAppliesTypedTransform() {
+    final var mapper = Telescope.mapperBuilder(GovtIndex.class, IdDetails.class)
+      .add(
+        Mapping.to(
+          GovtIndex::getSorId,
+          IdDetails::getSorId,
+          s -> s == null ? null : Integer.parseInt(s),
+          i -> i == null ? null : String.valueOf(i)
+        )
+      )
+      .build();
+
+    final var out = mapper.forward(new GovtIndex("42"));
+
+    assertEquals(Integer.valueOf(42), out.getSorId());
+  }
+}

--- a/core/src/test/java/io/github/eschizoid/telescope/bidirmapper/DocSrc.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/bidirmapper/DocSrc.java
@@ -1,0 +1,21 @@
+package io.github.eschizoid.telescope.bidirmapper;
+
+/** Source: docUpdateAttempts is an Integer. */
+public class DocSrc {
+
+  private Integer docUpdateAttempts;
+
+  public DocSrc() {}
+
+  public DocSrc(final Integer v) {
+    this.docUpdateAttempts = v;
+  }
+
+  public Integer getDocUpdateAttempts() {
+    return docUpdateAttempts;
+  }
+
+  public void setDocUpdateAttempts(final Integer v) {
+    this.docUpdateAttempts = v;
+  }
+}

--- a/core/src/test/java/io/github/eschizoid/telescope/bidirmapper/DocTgt.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/bidirmapper/DocTgt.java
@@ -1,0 +1,17 @@
+package io.github.eschizoid.telescope.bidirmapper;
+
+/** Target: numberOfAttempts is a String — renamed AND type-mismatched vs the source's Integer. */
+public class DocTgt {
+
+  private String numberOfAttempts;
+
+  public DocTgt() {}
+
+  public String getNumberOfAttempts() {
+    return numberOfAttempts;
+  }
+
+  public void setNumberOfAttempts(final String v) {
+    this.numberOfAttempts = v;
+  }
+}

--- a/core/src/test/java/io/github/eschizoid/telescope/bidirmapper/GovtIndex.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/bidirmapper/GovtIndex.java
@@ -1,0 +1,21 @@
+package io.github.eschizoid.telescope.bidirmapper;
+
+/** Source POJO: sorId is a String (mismatched with the target's Integer). */
+public class GovtIndex {
+
+  private String sorId;
+
+  public GovtIndex() {}
+
+  public GovtIndex(final String sorId) {
+    this.sorId = sorId;
+  }
+
+  public String getSorId() {
+    return sorId;
+  }
+
+  public void setSorId(final String sorId) {
+    this.sorId = sorId;
+  }
+}

--- a/core/src/test/java/io/github/eschizoid/telescope/bidirmapper/IdDetails.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/bidirmapper/IdDetails.java
@@ -1,0 +1,17 @@
+package io.github.eschizoid.telescope.bidirmapper;
+
+/** Target POJO: sorId is an Integer (mismatched with the source's String). */
+public class IdDetails {
+
+  private Integer sorId;
+
+  public IdDetails() {}
+
+  public Integer getSorId() {
+    return sorId;
+  }
+
+  public void setSorId(final Integer sorId) {
+    this.sorId = sorId;
+  }
+}

--- a/core/src/test/java/io/github/eschizoid/telescope/bidirmapper/RenameLeafTypeMismatchTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/bidirmapper/RenameLeafTypeMismatchTest.java
@@ -40,10 +40,13 @@ class RenameLeafTypeMismatchTest {
         .build()
     );
     assertTrue(ex.getMessage().contains("incompatible source/target shapes"), ex.getMessage());
+    assertTrue(ex.getMessage().contains("docUpdateAttempts"), ex.getMessage());
+    assertTrue(ex.getMessage().contains("numberOfAttempts"), ex.getMessage());
+    assertTrue(ex.getMessage().contains("to(src, tgt, forward, backward)"), ex.getMessage());
   }
 
   @Test
-  @DisplayName("the documented fix — 4-arg to(src, tgt, forward, backward) — maps the renamed field correctly")
+  @DisplayName("the documented fix — 4-arg to(src, tgt, forward, backward) — round-trips the renamed field both ways")
   void fourArgTransformIsTheFix() {
     final var mapper = Telescope.mapperBuilder(DocSrc.class, DocTgt.class)
       .add(
@@ -56,6 +59,8 @@ class RenameLeafTypeMismatchTest {
       )
       .build();
 
-    assertEquals("5", mapper.forward(new DocSrc(5)).getNumberOfAttempts());
+    final var forward = mapper.forward(new DocSrc(5));
+    assertEquals("5", forward.getNumberOfAttempts());
+    assertEquals(Integer.valueOf(5), mapper.backward(forward).getDocUpdateAttempts());
   }
 }

--- a/core/src/test/java/io/github/eschizoid/telescope/bidirmapper/RenameLeafTypeMismatchTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/bidirmapper/RenameLeafTypeMismatchTest.java
@@ -1,0 +1,61 @@
+package io.github.eschizoid.telescope.bidirmapper;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.github.eschizoid.telescope.Telescope;
+import io.github.eschizoid.telescope.mapping.Mapping;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * A 2-arg {@code to(src, tgt)} rename whose leaf types differ (javac infers the shared type as the
+ * LUB, so {@code to(Integer-getter, String-getter)} compiles) must be rejected at build with a
+ * precise, actionable error — not pass the value through identity into a mismatched setter, which
+ * ClassCastExceptions at runtime. The same root surfaces through the reflective writer AND the
+ * {@code @BeanFocus} FieldOptics construct; one build-time check covers both.
+ */
+class RenameLeafTypeMismatchTest {
+
+  @Test
+  @DisplayName("2-arg to() rename with mismatched leaf types fails at BUILD with a pointer to the 4-arg form")
+  void mismatchedSameTypedToRejectedAtBuild() {
+    final var ex = assertThrows(IllegalStateException.class, () ->
+      Telescope.mapperBuilder(DocSrc.class, DocTgt.class)
+        .add(Mapping.to(DocSrc::getDocUpdateAttempts, DocTgt::getNumberOfAttempts))
+        .build()
+    );
+    assertTrue(ex.getMessage().contains("docUpdateAttempts"), ex.getMessage());
+    assertTrue(ex.getMessage().contains("numberOfAttempts"), ex.getMessage());
+    assertTrue(ex.getMessage().contains("to(src, tgt, forward, backward)"), ex.getMessage());
+  }
+
+  @Test
+  @DisplayName("@BeanFocus construct path hits the SAME build-time rejection (one root, two construct paths)")
+  void mismatchedSameTypedToRejectedAtBuildBeanFocus() {
+    final var ex = assertThrows(IllegalStateException.class, () ->
+      Telescope.mapperBuilder(BfDocSrc.class, BfDocTgt.class)
+        .add(Mapping.to(BfDocSrc::getDocUpdateAttempts, BfDocTgt::getNumberOfAttempts))
+        .build()
+    );
+    assertTrue(ex.getMessage().contains("incompatible source/target shapes"), ex.getMessage());
+  }
+
+  @Test
+  @DisplayName("the documented fix — 4-arg to(src, tgt, forward, backward) — maps the renamed field correctly")
+  void fourArgTransformIsTheFix() {
+    final var mapper = Telescope.mapperBuilder(DocSrc.class, DocTgt.class)
+      .add(
+        Mapping.to(
+          DocSrc::getDocUpdateAttempts,
+          DocTgt::getNumberOfAttempts,
+          i -> i == null ? null : String.valueOf(i),
+          s -> s == null ? null : Integer.parseInt(s)
+        )
+      )
+      .build();
+
+    assertEquals("5", mapper.forward(new DocSrc(5)).getNumberOfAttempts());
+  }
+}


### PR DESCRIPTION
## Problem (P1, runtime ClassCastException)

A bidirectional `Mapper` (`Telescope.mapper()` / `mapperBuilder().build()`) throws `ClassCastException` at runtime when a **2-arg `to(src, tgt)` rename** maps a source field to a differently-typed target field:

```java
mapperBuilder(DocSrc.class, DocTgt.class)
    .add(to(DocSrc::getDocUpdateAttempts /* Integer */, DocTgt::getNumberOfAttempts /* String */))
    .build()
    .forward(src);   // CCE: Integer cannot be cast to String, at SettersWriter.construct / assembleIso
```

`mapperForward()` is unaffected (lenient). It surfaces through **both** construct paths — reflective `Beans.SettersWriter.construct` *and* the `@BeanFocus`-generated `FieldOptics.construct` — but they share one root.

## Root cause

`Mapping.to(Accessor<A,X>, Accessor<B,X>)` is meant to be *same-typed*, but javac infers the shared `X` as the **least-upper-bound** of the two accessors' return types — so `to(Integer-getter, String-getter)` compiles with `X = Serializable & Comparable` and reaches `DeepMap` as a `SameTypedTo`. `fieldIsoOf` returned a **blind `Iso.identity()`** without checking the actual leaf types, and a renamed explicit row **bypasses** the `computeAutoIso` shape check (which only runs for auto-matched same-name fields). So an `Integer` is identity-passed into a `String` setter at construct time → CCE. Build succeeds; it explodes at runtime.

(The reporter attributed the CCE to a typed `to(..., forward, backward)` transform on `sorId`; that path actually applies the conversion correctly — the real trigger is the 2-arg rename of `docUpdateAttempts → numberOfAttempts`.)

## Fix

A `SameTypedTo` carries no conversion, so it resolves exactly like an auto-matched (possibly renamed) field — **route it through `autoIso`** instead of a blind `Iso.identity()`. That one tested path supplies identity / null-safe primitive-wrapper / container lifting / `DEFAULT` null-wrapping **and** the clear incompatible-shapes rejection. Net `+31 / -13`: deletes the `SameTypedTo`-specific `wrapDefaultOnNull` special-casing, no new validation code. The shared incompatible-shapes message gained a pointer to `to(src, tgt, forward, backward)`. `fieldIsoOf`'s now-unreachable `SameTypedTo` branch became a defensive routing guard.

**Bonus correctness:** a `SameTypedTo` over `Integer↔int` or `List<X>↔List<X>` now resolves properly (it was previously blind identity, which only worked when the types were literally equal).

## `@Bridge` codegen — checked, no analogous hole

A `@Bridge` `@Rename` between mismatched-type fields is rejected at **compile** time (`@Bridge … field 'x' has incompatible types (Integer vs String)`) — `@Rename` reads field types from the model by name, so there's no method-ref LUB inference to slip through.

## Tests

- `RenameLeafTypeMismatchTest` — the 2-arg rename mismatch now fails at build with a field-named message pointing to the 4-arg form, on **both** the reflective and `@BeanFocus` construct paths; and the 4-arg `to(src, tgt, forward, backward)` maps correctly.
- `BidirMapperTypedTransformTest` — pins that an explicit typed transform on a mismatched scalar still round-trips.

Full `:core` / `:codegen` / `:lombok` + javadoc + spotless green.
