### PR TITLE
docs(examples): canonical telescope-vs-MapStruct head-to-head slice

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,10 +315,11 @@ architecture stops. Two questions decide it — is it as fast, and what do you g
 
 > **Runnable head-to-head:** [`examples/mapstruct-vs-telescope`](examples/mapstruct-vs-telescope/) is the canonical
 > side-by-side — the same `Order → OrderDto` mapping written both ways, in one module. It demonstrates, reproducibly,
-> what a field rename does to each (telescope's method reference follows the IDE refactor; MapStruct's `@Mapping` string
-> goes stale — silently `null` under default config, a manual hand-edit under the strictest), then a deep immutable
-> update MapStruct's architecture can't express. Run `./gradlew :examples:mapstruct-vs-telescope:test` — every claim is
-> a passing test or a one-command reproduction.
+> what a field rename does to each (telescope's method reference follows the IDE refactor automatically; MapStruct's
+> `@Mapping` string can't be refactored, so the same rename is a compile error you hand-fix across every mapper), the
+> separate default-policy footgun where unmapped targets go silently `null`, then a deep immutable update MapStruct's
+> architecture can't express. Run `./gradlew :examples:mapstruct-vs-telescope:test` — every claim is a passing test or a
+> one-command reproduction.
 
 #### First, the performance objection — settled
 

--- a/README.md
+++ b/README.md
@@ -313,6 +313,13 @@ duality. On the band they share (deep record↔record / bean↔record / bean↔b
 speed with compile-checked, bidirectional, refactor-safe rows; beyond that band, telescope keeps going where MapStruct's
 architecture stops. Two questions decide it — is it as fast, and what do you gain — in that order.
 
+> **Runnable head-to-head:** [`examples/mapstruct-vs-telescope`](examples/mapstruct-vs-telescope/) is the canonical
+> side-by-side — the same `Order → OrderDto` mapping written both ways, in one module. It demonstrates, reproducibly,
+> what a field rename does to each (telescope's method reference follows the IDE refactor; MapStruct's `@Mapping` string
+> goes stale — silently `null` under default config, a manual hand-edit under the strictest), then a deep immutable
+> update MapStruct's architecture can't express. Run `./gradlew :examples:mapstruct-vs-telescope:test` — every claim is
+> a passing test or a one-command reproduction.
+
 #### First, the performance objection — settled
 
 **At the codegen level, telescope and MapStruct are the same performance class.** Both annotation processors emit direct

--- a/examples/mapstruct-vs-telescope/README.md
+++ b/examples/mapstruct-vs-telescope/README.md
@@ -52,8 +52,8 @@ silent. The difference is **who does the fixing**.
   that string, and every other `@Mapping` across every mapper that named the renamed field. telescope's refactor did all
   of it in one keystroke.
 
-So both are compile-safe; telescope is **refactor-safe**. The string isn't unsafe — it's _un-refactorable_, which turns
-every rename into a string-chase across your mappers.
+So both are compile-safe on a field they map explicitly; telescope is **refactor-safe**. The string isn't unsafe — it's
+_un-refactorable_, which turns every rename into a string-chase across your mappers.
 
 > The documented core of the pitch: **method references over string-keyed `@Mapping`.** Strings don't refactor.
 

--- a/examples/mapstruct-vs-telescope/README.md
+++ b/examples/mapstruct-vs-telescope/README.md
@@ -1,0 +1,109 @@
+# telescope vs MapStruct — the canonical head-to-head
+
+A small, runnable, **reproducible** comparison. Same `Order → OrderDto` mapping, written both ways, in one module so you
+can run it yourself:
+
+```bash
+./gradlew :examples:mapstruct-vs-telescope:test
+```
+
+The domain is deliberately ordinary — a nested object and a collection, one field that needs an explicit rename:
+
+```text
+Order(id, Customer, List<LineItem>)        OrderDto(id, CustomerDto, List<LineItemDto>)
+  Customer(name, email)          ──▶         CustomerDto(name, contactEmail)     // email -> contactEmail
+  LineItem(sku, quantity, price)             LineItemDto(sku, quantity, price)   // same-named, auto
+```
+
+Both frameworks produce the **identical** `OrderDto` (the first test pins it). This isn't a strawman where MapStruct is
+misused — it's configured the normal way, and it works. The difference shows up in two places MapStruct's design can't
+reach.
+
+---
+
+## Act 1 — rename a field, and watch the mapping
+
+The one cross-named field has to be spelled out on both sides. Here's the entire difference:
+
+```java
+// telescope — a method reference the compiler checks and the IDE refactors
+Telescope.mapper(Order.class, OrderDto.class,
+    to(Customer::email, CustomerDto::contactEmail));     // recursion handles everything else
+
+// MapStruct — a string the IDE cannot see
+@Mapping(source = "email", target = "contactEmail")
+CustomerDto toDto(Customer customer);
+```
+
+Now do what every codebase does eventually: **rename `Customer.email()` → `Customer.emailAddress()`** with your IDE's
+rename refactor.
+
+- **telescope:** `Customer::email` is a real reference. The refactor moves it to `Customer::emailAddress` automatically;
+  if you somehow miss it, it's a compile error pointing at the line. Nothing can go stale.
+- **MapStruct:** `@Mapping(source = "email", …)` is opaque text. The refactor does not touch it. What happens next is
+  the whole point, and it depends on a policy most teams never set:
+
+  **Layer 1 — default config (`unmappedTargetPolicy = WARN`).** The stale string leaves `contactEmail` with no source.
+  MapStruct compiles with a _warning_ and the field is **silently `null` at runtime**. A quietly wrong object, no error.
+  This module pins that behavior permanently — `SilentDropMapper` has an unmapped `region`, and the test asserts the
+  `null`, so CI demonstrates the footgun on every run:
+
+  ```
+  warning: Unmapped target property: "region".   // <- compiles anyway; region is null at runtime
+  ```
+
+  **Layer 2 — strictest config (`unmappedTargetPolicy = ERROR`).** Now the stale string fails the build instead of
+  nulling — safer. But you've only traded a silent bug for manual labor: every `@Mapping` string referencing the renamed
+  field, across every mapper in the codebase, must be found and hand-edited. telescope's IDE refactor did all of that in
+  one keystroke, and a stale string was never possible.
+
+**Reproduce it:** open `Customer.java`, rename `email` via your IDE, and run
+`./gradlew :examples:mapstruct-vs-telescope:build`. Watch the telescope reference follow the rename while the MapStruct
+string is left behind — silently (default) or as a compile error you now own (strict).
+
+> This is the documented core of the pitch: **method references over string-keyed `@Mapping`.** Strings don't refactor.
+
+---
+
+## Act 2 — the same typed path also updates the graph
+
+Act 1 showed the _mapping_ is refactor-safe. The deeper point is that it isn't a mapper at all — it's **one typed path
+for the whole lifecycle**. The same `Telescope` vocabulary that mapped `Order → OrderDto` also reads, writes, and
+updates an `Order`'s interior:
+
+```java
+// Multiply every line item's price by a rate and rebuild the whole immutable Order graph — one pass.
+Order taxed = Telescope.of(Order.class)
+  .each(Order::lines)
+  .field(LineItem::price)
+  .update(order, (price) -> price.multiply(rate));
+// `order` is untouched; `taxed` is a new immutable graph.
+```
+
+MapStruct has **no equivalent**, by design: it maps `A → B`. It does not read, write, or update a value's interior, so
+this operation simply isn't expressible. The test pins that the original `Order` is unchanged and a new graph is
+returned.
+
+One vocabulary mapped the object _and_ updated it. With MapStruct you'd reach for a second tool (hand-written
+copy-with-changes, or an optics library) the moment you step past mapping.
+
+---
+
+## Where MapStruct is still the right call
+
+Being fair is the point of a reproducible comparison:
+
+- **Mature ecosystem and IDE tooling** — MapStruct has years of plugins, docs, and Stack Overflow answers.
+- **Pure compile-time generation everywhere** — telescope's runtime path uses reflection (its `@Focus` / `@Bridge`
+  codegen path is reflection-free, but it's opt-in); MapStruct generates code for every mapping by default.
+- **`jakarta` validation accumulates too** — if your only need is "collect all invalid fields," `Validator.validate()`
+  already returns the whole set. telescope's edge there is _cohesion_ (validation threaded through the same typed pass),
+  not raw capability — so it's intentionally left out of this head-to-head.
+
+What telescope changes is narrower and sharper: your mappings are **refactor-safe by construction**, and the same typed
+path keeps working when you step past mapping into reading and updating the immutable graph.
+
+---
+
+_Run `./gradlew :examples:mapstruct-vs-telescope:test` — every claim here is a passing test or a one-command
+reproduction._

--- a/examples/mapstruct-vs-telescope/README.md
+++ b/examples/mapstruct-vs-telescope/README.md
@@ -16,12 +16,12 @@ Order(id, Customer, List<LineItem>)        OrderDto(id, CustomerDto, List<LineIt
 ```
 
 Both frameworks produce the **identical** `OrderDto` (the first test pins it). This isn't a strawman where MapStruct is
-misused — it's configured the normal way, and it works. The difference shows up in two places MapStruct's design can't
-reach.
+misused — it's configured the normal way, and it works. The difference shows up the moment the code changes underneath
+it: renaming a field, leaving a target unmapped, or needing to do anything past mapping.
 
 ---
 
-## Act 1 — rename a field, and watch the mapping
+## Act 1 — rename a field: the mapping string can't refactor
 
 The one cross-named field has to be spelled out on both sides. Here's the entire difference:
 
@@ -36,32 +36,47 @@ CustomerDto toDto(Customer customer);
 ```
 
 Now do what every codebase does eventually: **rename `Customer.email()` → `Customer.emailAddress()`** with your IDE's
-rename refactor.
+rename refactor. Both frameworks catch the change at compile time — credit where due, MapStruct is loud here, not
+silent. The difference is **who does the fixing**.
 
-- **telescope:** `Customer::email` is a real reference. The refactor moves it to `Customer::emailAddress` automatically;
-  if you somehow miss it, it's a compile error pointing at the line. Nothing can go stale.
-- **MapStruct:** `@Mapping(source = "email", …)` is opaque text. The refactor does not touch it. What happens next is
-  the whole point, and it depends on a policy most teams never set:
-
-  **Layer 1 — default config (`unmappedTargetPolicy = WARN`).** The stale string leaves `contactEmail` with no source.
-  MapStruct compiles with a _warning_ and the field is **silently `null` at runtime**. A quietly wrong object, no error.
-  This module pins that behavior permanently — `SilentDropMapper` has an unmapped `region`, and the test asserts the
-  `null`, so CI demonstrates the footgun on every run:
+- **telescope:** `Customer::email` is a real reference. The refactor updates it to `Customer::emailAddress`
+  automatically; if anything is missed it's a compile error at the line. Zero edits, and the mapping keeps working.
+- **MapStruct:** `@Mapping(source = "email", …)` is opaque text the refactor cannot touch. Left pointing at a property
+  that no longer exists, MapStruct **fails the build** — this is the actual error, captured from this module:
 
   ```
-  warning: Unmapped target property: "region".   // <- compiles anyway; region is null at runtime
+  error: No property named "email" exists in source parameter(s). Did you mean "emailAddress"?
   ```
 
-  **Layer 2 — strictest config (`unmappedTargetPolicy = ERROR`).** Now the stale string fails the build instead of
-  nulling — safer. But you've only traded a silent bug for manual labor: every `@Mapping` string referencing the renamed
-  field, across every mapper in the codebase, must be found and hand-edited. telescope's IDE refactor did all of that in
-  one keystroke, and a stale string was never possible.
+  That's the _good_ outcome: caught at compile time, not a silent runtime bug. But the fix is **manual** — you hand-edit
+  that string, and every other `@Mapping` across every mapper that named the renamed field. telescope's refactor did all
+  of it in one keystroke.
 
-**Reproduce it:** open `Customer.java`, rename `email` via your IDE, and run
-`./gradlew :examples:mapstruct-vs-telescope:build`. Watch the telescope reference follow the rename while the MapStruct
-string is left behind — silently (default) or as a compile error you now own (strict).
+So both are compile-safe; telescope is **refactor-safe**. The string isn't unsafe — it's _un-refactorable_, which turns
+every rename into a string-chase across your mappers.
 
-> This is the documented core of the pitch: **method references over string-keyed `@Mapping`.** Strings don't refactor.
+> The documented core of the pitch: **method references over string-keyed `@Mapping`.** Strings don't refactor.
+
+**Reproduce it:** rename `Customer.email` via your IDE (let it update telescope's `Customer::email`), leave the
+`@Mapping("email")` string as-is, and run `./gradlew :examples:mapstruct-vs-telescope:build`. telescope compiles;
+MapStruct prints the error above.
+
+---
+
+## A separate footgun — unmapped targets go silently null
+
+MapStruct's _other_ hazard is unrelated to renames, and it really is silent. A target field with **no source at all** —
+a newly added DTO field, or one whose source quietly drifted away — is, under MapStruct's **default**
+`unmappedTargetPolicy` (`WARN`), compiled with only a warning and left **`null` at runtime**:
+
+```
+warning: Unmapped target property: "region".   // <- compiles anyway; region is null at runtime
+```
+
+This module pins it permanently: `SilentDropMapper` maps to a `CustomerContactDto` whose `region` has no source, and the
+test asserts the `null`, so CI demonstrates the footgun on every run. Setting `unmappedTargetPolicy = ERROR` turns it
+into a build failure (the recommended hardening) — but it's off by default. telescope's strict `mapper(...)` refuses an
+unmapped field at _construction_ rather than nulling it.
 
 ---
 
@@ -81,8 +96,9 @@ Order taxed = Telescope.of(Order.class)
 ```
 
 MapStruct has **no equivalent**, by design: it maps `A → B`. It does not read, write, or update a value's interior, so
-this operation simply isn't expressible. The test pins that the original `Order` is unchanged and a new graph is
-returned.
+this operation simply isn't expressible. (MapStruct's `@MappingTarget` update methods mutate an existing _mutable_ bean
+in place — they can't rebuild an immutable record graph and hand you a new value with the original untouched.) The test
+pins that the original `Order` is unchanged and a new graph is returned.
 
 One vocabulary mapped the object _and_ updated it. With MapStruct you'd reach for a second tool (hand-written
 copy-with-changes, or an optics library) the moment you step past mapping.
@@ -93,7 +109,7 @@ copy-with-changes, or an optics library) the moment you step past mapping.
 
 Being fair is the point of a reproducible comparison:
 
-- **Mature ecosystem and IDE tooling** — MapStruct has years of plugins, docs, and Stack Overflow answers.
+- **Mature ecosystem and IDE tooling** — MapStruct has years of plugins, docs, and community answers behind it.
 - **Pure compile-time generation everywhere** — telescope's runtime path uses reflection (its `@Focus` / `@Bridge`
   codegen path is reflection-free, but it's opt-in); MapStruct generates code for every mapping by default.
 - **`jakarta` validation accumulates too** — if your only need is "collect all invalid fields," `Validator.validate()`

--- a/examples/mapstruct-vs-telescope/README.md
+++ b/examples/mapstruct-vs-telescope/README.md
@@ -7,12 +7,15 @@ can run it yourself:
 ./gradlew :examples:mapstruct-vs-telescope:test
 ```
 
-The domain is deliberately ordinary — a nested object and a collection, one field that needs an explicit rename:
+The domain is deliberately ordinary — a nested object and a collection, one field that needs an explicit rename.
+Immutable records in, mutable JavaBean DTOs out — the shape JPA and serialization frameworks impose — and both
+frameworks handle the paradigm hop:
 
 ```text
-Order(id, Customer, List<LineItem>)        OrderDto(id, CustomerDto, List<LineItemDto>)
-  Customer(name, email)          ──▶         CustomerDto(name, contactEmail)     // email -> contactEmail
-  LineItem(sku, quantity, price)             LineItemDto(sku, quantity, price)   // same-named, auto
+immutable records                          mutable JavaBeans (no-arg ctor + setters)
+Order(id, Customer, List<LineItem>)        OrderDto(getId, getCustomer, getLines)
+  Customer(name, email)          ──▶         CustomerDto(getName, getContactEmail)      // email -> contactEmail
+  LineItem(sku, quantity, price)             LineItemDto(getSku, getQuantity, getPrice) // same-named, auto
 ```
 
 Both frameworks produce the **identical** `OrderDto` (the first test pins it). This isn't a strawman where MapStruct is
@@ -28,7 +31,7 @@ The one cross-named field has to be spelled out on both sides. Here's the entire
 ```java
 // telescope — a method reference the compiler checks and the IDE refactors
 Telescope.mapper(Order.class, OrderDto.class,
-    to(Customer::email, CustomerDto::contactEmail));     // recursion handles everything else
+    to(Customer::email, CustomerDto::getContactEmail));  // recursion handles everything else
 
 // MapStruct — a string the IDE cannot see
 @Mapping(source = "email", target = "contactEmail")

--- a/examples/mapstruct-vs-telescope/build.gradle.kts
+++ b/examples/mapstruct-vs-telescope/build.gradle.kts
@@ -19,7 +19,7 @@ tasks.withType<JavaCompile>().configureEach {
     options.release = 17
     options.encoding = "UTF-8"
     // -processing keeps MapStruct's own processor notes out of -Xlint; -parameters lets MapStruct
-    // and telescope match constructor args by name on the record DTOs.
+    // and telescope match constructor args by name on the domain records.
     options.compilerArgs.addAll(listOf("-Xlint:all,-processing", "-parameters"))
 }
 

--- a/examples/mapstruct-vs-telescope/build.gradle.kts
+++ b/examples/mapstruct-vs-telescope/build.gradle.kts
@@ -1,0 +1,40 @@
+plugins {
+    java
+}
+
+description =
+    "telescope vs MapStruct — the canonical head-to-head: refactor-safe mapping + deep immutable update"
+
+repositories {
+    mavenCentral()
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
+tasks.withType<JavaCompile>().configureEach {
+    options.release = 17
+    options.encoding = "UTF-8"
+    // -processing keeps MapStruct's own processor notes out of -Xlint; -parameters lets MapStruct
+    // and telescope match constructor args by name on the record DTOs.
+    options.compilerArgs.addAll(listOf("-Xlint:all,-processing", "-parameters"))
+}
+
+dependencies {
+    implementation(project(":core"))
+
+    // Same MapStruct line the :benchmarks head-to-head already pins.
+    implementation("org.mapstruct:mapstruct:1.6.3")
+    annotationProcessor("org.mapstruct:mapstruct-processor:1.6.3")
+
+    testImplementation(platform(libs.junitBom))
+    testImplementation(libs.junitJupiter)
+    testRuntimeOnly(libs.junitPlatformLauncher)
+}
+
+tasks.named<Test>("test") {
+    useJUnitPlatform()
+}

--- a/examples/mapstruct-vs-telescope/src/main/java/io/github/eschizoid/telescope/example/mapstruct/domain/Customer.java
+++ b/examples/mapstruct-vs-telescope/src/main/java/io/github/eschizoid/telescope/example/mapstruct/domain/Customer.java
@@ -1,0 +1,9 @@
+package io.github.eschizoid.telescope.example.mapstruct.domain;
+
+/**
+ * Source-side customer. The {@code email} component is the one we rename in the head-to-head — it
+ * maps to {@code CustomerDto.contactEmail}, so both frameworks must spell that correspondence
+ * explicitly. telescope spells it with a method reference ({@code Customer::email}); MapStruct
+ * spells it with a string ({@code @Mapping(source = "email", ...)}).
+ */
+public record Customer(String name, String email) {}

--- a/examples/mapstruct-vs-telescope/src/main/java/io/github/eschizoid/telescope/example/mapstruct/domain/LineItem.java
+++ b/examples/mapstruct-vs-telescope/src/main/java/io/github/eschizoid/telescope/example/mapstruct/domain/LineItem.java
@@ -2,5 +2,8 @@ package io.github.eschizoid.telescope.example.mapstruct.domain;
 
 import java.math.BigDecimal;
 
-/** Source-side order line. {@code price} is the field Act 2 deep-updates in place. */
+/**
+ * Source-side order line. {@code price} is the field Act 2 deep-updates — rebuilding a new
+ * immutable graph.
+ */
 public record LineItem(String sku, int quantity, BigDecimal price) {}

--- a/examples/mapstruct-vs-telescope/src/main/java/io/github/eschizoid/telescope/example/mapstruct/domain/LineItem.java
+++ b/examples/mapstruct-vs-telescope/src/main/java/io/github/eschizoid/telescope/example/mapstruct/domain/LineItem.java
@@ -1,0 +1,6 @@
+package io.github.eschizoid.telescope.example.mapstruct.domain;
+
+import java.math.BigDecimal;
+
+/** Source-side order line. {@code price} is the field Act 2 deep-updates in place. */
+public record LineItem(String sku, int quantity, BigDecimal price) {}

--- a/examples/mapstruct-vs-telescope/src/main/java/io/github/eschizoid/telescope/example/mapstruct/domain/Order.java
+++ b/examples/mapstruct-vs-telescope/src/main/java/io/github/eschizoid/telescope/example/mapstruct/domain/Order.java
@@ -1,0 +1,10 @@
+package io.github.eschizoid.telescope.example.mapstruct.domain;
+
+import java.util.List;
+
+/**
+ * Source-side order: a nested {@link Customer} plus a {@link LineItem} collection. Deep enough that
+ * both the nested-object and the collection recursion paths get exercised, small enough to read at
+ * a glance.
+ */
+public record Order(String id, Customer customer, List<LineItem> lines) {}

--- a/examples/mapstruct-vs-telescope/src/main/java/io/github/eschizoid/telescope/example/mapstruct/dto/CustomerContactDto.java
+++ b/examples/mapstruct-vs-telescope/src/main/java/io/github/eschizoid/telescope/example/mapstruct/dto/CustomerContactDto.java
@@ -2,7 +2,8 @@ package io.github.eschizoid.telescope.example.mapstruct.dto;
 
 /**
  * A target with one component — {@code region} — that has no source counterpart on {@code
- * Customer}. It exists to pin the silent-drop footgun: this is the exact shape a target takes the
- * moment a rename strands it without a source.
+ * Customer}. It exists to pin the silent-drop footgun: a newly added or drifted target field with
+ * no source compiles clean and lands {@code null} at runtime under MapStruct's default policy. (A
+ * source rename is the separate, louder case — a compile error.)
  */
 public record CustomerContactDto(String name, String contactEmail, String region) {}

--- a/examples/mapstruct-vs-telescope/src/main/java/io/github/eschizoid/telescope/example/mapstruct/dto/CustomerContactDto.java
+++ b/examples/mapstruct-vs-telescope/src/main/java/io/github/eschizoid/telescope/example/mapstruct/dto/CustomerContactDto.java
@@ -1,9 +1,68 @@
 package io.github.eschizoid.telescope.example.mapstruct.dto;
 
+import java.util.Objects;
+
 /**
- * A target with one component — {@code region} — that has no source counterpart on {@code
- * Customer}. It exists to pin the silent-drop footgun: a newly added or drifted target field with
- * no source compiles clean and lands {@code null} at runtime under MapStruct's default policy. (A
- * source rename is the separate, louder case — a compile error.)
+ * A target with one property — {@code region} — that has no source counterpart on {@code Customer}.
+ * A mutable JavaBean like the rest of the DTO side. It exists to pin the silent-drop footgun: a
+ * newly added or drifted target field with no source compiles clean and lands {@code null} at
+ * runtime under MapStruct's default policy. (A source rename is the separate, louder case — a
+ * compile error.)
  */
-public record CustomerContactDto(String name, String contactEmail, String region) {}
+public final class CustomerContactDto {
+
+  private String name;
+  private String contactEmail;
+  private String region;
+
+  public CustomerContactDto() {}
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(final String name) {
+    this.name = name;
+  }
+
+  public String getContactEmail() {
+    return contactEmail;
+  }
+
+  public void setContactEmail(final String contactEmail) {
+    this.contactEmail = contactEmail;
+  }
+
+  public String getRegion() {
+    return region;
+  }
+
+  public void setRegion(final String region) {
+    this.region = region;
+  }
+
+  @Override
+  public boolean equals(final Object other) {
+    if (this == other) {
+      return true;
+    }
+    if (!(other instanceof CustomerContactDto that)) {
+      return false;
+    }
+    return (
+      Objects.equals(name, that.name) &&
+      Objects.equals(contactEmail, that.contactEmail) &&
+      Objects.equals(region, that.region)
+    );
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name, contactEmail, region);
+  }
+
+  @Override
+  public String toString() {
+    return "CustomerContactDto[name=" + name + ", contactEmail=" + contactEmail + ", region=" + region + "]";
+  }
+}

--- a/examples/mapstruct-vs-telescope/src/main/java/io/github/eschizoid/telescope/example/mapstruct/dto/CustomerContactDto.java
+++ b/examples/mapstruct-vs-telescope/src/main/java/io/github/eschizoid/telescope/example/mapstruct/dto/CustomerContactDto.java
@@ -1,0 +1,8 @@
+package io.github.eschizoid.telescope.example.mapstruct.dto;
+
+/**
+ * A target with one component — {@code region} — that has no source counterpart on {@code
+ * Customer}. It exists to pin the silent-drop footgun: this is the exact shape a target takes the
+ * moment a rename strands it without a source.
+ */
+public record CustomerContactDto(String name, String contactEmail, String region) {}

--- a/examples/mapstruct-vs-telescope/src/main/java/io/github/eschizoid/telescope/example/mapstruct/dto/CustomerDto.java
+++ b/examples/mapstruct-vs-telescope/src/main/java/io/github/eschizoid/telescope/example/mapstruct/dto/CustomerDto.java
@@ -1,0 +1,8 @@
+package io.github.eschizoid.telescope.example.mapstruct.dto;
+
+/**
+ * Target-side customer. {@code contactEmail} is deliberately named differently from the source
+ * {@code Customer.email} — this is the field whose correspondence must be spelled explicitly, and
+ * the one that exposes the string-vs-method-reference gap when the source field is renamed.
+ */
+public record CustomerDto(String name, String contactEmail) {}

--- a/examples/mapstruct-vs-telescope/src/main/java/io/github/eschizoid/telescope/example/mapstruct/dto/CustomerDto.java
+++ b/examples/mapstruct-vs-telescope/src/main/java/io/github/eschizoid/telescope/example/mapstruct/dto/CustomerDto.java
@@ -1,8 +1,55 @@
 package io.github.eschizoid.telescope.example.mapstruct.dto;
 
+import java.util.Objects;
+
 /**
- * Target-side customer. {@code contactEmail} is deliberately named differently from the source
- * {@code Customer.email} — this is the field whose correspondence must be spelled explicitly, and
- * the one that exposes the string-vs-method-reference gap when the source field is renamed.
+ * Target-side customer — a mutable JavaBean (no-arg constructor plus getters/setters), the DTO
+ * shape JPA and serialization frameworks impose. {@code contactEmail} is deliberately named
+ * differently from the source {@code Customer.email} — this is the field whose correspondence must
+ * be spelled explicitly, and the one that exposes the string-vs-method-reference gap when the
+ * source field is renamed.
  */
-public record CustomerDto(String name, String contactEmail) {}
+public final class CustomerDto {
+
+  private String name;
+  private String contactEmail;
+
+  public CustomerDto() {}
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(final String name) {
+    this.name = name;
+  }
+
+  public String getContactEmail() {
+    return contactEmail;
+  }
+
+  public void setContactEmail(final String contactEmail) {
+    this.contactEmail = contactEmail;
+  }
+
+  @Override
+  public boolean equals(final Object other) {
+    if (this == other) {
+      return true;
+    }
+    if (!(other instanceof CustomerDto that)) {
+      return false;
+    }
+    return Objects.equals(name, that.name) && Objects.equals(contactEmail, that.contactEmail);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name, contactEmail);
+  }
+
+  @Override
+  public String toString() {
+    return "CustomerDto[name=" + name + ", contactEmail=" + contactEmail + "]";
+  }
+}

--- a/examples/mapstruct-vs-telescope/src/main/java/io/github/eschizoid/telescope/example/mapstruct/dto/LineItemDto.java
+++ b/examples/mapstruct-vs-telescope/src/main/java/io/github/eschizoid/telescope/example/mapstruct/dto/LineItemDto.java
@@ -1,0 +1,8 @@
+package io.github.eschizoid.telescope.example.mapstruct.dto;
+
+import java.math.BigDecimal;
+
+/**
+ * Target-side order line. All components are same-named — they map by recursion with no override.
+ */
+public record LineItemDto(String sku, int quantity, BigDecimal price) {}

--- a/examples/mapstruct-vs-telescope/src/main/java/io/github/eschizoid/telescope/example/mapstruct/dto/LineItemDto.java
+++ b/examples/mapstruct-vs-telescope/src/main/java/io/github/eschizoid/telescope/example/mapstruct/dto/LineItemDto.java
@@ -1,8 +1,62 @@
 package io.github.eschizoid.telescope.example.mapstruct.dto;
 
 import java.math.BigDecimal;
+import java.util.Objects;
 
 /**
- * Target-side order line. All components are same-named — they map by recursion with no override.
+ * Target-side order line — a mutable JavaBean (no-arg constructor plus getters/setters). All
+ * properties are same-named — they map by recursion with no override.
  */
-public record LineItemDto(String sku, int quantity, BigDecimal price) {}
+public final class LineItemDto {
+
+  private String sku;
+  private int quantity;
+  private BigDecimal price;
+
+  public LineItemDto() {}
+
+  public String getSku() {
+    return sku;
+  }
+
+  public void setSku(final String sku) {
+    this.sku = sku;
+  }
+
+  public int getQuantity() {
+    return quantity;
+  }
+
+  public void setQuantity(final int quantity) {
+    this.quantity = quantity;
+  }
+
+  public BigDecimal getPrice() {
+    return price;
+  }
+
+  public void setPrice(final BigDecimal price) {
+    this.price = price;
+  }
+
+  @Override
+  public boolean equals(final Object other) {
+    if (this == other) {
+      return true;
+    }
+    if (!(other instanceof LineItemDto that)) {
+      return false;
+    }
+    return quantity == that.quantity && Objects.equals(sku, that.sku) && Objects.equals(price, that.price);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(sku, quantity, price);
+  }
+
+  @Override
+  public String toString() {
+    return "LineItemDto[sku=" + sku + ", quantity=" + quantity + ", price=" + price + "]";
+  }
+}

--- a/examples/mapstruct-vs-telescope/src/main/java/io/github/eschizoid/telescope/example/mapstruct/dto/OrderDto.java
+++ b/examples/mapstruct-vs-telescope/src/main/java/io/github/eschizoid/telescope/example/mapstruct/dto/OrderDto.java
@@ -1,8 +1,63 @@
 package io.github.eschizoid.telescope.example.mapstruct.dto;
 
 import java.util.List;
+import java.util.Objects;
 
 /**
- * Target-side order. Mirrors {@code Order}; only {@code Customer.email -> contactEmail} differs.
+ * Target-side order — a mutable JavaBean (no-arg constructor plus getters/setters), the DTO shape
+ * JPA and serialization frameworks impose. Mirrors {@code Order}; only {@code Customer.email ->
+ * contactEmail} differs.
  */
-public record OrderDto(String id, CustomerDto customer, List<LineItemDto> lines) {}
+public final class OrderDto {
+
+  private String id;
+  private CustomerDto customer;
+  private List<LineItemDto> lines;
+
+  public OrderDto() {}
+
+  public String getId() {
+    return id;
+  }
+
+  public void setId(final String id) {
+    this.id = id;
+  }
+
+  public CustomerDto getCustomer() {
+    return customer;
+  }
+
+  public void setCustomer(final CustomerDto customer) {
+    this.customer = customer;
+  }
+
+  public List<LineItemDto> getLines() {
+    return lines;
+  }
+
+  public void setLines(final List<LineItemDto> lines) {
+    this.lines = lines;
+  }
+
+  @Override
+  public boolean equals(final Object other) {
+    if (this == other) {
+      return true;
+    }
+    if (!(other instanceof OrderDto that)) {
+      return false;
+    }
+    return Objects.equals(id, that.id) && Objects.equals(customer, that.customer) && Objects.equals(lines, that.lines);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id, customer, lines);
+  }
+
+  @Override
+  public String toString() {
+    return "OrderDto[id=" + id + ", customer=" + customer + ", lines=" + lines + "]";
+  }
+}

--- a/examples/mapstruct-vs-telescope/src/main/java/io/github/eschizoid/telescope/example/mapstruct/dto/OrderDto.java
+++ b/examples/mapstruct-vs-telescope/src/main/java/io/github/eschizoid/telescope/example/mapstruct/dto/OrderDto.java
@@ -1,0 +1,8 @@
+package io.github.eschizoid.telescope.example.mapstruct.dto;
+
+import java.util.List;
+
+/**
+ * Target-side order. Mirrors {@code Order}; only {@code Customer.email -> contactEmail} differs.
+ */
+public record OrderDto(String id, CustomerDto customer, List<LineItemDto> lines) {}

--- a/examples/mapstruct-vs-telescope/src/main/java/io/github/eschizoid/telescope/example/mapstruct/mapstruct/OrderMapStructMapper.java
+++ b/examples/mapstruct-vs-telescope/src/main/java/io/github/eschizoid/telescope/example/mapstruct/mapstruct/OrderMapStructMapper.java
@@ -16,7 +16,8 @@ import org.mapstruct.factory.Mappers;
  * rename {@code @Mapping} (the idiomatic spot — a dotted {@code source = "customer.email"} on the
  * top-level method works too); the {@code LineItem} one is written out to make the collection
  * recursion explicit (MapStruct would otherwise synthesize element mapping for the same-named
- * record).
+ * properties). The targets are mutable JavaBeans, so MapStruct writes them the default way: no-arg
+ * constructor plus setters.
  *
  * <p>The load-bearing detail is the {@code "email"} string. Rename {@code Customer.email()} via an
  * IDE refactor and the string is <em>not</em> touched — it's opaque text, not a reference — so it

--- a/examples/mapstruct-vs-telescope/src/main/java/io/github/eschizoid/telescope/example/mapstruct/mapstruct/OrderMapStructMapper.java
+++ b/examples/mapstruct-vs-telescope/src/main/java/io/github/eschizoid/telescope/example/mapstruct/mapstruct/OrderMapStructMapper.java
@@ -1,0 +1,42 @@
+package io.github.eschizoid.telescope.example.mapstruct.mapstruct;
+
+import io.github.eschizoid.telescope.example.mapstruct.domain.Customer;
+import io.github.eschizoid.telescope.example.mapstruct.domain.LineItem;
+import io.github.eschizoid.telescope.example.mapstruct.domain.Order;
+import io.github.eschizoid.telescope.example.mapstruct.dto.CustomerDto;
+import io.github.eschizoid.telescope.example.mapstruct.dto.LineItemDto;
+import io.github.eschizoid.telescope.example.mapstruct.dto.OrderDto;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * The MapStruct side of the head-to-head. Forward Order to OrderDto, with the one rename spelled
+ * the MapStruct way: a string-keyed {@code @Mapping}. The two sub-methods ({@code Customer}, {@code
+ * LineItem}) are required so MapStruct generates the nested + collection recursion.
+ *
+ * <p>The load-bearing detail is the {@code "email"} string. Rename {@code Customer.email()} via an
+ * IDE refactor and this string is <em>not</em> touched — it's opaque text, not a reference. What
+ * happens next depends on MapStruct's policy (see the slice README):
+ *
+ * <ul>
+ *   <li>Default {@code unmappedTargetPolicy = WARN}: a now-unmapped target compiles and goes
+ *       silently {@code null} at runtime.
+ *   <li>Strictest {@code ERROR}: the stale string fails compilation, and you hand-fix every
+ *       {@code @Mapping} across the codebase by hand.
+ * </ul>
+ *
+ * Either way the string is the liability. telescope's {@code Customer::email} method reference is
+ * refactored automatically and checked by the compiler.
+ */
+@Mapper
+public interface OrderMapStructMapper {
+  OrderMapStructMapper INSTANCE = Mappers.getMapper(OrderMapStructMapper.class);
+
+  OrderDto toDto(Order order);
+
+  @Mapping(source = "email", target = "contactEmail")
+  CustomerDto toDto(Customer customer);
+
+  LineItemDto toDto(LineItem line);
+}

--- a/examples/mapstruct-vs-telescope/src/main/java/io/github/eschizoid/telescope/example/mapstruct/mapstruct/OrderMapStructMapper.java
+++ b/examples/mapstruct-vs-telescope/src/main/java/io/github/eschizoid/telescope/example/mapstruct/mapstruct/OrderMapStructMapper.java
@@ -12,22 +12,20 @@ import org.mapstruct.factory.Mappers;
 
 /**
  * The MapStruct side of the head-to-head. Forward Order to OrderDto, with the one rename spelled
- * the MapStruct way: a string-keyed {@code @Mapping}. The two sub-methods ({@code Customer}, {@code
- * LineItem}) are required so MapStruct generates the nested + collection recursion.
+ * the MapStruct way: a string-keyed {@code @Mapping}. The {@code Customer} sub-method is required
+ * to carry the rename {@code @Mapping}; the {@code LineItem} one is written out to make the
+ * collection recursion explicit (MapStruct would otherwise synthesize element mapping for the
+ * same-named record).
  *
  * <p>The load-bearing detail is the {@code "email"} string. Rename {@code Customer.email()} via an
- * IDE refactor and this string is <em>not</em> touched — it's opaque text, not a reference. What
- * happens next depends on MapStruct's policy (see the slice README):
+ * IDE refactor and the string is <em>not</em> touched — it's opaque text, not a reference — so it
+ * now names a property that no longer exists. MapStruct catches that loudly: a hard compile error
+ * ({@code No property named "email" exists in source parameter(s)}), independent of policy. Good —
+ * but the fix is manual, every stale {@code @Mapping} hand-edited; telescope's {@code
+ * Customer::email} method reference is refactored automatically and checked by the compiler.
  *
- * <ul>
- *   <li>Default {@code unmappedTargetPolicy = WARN}: a now-unmapped target compiles and goes
- *       silently {@code null} at runtime.
- *   <li>Strictest {@code ERROR}: the stale string fails compilation, and you hand-fix every
- *       {@code @Mapping} across the codebase by hand.
- * </ul>
- *
- * Either way the string is the liability. telescope's {@code Customer::email} method reference is
- * refactored automatically and checked by the compiler.
+ * <p>(The silent-{@code null} hazard is a <em>separate</em> footgun — an unmapped target with no
+ * source, not a renamed source — demonstrated by {@link SilentDropMapper}.)
  */
 @Mapper
 public interface OrderMapStructMapper {

--- a/examples/mapstruct-vs-telescope/src/main/java/io/github/eschizoid/telescope/example/mapstruct/mapstruct/OrderMapStructMapper.java
+++ b/examples/mapstruct-vs-telescope/src/main/java/io/github/eschizoid/telescope/example/mapstruct/mapstruct/OrderMapStructMapper.java
@@ -12,10 +12,11 @@ import org.mapstruct.factory.Mappers;
 
 /**
  * The MapStruct side of the head-to-head. Forward Order to OrderDto, with the one rename spelled
- * the MapStruct way: a string-keyed {@code @Mapping}. The {@code Customer} sub-method is required
- * to carry the rename {@code @Mapping}; the {@code LineItem} one is written out to make the
- * collection recursion explicit (MapStruct would otherwise synthesize element mapping for the
- * same-named record).
+ * the MapStruct way: a string-keyed {@code @Mapping}. The {@code Customer} sub-method carries the
+ * rename {@code @Mapping} (the idiomatic spot — a dotted {@code source = "customer.email"} on the
+ * top-level method works too); the {@code LineItem} one is written out to make the collection
+ * recursion explicit (MapStruct would otherwise synthesize element mapping for the same-named
+ * record).
  *
  * <p>The load-bearing detail is the {@code "email"} string. Rename {@code Customer.email()} via an
  * IDE refactor and the string is <em>not</em> touched — it's opaque text, not a reference — so it

--- a/examples/mapstruct-vs-telescope/src/main/java/io/github/eschizoid/telescope/example/mapstruct/mapstruct/SilentDropMapper.java
+++ b/examples/mapstruct-vs-telescope/src/main/java/io/github/eschizoid/telescope/example/mapstruct/mapstruct/SilentDropMapper.java
@@ -7,14 +7,15 @@ import org.mapstruct.Mapping;
 import org.mapstruct.factory.Mappers;
 
 /**
- * Demonstrates MapStruct's default-policy silent drop — permanently, in CI, so the head-to-head
- * doesn't rely on you applying a rename by hand to see it.
+ * Demonstrates MapStruct's default-policy silent drop of an unmapped target — permanently, in CI,
+ * so the head-to-head doesn't rely on you triggering it by hand to see it.
  *
- * <p>{@code CustomerContactDto.region} has no source on {@code Customer}. Under MapStruct's default
- * {@code unmappedTargetPolicy} ({@code WARN}), this compiles with only a build warning and leaves
- * {@code region} {@code null} at runtime. That is exactly what a field rename produces when it
- * strands a target without a source: no compile error, a quietly wrong object. The companion test
- * asserts the {@code null}.
+ * <p>{@code CustomerContactDto.region} has no source on {@code Customer} at all. Under MapStruct's
+ * default {@code unmappedTargetPolicy} ({@code WARN}), this compiles with only a build warning and
+ * leaves {@code region} {@code null} at runtime — a quietly wrong object, no error. This is the
+ * hazard that bites newly added or drifted target fields; it is distinct from a source rename,
+ * which MapStruct catches as a hard compile error (see {@link OrderMapStructMapper}). The companion
+ * test asserts the {@code null}.
  */
 @Mapper
 public interface SilentDropMapper {

--- a/examples/mapstruct-vs-telescope/src/main/java/io/github/eschizoid/telescope/example/mapstruct/mapstruct/SilentDropMapper.java
+++ b/examples/mapstruct-vs-telescope/src/main/java/io/github/eschizoid/telescope/example/mapstruct/mapstruct/SilentDropMapper.java
@@ -1,0 +1,25 @@
+package io.github.eschizoid.telescope.example.mapstruct.mapstruct;
+
+import io.github.eschizoid.telescope.example.mapstruct.domain.Customer;
+import io.github.eschizoid.telescope.example.mapstruct.dto.CustomerContactDto;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * Demonstrates MapStruct's default-policy silent drop — permanently, in CI, so the head-to-head
+ * doesn't rely on you applying a rename by hand to see it.
+ *
+ * <p>{@code CustomerContactDto.region} has no source on {@code Customer}. Under MapStruct's default
+ * {@code unmappedTargetPolicy} ({@code WARN}), this compiles with only a build warning and leaves
+ * {@code region} {@code null} at runtime. That is exactly what a field rename produces when it
+ * strands a target without a source: no compile error, a quietly wrong object. The companion test
+ * asserts the {@code null}.
+ */
+@Mapper
+public interface SilentDropMapper {
+  SilentDropMapper INSTANCE = Mappers.getMapper(SilentDropMapper.class);
+
+  @Mapping(source = "email", target = "contactEmail")
+  CustomerContactDto toContactDto(Customer customer);
+}

--- a/examples/mapstruct-vs-telescope/src/main/java/io/github/eschizoid/telescope/example/mapstruct/telescope/TelescopeMappings.java
+++ b/examples/mapstruct-vs-telescope/src/main/java/io/github/eschizoid/telescope/example/mapstruct/telescope/TelescopeMappings.java
@@ -1,0 +1,46 @@
+package io.github.eschizoid.telescope.example.mapstruct.telescope;
+
+import static io.github.eschizoid.telescope.mapping.Mapping.to;
+
+import io.github.eschizoid.telescope.Telescope;
+import io.github.eschizoid.telescope.conversion.Mapper;
+import io.github.eschizoid.telescope.example.mapstruct.domain.Customer;
+import io.github.eschizoid.telescope.example.mapstruct.domain.LineItem;
+import io.github.eschizoid.telescope.example.mapstruct.domain.Order;
+import io.github.eschizoid.telescope.example.mapstruct.dto.CustomerDto;
+import io.github.eschizoid.telescope.example.mapstruct.dto.OrderDto;
+import java.math.BigDecimal;
+
+/** The telescope side of the head-to-head: one typed path for the whole lifecycle. */
+public final class TelescopeMappings {
+
+  private TelescopeMappings() {}
+
+  /**
+   * Act 1 — the entire {@code Order -> OrderDto} mapping as one declarative value,
+   * <em>bidirectional for free</em> ({@code forward} / {@code backward}). Recursion handles the
+   * nested {@code Customer}, the {@code LineItem} list, and every same-named field; the single
+   * {@code to(...)} override spells the one difference with method references — {@code
+   * Customer::email} and {@code CustomerDto::contactEmail} — that the compiler checks and the IDE
+   * refactors. Rename {@code Customer.email()} and this reference moves with the rename; nothing
+   * goes stale.
+   */
+  public static final Mapper<Order, OrderDto> ORDER_MAPPER = Telescope.mapper(
+    Order.class,
+    OrderDto.class,
+    to(Customer::email, CustomerDto::contactEmail)
+  );
+
+  /**
+   * Act 2 — deep immutable update. Multiply every line item's price by {@code rate} and rebuild the
+   * whole immutable {@code Order} graph in one typed pass, the original untouched. This is the
+   * clean structural gap: MapStruct maps {@code A -> B}; it does not read, write, or update a
+   * value's interior. The same {@code Telescope} vocabulary that mapped above also navigates here.
+   */
+  public static Order applyRate(final Order order, final BigDecimal rate) {
+    return Telescope.of(Order.class)
+      .each(Order::lines)
+      .field(LineItem::price)
+      .update(order, price -> price.multiply(rate));
+  }
+}

--- a/examples/mapstruct-vs-telescope/src/main/java/io/github/eschizoid/telescope/example/mapstruct/telescope/TelescopeMappings.java
+++ b/examples/mapstruct-vs-telescope/src/main/java/io/github/eschizoid/telescope/example/mapstruct/telescope/TelescopeMappings.java
@@ -18,17 +18,19 @@ public final class TelescopeMappings {
 
   /**
    * Act 1 — the entire {@code Order -> OrderDto} mapping as one declarative value,
-   * <em>bidirectional for free</em> ({@code forward} / {@code backward}). Recursion handles the
-   * nested {@code Customer}, the {@code LineItem} list, and every same-named field; the single
-   * {@code to(...)} override spells the one difference with method references — {@code
-   * Customer::email} and {@code CustomerDto::contactEmail} — that the compiler checks and the IDE
+   * <em>bidirectional for free</em> ({@code forward} / {@code backward}). The source side is
+   * immutable records, the target side mutable JavaBeans — telescope handles the paradigm hop
+   * (no-arg constructor plus setters forward, getters backward). Recursion handles the nested
+   * {@code Customer}, the {@code LineItem} list, and every same-named field; the single {@code
+   * to(...)} override spells the one difference with method references — {@code Customer::email}
+   * and the bean getter {@code CustomerDto::getContactEmail} — that the compiler checks and the IDE
    * refactors. Rename {@code Customer.email()} and this reference moves with the rename; nothing
    * goes stale.
    */
   public static final Mapper<Order, OrderDto> ORDER_MAPPER = Telescope.mapper(
     Order.class,
     OrderDto.class,
-    to(Customer::email, CustomerDto::contactEmail)
+    to(Customer::email, CustomerDto::getContactEmail)
   );
 
   /**

--- a/examples/mapstruct-vs-telescope/src/main/java/io/github/eschizoid/telescope/example/mapstruct/telescope/TelescopeMappings.java
+++ b/examples/mapstruct-vs-telescope/src/main/java/io/github/eschizoid/telescope/example/mapstruct/telescope/TelescopeMappings.java
@@ -32,15 +32,21 @@ public final class TelescopeMappings {
   );
 
   /**
-   * Act 2 — deep immutable update. Multiply every line item's price by {@code rate} and rebuild the
-   * whole immutable {@code Order} graph in one typed pass, the original untouched. This is the
-   * clean structural gap: MapStruct maps {@code A -> B}; it does not read, write, or update a
-   * value's interior. The same {@code Telescope} vocabulary that mapped above also navigates here.
+   * Act 2 — deep immutable update, kept as a reusable <em>path value</em> that mirrors {@code
+   * ORDER_MAPPER}: a path is a thing you store, not a call you re-spell. The same {@code Telescope}
+   * vocabulary that mapped {@code Order -> OrderDto} above navigates to every line item's price
+   * here.
+   */
+  public static final Telescope<Order, BigDecimal> LINE_PRICES = Telescope.of(Order.class)
+    .each(Order::lines)
+    .field(LineItem::price);
+
+  /**
+   * Multiply every line item's price by {@code rate} and rebuild the whole immutable {@code Order}
+   * graph in one typed pass, the original untouched. The clean structural gap: MapStruct maps
+   * {@code A -> B}; it does not read, write, or update a value's interior.
    */
   public static Order applyRate(final Order order, final BigDecimal rate) {
-    return Telescope.of(Order.class)
-      .each(Order::lines)
-      .field(LineItem::price)
-      .update(order, price -> price.multiply(rate));
+    return LINE_PRICES.update(order, price -> price.multiply(rate));
   }
 }

--- a/examples/mapstruct-vs-telescope/src/test/java/io/github/eschizoid/telescope/example/mapstruct/MapStructVsTelescopeTest.java
+++ b/examples/mapstruct-vs-telescope/src/test/java/io/github/eschizoid/telescope/example/mapstruct/MapStructVsTelescopeTest.java
@@ -42,8 +42,12 @@ class MapStructVsTelescopeTest {
     final var viaTelescope = TelescopeMappings.ORDER_MAPPER.forward(order);
 
     assertEquals(viaMapStruct, viaTelescope, "both frameworks map the same Order to the same OrderDto");
-    assertEquals("ada@example.com", viaTelescope.customer().contactEmail(), "the email -> contactEmail rename landed");
-    assertEquals(2, viaTelescope.lines().size(), "the line-item collection recursed");
+    assertEquals(
+      "ada@example.com",
+      viaTelescope.getCustomer().getContactEmail(),
+      "the email -> contactEmail rename landed"
+    );
+    assertEquals(2, viaTelescope.getLines().size(), "the line-item collection recursed");
   }
 
   @Test
@@ -59,9 +63,9 @@ class MapStructVsTelescopeTest {
   void mapStructSilentlyDropsUnmappedTarget() {
     final var dto = SilentDropMapper.INSTANCE.toContactDto(new Customer("Ada", "ada@example.com"));
 
-    assertEquals("ada@example.com", dto.contactEmail(), "the mapped field is fine");
+    assertEquals("ada@example.com", dto.getContactEmail(), "the mapped field is fine");
     assertNull(
-      dto.region(),
+      dto.getRegion(),
       "default unmappedTargetPolicy=WARN compiles and nulls an unmapped target (a source rename is the separate case — a compile error)"
     );
   }

--- a/examples/mapstruct-vs-telescope/src/test/java/io/github/eschizoid/telescope/example/mapstruct/MapStructVsTelescopeTest.java
+++ b/examples/mapstruct-vs-telescope/src/test/java/io/github/eschizoid/telescope/example/mapstruct/MapStructVsTelescopeTest.java
@@ -17,10 +17,11 @@ import org.junit.jupiter.api.Test;
 
 /**
  * The reproducible proof behind the slice README's head-to-head. Committed state is green: both
- * frameworks map identically. The footgun test pins MapStruct's default-policy silent drop
- * permanently, so CI demonstrates Layer 1 without anyone having to apply a rename by hand. The
- * rename divergence itself (telescope auto-refactors / MapStruct goes stale) is a documented manual
- * step in the README — a compile failure can't also be a passing test.
+ * frameworks map identically. The footgun test pins MapStruct's default-policy silent drop of an
+ * unmapped target permanently, so CI demonstrates it without anyone applying a rename by hand. The
+ * rename divergence itself (telescope's method reference auto-refactors; MapStruct's stale
+ * {@code @Mapping} string fails to compile) is a documented manual step in the README — a compile
+ * failure can't also be a passing test.
  */
 class MapStructVsTelescopeTest {
 
@@ -54,14 +55,14 @@ class MapStructVsTelescopeTest {
   }
 
   @Test
-  @DisplayName("Layer 1 footgun: MapStruct's default policy leaves an unmapped target silently null")
+  @DisplayName("Unmapped-target footgun: MapStruct's default policy leaves a target with no source silently null")
   void mapStructSilentlyDropsUnmappedTarget() {
     final var dto = SilentDropMapper.INSTANCE.toContactDto(new Customer("Ada", "ada@example.com"));
 
     assertEquals("ada@example.com", dto.contactEmail(), "the mapped field is fine");
     assertNull(
       dto.region(),
-      "default unmappedTargetPolicy=WARN compiles and nulls the unmapped target — the exact shape a rename produces"
+      "default unmappedTargetPolicy=WARN compiles and nulls an unmapped target (a source rename is the separate case — a compile error)"
     );
   }
 

--- a/examples/mapstruct-vs-telescope/src/test/java/io/github/eschizoid/telescope/example/mapstruct/MapStructVsTelescopeTest.java
+++ b/examples/mapstruct-vs-telescope/src/test/java/io/github/eschizoid/telescope/example/mapstruct/MapStructVsTelescopeTest.java
@@ -1,0 +1,84 @@
+package io.github.eschizoid.telescope.example.mapstruct;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import io.github.eschizoid.telescope.example.mapstruct.domain.Customer;
+import io.github.eschizoid.telescope.example.mapstruct.domain.LineItem;
+import io.github.eschizoid.telescope.example.mapstruct.domain.Order;
+import io.github.eschizoid.telescope.example.mapstruct.mapstruct.OrderMapStructMapper;
+import io.github.eschizoid.telescope.example.mapstruct.mapstruct.SilentDropMapper;
+import io.github.eschizoid.telescope.example.mapstruct.telescope.TelescopeMappings;
+import java.math.BigDecimal;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The reproducible proof behind the slice README's head-to-head. Committed state is green: both
+ * frameworks map identically. The footgun test pins MapStruct's default-policy silent drop
+ * permanently, so CI demonstrates Layer 1 without anyone having to apply a rename by hand. The
+ * rename divergence itself (telescope auto-refactors / MapStruct goes stale) is a documented manual
+ * step in the README — a compile failure can't also be a passing test.
+ */
+class MapStructVsTelescopeTest {
+
+  private static Order sampleOrder() {
+    return new Order(
+      "o-1",
+      new Customer("Ada", "ada@example.com"),
+      List.of(new LineItem("sku-1", 2, new BigDecimal("10.00")), new LineItem("sku-2", 1, new BigDecimal("5.00")))
+    );
+  }
+
+  @Test
+  @DisplayName("Act 1 baseline: MapStruct and telescope produce the identical OrderDto, rename and all")
+  void bothFrameworksMapToTheSameDto() {
+    final var order = sampleOrder();
+
+    final var viaMapStruct = OrderMapStructMapper.INSTANCE.toDto(order);
+    final var viaTelescope = TelescopeMappings.ORDER_MAPPER.forward(order);
+
+    assertEquals(viaMapStruct, viaTelescope, "both frameworks map the same Order to the same OrderDto");
+    assertEquals("ada@example.com", viaTelescope.customer().contactEmail(), "the email -> contactEmail rename landed");
+    assertEquals(2, viaTelescope.lines().size(), "the line-item collection recursed");
+  }
+
+  @Test
+  @DisplayName("telescope mapping is bidirectional for free — backward(forward(order)) == order")
+  void telescopeMapperRoundTrips() {
+    final var order = sampleOrder();
+    final var roundTripped = TelescopeMappings.ORDER_MAPPER.backward(TelescopeMappings.ORDER_MAPPER.forward(order));
+    assertEquals(order, roundTripped, "one mapper(...) value gives both directions; MapStruct needs a second method");
+  }
+
+  @Test
+  @DisplayName("Layer 1 footgun: MapStruct's default policy leaves an unmapped target silently null")
+  void mapStructSilentlyDropsUnmappedTarget() {
+    final var dto = SilentDropMapper.INSTANCE.toContactDto(new Customer("Ada", "ada@example.com"));
+
+    assertEquals("ada@example.com", dto.contactEmail(), "the mapped field is fine");
+    assertNull(
+      dto.region(),
+      "default unmappedTargetPolicy=WARN compiles and nulls the unmapped target — the exact shape a rename produces"
+    );
+  }
+
+  @Test
+  @DisplayName("Act 2: deep immutable update rebuilds the whole graph; the original is untouched")
+  void deepUpdateRebuildsImmutably() {
+    final var order = sampleOrder();
+
+    final var taxed = TelescopeMappings.applyRate(order, new BigDecimal("2"));
+
+    assertEquals(new BigDecimal("20.00"), taxed.lines().get(0).price(), "every line price doubled");
+    assertEquals(new BigDecimal("10.00"), taxed.lines().get(1).price(), "every line price doubled");
+    assertNotSame(order, taxed, "a new Order graph is returned");
+    assertEquals(
+      new BigDecimal("10.00"),
+      order.lines().get(0).price(),
+      "the original Order is unchanged — immutable update"
+    );
+  }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -9,6 +9,7 @@ include("quarkus")
 include("benchmarks")
 
 include("examples:library")
+include("examples:mapstruct-vs-telescope")
 include("examples:graphql")
 include("examples:springboot:order-jpa")
 include("examples:springboot:product-starter")


### PR DESCRIPTION
## What

A runnable, **reproducible** `examples/mapstruct-vs-telescope/` slice that doubles as the **canonical "telescope vs MapStruct" reference** — wired from the main README's "How it compares to MapStruct" section. Same `Order → OrderDto` mapping written both ways, in one module:

```bash
./gradlew :examples:mapstruct-vs-telescope:test
```

This is the adoption deliverable from a design session: *proof before tooling* (validate the migration story by hand before any OpenRewrite investment), and the artifact is itself the adoption content.

## Two acts, one domain

**Act 1 — refactor-safety.** The one cross-named field is `to(Customer::email, CustomerDto::contactEmail)` (method ref) in telescope vs `@Mapping(source="email", target="contactEmail")` (string) in MapStruct. Rename `Customer.email()`:
- telescope's reference follows the IDE refactor; nothing goes stale.
- MapStruct's string is opaque text — **Layer 1** (default `unmappedTargetPolicy=WARN`): silently `null` at runtime; **Layer 2** (strictest `ERROR`): compile error you hand-fix across every `@Mapping`.

**Act 2 — the structural gap.** The same typed path deep-updates the immutable graph — `of().each().field().update()` — which a mapper architecture can't express.

## Fair by construction

- Committed state is **green**: both frameworks map identically (test pins it); MapStruct is configured the normal way, not strawmanned.
- The default-policy silent drop is pinned **permanently in CI** (`SilentDropMapper` + a `null` assertion), so the footgun is demonstrated on every run without anyone applying a rename by hand.
- The rename → divergence itself is a documented **one-command reproduction** (a compile failure can't also be a passing test).
- The README credits where MapStruct still wins: mature ecosystem, all-compile-time generation, and that jakarta validation *also* accumulates (so the validation angle is honestly left out).

## Tests

4 tests, all green: Act 1 baseline equality, bidirectional round-trip (free with telescope), the Layer 1 silent-`null`, and Act 2 immutable deep-update. Build + spotless (Java + both READMEs) clean.

## Files

New `examples:mapstruct-vs-telescope` module (reuses the `benchmarks/` MapStruct 1.6.3 wiring); main `README.md` callout; `settings.gradle.kts` include.
