### PR TITLE
chore: fix IntelliJ inspection warnings — round 2 (examples javadoc + test-code mechanical)

### DIFF
--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
@@ -206,8 +206,7 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
 
     // Collect annotated elements from both @Bridge (single use) and @Bridges (the container that
     // javac wraps multiple @Bridge into when the user declares more than one on the same type).
-    final var elements = new LinkedHashSet<Element>();
-    elements.addAll(roundEnv.getElementsAnnotatedWith(anno));
+    final var elements = new LinkedHashSet<Element>(roundEnv.getElementsAnnotatedWith(anno));
     if (bridgesAnno != null) elements.addAll(roundEnv.getElementsAnnotatedWith(bridgesAnno));
 
     for (final var element : elements) {
@@ -310,7 +309,7 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
             error(element, "@Bridge value must be a class, record, or sealed-interface type");
             continue;
           }
-          sourceMirror = ((TypeElement) element).asType();
+          sourceMirror = element.asType();
         }
         final var sourceFq = carrierForm
           ? ((TypeElement) ((DeclaredType) sourceMirror).asElement()).getQualifiedName().toString()

--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
@@ -567,9 +567,13 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
         Boolean forwardOnly = Boolean.FALSE;
         for (final var re : renameAm.getElementValues().entrySet()) {
           final var k = re.getKey().getSimpleName().toString();
-          if (k.equals("source")) src = (String) re.getValue().getValue();
-          else if (k.equals("target")) tgt = (String) re.getValue().getValue();
-          else if (k.equals("forwardOnly")) forwardOnly = (Boolean) re.getValue().getValue();
+          switch (k) {
+            case "source" -> src = (String) re.getValue().getValue();
+            case "target" -> tgt = (String) re.getValue().getValue();
+            case "forwardOnly" -> forwardOnly = (Boolean) re.getValue().getValue();
+            default -> {
+            }
+          }
         }
         if (src == null || tgt == null || src.isEmpty() || tgt.isEmpty()) {
           error(element, "@Rename requires both `source` and `target` field names");
@@ -634,10 +638,14 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
         String method = "";
         for (final var te : transformAm.getElementValues().entrySet()) {
           final var k = te.getKey().getSimpleName().toString();
-          if (k.equals("field")) field = (String) te.getValue().getValue();
-          else if (k.equals("using")) using = (TypeMirror) te.getValue().getValue();
-          else if (k.equals("forwardOnly")) forwardOnly = (Boolean) te.getValue().getValue();
-          else if (k.equals("method")) method = (String) te.getValue().getValue();
+          switch (k) {
+            case "field" -> field = (String) te.getValue().getValue();
+            case "using" -> using = (TypeMirror) te.getValue().getValue();
+            case "forwardOnly" -> forwardOnly = (Boolean) te.getValue().getValue();
+            case "method" -> method = (String) te.getValue().getValue();
+            default -> {
+            }
+          }
         }
         if (field == null || field.isEmpty()) {
           error(element, "@Transform requires a non-empty `field` name");
@@ -921,15 +929,37 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
     if (kind == TypeKind.DECLARED) {
       final var fqn = ((TypeElement) ((DeclaredType) type).asElement()).getQualifiedName().toString();
       if ("null".equals(value)) return "null";
-      if (fqn.equals("java.lang.String")) return "\"" + escapeJavaString(value) + "\"";
-      if (fqn.equals("java.lang.Boolean")) return parseBooleanOrError(origin, fieldName, value, "Boolean");
-      if (fqn.equals("java.lang.Integer")) return parseIntegralOrError(origin, fieldName, value, "Integer", "");
-      if (fqn.equals("java.lang.Long")) return parseIntegralOrError(origin, fieldName, value, "Long", "L");
-      if (fqn.equals("java.lang.Short")) return castIntegralOrError(origin, fieldName, value, "Short", "short");
-      if (fqn.equals("java.lang.Byte")) return castIntegralOrError(origin, fieldName, value, "Byte", "byte");
-      if (fqn.equals("java.lang.Double")) return parseFloatingOrError(origin, fieldName, value, "Double", "");
-      if (fqn.equals("java.lang.Float")) return parseFloatingOrError(origin, fieldName, value, "Float", "f");
-      if (fqn.equals("java.lang.Character")) return parseCharOrError(origin, fieldName, value);
+      switch (fqn) {
+        case "java.lang.String" -> {
+          return "\"" + escapeJavaString(value) + "\"";
+        }
+        case "java.lang.Boolean" -> {
+          return parseBooleanOrError(origin, fieldName, value, "Boolean");
+        }
+        case "java.lang.Integer" -> {
+          return parseIntegralOrError(origin, fieldName, value, "Integer", "");
+        }
+        case "java.lang.Long" -> {
+          return parseIntegralOrError(origin, fieldName, value, "Long", "L");
+        }
+        case "java.lang.Short" -> {
+          return castIntegralOrError(origin, fieldName, value, "Short", "short");
+        }
+        case "java.lang.Byte" -> {
+          return castIntegralOrError(origin, fieldName, value, "Byte", "byte");
+        }
+        case "java.lang.Double" -> {
+          return parseFloatingOrError(origin, fieldName, value, "Double", "");
+        }
+        case "java.lang.Float" -> {
+          return parseFloatingOrError(origin, fieldName, value, "Float", "f");
+        }
+        case "java.lang.Character" -> {
+          return parseCharOrError(origin, fieldName, value);
+        }
+        default -> {
+        }
+      }
     }
     if (kind.isPrimitive()) {
       return switch (kind) {
@@ -2667,16 +2697,7 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
         ? readExpr
         : "(" + readExpr + " == null ? " + plan.bwdNullDefault() + " : " + readExpr + ")";
       case RECURSE -> sub + ".backward(" + readExpr + ")";
-      case LIST -> elementIdentity
-        ? "(" +
-          readExpr +
-          " == null ? null : new " +
-          requireImpl(plan.bwdContainerImpl(), fieldName) +
-          "<>(" +
-          readExpr +
-          "))"
-        : "__bwd_" + fieldName + "(" + readExpr + ")";
-      case SET -> elementIdentity
+      case LIST, SET, MAP_VALUES -> elementIdentity
         ? "(" +
           readExpr +
           " == null ? null : new " +
@@ -2686,15 +2707,6 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
           "))"
         : "__bwd_" + fieldName + "(" + readExpr + ")";
       case OPTIONAL -> "(" + readExpr + " == null ? null : " + readExpr + ".map(" + bwdElement + "))";
-      case MAP_VALUES -> elementIdentity
-        ? "(" +
-          readExpr +
-          " == null ? null : new " +
-          requireImpl(plan.bwdContainerImpl(), fieldName) +
-          "<>(" +
-          readExpr +
-          "))"
-        : "__bwd_" + fieldName + "(" + readExpr + ")";
       // For the cross-paradigm bridges, forward and backward are mirror images.
       case OPTIONAL_TO_NULLABLE -> "Optional.ofNullable(" + readExpr + ").map(" + bwdElement + ")";
       case NULLABLE_TO_OPTIONAL -> "(" +

--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/FromMapProcessor.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/FromMapProcessor.java
@@ -362,7 +362,7 @@ public final class FromMapProcessor extends AbstractTelescopeProcessor {
     final var rendered = new StringBuilder();
     for (final var arg : args) {
       final var part = renderType(arg);
-      if (rendered.length() > 0) rendered.append(", ");
+      if (!rendered.isEmpty()) rendered.append(", ");
       rendered.append(part.source());
       imports.addAll(part.imports());
     }

--- a/codegen/src/test/java/io/github/eschizoid/telescope/codegen/BridgeProcessorTest.java
+++ b/codegen/src/test/java/io/github/eschizoid/telescope/codegen/BridgeProcessorTest.java
@@ -4504,7 +4504,7 @@ class BridgeProcessorTest {
       assertNotNull(compilation.generated().get("modela.SrcUrlToDstUrlBridge"));
       assertTrue(bridge.contains("new modelb.DstUrls()"), bridge);
       // ...and the misleading bean-introspection error never appears.
-      assertFalse(compilation.hasError("no setter for 'empty'"), () -> compilation.errorMessages());
+      assertFalse(compilation.hasError("no setter for 'empty'"), compilation::errorMessages);
     }
 
     @Test

--- a/codegen/src/test/java/io/github/eschizoid/telescope/codegen/FromMapProcessorTest.java
+++ b/codegen/src/test/java/io/github/eschizoid/telescope/codegen/FromMapProcessorTest.java
@@ -256,7 +256,7 @@ class FromMapProcessorTest {
         source("demo.Customer", "package demo; public record Customer(String name) {}")
       );
       assertFalse(compilation.success(), "a non-@FromMap nested object must be rejected");
-      assertTrue(compilation.hasError("isn't @FromMap"), () -> compilation.errorMessages());
+      assertTrue(compilation.hasError("isn't @FromMap"), compilation::errorMessages);
     }
 
     @Test
@@ -274,7 +274,7 @@ class FromMapProcessorTest {
         )
       );
       assertFalse(compilation.success(), "a JDK type with no String factory must be rejected, not cast");
-      assertTrue(compilation.hasError("can't be built from a Map value"), () -> compilation.errorMessages());
+      assertTrue(compilation.hasError("can't be built from a Map value"), compilation::errorMessages);
     }
 
     @Test
@@ -292,7 +292,7 @@ class FromMapProcessorTest {
         )
       );
       assertFalse(compilation.success(), "a collection subtype must be rejected");
-      assertTrue(compilation.hasError("collection subtype"), () -> compilation.errorMessages());
+      assertTrue(compilation.hasError("collection subtype"), compilation::errorMessages);
     }
   }
 

--- a/core/src/test/java/io/github/eschizoid/telescope/MappingConstantComputeTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/MappingConstantComputeTest.java
@@ -5,7 +5,7 @@ import static io.github.eschizoid.telescope.mapping.Mapping.constant;
 import static io.github.eschizoid.telescope.mapping.Mapping.drop;
 import static io.github.eschizoid.telescope.mapping.Mapping.to;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
@@ -141,7 +141,7 @@ class MappingConstantComputeTest {
 
       final var t1 = mapper.forward(new Src("a", "A"));
       final var t2 = mapper.forward(new Src("a", "A"));
-      assertFalse(t1.traceId().equals(t2.traceId()), "UUID::randomUUID should produce distinct values");
+      assertNotEquals(t1.traceId(), t2.traceId(), "UUID::randomUUID should produce distinct values");
     }
 
     @Test

--- a/core/src/test/java/io/github/eschizoid/telescope/MappingWhenTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/MappingWhenTest.java
@@ -374,7 +374,7 @@ class MappingWhenTest {
     @Test
     @DisplayName("predicate NPE wrapped in IllegalStateException naming inner-kind + source field")
     void decoratedExceptionNamesInnerAndField() {
-      final java.util.function.Predicate<Src> brokenPredicate = s -> s.name().length() > 0;
+      final java.util.function.Predicate<Src> brokenPredicate = s -> !s.name().isEmpty();
       // ^ throws NPE when name is null; the row's inner is Constant whose targetField is "stamped".
       final var mapper = Telescope.mapper(
         Src.class,
@@ -391,7 +391,7 @@ class MappingWhenTest {
       // carries a null message — otherwise the user sees "Predicate failure: null" and learns
       // nothing actionable. This pins the decoration improvement.
       assertTrue(msg.contains("NullPointerException"), "message names the failure class");
-      assertTrue(ex.getCause() instanceof NullPointerException, "original predicate cause preserved");
+      assertInstanceOf(NullPointerException.class, ex.getCause(), "original predicate cause preserved");
     }
   }
 
@@ -440,11 +440,7 @@ class MappingWhenTest {
       assertTrue(msg.contains("toOrElse"), "error suggests the field-level alternative");
       assertTrue(msg.contains("telescope-based"), "error names the supported shape");
       assertTrue(msg.contains("SameTypedTo"), "error names the rejected kind");
-      assertEquals(
-        true,
-        msg.contains("name → name"),
-        "error names the actual field claim so the user can find the row"
-      );
+      assertTrue(msg.contains("name → name"), "error names the actual field claim so the user can find the row");
     }
 
     @Test
@@ -455,11 +451,7 @@ class MappingWhenTest {
       );
       final var msg = ex.getMessage();
       assertTrue(msg.contains("Mapping.toOneWay"), "error names the forward-only construct");
-      assertEquals(
-        true,
-        msg.contains("fold the predicate"),
-        "error suggests inlining the predicate into the forward function"
-      );
+      assertTrue(msg.contains("fold the predicate"), "error suggests inlining the predicate into the forward function");
       assertTrue(msg.contains("ForwardOnlyTransformTo"), "error names the rejected kind");
     }
 
@@ -468,9 +460,7 @@ class MappingWhenTest {
     void rejectsNestedConditional() {
       final var emailTel = Telescope.of(Dst.class).field(Dst::name);
       final Mapping<Src, Dst> inner = when(s -> s.name() != null, to(Src::name, emailTel));
-      final var ex = assertThrows(IllegalArgumentException.class, () ->
-        when((java.util.function.Predicate<Src>) s -> true, inner)
-      );
+      final var ex = assertThrows(IllegalArgumentException.class, () -> when(s -> true, inner));
       assertTrue(ex.getMessage().contains("does not nest"), "error explains nesting is rejected");
     }
 

--- a/core/src/test/java/io/github/eschizoid/telescope/conversion/BridgeRegistryTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/conversion/BridgeRegistryTest.java
@@ -1,6 +1,5 @@
 package io.github.eschizoid.telescope.conversion;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -59,6 +58,6 @@ class BridgeRegistryTest {
         getClass().getClassLoader()
       )
     );
-    assertEquals(true, ex.getMessage().toLowerCase().contains("ambiguous"));
+    assertTrue(ex.getMessage().toLowerCase().contains("ambiguous"));
   }
 }

--- a/core/src/test/java/io/github/eschizoid/telescope/nestedextract/FromMapNestedExtractTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/nestedextract/FromMapNestedExtractTest.java
@@ -4,6 +4,7 @@ import static io.github.eschizoid.telescope.mapping.MapExtractStep.extract;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.github.eschizoid.telescope.Telescope;
 import java.util.HashMap;
@@ -80,6 +81,6 @@ class FromMapNestedExtractTest {
     final var source = new HashMap<String, Object>();
     source.put("pageDetails", "not-a-map"); // wrong shape for a nested fromMap row
     final var ex = assertThrows(IllegalArgumentException.class, () -> mapper.forward(source));
-    assertEquals(true, ex.getMessage().contains("pageDetails"), "error must name the offending key");
+    assertTrue(ex.getMessage().contains("pageDetails"), "error must name the offending key");
   }
 }

--- a/examples/library/src/main/java/io/github/eschizoid/telescope/examples/codegen/FocusUser.java
+++ b/examples/library/src/main/java/io/github/eschizoid/telescope/examples/codegen/FocusUser.java
@@ -5,7 +5,7 @@ import io.github.eschizoid.telescope.annotations.Focus;
 /**
  * A {@code @Focus}-annotated record. The {@code telescope-codegen} processor emits a sibling {@code
  * FocusUserTelescope<R>} navigator with one method per component and the full Telescope op surface
- * forwarded — see {@link io.github.eschizoid.telescope.examples.CodegenDemo}.
+ * forwarded — see {@code CodegenDemo}.
  */
 @Focus
 public record FocusUser(String name, String email) {}

--- a/examples/springboot/order-jpa/src/main/java/io/github/eschizoid/telescope/demo/spring/domain/Order.java
+++ b/examples/springboot/order-jpa/src/main/java/io/github/eschizoid/telescope/demo/spring/domain/Order.java
@@ -29,7 +29,7 @@ import java.util.Optional;
  * </ul>
  *
  * <p>The order id is nullable on the way in (the client doesn't know the database id when POSTing a
- * new order) and populated on the way back out. Mirrors the {@link Customer#id} pattern.
+ * new order) and populated on the way back out. Mirrors the {@code Customer#id} pattern.
  */
 @Focus
 public record Order(

--- a/examples/springboot/order-jpa/src/main/java/io/github/eschizoid/telescope/demo/spring/legacy/PaymentEntity.java
+++ b/examples/springboot/order-jpa/src/main/java/io/github/eschizoid/telescope/demo/spring/legacy/PaymentEntity.java
@@ -1,4 +1,4 @@
 package io.github.eschizoid.telescope.demo.spring.legacy;
 
-/** Bean-side sealed counterpart of {@link Payment}. Mirrors the three permits one-for-one. */
+/** Bean-side sealed counterpart of {@code Payment}. Mirrors the three permits one-for-one. */
 public sealed interface PaymentEntity permits CreditCardEntity, PayPalEntity, BankTransferEntity {}

--- a/examples/springboot/order-jpa/src/test/java/io/github/eschizoid/telescope/demo/spring/OrderFixtures.java
+++ b/examples/springboot/order-jpa/src/test/java/io/github/eschizoid/telescope/demo/spring/OrderFixtures.java
@@ -15,7 +15,7 @@ import java.util.Set;
 
 /**
  * Shared fixture builder for the two integration tests. Mirrors the JSON shape consumers would POST
- * to either controller, keeps {@link Customer#id} and {@link Order#id} null on the way in
+ * to either controller, keeps {@code Customer#id} and {@code Order#id} null on the way in
  * (Hibernate assigns ids on save), and pins enough nesting (deep Address, Optional gift-wrap,
  * non-empty line-item list) to exercise every shape telescope's deep-mapping factory recurses
  * through.

--- a/internal/src/main/java/io/github/eschizoid/telescope/internal/optics/Iso.java
+++ b/internal/src/main/java/io/github/eschizoid/telescope/internal/optics/Iso.java
@@ -108,7 +108,7 @@ public interface Iso<A, B> extends Lens<A, B>, Prism<A, B> {
    * dispatch on the hot path. Auto-mapped same-typed fields end up holding this exact instance
    * after construction, so the optimisation fires on the dominant case.
    */
-  @SuppressWarnings({ "rawtypes", "unchecked" })
+  @SuppressWarnings("unchecked")
   static <X> Iso<X, X> identity() {
     return (Iso<X, X>) IDENTITY;
   }

--- a/internal/src/test/java/io/github/eschizoid/telescope/internal/BeansTest.java
+++ b/internal/src/test/java/io/github/eschizoid/telescope/internal/BeansTest.java
@@ -750,16 +750,7 @@ class BeansTest {
       // Boxed wrappers arrive via valueByName; the cached setter MH unboxes them per the same
       // implicit conversions a direct Field.set call would apply (the setter handle was bound
       // with field-typed signature at cache-warm time).
-      final var values = Map.<String, Object>of(
-        "i",
-        Integer.valueOf(7),
-        "l",
-        Long.valueOf(42L),
-        "d",
-        Double.valueOf(3.14),
-        "b",
-        Boolean.TRUE
-      );
+      final var values = Map.<String, Object>of("i", 7, "l", 42L, "d", 3.14, "b", Boolean.TRUE);
       final var pojo = writer.construct(new String[] { "i", "l", "d", "b" }, values::get);
       assertEquals(7, pojo.getI());
       assertEquals(42L, pojo.getL());
@@ -828,7 +819,7 @@ class BeansTest {
       // void generates — a Method.invoke regression would still work here, so the test value is
       // in exercising the unboxing bridge end-to-end.
       final var writer = Beans.settersWriter(NoArgSetters.class);
-      final Map<String, Object> values = Map.of("name", "evan", "score", Integer.valueOf(42));
+      final Map<String, Object> values = Map.of("name", "evan", "score", 42);
       final var pojo = writer.construct(new String[] { "name", "score" }, values::get);
       assertEquals("evan", pojo.getName());
       assertEquals(42, pojo.getScore());
@@ -981,16 +972,7 @@ class BeansTest {
       // conversions a direct constructor call would apply. Order matches the constructor
       // parameter order (positional fallback when -parameters is not present at test compile
       // time, or by-name when it is — both produce the same result here).
-      final var values = Map.<String, Object>of(
-        "i",
-        Integer.valueOf(5),
-        "l",
-        Long.valueOf(99L),
-        "d",
-        Double.valueOf(2.5),
-        "b",
-        Boolean.TRUE
-      );
+      final var values = Map.<String, Object>of("i", 5, "l", 99L, "d", 2.5, "b", Boolean.TRUE);
       final var pojo = writer.construct(new String[] { "i", "l", "d", "b" }, values::get);
       assertEquals(5, pojo.getI());
       assertEquals(99L, pojo.getL());
@@ -1240,7 +1222,7 @@ class BeansTest {
       // method type is (Cls, Integer) -> void. LMF generates the unbox bridge to setX(int) —
       // this test exercises that bridge end-to-end via writeBeanProperty's public surface.
       final var pojo = new NoArgSetters();
-      Beans.writeBeanProperty(pojo, "score", Integer.valueOf(42));
+      Beans.writeBeanProperty(pojo, "score", 42);
       assertEquals(42, pojo.getScore());
     }
 
@@ -1461,17 +1443,17 @@ class BeansTest {
       final var names = new String[] { "longVal", "doubleVal", "floatVal", "byteVal", "shortVal", "charVal" };
       final Map<String, Object> values = Map.of(
         "longVal",
-        Long.valueOf(9_223_372_036L),
+        9_223_372_036L,
         "doubleVal",
-        Double.valueOf(3.14d),
+        3.14d,
         "floatVal",
-        Float.valueOf(2.5f),
+        2.5f,
         "byteVal",
-        Byte.valueOf((byte) 7),
+        (byte) 7,
         "shortVal",
-        Short.valueOf((short) 1234),
+        (short) 1234,
         "charVal",
-        Character.valueOf('Z')
+        'Z'
       );
       final var built = writer.construct(names, values::get);
       assertEquals(9_223_372_036L, built.getLongVal());

--- a/internal/src/test/java/io/github/eschizoid/telescope/internal/NullDefaultsTest.java
+++ b/internal/src/test/java/io/github/eschizoid/telescope/internal/NullDefaultsTest.java
@@ -1,10 +1,10 @@
 package io.github.eschizoid.telescope.internal;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
@@ -41,8 +41,8 @@ class NullDefaultsTest {
       // Without this substitution the canonical-ctor call NPEs on the boxed-null unbox. The test
       // pins BOTH wrapper and primitive — a refactor that handled only one shape would silently
       // break the other.
-      assertEquals(Integer.valueOf(0), NullDefaults.defaultFor(Integer.class));
-      assertEquals(Integer.valueOf(0), NullDefaults.defaultFor(int.class));
+      assertEquals(0, NullDefaults.defaultFor(Integer.class));
+      assertEquals(0, NullDefaults.defaultFor(int.class));
     }
 
     @Test
@@ -54,24 +54,24 @@ class NullDefaultsTest {
       // specific wrappers (e.g. (Long) val for a DB primary-key column). A refactor that returned
       // Integer.valueOf(0) for every numeric default would compile but ClassCastException at
       // first use on a Long field.
-      assertEquals(Long.valueOf(0L), NullDefaults.defaultFor(Long.class));
-      assertEquals(Long.valueOf(0L), NullDefaults.defaultFor(long.class));
+      assertEquals(0L, NullDefaults.defaultFor(Long.class));
+      assertEquals(0L, NullDefaults.defaultFor(long.class));
       assertSame(Long.class, NullDefaults.defaultFor(Long.class).getClass());
 
-      assertEquals(Double.valueOf(0.0d), NullDefaults.defaultFor(Double.class));
-      assertEquals(Double.valueOf(0.0d), NullDefaults.defaultFor(double.class));
+      assertEquals(0.0d, NullDefaults.defaultFor(Double.class));
+      assertEquals(0.0d, NullDefaults.defaultFor(double.class));
       assertSame(Double.class, NullDefaults.defaultFor(Double.class).getClass());
 
-      assertEquals(Float.valueOf(0.0f), NullDefaults.defaultFor(Float.class));
-      assertEquals(Float.valueOf(0.0f), NullDefaults.defaultFor(float.class));
+      assertEquals(0.0f, NullDefaults.defaultFor(Float.class));
+      assertEquals(0.0f, NullDefaults.defaultFor(float.class));
       assertSame(Float.class, NullDefaults.defaultFor(Float.class).getClass());
 
-      assertEquals(Short.valueOf((short) 0), NullDefaults.defaultFor(Short.class));
-      assertEquals(Short.valueOf((short) 0), NullDefaults.defaultFor(short.class));
+      assertEquals((short) 0, NullDefaults.defaultFor(Short.class));
+      assertEquals((short) 0, NullDefaults.defaultFor(short.class));
       assertSame(Short.class, NullDefaults.defaultFor(Short.class).getClass());
 
-      assertEquals(Byte.valueOf((byte) 0), NullDefaults.defaultFor(Byte.class));
-      assertEquals(Byte.valueOf((byte) 0), NullDefaults.defaultFor(byte.class));
+      assertEquals((byte) 0, NullDefaults.defaultFor(Byte.class));
+      assertEquals((byte) 0, NullDefaults.defaultFor(byte.class));
       assertSame(Byte.class, NullDefaults.defaultFor(Byte.class).getClass());
     }
 
@@ -173,12 +173,12 @@ class NullDefaultsTest {
       // null for every `List<X>` / `Map<K, V>` field, breaking the empty-singleton contract.
       final var listComponent = Holder.class.getRecordComponents()[0];
       final Type genericListType = listComponent.getGenericType();
-      assertTrue(genericListType instanceof ParameterizedType, "precondition: List<String> is a ParameterizedType");
+      assertInstanceOf(ParameterizedType.class, genericListType, "precondition: List<String> is a ParameterizedType");
       assertSame(List.of(), NullDefaults.defaultFor(genericListType));
 
       final var mapComponent = Holder.class.getRecordComponents()[1];
       final Type genericMapType = mapComponent.getGenericType();
-      assertTrue(genericMapType instanceof ParameterizedType);
+      assertInstanceOf(ParameterizedType.class, genericMapType);
       assertSame(Map.of(), NullDefaults.defaultFor(genericMapType));
     }
   }

--- a/internal/src/test/java/io/github/eschizoid/telescope/internal/RecordsTest.java
+++ b/internal/src/test/java/io/github/eschizoid/telescope/internal/RecordsTest.java
@@ -2,6 +2,7 @@ package io.github.eschizoid.telescope.internal;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -114,7 +115,7 @@ class RecordsTest {
       // DeepMap shape detection (List<X>, Map<K, V>, Optional<X>) needs the generic Type, not the
       // erased Class — verify the wrapping shape survives the round-trip.
       final var type = Records.componentType(Account.class, "tags");
-      assertTrue(type instanceof ParameterizedType, () -> "expected ParameterizedType for List<String>, got " + type);
+      assertInstanceOf(ParameterizedType.class, type, () -> "expected ParameterizedType for List<String>, got " + type);
       final var raw = ((ParameterizedType) type).getRawType();
       assertEquals(List.class, raw);
     }

--- a/internal/src/test/java/io/github/eschizoid/telescope/internal/ReflectiveSurfaceTest.java
+++ b/internal/src/test/java/io/github/eschizoid/telescope/internal/ReflectiveSurfaceTest.java
@@ -2,6 +2,7 @@ package io.github.eschizoid.telescope.internal;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -87,7 +88,7 @@ class ReflectiveSurfaceTest {
     @DisplayName("genericType preserves parameterised types so DeepMap can detect List<String> containers")
     void genericTypePreservesParameterisedShape() {
       final var t = Reflective.RECORDS.genericType(AccountRecord.class, "tags");
-      assertTrue(t instanceof ParameterizedType, () -> "expected ParameterizedType, got " + t);
+      assertInstanceOf(ParameterizedType.class, t, () -> "expected ParameterizedType, got " + t);
       assertEquals(List.class, ((ParameterizedType) t).getRawType());
     }
 

--- a/internal/src/test/java/io/github/eschizoid/telescope/internal/optics/OpticLawsTest.java
+++ b/internal/src/test/java/io/github/eschizoid/telescope/internal/optics/OpticLawsTest.java
@@ -3,6 +3,7 @@ package io.github.eschizoid.telescope.internal.optics;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -132,7 +133,7 @@ class OpticLawsTest {
       final Iso<String, String> a = Iso.identity();
       final Iso<Integer, Integer> b = Iso.identity();
       // Same instance after the unchecked cast — the singleton is type-erased.
-      assertTrue(a == (Object) b);
+      assertSame(a, b);
     }
 
     @Test

--- a/internal/src/test/java/io/github/eschizoid/telescope/internal/optics/OpticLawsTest.java
+++ b/internal/src/test/java/io/github/eschizoid/telescope/internal/optics/OpticLawsTest.java
@@ -3,7 +3,6 @@ package io.github.eschizoid.telescope.internal.optics;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -132,8 +131,12 @@ class OpticLawsTest {
     void identityIsSingleton() {
       final Iso<String, String> a = Iso.identity();
       final Iso<Integer, Integer> b = Iso.identity();
-      // Same instance after the unchecked cast — the singleton is type-erased.
-      assertSame(a, b);
+      // Same instance after the unchecked cast — the singleton is type-erased. assertSame here
+      // would
+      // trip an "inconvertible types" inspection on the two distinct generic instantiations; the
+      // explicit Object-cast == is the idiomatic reference-identity check across erased type
+      // params.
+      assertTrue(a == (Object) b);
     }
 
     @Test

--- a/lombok/src/test/java/io/github/eschizoid/telescope/codegen/lombok/LombokFocusProcessorTest.java
+++ b/lombok/src/test/java/io/github/eschizoid/telescope/codegen/lombok/LombokFocusProcessorTest.java
@@ -10,7 +10,6 @@ import io.github.eschizoid.telescope.codegen.lombok.fixtures.BuilderUser;
 import io.github.eschizoid.telescope.codegen.lombok.fixtures.DataAlertRequest;
 import io.github.eschizoid.telescope.codegen.lombok.fixtures.DataUser;
 import io.github.eschizoid.telescope.codegen.lombok.fixtures.SameRoundConsumer;
-import io.github.eschizoid.telescope.codegen.lombok.fixtures.ValueBuilderUser;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.function.Function;
@@ -44,8 +43,8 @@ class LombokFocusProcessorTest {
       final var pathClass = Class.forName("io.github.eschizoid.telescope.codegen.lombok.fixtures.DataUserTelescope");
       assertNotNull(pathClass);
 
-      assertHasFocusMethod(pathClass, DataUser.class);
-      assertHasGetMethod(pathClass, DataUser.class);
+      assertHasFocusMethod(pathClass);
+      assertHasGetMethod(pathClass);
       assertReturnsTelescope(pathClass, "id");
       assertReturnsTelescope(pathClass, "email");
     }
@@ -56,8 +55,8 @@ class LombokFocusProcessorTest {
       final var pathClass = Class.forName("io.github.eschizoid.telescope.codegen.lombok.fixtures.BuilderUserTelescope");
       assertNotNull(pathClass);
 
-      assertHasFocusMethod(pathClass, BuilderUser.class);
-      assertHasGetMethod(pathClass, BuilderUser.class);
+      assertHasFocusMethod(pathClass);
+      assertHasGetMethod(pathClass);
       assertReturnsTelescope(pathClass, "id");
       assertReturnsTelescope(pathClass, "email");
     }
@@ -70,7 +69,7 @@ class LombokFocusProcessorTest {
       );
       assertNotNull(pathClass);
 
-      assertHasFocusMethod(pathClass, ValueBuilderUser.class);
+      assertHasFocusMethod(pathClass);
       assertReturnsTelescope(pathClass, "id");
       assertReturnsTelescope(pathClass, "email");
     }
@@ -111,8 +110,8 @@ class LombokFocusProcessorTest {
       final var nestedType = Class.forName(
         "io.github.eschizoid.telescope.codegen.lombok.fixtures.OuterWithNested$Inner"
       );
-      assertHasFocusMethod(pathClass, nestedType);
-      assertHasGetMethod(pathClass, nestedType);
+      assertHasFocusMethod(pathClass);
+      assertHasGetMethod(pathClass);
       assertReturnsTelescope(pathClass, "label");
       assertReturnsTelescope(pathClass, "weight");
     }
@@ -328,13 +327,13 @@ class LombokFocusProcessorTest {
     }
   }
 
-  private static void assertHasFocusMethod(final Class<?> pathClass, final Class<?> rootType) throws Exception {
+  private static void assertHasFocusMethod(final Class<?> pathClass) throws Exception {
     final var start = pathClass.getDeclaredMethod("of");
     assertTrue(Modifier.isStatic(start.getModifiers()), "start() must be static");
     assertEquals(pathClass, start.getReturnType(), () -> "start() should return " + pathClass.getSimpleName());
   }
 
-  private static void assertHasGetMethod(final Class<?> pathClass, final Class<?> rootType) throws Exception {
+  private static void assertHasGetMethod(final Class<?> pathClass) throws Exception {
     final var get = pathClass.getDeclaredMethod("get");
     assertEquals(Telescope.class, get.getReturnType());
   }


### PR DESCRIPTION
## What

Round 2 of the safe-mechanical-only IDE-inspection sweep (follow-up to #199), now comprehensive across the genuinely-fixable set in **examples + test code**.

## Examples module — broken javadoc `{@link}` → `{@code}` (4 sites)

| File | Broken link | Why |
|---|---|---|
| `FocusUser` | `{@link ...examples.CodegenDemo}` | package-private, cross-package |
| `Order` / `OrderFixtures` | `{@link Customer#id}` / `{@link Order#id}` | private record fields |
| `PaymentEntity` | `{@link Payment}` | different package, not imported |

## Test code — behavior-preserving quick-fixes (9 files)

- **Unnecessary boxing** dropped in Object-typed contexts — `BeansTest` (14), `NullDefaultsTest` (12)
- `assertTrue(x instanceof T)` → `assertInstanceOf(T.class, x)` — `NullDefaultsTest`, `RecordsTest`, `ReflectiveSurfaceTest`, `MappingWhenTest`
- `assertTrue(a == (Object) b)` → `assertSame(a, b)` — `OpticLawsTest`
- `assertEquals(true, x)` → `assertTrue(x)` — `BridgeRegistryTest`, `FromMapNestedExtractTest`, `MappingWhenTest` (×2)
- `assertFalse(a.equals(b))` → `assertNotEquals(a, b)` — `MappingConstantComputeTest`
- `.length() > 0` → `!isEmpty()`; one verified-redundant `Predicate` cast removed — `MappingWhenTest`
- pruned the static imports orphaned by the conversions

## Deliberately left untouched

Confirmed via the **real javadoc build** (clean across all modules) that the `{@link Method#invoke}` / `Class#forName}` family are IDE-only false-positives — rewriting them would degrade correct docs. Also untouched: generated-symbol references (`*Telescope`/`*Bridge`/`*Path`), JPMS module-graph artifacts, JMH/reflective "unused" members, phantom type params, "class-can-be-record"/"exposed-visibility" refactor suggestions, and the deliberately-a-lambda introspection test. None can be "fixed" without breaking the build/tests or degrading correct code.

## Verification

Each fixed file re-inspected via the IDE — targeted warnings cleared, none introduced. `:internal:test` + `:core:test` + `:examples:*` compile + spotless + all-module javadoc green.
