### PR TITLE
feat: compile-time mapper verification — shared PairingRules + MapperVerifierProcessor (ADR-0012)

### DIFF
--- a/codegen/build.gradle.kts
+++ b/codegen/build.gradle.kts
@@ -53,6 +53,10 @@ tasks.withType<Javadoc>().configureEach {
 
 dependencies {
     api(project(":core"))
+    // MapperVerifierProcessor executes PairingRules at annotation-processing runtime. The classes
+    // arrive transitively through :core's api scope today, but the verifier's dependency is direct
+    // — declared explicitly so a future :core scope change can't silently break the processor path.
+    implementation(project(":internal"))
 
     testImplementation(project(":core"))
     testImplementation(platform(libs.junitBom))

--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/MapperVerifierProcessor.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/MapperVerifierProcessor.java
@@ -138,9 +138,8 @@ public final class MapperVerifierProcessor extends AbstractProcessor {
             } catch (final RuntimeException e) {
               // The verifier must never break a build except through its own diagnostics — an
               // uncaught exception in a task listener aborts the compile. Skip the unit; the
-              // construction-time validation still applies. If this ever fires it is a
-              // verifier
-              // bug: verbose mode appends the stack trace so the report is debuggable.
+              // construction-time validation still applies. If this ever fires it is a verifier
+              // bug; verbose mode appends the stack trace so the report is debuggable.
               final var detail = new StringWriter();
               if (verbose) e.printStackTrace(new PrintWriter(detail));
               processingEnv
@@ -452,8 +451,9 @@ public final class MapperVerifierProcessor extends AbstractProcessor {
         report(row, PairingMessages.writeBeanTargetsRecord(elements.getBinaryName(targetEl).toString()));
         return;
       }
-      if (!hintTargets.add(elements.getBinaryName(targetEl).toString())) {
-        report(row, PairingMessages.duplicateWriteBeanHint(elements.getBinaryName(targetEl).toString()));
+      final var binaryName = elements.getBinaryName(targetEl).toString();
+      if (!hintTargets.add(binaryName)) {
+        report(row, PairingMessages.duplicateWriteBeanHint(binaryName));
       }
     }
 

--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/MapperVerifierProcessor.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/MapperVerifierProcessor.java
@@ -16,6 +16,8 @@ import io.github.eschizoid.telescope.annotations.UncheckedMapping;
 import io.github.eschizoid.telescope.internal.pairing.PairDecision;
 import io.github.eschizoid.telescope.internal.pairing.PairingMessages;
 import io.github.eschizoid.telescope.internal.pairing.PairingRules;
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.IdentityHashMap;
@@ -63,7 +65,7 @@ import javax.tools.Diagnostic;
  *
  * <p>Scope notes, mirroring the runtime exactly: {@code mapperForward} is lenient by contract, so
  * only its explicit rows are checked (no completeness). Rows that carry user conversion functions
- * ({@code to(src, tgt, fwd, bwd)}, {@code forward}, {@code enumTo}, {@code via}) are claims only —
+ * ({@code to(src, tgt, fwd, bwd)}, {@code toOneWay}, {@code enumTo}, {@code via}) are claims only —
  * their leaf conversion is the user's. Presence of a target-telescope / {@code constant} / {@code
  * compute} row switches the runtime into its permissive mode, so completeness checking is disabled
  * for that site too. Nested auto-recursed pairs are lenient about unmatched fields (as at runtime)
@@ -95,6 +97,7 @@ public final class MapperVerifierProcessor extends AbstractProcessor {
   private boolean off;
   private boolean verbose;
   private boolean notedUnavailable;
+  private String unavailableReason;
 
   @Override
   public synchronized void init(final ProcessingEnvironment processingEnv) {
@@ -104,6 +107,14 @@ public final class MapperVerifierProcessor extends AbstractProcessor {
     props = new MirrorProps(types, elements);
     rules = new PairingRules<>(props);
     final var mode = processingEnv.getOptions().getOrDefault("telescope.verify", "error");
+    if (!"error".equals(mode) && !"warn".equals(mode) && !"off".equals(mode)) {
+      processingEnv
+        .getMessager()
+        .printMessage(
+          Diagnostic.Kind.NOTE,
+          "telescope: unrecognized -Atelescope.verify value '" + mode + "'; using 'error'."
+        );
+    }
     off = "off".equals(mode);
     reportKind = "warn".equals(mode) ? Diagnostic.Kind.WARNING : Diagnostic.Kind.ERROR;
     verbose = processingEnv.getOptions().containsKey("telescope.verify.verbose");
@@ -127,7 +138,11 @@ public final class MapperVerifierProcessor extends AbstractProcessor {
             } catch (final RuntimeException e) {
               // The verifier must never break a build except through its own diagnostics — an
               // uncaught exception in a task listener aborts the compile. Skip the unit; the
-              // construction-time validation still applies.
+              // construction-time validation still applies. If this ever fires it is a
+              // verifier
+              // bug: verbose mode appends the stack trace so the report is debuggable.
+              final var detail = new StringWriter();
+              if (verbose) e.printStackTrace(new PrintWriter(detail));
               processingEnv
                 .getMessager()
                 .printMessage(
@@ -136,14 +151,19 @@ public final class MapperVerifierProcessor extends AbstractProcessor {
                     unit.getSourceFile().getName() +
                     " (" +
                     e +
-                    "); construction-time validation still applies."
+                    "); construction-time validation still applies." +
+                    (verbose ? "\n" + detail : "")
                 );
             }
           }
         }
       );
     } catch (final RuntimeException e) {
+      // Trees.instance / JavacTask.instance throw for non-javac environments; anything else
+      // escaping here is a real init bug. Either way the reason is carried into the one NOTE so
+      // the two causes are distinguishable in a report.
       trees = null;
+      unavailableReason = e.toString();
     }
   }
 
@@ -167,7 +187,8 @@ public final class MapperVerifierProcessor extends AbstractProcessor {
         .printMessage(
           Diagnostic.Kind.NOTE,
           "telescope: compile-time mapping verification needs the javac tree API; " +
-            "skipping (construction-time validation still applies)."
+            "skipping (construction-time validation still applies). Cause: " +
+            unavailableReason
         );
     }
     return false;
@@ -240,7 +261,13 @@ public final class MapperVerifierProcessor extends AbstractProcessor {
       }
       final var srcEl = props.elementOf(srcType);
       final var tgtEl = props.elementOf(tgtType);
-      if (srcEl == null || tgtEl == null || !rules.reflectable(srcType) || !rules.reflectable(tgtType)) return;
+      if (srcEl == null || tgtEl == null || !rules.reflectable(srcType) || !rules.reflectable(tgtType)) {
+        note(
+          node,
+          "telescope: mapping not statically verifiable (non-reflectable class argument); deferring to construction"
+        );
+        return;
+      }
 
       final var srcSimple = srcEl.getSimpleName().toString();
       final var tgtSimple = tgtEl.getSimpleName().toString();
@@ -275,7 +302,7 @@ public final class MapperVerifierProcessor extends AbstractProcessor {
           continue;
         }
         analyzable &= verifyRow(row, rowExec, srcType, tgtType, srcSimple, tgtSimple, claimedSrc, claimedTgt);
-        permissive |= isPermissiveRow(rowExec);
+        permissive |= isPermissiveRow(row, rowExec);
       }
 
       if (!analyzable) {
@@ -323,16 +350,18 @@ public final class MapperVerifierProcessor extends AbstractProcessor {
       final var rowName = rowExec.getSimpleName().toString();
       final var rowArgs = row.getArguments();
       switch (rowName) {
-        case "to", "toOrElse", "toOrElseGet", "forward", "enumTo", "via" -> {
+        case "to", "toOrElse", "toOrElseGet", "toOneWay", "enumTo", "via" -> {
           final var src = accessorProp(rowArgs.isEmpty() ? null : rowArgs.get(0));
           final var tgt = rowArgs.size() < 2 ? null : accessorProp(rowArgs.get(1));
           if (src == null || tgt == null) return false;
           // Rows are grouped by the accessors' OWN classes at construction (a row may be keyed to
           // a nested pair encountered during recursion). Only rows keyed to THIS call's pair claim
           // fields here; nested-keyed rows are still shape-checked against their own types below.
+          // Both sides erased: a generic owner's asType() is the parameterized prototype, which
+          // isSameType would never match against the raw class literal.
           final var topLevelRow =
-            types.isSameType(src.owner().asType(), types.erasure(srcType)) &&
-            types.isSameType(tgt.owner().asType(), types.erasure(tgtType));
+            types.isSameType(types.erasure(src.owner().asType()), types.erasure(srcType)) &&
+            types.isSameType(types.erasure(tgt.owner().asType()), types.erasure(tgtType));
           if (topLevelRow) {
             // Always consume the source side — even when the target is a duplicate — so the source
             // field isn't later reported as unmatched (which would be a cascade error on top of the
@@ -355,7 +384,9 @@ public final class MapperVerifierProcessor extends AbstractProcessor {
         case "drop" -> {
           final var src = accessorProp(rowArgs.isEmpty() ? null : rowArgs.get(0));
           if (src == null) return false;
-          if (types.isSameType(src.owner().asType(), types.erasure(srcType)) && !claimedSrc.add(src.name())) {
+          if (
+            types.isSameType(types.erasure(src.owner().asType()), types.erasure(srcType)) && !claimedSrc.add(src.name())
+          ) {
             report(row, PairingMessages.duplicateSourceRow(srcSimple, tgtSimple, src.name()));
           }
           return true;
@@ -382,10 +413,24 @@ public final class MapperVerifierProcessor extends AbstractProcessor {
       }
     }
 
-    /** {@code constant} / {@code compute} switch the runtime into its permissive fixup mode. */
-    private boolean isPermissiveRow(final ExecutableElement rowExec) {
+    /**
+     * {@code constant} / {@code compute} switch the runtime into its permissive fixup mode — and a
+     * {@code when(...)} wrapper is peeled to its inner row at construction, so a wrapped {@code
+     * constant}/{@code compute} is exactly as permissive as a bare one.
+     */
+    private boolean isPermissiveRow(final MethodInvocationTree row, final ExecutableElement rowExec) {
       final var n = rowExec.getSimpleName().toString();
-      return "constant".equals(n) || "compute".equals(n);
+      if ("constant".equals(n) || "compute".equals(n)) return true;
+      if (
+        "when".equals(n) &&
+        row.getArguments().size() == 2 &&
+        row.getArguments().get(1) instanceof MethodInvocationTree inner
+      ) {
+        return (
+          elementAt(inner.getMethodSelect()) instanceof ExecutableElement innerExec && isPermissiveRow(inner, innerExec)
+        );
+      }
+      return false;
     }
 
     private void verifyWriteHint(
@@ -396,24 +441,19 @@ public final class MapperVerifierProcessor extends AbstractProcessor {
       if (!"writeBean".contentEquals(rowExec.getSimpleName())) return;
       final var target = row.getArguments().isEmpty() ? null : classLiteral(row.getArguments().get(0));
       final var targetEl = target == null ? null : props.elementOf(target);
-      if (targetEl == null) return;
-      if (targetEl.getKind() == ElementKind.RECORD) {
-        report(
+      if (targetEl == null) {
+        note(
           row,
-          "writeBean hint targets a record class (" +
-            elements.getBinaryName(targetEl) +
-            "). Records are always reconstructed via the canonical constructor; the hint cannot apply. " +
-            "Remove the writeBean(...) row, or move it to the bean side of the mapping."
+          "telescope: writeBean hint not statically verifiable (non-literal class argument); deferring to construction"
         );
         return;
       }
+      if (targetEl.getKind() == ElementKind.RECORD) {
+        report(row, PairingMessages.writeBeanTargetsRecord(elements.getBinaryName(targetEl).toString()));
+        return;
+      }
       if (!hintTargets.add(elements.getBinaryName(targetEl).toString())) {
-        report(
-          row,
-          "Duplicate writeBean hint for " +
-            elements.getBinaryName(targetEl) +
-            ". Each target class may declare at most one writeBean(...) row per Telescope.map(...) call."
-        );
+        report(row, PairingMessages.duplicateWriteBeanHint(elements.getBinaryName(targetEl).toString()));
       }
     }
 
@@ -430,6 +470,10 @@ public final class MapperVerifierProcessor extends AbstractProcessor {
       final Tree at,
       final Set<String> seen
     ) {
+      // Wildcards and type variables aren't statically comparable across the two worlds — the
+      // runtime's structural Type#equals calls identical wildcard pairs equal where isSameType is
+      // specified false. Skip rather than mis-decide: the construction backstop still applies.
+      if (!staticallyComparable(srcType) || !staticallyComparable(tgtType)) return;
       final var decision = rules.decidePair(srcType, tgtType, componentName);
       if (decision instanceof PairDecision.Incompatible<TypeMirror> incompatible) {
         report(at, incompatible.message());
@@ -464,6 +508,17 @@ public final class MapperVerifierProcessor extends AbstractProcessor {
       if (decision instanceof PairDecision.LiftContainer<TypeMirror> d) {
         verifyDeep(d.src().elementType(), d.tgt().elementType(), componentName + "[*]", at, seen);
       }
+    }
+
+    /** True when {@code t} contains no wildcard or type variable at any depth. */
+    private boolean staticallyComparable(final TypeMirror t) {
+      if (t.getKind() == TypeKind.WILDCARD || t.getKind() == TypeKind.TYPEVAR) return false;
+      if (t instanceof DeclaredType dt) {
+        for (final var arg : dt.getTypeArguments()) {
+          if (!staticallyComparable(arg)) return false;
+        }
+      }
+      return true;
     }
 
     /** The {@code TypeMirror} behind a class-literal argument ({@code Order.class}), or null. */
@@ -533,8 +588,13 @@ public final class MapperVerifierProcessor extends AbstractProcessor {
       if (!method.getParameters().isEmpty()) continue;
       if (!method.getModifiers().contains(Modifier.PUBLIC) || method.getModifiers().contains(Modifier.STATIC)) continue;
       final var declaringType = (TypeElement) method.getEnclosingElement();
-      final var pkg = elements.getPackageOf(declaringType).getQualifiedName().toString();
-      if (pkg.startsWith("java.") || pkg.startsWith("jdk.")) continue;
+      // Skip platform supertypes by MODULE name, exactly like the runtime getter scan — a package
+      // prefix would miss javax.* packages living inside java.* modules (java.sql, java.naming, …).
+      final var declaringModule = elements.getModuleOf(declaringType);
+      if (declaringModule != null && !declaringModule.isUnnamed()) {
+        final var moduleName = declaringModule.getQualifiedName().toString();
+        if (moduleName.startsWith("java.") || moduleName.startsWith("jdk.")) continue;
+      }
       final var rawName = method.getSimpleName().toString();
       final String prop;
       if (rawName.length() > 3 && rawName.startsWith("get") && method.getReturnType().getKind() != TypeKind.VOID) {

--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/MapperVerifierProcessor.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/MapperVerifierProcessor.java
@@ -1,6 +1,5 @@
 package io.github.eschizoid.telescope.codegen;
 
-import com.sun.source.tree.CompilationUnitTree;
 import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.MemberReferenceTree;
 import com.sun.source.tree.MemberSelectTree;
@@ -18,9 +17,7 @@ import io.github.eschizoid.telescope.internal.pairing.PairingMessages;
 import io.github.eschizoid.telescope.internal.pairing.PairingRules;
 import java.io.PrintWriter;
 import java.io.StringWriter;
-import java.util.Collections;
 import java.util.HashSet;
-import java.util.IdentityHashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -121,24 +118,29 @@ public final class MapperVerifierProcessor extends AbstractProcessor {
     if (off) return;
     try {
       trees = Trees.instance(processingEnv);
-      // Scan AFTER each unit's analysis completes — bodies are fully attributed there, so tree
-      // queries are pure reads. Attributing on demand from inside processing rounds instead would
-      // corrupt javac's symbol bookkeeping for anonymous classes when the final compile
+      // Scan each top-level type EXACTLY when its own analysis completes — its bodies are fully
+      // attributed there, so tree queries are pure reads. Scanning the whole unit on the first
+      // type's event would touch not-yet-attributed sibling types, and attributing on demand
+      // corrupts javac's symbol bookkeeping for anonymous classes when the final compile
       // re-attributes the same trees (the classic reason body-level checkers run post-analysis).
+      // ANALYZE-finished fires once per top-level type, so per-type scanning needs no dedup.
       // Registering from init keeps the processor packaging: one artifact, SPI-discovered.
       JavacTask.instance(processingEnv).addTaskListener(
         new TaskListener() {
           @Override
           public void finished(final TaskEvent event) {
             if (event.getKind() != TaskEvent.Kind.ANALYZE) return;
-            final var unit = event.getCompilationUnit();
-            if (unit == null || !scannedUnits.add(unit)) return;
+            final var type = event.getTypeElement();
+            if (type == null) return;
+            final var path = trees.getPath(type);
+            if (path == null) return;
             try {
-              new CallSiteScanner().scan(new TreePath(unit), null);
+              new CallSiteScanner().scan(path, null);
             } catch (final RuntimeException e) {
               // The verifier must never break a build except through its own diagnostics — an
-              // uncaught exception in a task listener aborts the compile. Skip the unit; the
-              // construction-time validation still applies. If this ever fires it is a verifier
+              // uncaught exception in a task listener aborts the compile. Skip the type; the
+              // construction-time validation still applies. If this ever fires it is a
+              // verifier
               // bug; verbose mode appends the stack trace so the report is debuggable.
               final var detail = new StringWriter();
               if (verbose) e.printStackTrace(new PrintWriter(detail));
@@ -147,7 +149,7 @@ public final class MapperVerifierProcessor extends AbstractProcessor {
                 .printMessage(
                   Diagnostic.Kind.NOTE,
                   "telescope: mapping verification skipped for " +
-                    unit.getSourceFile().getName() +
+                    type.getQualifiedName() +
                     " (" +
                     e +
                     "); construction-time validation still applies." +
@@ -170,9 +172,6 @@ public final class MapperVerifierProcessor extends AbstractProcessor {
   public SourceVersion getSupportedSourceVersion() {
     return SourceVersion.latestSupported();
   }
-
-  /** Units already scanned — ANALYZE events fire once per top-level type, not per unit. */
-  private final Set<CompilationUnitTree> scannedUnits = Collections.newSetFromMap(new IdentityHashMap<>());
 
   @Override
   public boolean process(final Set<? extends TypeElement> annotations, final RoundEnvironment roundEnv) {

--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/MapperVerifierProcessor.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/MapperVerifierProcessor.java
@@ -334,11 +334,14 @@ public final class MapperVerifierProcessor extends AbstractProcessor {
             types.isSameType(src.owner().asType(), types.erasure(srcType)) &&
             types.isSameType(tgt.owner().asType(), types.erasure(tgtType));
           if (topLevelRow) {
+            // Always consume the source side — even when the target is a duplicate — so the source
+            // field isn't later reported as unmatched (which would be a cascade error on top of the
+            // real duplicate-target diagnostic).
+            claimedSrc.add(src.name());
             if (!claimedTgt.add(tgt.name())) {
               report(row, PairingMessages.duplicateTargetRow(srcSimple, tgtSimple, tgt.name()));
               return true;
             }
-            claimedSrc.add(src.name());
           }
           // Only the 2-arg same-typed to(src, tgt) carries no conversion — the one row shape the
           // runtime itself routes through the pairing decision at construction. Every other form

--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/MapperVerifierProcessor.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/MapperVerifierProcessor.java
@@ -33,7 +33,9 @@ import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.Modifier;
+import javax.lang.model.element.NestingKind;
 import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.ArrayType;
 import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.ExecutableType;
 import javax.lang.model.type.TypeKind;
@@ -61,13 +63,13 @@ import javax.tools.Diagnostic;
  * {@code @UncheckedMapping("reason")} on an enclosing field, method, constructor, or class.
  *
  * <p>Scope notes, mirroring the runtime exactly: {@code mapperForward} is lenient by contract, so
- * only its explicit rows are checked (no completeness). Rows that carry user conversion functions
- * ({@code to(src, tgt, fwd, bwd)}, {@code toOneWay}, {@code enumTo}, {@code via}) are claims only —
- * their leaf conversion is the user's. Presence of a target-telescope / {@code constant} / {@code
- * compute} row switches the runtime into its permissive mode, so completeness checking is disabled
- * for that site too. Nested auto-recursed pairs are lenient about unmatched fields (as at runtime)
- * but still shape-checked. {@code toOrElse} / {@code toOrElseGet} are claims only: the runtime
- * constructs them without a shape gate, and this verifier never fires where construction succeeds.
+ * only its explicit rows are checked (no completeness). Rows that carry a conversion the verifier
+ * can't check ({@code to(src, tgt, fwd, bwd)}, {@code toOneWay}, {@code enumTo}, {@code via}) are
+ * claims only. Presence of a target-telescope / {@code constant} / {@code compute} row switches the
+ * runtime into its permissive mode, so completeness checking is disabled for that site too. Nested
+ * auto-recursed pairs are lenient about unmatched fields (as at runtime) but still shape-checked.
+ * {@code toOrElse} / {@code toOrElseGet} are claims only: the runtime constructs them without a
+ * shape gate, and this verifier never fires where construction succeeds.
  */
 @SupportedAnnotationTypes("*")
 @SupportedOptions({ "telescope.verify", "telescope.verify.verbose" })
@@ -118,12 +120,13 @@ public final class MapperVerifierProcessor extends AbstractProcessor {
     if (off) return;
     try {
       trees = Trees.instance(processingEnv);
-      // Scan each top-level type EXACTLY when its own analysis completes — its bodies are fully
-      // attributed there, so tree queries are pure reads. Scanning the whole unit on the first
-      // type's event would touch not-yet-attributed sibling types, and attributing on demand
-      // corrupts javac's symbol bookkeeping for anonymous classes when the final compile
-      // re-attributes the same trees (the classic reason body-level checkers run post-analysis).
-      // ANALYZE-finished fires once per top-level type, so per-type scanning needs no dedup.
+      // Scan each top-level type EXACTLY when its own analysis completes — its bodies (including
+      // every nested type's) are fully attributed there, so tree queries are pure reads. Scanning
+      // the whole unit on the first type's event would touch not-yet-attributed sibling types, and
+      // attributing on demand corrupts javac's symbol bookkeeping for anonymous classes when the
+      // final compile re-attributes the same trees (the classic reason body-level checkers run
+      // post-analysis). ANALYZE-finished fires per type DECLARATION — nested types included — so
+      // the top-level gate below is what prevents a nested type's subtree being scanned twice.
       // Registering from init keeps the processor packaging: one artifact, SPI-discovered.
       JavacTask.instance(processingEnv).addTaskListener(
         new TaskListener() {
@@ -131,7 +134,7 @@ public final class MapperVerifierProcessor extends AbstractProcessor {
           public void finished(final TaskEvent event) {
             if (event.getKind() != TaskEvent.Kind.ANALYZE) return;
             final var type = event.getTypeElement();
-            if (type == null) return;
+            if (type == null || type.getNestingKind() != NestingKind.TOP_LEVEL) return;
             final var path = trees.getPath(type);
             if (path == null) return;
             try {
@@ -139,9 +142,8 @@ public final class MapperVerifierProcessor extends AbstractProcessor {
             } catch (final RuntimeException e) {
               // The verifier must never break a build except through its own diagnostics — an
               // uncaught exception in a task listener aborts the compile. Skip the type; the
-              // construction-time validation still applies. If this ever fires it is a
-              // verifier
-              // bug; verbose mode appends the stack trace so the report is debuggable.
+              // construction-time validation still applies. A firing here is a verifier bug;
+              // verbose mode appends the stack trace so the report is debuggable.
               final var detail = new StringWriter();
               if (verbose) e.printStackTrace(new PrintWriter(detail));
               processingEnv
@@ -512,6 +514,7 @@ public final class MapperVerifierProcessor extends AbstractProcessor {
     /** True when {@code t} contains no wildcard or type variable at any depth. */
     private boolean staticallyComparable(final TypeMirror t) {
       if (t.getKind() == TypeKind.WILDCARD || t.getKind() == TypeKind.TYPEVAR) return false;
+      if (t instanceof ArrayType at) return staticallyComparable(at.getComponentType());
       if (t instanceof DeclaredType dt) {
         for (final var arg : dt.getTypeArguments()) {
           if (!staticallyComparable(arg)) return false;

--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/MapperVerifierProcessor.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/MapperVerifierProcessor.java
@@ -1,0 +1,575 @@
+package io.github.eschizoid.telescope.codegen;
+
+import com.sun.source.tree.CompilationUnitTree;
+import com.sun.source.tree.ExpressionTree;
+import com.sun.source.tree.MemberReferenceTree;
+import com.sun.source.tree.MemberSelectTree;
+import com.sun.source.tree.MethodInvocationTree;
+import com.sun.source.tree.Tree;
+import com.sun.source.util.JavacTask;
+import com.sun.source.util.TaskEvent;
+import com.sun.source.util.TaskListener;
+import com.sun.source.util.TreePath;
+import com.sun.source.util.TreePathScanner;
+import com.sun.source.util.Trees;
+import io.github.eschizoid.telescope.annotations.UncheckedMapping;
+import io.github.eschizoid.telescope.internal.pairing.PairDecision;
+import io.github.eschizoid.telescope.internal.pairing.PairingMessages;
+import io.github.eschizoid.telescope.internal.pairing.PairingRules;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.IdentityHashMap;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import javax.annotation.processing.AbstractProcessor;
+import javax.annotation.processing.ProcessingEnvironment;
+import javax.annotation.processing.RoundEnvironment;
+import javax.annotation.processing.SupportedAnnotationTypes;
+import javax.annotation.processing.SupportedOptions;
+import javax.lang.model.SourceVersion;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ElementKind;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.Modifier;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.ExecutableType;
+import javax.lang.model.type.TypeKind;
+import javax.lang.model.type.TypeMirror;
+import javax.lang.model.util.Elements;
+import javax.lang.model.util.Types;
+import javax.tools.Diagnostic;
+
+/**
+ * Compile-time verification of {@code Telescope.map} / {@code Telescope.mapper} / {@code
+ * Telescope.mapperForward} call sites. Walks every compiled class's tree for invocations of those
+ * factories, extracts the statically-visible facts (class-literal source/target, inline {@code
+ * Mapping} rows whose accessors are method references), and replays the construction-time pairing
+ * decisions through the same shared spec the runtime uses — reporting the runtime's own diagnostic
+ * text as compile errors anchored on the offending expression.
+ *
+ * <p>Verification is additive, never load-bearing. Anything not statically visible — a non-literal
+ * class argument, a row built by a helper, a factory the scanner doesn't recognize — silently
+ * defers to the construction-time backstop (a NOTE under {@code -Atelescope.verify.verbose}), so
+ * the verifier can only add errors for provably-broken code, never make broken code pass. On a
+ * compiler without the {@code com.sun.source} tree API the processor prints one NOTE and no-ops.
+ *
+ * <p>Options: {@code -Atelescope.verify=error|warn|off} (default {@code error}); {@code
+ * -Atelescope.verify.verbose} notes skipped sites. Per-site exemption:
+ * {@code @UncheckedMapping("reason")} on an enclosing field, method, constructor, or class.
+ *
+ * <p>Scope notes, mirroring the runtime exactly: {@code mapperForward} is lenient by contract, so
+ * only its explicit rows are checked (no completeness). Rows that carry user conversion functions
+ * ({@code to(src, tgt, fwd, bwd)}, {@code forward}, {@code enumTo}, {@code via}) are claims only —
+ * their leaf conversion is the user's. Presence of a target-telescope / {@code constant} / {@code
+ * compute} row switches the runtime into its permissive mode, so completeness checking is disabled
+ * for that site too. Nested auto-recursed pairs are lenient about unmatched fields (as at runtime)
+ * but still shape-checked. {@code toOrElse} / {@code toOrElseGet} are claims only: the runtime
+ * constructs them without a shape gate, and this verifier never fires where construction succeeds.
+ */
+@SupportedAnnotationTypes("*")
+@SupportedOptions({ "telescope.verify", "telescope.verify.verbose" })
+public final class MapperVerifierProcessor extends AbstractProcessor {
+
+  private static final String TELESCOPE_FQN = "io.github.eschizoid.telescope.Telescope";
+  private static final String MAPPING_FQN = "io.github.eschizoid.telescope.mapping.Mapping";
+  private static final String WRITE_HINT_FQN = "io.github.eschizoid.telescope.mapping.WriteHint";
+  private static final String NULL_HINT_FQN = "io.github.eschizoid.telescope.mapping.NullHint";
+
+  /**
+   * Public no-arg constructor required by the {@link javax.annotation.processing.Processor} SPI.
+   */
+  public MapperVerifierProcessor() {
+    super();
+  }
+
+  private Trees trees;
+  private Types types;
+  private Elements elements;
+  private MirrorProps props;
+  private PairingRules<TypeMirror> rules;
+  private Diagnostic.Kind reportKind;
+  private boolean off;
+  private boolean verbose;
+  private boolean notedUnavailable;
+
+  @Override
+  public synchronized void init(final ProcessingEnvironment processingEnv) {
+    super.init(processingEnv);
+    types = processingEnv.getTypeUtils();
+    elements = processingEnv.getElementUtils();
+    props = new MirrorProps(types, elements);
+    rules = new PairingRules<>(props);
+    final var mode = processingEnv.getOptions().getOrDefault("telescope.verify", "error");
+    off = "off".equals(mode);
+    reportKind = "warn".equals(mode) ? Diagnostic.Kind.WARNING : Diagnostic.Kind.ERROR;
+    verbose = processingEnv.getOptions().containsKey("telescope.verify.verbose");
+    if (off) return;
+    try {
+      trees = Trees.instance(processingEnv);
+      // Scan AFTER each unit's analysis completes — bodies are fully attributed there, so tree
+      // queries are pure reads. Attributing on demand from inside processing rounds instead would
+      // corrupt javac's symbol bookkeeping for anonymous classes when the final compile
+      // re-attributes the same trees (the classic reason body-level checkers run post-analysis).
+      // Registering from init keeps the processor packaging: one artifact, SPI-discovered.
+      JavacTask.instance(processingEnv).addTaskListener(
+        new TaskListener() {
+          @Override
+          public void finished(final TaskEvent event) {
+            if (event.getKind() != TaskEvent.Kind.ANALYZE) return;
+            final var unit = event.getCompilationUnit();
+            if (unit == null || !scannedUnits.add(unit)) return;
+            try {
+              new CallSiteScanner().scan(new TreePath(unit), null);
+            } catch (final RuntimeException e) {
+              // The verifier must never break a build except through its own diagnostics — an
+              // uncaught exception in a task listener aborts the compile. Skip the unit; the
+              // construction-time validation still applies.
+              processingEnv
+                .getMessager()
+                .printMessage(
+                  Diagnostic.Kind.NOTE,
+                  "telescope: mapping verification skipped for " +
+                    unit.getSourceFile().getName() +
+                    " (" +
+                    e +
+                    "); construction-time validation still applies."
+                );
+            }
+          }
+        }
+      );
+    } catch (final RuntimeException e) {
+      trees = null;
+    }
+  }
+
+  @Override
+  public SourceVersion getSupportedSourceVersion() {
+    return SourceVersion.latestSupported();
+  }
+
+  /** Units already scanned — ANALYZE events fire once per top-level type, not per unit. */
+  private final Set<CompilationUnitTree> scannedUnits = Collections.newSetFromMap(new IdentityHashMap<>());
+
+  @Override
+  public boolean process(final Set<? extends TypeElement> annotations, final RoundEnvironment roundEnv) {
+    // All scanning happens in the post-ANALYZE task listener registered in init(); the rounds
+    // themselves are a no-op. One NOTE when the tree API isn't available (non-javac compiler) —
+    // verification is additive, the construction-time validation still applies.
+    if (!off && trees == null && !notedUnavailable) {
+      notedUnavailable = true;
+      processingEnv
+        .getMessager()
+        .printMessage(
+          Diagnostic.Kind.NOTE,
+          "telescope: compile-time mapping verification needs the javac tree API; " +
+            "skipping (construction-time validation still applies)."
+        );
+    }
+    return false;
+  }
+
+  /**
+   * One statically-recognized accessor reference: normalized property name, its declared type (as a
+   * member of the accessor's own class), and that owning class. The owner matters because rows may
+   * be keyed to NESTED pairs — {@code to(UserEntity::name, UserDto::fullName)} inside {@code
+   * map(CompanyEntity, CompanyDto, ...)} — which the runtime groups by the accessors' classes; such
+   * rows claim nothing at the call's top-level pair.
+   */
+  private record Prop(String name, TypeMirror type, TypeElement owner) {}
+
+  private final class CallSiteScanner extends TreePathScanner<Void, Void> {
+
+    @Override
+    public Void visitMethodInvocation(final MethodInvocationTree node, final Void unused) {
+      verifyIfTelescopeFactory(node);
+      return super.visitMethodInvocation(node, unused);
+    }
+
+    private void verifyIfTelescopeFactory(final MethodInvocationTree node) {
+      final var invoked = elementAt(node.getMethodSelect());
+      if (!(invoked instanceof ExecutableElement method)) return;
+      if (!(method.getEnclosingElement() instanceof TypeElement owner)) return;
+      if (!owner.getQualifiedName().contentEquals(TELESCOPE_FQN)) return;
+      final var name = method.getSimpleName().toString();
+      final boolean strict;
+      switch (name) {
+        case "map", "mapper" -> strict = true;
+        case "mapperForward" -> strict = false;
+        default -> {
+          return;
+        }
+      }
+      if (suppressed()) return;
+      verifyPairCall(node, strict);
+    }
+
+    private boolean suppressed() {
+      for (var path = getCurrentPath(); path != null; path = path.getParentPath()) {
+        final var kind = path.getLeaf().getKind();
+        if (
+          kind == Tree.Kind.METHOD ||
+          kind == Tree.Kind.VARIABLE ||
+          kind == Tree.Kind.CLASS ||
+          kind == Tree.Kind.RECORD ||
+          kind == Tree.Kind.INTERFACE ||
+          kind == Tree.Kind.ENUM
+        ) {
+          final var element = trees.getElement(path);
+          if (element != null && element.getAnnotation(UncheckedMapping.class) != null) return true;
+        }
+      }
+      return false;
+    }
+
+    private void verifyPairCall(final MethodInvocationTree node, final boolean strict) {
+      final var args = node.getArguments();
+      if (args.size() < 2) return;
+      final var srcType = classLiteral(args.get(0));
+      final var tgtType = classLiteral(args.get(1));
+      if (srcType == null || tgtType == null) {
+        note(
+          node,
+          "telescope: mapping not statically verifiable (non-literal class argument); deferring to construction"
+        );
+        return;
+      }
+      final var srcEl = props.elementOf(srcType);
+      final var tgtEl = props.elementOf(tgtType);
+      if (srcEl == null || tgtEl == null || !rules.reflectable(srcType) || !rules.reflectable(tgtType)) return;
+
+      final var srcSimple = srcEl.getSimpleName().toString();
+      final var tgtSimple = tgtEl.getSimpleName().toString();
+      final var claimedSrc = new LinkedHashSet<String>();
+      final var claimedTgt = new LinkedHashSet<String>();
+      final var hintTargets = new HashSet<String>();
+      var analyzable = true;
+      var permissive = false;
+
+      for (var i = 2; i < args.size(); i++) {
+        final var arg = args.get(i);
+        if (!(arg instanceof MethodInvocationTree row)) {
+          analyzable = false;
+          continue;
+        }
+        final var rowMethod = elementAt(row.getMethodSelect());
+        if (
+          !(rowMethod instanceof ExecutableElement rowExec) ||
+          !(rowExec.getEnclosingElement() instanceof TypeElement rowOwner)
+        ) {
+          analyzable = false;
+          continue;
+        }
+        final var ownerFqn = rowOwner.getQualifiedName().toString();
+        if (WRITE_HINT_FQN.equals(ownerFqn)) {
+          verifyWriteHint(row, rowExec, hintTargets);
+          continue;
+        }
+        if (NULL_HINT_FQN.equals(ownerFqn)) continue;
+        if (!MAPPING_FQN.equals(ownerFqn)) {
+          analyzable = false;
+          continue;
+        }
+        analyzable &= verifyRow(row, rowExec, srcType, tgtType, srcSimple, tgtSimple, claimedSrc, claimedTgt);
+        permissive |= isPermissiveRow(rowExec);
+      }
+
+      if (!analyzable) {
+        note(node, "telescope: some mapping rows are not statically analyzable; completeness deferred to construction");
+      }
+
+      // Completeness — top-level only, strict factories only, and only when the runtime itself
+      // would be strict (no permissive telescope/constant/compute rows) and every row was visible.
+      final var srcProps = propertiesOf(srcType, srcEl);
+      final var tgtProps = propertiesOf(tgtType, tgtEl);
+      if (strict && analyzable && !permissive) {
+        final var match = PairingRules.matchFields(
+          List.copyOf(srcProps.keySet()),
+          List.copyOf(tgtProps.keySet()),
+          claimedSrc,
+          claimedTgt
+        );
+        final var srcSlot = srcEl.getKind() == ElementKind.RECORD ? "field" : "property";
+        final var tgtSlot = tgtEl.getKind() == ElementKind.RECORD ? "field" : "property";
+        for (final var name : match.unmatchedTargets()) {
+          report(node, PairingMessages.noSameNameSource(srcSimple, tgtSimple, tgtSlot, srcSlot, name));
+        }
+        for (final var name : match.unmatchedSources()) {
+          report(node, PairingMessages.noSameNameTarget(srcSimple, tgtSimple, srcSlot, tgtSlot, name));
+        }
+        final var seen = new HashSet<String>();
+        seen.add(pairKey(srcType, tgtType));
+        for (final var name : match.matched()) {
+          verifyDeep(srcProps.get(name), tgtProps.get(name), name, node, seen);
+        }
+      }
+    }
+
+    /** Returns false when the row's accessors defeat static analysis (kills completeness only). */
+    private boolean verifyRow(
+      final MethodInvocationTree row,
+      final ExecutableElement rowExec,
+      final TypeMirror srcType,
+      final TypeMirror tgtType,
+      final String srcSimple,
+      final String tgtSimple,
+      final Set<String> claimedSrc,
+      final Set<String> claimedTgt
+    ) {
+      final var rowName = rowExec.getSimpleName().toString();
+      final var rowArgs = row.getArguments();
+      switch (rowName) {
+        case "to", "toOrElse", "toOrElseGet", "forward", "enumTo", "via" -> {
+          final var src = accessorProp(rowArgs.isEmpty() ? null : rowArgs.get(0));
+          final var tgt = rowArgs.size() < 2 ? null : accessorProp(rowArgs.get(1));
+          if (src == null || tgt == null) return false;
+          // Rows are grouped by the accessors' OWN classes at construction (a row may be keyed to
+          // a nested pair encountered during recursion). Only rows keyed to THIS call's pair claim
+          // fields here; nested-keyed rows are still shape-checked against their own types below.
+          final var topLevelRow =
+            types.isSameType(src.owner().asType(), types.erasure(srcType)) &&
+            types.isSameType(tgt.owner().asType(), types.erasure(tgtType));
+          if (topLevelRow) {
+            if (!claimedTgt.add(tgt.name())) {
+              report(row, PairingMessages.duplicateTargetRow(srcSimple, tgtSimple, tgt.name()));
+              return true;
+            }
+            claimedSrc.add(src.name());
+          }
+          // Only the 2-arg same-typed to(src, tgt) carries no conversion — the one row shape the
+          // runtime itself routes through the pairing decision at construction. Every other form
+          // carries user functions (or a user default), which construction accepts as-is.
+          if ("to".equals(rowName) && rowArgs.size() == 2) {
+            final var seen = new HashSet<String>();
+            verifyDeep(src.type(), tgt.type(), src.name() + " → " + tgt.name(), row, seen);
+          }
+          return true;
+        }
+        case "drop" -> {
+          final var src = accessorProp(rowArgs.isEmpty() ? null : rowArgs.get(0));
+          if (src == null) return false;
+          if (types.isSameType(src.owner().asType(), types.erasure(srcType)) && !claimedSrc.add(src.name())) {
+            report(row, PairingMessages.duplicateSourceRow(srcSimple, tgtSimple, src.name()));
+          }
+          return true;
+        }
+        case "when" -> {
+          // Conditional wrapper: the predicate is opaque; the inner row is the real claim.
+          if (rowArgs.size() == 2 && rowArgs.get(1) instanceof MethodInvocationTree inner) {
+            final var innerMethod = elementAt(inner.getMethodSelect());
+            if (innerMethod instanceof ExecutableElement innerExec) {
+              return verifyRow(inner, innerExec, srcType, tgtType, srcSimple, tgtSimple, claimedSrc, claimedTgt);
+            }
+          }
+          return false;
+        }
+        case "constant", "compute" -> {
+          // Accessor-form rows put the runtime into permissive mode (handled by the caller); the
+          // telescope-form has no statically-recoverable target either way. Claims are irrelevant
+          // because permissive mode disables completeness.
+          return true;
+        }
+        default -> {
+          return false;
+        }
+      }
+    }
+
+    /** {@code constant} / {@code compute} switch the runtime into its permissive fixup mode. */
+    private boolean isPermissiveRow(final ExecutableElement rowExec) {
+      final var n = rowExec.getSimpleName().toString();
+      return "constant".equals(n) || "compute".equals(n);
+    }
+
+    private void verifyWriteHint(
+      final MethodInvocationTree row,
+      final ExecutableElement rowExec,
+      final Set<String> hintTargets
+    ) {
+      if (!"writeBean".contentEquals(rowExec.getSimpleName())) return;
+      final var target = row.getArguments().isEmpty() ? null : classLiteral(row.getArguments().get(0));
+      final var targetEl = target == null ? null : props.elementOf(target);
+      if (targetEl == null) return;
+      if (targetEl.getKind() == ElementKind.RECORD) {
+        report(
+          row,
+          "writeBean hint targets a record class (" +
+            elements.getBinaryName(targetEl) +
+            "). Records are always reconstructed via the canonical constructor; the hint cannot apply. " +
+            "Remove the writeBean(...) row, or move it to the bean side of the mapping."
+        );
+        return;
+      }
+      if (!hintTargets.add(elements.getBinaryName(targetEl).toString())) {
+        report(
+          row,
+          "Duplicate writeBean hint for " +
+            elements.getBinaryName(targetEl) +
+            ". Each target class may declare at most one writeBean(...) row per Telescope.map(...) call."
+        );
+      }
+    }
+
+    /**
+     * Replay the shared pair decision for one field pair, recursing exactly as construction does:
+     * container lifts and Optional bridges recurse on elements; reflectable pairs recurse on their
+     * same-name matches (nested pairs are lenient about unmatched fields, as at runtime, but each
+     * matched nested field is still shape-checked). Cycles terminate via {@code seen}.
+     */
+    private void verifyDeep(
+      final TypeMirror srcType,
+      final TypeMirror tgtType,
+      final String componentName,
+      final Tree at,
+      final Set<String> seen
+    ) {
+      final var decision = rules.decidePair(srcType, tgtType, componentName);
+      if (decision instanceof PairDecision.Incompatible<TypeMirror> incompatible) {
+        report(at, incompatible.message());
+        return;
+      }
+      if (decision instanceof PairDecision.RecursePair) {
+        if (!seen.add(pairKey(srcType, tgtType))) return;
+        final var srcEl = props.elementOf(srcType);
+        final var tgtEl = props.elementOf(tgtType);
+        if (srcEl == null || tgtEl == null) return;
+        final var srcProps = propertiesOf(srcType, srcEl);
+        final var tgtProps = propertiesOf(tgtType, tgtEl);
+        final var match = PairingRules.matchFields(
+          List.copyOf(srcProps.keySet()),
+          List.copyOf(tgtProps.keySet()),
+          Set.of(),
+          Set.of()
+        );
+        for (final var name : match.matched()) {
+          verifyDeep(srcProps.get(name), tgtProps.get(name), name, at, seen);
+        }
+        return;
+      }
+      if (decision instanceof PairDecision.OptionalToNullable<TypeMirror> d) {
+        verifyDeep(d.elementSrc(), d.elementTgt(), componentName + "[*]", at, seen);
+        return;
+      }
+      if (decision instanceof PairDecision.NullableToOptional<TypeMirror> d) {
+        verifyDeep(d.elementSrc(), d.elementTgt(), componentName + "[*]", at, seen);
+        return;
+      }
+      if (decision instanceof PairDecision.LiftContainer<TypeMirror> d) {
+        verifyDeep(d.src().elementType(), d.tgt().elementType(), componentName + "[*]", at, seen);
+      }
+    }
+
+    /** The {@code TypeMirror} behind a class-literal argument ({@code Order.class}), or null. */
+    private TypeMirror classLiteral(final ExpressionTree arg) {
+      if (!(arg instanceof MemberSelectTree select) || !select.getIdentifier().contentEquals("class")) return null;
+      final var path = TreePath.getPath(getCurrentPath().getCompilationUnit(), select.getExpression());
+      return path == null ? null : trees.getTypeMirror(path);
+    }
+
+    /** A method-reference accessor resolved to its normalized property name + declared type. */
+    private Prop accessorProp(final ExpressionTree arg) {
+      if (!(arg instanceof MemberReferenceTree)) return null;
+      final var path = TreePath.getPath(getCurrentPath().getCompilationUnit(), arg);
+      if (path == null) return null;
+      if (!(trees.getElement(path) instanceof ExecutableElement accessor)) return null;
+      if (!(accessor.getEnclosingElement() instanceof TypeElement owner)) return null;
+      final var name = normalize(accessor.getSimpleName().toString());
+      // Resolve the return type against the accessor's OWN class — a row may be keyed to a nested
+      // pair, so the call's top-level types are the wrong receiver for asMemberOf.
+      final var type =
+        owner.asType() instanceof DeclaredType dt
+          ? ((ExecutableType) types.asMemberOf(dt, accessor)).getReturnType()
+          : accessor.getReturnType();
+      return new Prop(name, type, owner);
+    }
+
+    private Element elementAt(final ExpressionTree tree) {
+      final var path = TreePath.getPath(getCurrentPath().getCompilationUnit(), tree);
+      return path == null ? null : trees.getElement(path);
+    }
+
+    private void report(final Tree at, final String message) {
+      trees.printMessage(reportKind, message, at, getCurrentPath().getCompilationUnit());
+    }
+
+    private void note(final Tree at, final String message) {
+      if (verbose) trees.printMessage(Diagnostic.Kind.NOTE, message, at, getCurrentPath().getCompilationUnit());
+    }
+  }
+
+  private String pairKey(final TypeMirror src, final TypeMirror tgt) {
+    return src.toString() + "→" + tgt.toString();
+  }
+
+  /**
+   * Enumerate the pairing-relevant properties of a record (components, declaration order) or a bean
+   * (public zero-arg {@code getX} / {@code isX} getters — skipping {@code Object}, platform ({@code
+   * java.*} / {@code jdk.*}) supertypes, and the {@code class} pseudo-property — mirroring the
+   * runtime's getter scan).
+   */
+  private Map<String, TypeMirror> propertiesOf(final TypeMirror type, final TypeElement element) {
+    final var result = new LinkedHashMap<String, TypeMirror>();
+    final var declared = type instanceof DeclaredType dt ? dt : null;
+    if (element.getKind() == ElementKind.RECORD) {
+      for (final var component : element.getRecordComponents()) {
+        final var accessor = component.getAccessor();
+        final var memberType =
+          declared == null
+            ? accessor.getReturnType()
+            : ((ExecutableType) types.asMemberOf(declared, accessor)).getReturnType();
+        result.put(component.getSimpleName().toString(), memberType);
+      }
+      return result;
+    }
+    for (final var member : elements.getAllMembers(element)) {
+      if (!(member instanceof ExecutableElement method)) continue;
+      if (!method.getParameters().isEmpty()) continue;
+      if (!method.getModifiers().contains(Modifier.PUBLIC) || method.getModifiers().contains(Modifier.STATIC)) continue;
+      final var declaringType = (TypeElement) method.getEnclosingElement();
+      final var pkg = elements.getPackageOf(declaringType).getQualifiedName().toString();
+      if (pkg.startsWith("java.") || pkg.startsWith("jdk.")) continue;
+      final var rawName = method.getSimpleName().toString();
+      final String prop;
+      if (rawName.length() > 3 && rawName.startsWith("get") && method.getReturnType().getKind() != TypeKind.VOID) {
+        prop = decapitalize(rawName.substring(3));
+      } else if (rawName.length() > 2 && rawName.startsWith("is") && booleanReturn(method)) {
+        prop = decapitalize(rawName.substring(2));
+      } else {
+        continue;
+      }
+      if ("class".equals(prop) || result.containsKey(prop)) continue;
+      final var memberType =
+        declared == null
+          ? method.getReturnType()
+          : ((ExecutableType) types.asMemberOf(declared, method)).getReturnType();
+      result.put(prop, memberType);
+    }
+    return result;
+  }
+
+  private static boolean booleanReturn(final ExecutableElement method) {
+    final var rt = method.getReturnType();
+    return rt.getKind() == TypeKind.BOOLEAN || "java.lang.Boolean".equals(rt.toString());
+  }
+
+  /**
+   * Normalize an accessor-reference name to its property name: {@code getX} / {@code isX} strip +
+   * JavaBeans decapitalize (two leading uppers stay, e.g. {@code URL}); record accessors pass
+   * through unchanged.
+   */
+  private static String normalize(final String raw) {
+    if (raw.length() > 3 && raw.startsWith("get")) return decapitalize(raw.substring(3));
+    if (raw.length() > 2 && raw.startsWith("is")) return decapitalize(raw.substring(2));
+    return raw;
+  }
+
+  private static String decapitalize(final String s) {
+    if (s.isEmpty()) return s;
+    if (s.length() > 1 && Character.isUpperCase(s.charAt(0)) && Character.isUpperCase(s.charAt(1))) return s;
+    return Character.toLowerCase(s.charAt(0)) + s.substring(1);
+  }
+}

--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/MirrorProps.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/MirrorProps.java
@@ -88,8 +88,8 @@ final class MirrorProps implements PropertySystem<TypeMirror> {
   }
 
   @Override
-  public boolean copyAllocable(final TypeMirror src, final TypeMirror tgt) {
-    return true;
+  public Allocability copyAllocability(final TypeMirror src, final TypeMirror tgt) {
+    return Allocability.UNKNOWN;
   }
 
   @Override

--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/MirrorProps.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/MirrorProps.java
@@ -1,0 +1,124 @@
+package io.github.eschizoid.telescope.codegen;
+
+import io.github.eschizoid.telescope.internal.pairing.PropertySystem;
+import java.util.List;
+import javax.lang.model.element.ElementKind;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.PrimitiveType;
+import javax.lang.model.type.TypeKind;
+import javax.lang.model.type.TypeMirror;
+import javax.lang.model.util.Elements;
+import javax.lang.model.util.Types;
+
+/**
+ * The {@code javax.lang.model} world's {@link PropertySystem}: type handles are {@link TypeMirror},
+ * class handles are non-parameterized declared types (or primitives, matching the reflection
+ * world's {@code Class} handles). {@link #copyAllocable} answers optimistically — compile-time
+ * can't probe the real intermediate allocator, and optimism is the safe direction: an infeasible
+ * copy surfaces at the construction-time backstop instead of as a speculative compile error.
+ */
+final class MirrorProps implements PropertySystem<TypeMirror> {
+
+  private final Types types;
+  private final Elements elements;
+
+  MirrorProps(final Types types, final Elements elements) {
+    this.types = types;
+    this.elements = elements;
+  }
+
+  @Override
+  public boolean sameType(final TypeMirror a, final TypeMirror b) {
+    return types.isSameType(a, b);
+  }
+
+  @Override
+  public boolean isClassType(final TypeMirror t) {
+    if (t.getKind().isPrimitive()) return true;
+    return t instanceof DeclaredType dt && dt.getTypeArguments().isEmpty();
+  }
+
+  @Override
+  public boolean isPrimitive(final TypeMirror t) {
+    return t.getKind().isPrimitive();
+  }
+
+  @Override
+  public TypeMirror boxed(final TypeMirror t) {
+    return t instanceof PrimitiveType pt ? types.boxedClass(pt).asType() : t;
+  }
+
+  @Override
+  public boolean isRecordType(final TypeMirror t) {
+    return t instanceof DeclaredType dt && dt.asElement().getKind() == ElementKind.RECORD;
+  }
+
+  @Override
+  public boolean isArrayType(final TypeMirror t) {
+    return t.getKind() == TypeKind.ARRAY;
+  }
+
+  @Override
+  public boolean isEnumType(final TypeMirror t) {
+    return t instanceof DeclaredType dt && dt.asElement().getKind() == ElementKind.ENUM;
+  }
+
+  @Override
+  public boolean isInterfaceType(final TypeMirror t) {
+    return t instanceof DeclaredType dt && dt.asElement().getKind().isInterface();
+  }
+
+  @Override
+  public boolean isSubtypeOf(final TypeMirror t, final WellKnown wellKnown) {
+    final var target = elements.getTypeElement(fqnOf(wellKnown));
+    if (target == null) return false;
+    if (t.getKind().isPrimitive()) return false;
+    return types.isAssignable(types.erasure(t), types.erasure(target.asType()));
+  }
+
+  @Override
+  public List<TypeMirror> typeArguments(final TypeMirror t) {
+    return t instanceof DeclaredType dt ? List.copyOf(dt.getTypeArguments()) : List.of();
+  }
+
+  @Override
+  public TypeMirror rawType(final TypeMirror t) {
+    return types.erasure(t);
+  }
+
+  @Override
+  public boolean copyAllocable(final TypeMirror src, final TypeMirror tgt) {
+    return true;
+  }
+
+  @Override
+  public String typeName(final TypeMirror t) {
+    return t.toString();
+  }
+
+  /** The {@link TypeElement} of a declared type handle, or {@code null}. */
+  TypeElement elementOf(final TypeMirror t) {
+    return t instanceof DeclaredType dt && dt.asElement() instanceof TypeElement te ? te : null;
+  }
+
+  private static String fqnOf(final WellKnown wellKnown) {
+    return switch (wellKnown) {
+      case COLLECTION -> "java.util.Collection";
+      case LIST -> "java.util.List";
+      case SET -> "java.util.Set";
+      case SORTED_SET -> "java.util.SortedSet";
+      case QUEUE -> "java.util.Queue";
+      case DEQUE -> "java.util.Deque";
+      case MAP -> "java.util.Map";
+      case SORTED_MAP -> "java.util.SortedMap";
+      case OPTIONAL -> "java.util.Optional";
+      case CHAR_SEQUENCE -> "java.lang.CharSequence";
+      case NUMBER -> "java.lang.Number";
+      case TEMPORAL -> "java.time.temporal.Temporal";
+      case UUID -> "java.util.UUID";
+      case BOOLEAN_WRAPPER -> "java.lang.Boolean";
+      case CHARACTER_WRAPPER -> "java.lang.Character";
+    };
+  }
+}

--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/MirrorProps.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/MirrorProps.java
@@ -14,9 +14,9 @@ import javax.lang.model.util.Types;
 /**
  * The {@code javax.lang.model} world's {@link PropertySystem}: type handles are {@link TypeMirror},
  * class handles are non-parameterized declared types (or primitives, matching the reflection
- * world's {@code Class} handles). {@link #copyAllocable} answers optimistically — compile-time
- * can't probe the real intermediate allocator, and optimism is the safe direction: an infeasible
- * copy surfaces at the construction-time backstop instead of as a speculative compile error.
+ * world's {@code Class} handles). {@link #copyAllocability} reports {@code UNKNOWN} — compile-time
+ * can't probe the real intermediate allocator; how that uncertainty resolves is the shared rules'
+ * policy, not this adapter's.
  */
 final class MirrorProps implements PropertySystem<TypeMirror> {
 
@@ -35,7 +35,9 @@ final class MirrorProps implements PropertySystem<TypeMirror> {
 
   @Override
   public boolean isClassType(final TypeMirror t) {
-    if (t.getKind().isPrimitive()) return true;
+    // Arrays count: in the reflection world an array is a Class instance, and the container-view
+    // map-key gate relies on the two worlds agreeing.
+    if (t.getKind().isPrimitive() || t.getKind() == TypeKind.ARRAY) return true;
     return t instanceof DeclaredType dt && dt.getTypeArguments().isEmpty();
   }
 

--- a/codegen/src/main/java/module-info.java
+++ b/codegen/src/main/java/module-info.java
@@ -12,6 +12,10 @@
 module io.github.eschizoid.telescope.codegen {
   requires transitive java.compiler;
   requires transitive io.github.eschizoid.telescope;
+  // The shared pairing decision spec (qualified-exported to this module) plus the javac tree API
+  // power MapperVerifierProcessor's compile-time replay of construction-time pairing decisions.
+  requires io.github.eschizoid.telescope.internal;
+  requires jdk.compiler;
 
   exports io.github.eschizoid.telescope.codegen;
 
@@ -20,5 +24,6 @@ module io.github.eschizoid.telescope.codegen {
       io.github.eschizoid.telescope.codegen.FocusProcessor,
       io.github.eschizoid.telescope.codegen.BeanFocusProcessor,
       io.github.eschizoid.telescope.codegen.BridgeProcessor,
-      io.github.eschizoid.telescope.codegen.FromMapProcessor;
+      io.github.eschizoid.telescope.codegen.FromMapProcessor,
+      io.github.eschizoid.telescope.codegen.MapperVerifierProcessor;
 }

--- a/codegen/src/main/resources/META-INF/services/javax.annotation.processing.Processor
+++ b/codegen/src/main/resources/META-INF/services/javax.annotation.processing.Processor
@@ -2,3 +2,4 @@ io.github.eschizoid.telescope.codegen.FocusProcessor
 io.github.eschizoid.telescope.codegen.BridgeProcessor
 io.github.eschizoid.telescope.codegen.BeanFocusProcessor
 io.github.eschizoid.telescope.codegen.FromMapProcessor
+io.github.eschizoid.telescope.codegen.MapperVerifierProcessor

--- a/codegen/src/test/java/io/github/eschizoid/telescope/codegen/MapperVerifierProcessorTest.java
+++ b/codegen/src/test/java/io/github/eschizoid/telescope/codegen/MapperVerifierProcessorTest.java
@@ -459,8 +459,7 @@ class MapperVerifierProcessorTest {
     );
     assertFalse(compilation.success(), () -> compilation.errorMessages());
     assertTrue(compilation.hasError("duplicate override row for target field 'x'"), () -> compilation.errorMessages());
-    // The duplicate-target error is the only diagnostic — 'b' must not cascade as "unmatched
-    // source"
+    // The duplicate-target error is the only diagnostic — 'b' must not cascade as unmatched-source
     // because the duplicate row still consumes 'b' from the source side.
     final var errors = compilation
       .diagnostics()
@@ -471,6 +470,37 @@ class MapperVerifierProcessorTest {
       1,
       errors,
       () -> "the duplicate must not cascade into unmatched-field errors:\n" + compilation.errorMessages()
+    );
+  }
+
+  @Test
+  @DisplayName("a call site inside a NESTED class is diagnosed exactly once, not once per enclosing type")
+  void nestedClassCallSiteDiagnosedOnce() {
+    final var compilation = verify(
+      """
+      package demo;
+      import io.github.eschizoid.telescope.Telescope;
+      import io.github.eschizoid.telescope.conversion.Mapper;
+      record Src(String a) {}
+      record Tgt(String a, String b) {}
+      class Holder {
+        static class Inner {
+          static final Mapper<Src, Tgt> M = Telescope.mapper(Src.class, Tgt.class);
+        }
+      }
+      """
+    );
+    assertFalse(compilation.success(), () -> compilation.errorMessages());
+    final var errors = compilation
+      .diagnostics()
+      .stream()
+      .filter(d -> d.getKind() == Diagnostic.Kind.ERROR)
+      .count();
+    assertEquals(
+      1,
+      errors,
+      () ->
+        "ANALYZE fires per type declaration; the nested subtree must be scanned once:\n" + compilation.errorMessages()
     );
   }
 

--- a/codegen/src/test/java/io/github/eschizoid/telescope/codegen/MapperVerifierProcessorTest.java
+++ b/codegen/src/test/java/io/github/eschizoid/telescope/codegen/MapperVerifierProcessorTest.java
@@ -1,0 +1,406 @@
+package io.github.eschizoid.telescope.codegen;
+
+import static io.github.eschizoid.telescope.codegen.ProcessorHarness.compileFully;
+import static io.github.eschizoid.telescope.codegen.ProcessorHarness.source;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import javax.tools.Diagnostic;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Drives {@link MapperVerifierProcessor} through the in-memory harness and asserts the compile-time
+ * diagnostics replay the construction-time pairing rejections — same message text, error severity
+ * by default, silence wherever the site isn't statically analyzable.
+ */
+class MapperVerifierProcessorTest {
+
+  private static ProcessorHarness.Compilation verify(final String code) {
+    return verify(List.of(), code);
+  }
+
+  private static ProcessorHarness.Compilation verify(final List<String> options, final String code) {
+    // Full pipeline (not -proc:only): the verifier scans from a post-ANALYZE task listener, which
+    // never fires when compilation stops after the processing rounds.
+    return compileFully(List.of(new MapperVerifierProcessor()), options, source("demo.Holder", code));
+  }
+
+  @Nested
+  @DisplayName("Strict factories — completeness")
+  class Completeness {
+
+    @Test
+    @DisplayName("an unmatched target field is a compile error with the construction-time message")
+    void unmatchedTargetErrors() {
+      final var compilation = verify(
+        """
+        package demo;
+        import io.github.eschizoid.telescope.Telescope;
+        import io.github.eschizoid.telescope.conversion.Mapper;
+        record Src(String a) {}
+        record Tgt(String a, String b) {}
+        class Holder {
+          static final Mapper<Src, Tgt> M = Telescope.mapper(Src.class, Tgt.class);
+        }
+        """
+      );
+      assertFalse(compilation.success(), () -> compilation.errorMessages());
+      assertTrue(compilation.hasError("target field 'b' has no same-name source"), () -> compilation.errorMessages());
+    }
+
+    @Test
+    @DisplayName("an unmatched source field is a compile error with the construction-time message")
+    void unmatchedSourceErrors() {
+      final var compilation = verify(
+        """
+        package demo;
+        import io.github.eschizoid.telescope.Telescope;
+        import io.github.eschizoid.telescope.conversion.Mapper;
+        record Src(String a, String extra) {}
+        record Tgt(String a) {}
+        class Holder {
+          static final Mapper<Src, Tgt> M = Telescope.mapper(Src.class, Tgt.class);
+        }
+        """
+      );
+      assertFalse(compilation.success(), () -> compilation.errorMessages());
+      assertTrue(compilation.hasError("source field 'extra' has no same-name target"), () ->
+        compilation.errorMessages()
+      );
+    }
+
+    @Test
+    @DisplayName("a complete same-name mapper compiles clean")
+    void cleanMapperPasses() {
+      final var compilation = verify(
+        """
+        package demo;
+        import io.github.eschizoid.telescope.Telescope;
+        import io.github.eschizoid.telescope.conversion.Mapper;
+        record Src(String a, Integer n) {}
+        record Tgt(String a, Integer n) {}
+        class Holder {
+          static final Mapper<Src, Tgt> M = Telescope.mapper(Src.class, Tgt.class);
+        }
+        """
+      );
+      assertTrue(compilation.success(), () -> compilation.errorMessages());
+    }
+
+    @Test
+    @DisplayName("a rename row claims both sides — the renamed pair is not reported unmatched")
+    void renameRowClaims() {
+      final var compilation = verify(
+        """
+        package demo;
+        import io.github.eschizoid.telescope.Telescope;
+        import io.github.eschizoid.telescope.conversion.Mapper;
+        import io.github.eschizoid.telescope.mapping.Mapping;
+        record Src(String email) {}
+        record Tgt(String contactEmail) {}
+        class Holder {
+          static final Mapper<Src, Tgt> M = Telescope.mapper(
+            Src.class, Tgt.class, Mapping.to(Src::email, Tgt::contactEmail));
+        }
+        """
+      );
+      assertTrue(compilation.success(), () -> compilation.errorMessages());
+    }
+
+    @Test
+    @DisplayName("mapperForward is lenient by contract — unmatched fields are not reported")
+    void mapperForwardLenient() {
+      final var compilation = verify(
+        """
+        package demo;
+        import io.github.eschizoid.telescope.Telescope;
+        import io.github.eschizoid.telescope.conversion.ForwardMapper;
+        record Src(String a) {}
+        record Tgt(String a, String b) {}
+        class Holder {
+          static final ForwardMapper<Src, Tgt> M = Telescope.mapperForward(Src.class, Tgt.class);
+        }
+        """
+      );
+      assertTrue(compilation.success(), () -> compilation.errorMessages());
+    }
+  }
+
+  @Nested
+  @DisplayName("Shape checks — the shared pairing lattice at compile time")
+  class ShapeChecks {
+
+    @Test
+    @DisplayName("a same-typed to(...) rename over incompatible scalars errors with the 4-arg pointer")
+    void incompatibleRenameErrors() {
+      final var compilation = verify(
+        """
+        package demo;
+        import io.github.eschizoid.telescope.Telescope;
+        import io.github.eschizoid.telescope.conversion.Mapper;
+        import io.github.eschizoid.telescope.mapping.Mapping;
+        record Src(Integer count) {}
+        record Tgt(String label) {}
+        class Holder {
+          static final Mapper<Src, Tgt> M = Telescope.mapper(
+            Src.class, Tgt.class, Mapping.to(Src::count, Tgt::label));
+        }
+        """
+      );
+      assertFalse(compilation.success(), () -> compilation.errorMessages());
+      assertTrue(compilation.hasError("incompatible source/target shapes"), () -> compilation.errorMessages());
+      assertTrue(compilation.hasError("to(src, tgt, forward, backward)"), () -> compilation.errorMessages());
+    }
+
+    @Test
+    @DisplayName("an incompatible same-name field inside a NESTED auto-recursed pair errors")
+    void nestedIncompatibleErrors() {
+      final var compilation = verify(
+        """
+        package demo;
+        import io.github.eschizoid.telescope.Telescope;
+        import io.github.eschizoid.telescope.conversion.Mapper;
+        record SrcIn(Integer v) {}
+        record TgtIn(String v) {}
+        record Src(SrcIn in) {}
+        record Tgt(TgtIn in) {}
+        class Holder {
+          static final Mapper<Src, Tgt> M = Telescope.mapper(Src.class, Tgt.class);
+        }
+        """
+      );
+      assertFalse(compilation.success(), () -> compilation.errorMessages());
+      assertTrue(compilation.hasError("incompatible source/target shapes"), () -> compilation.errorMessages());
+    }
+
+    @Test
+    @DisplayName("container elements are shape-checked through the lift — List<Integer> vs List<String>")
+    void liftedElementIncompatibleErrors() {
+      final var compilation = verify(
+        """
+        package demo;
+        import io.github.eschizoid.telescope.Telescope;
+        import io.github.eschizoid.telescope.conversion.Mapper;
+        import java.util.List;
+        record Src(List<Integer> xs) {}
+        record Tgt(List<String> xs) {}
+        class Holder {
+          static final Mapper<Src, Tgt> M = Telescope.mapper(Src.class, Tgt.class);
+        }
+        """
+      );
+      assertFalse(compilation.success(), () -> compilation.errorMessages());
+      assertTrue(compilation.hasError("incompatible source/target shapes"), () -> compilation.errorMessages());
+    }
+
+    @Test
+    @DisplayName("a 4-arg to(...) carries the user's conversion — no shape error")
+    void fourArgTransformPasses() {
+      final var compilation = verify(
+        """
+        package demo;
+        import io.github.eschizoid.telescope.Telescope;
+        import io.github.eschizoid.telescope.conversion.Mapper;
+        import io.github.eschizoid.telescope.mapping.Mapping;
+        record Src(Integer count) {}
+        record Tgt(String label) {}
+        class Holder {
+          static final Mapper<Src, Tgt> M = Telescope.mapper(
+            Src.class, Tgt.class,
+            Mapping.to(Src::count, Tgt::label, i -> i == null ? null : String.valueOf(i), s -> s == null ? null : Integer.parseInt(s)));
+        }
+        """
+      );
+      assertTrue(compilation.success(), () -> compilation.errorMessages());
+    }
+  }
+
+  @Nested
+  @DisplayName("Degradation — never guess, never false-positive")
+  class Degradation {
+
+    @Test
+    @DisplayName("a dynamic row disables completeness but visible rows are still shape-checked")
+    void dynamicRowKeepsVisibleChecks() {
+      final var compilation = verify(
+        """
+        package demo;
+        import io.github.eschizoid.telescope.Telescope;
+        import io.github.eschizoid.telescope.conversion.Mapper;
+        import io.github.eschizoid.telescope.mapping.Mapping;
+        record Src(Integer count, String orphan) {}
+        record Tgt(String label) {}
+        class Holder {
+          static Mapping<Src, Tgt> helperRow() { return null; }
+          static final Mapper<Src, Tgt> M = Telescope.mapper(
+            Src.class, Tgt.class, Mapping.to(Src::count, Tgt::label), helperRow());
+        }
+        """
+      );
+      assertFalse(compilation.success(), () -> compilation.errorMessages());
+      assertTrue(compilation.hasError("incompatible source/target shapes"), () -> compilation.errorMessages());
+      assertFalse(compilation.hasError("has no same-name"), () -> compilation.errorMessages());
+    }
+
+    @Test
+    @DisplayName("a non-literal class argument skips the site entirely")
+    void nonLiteralClassSkips() {
+      final var compilation = verify(
+        """
+        package demo;
+        import io.github.eschizoid.telescope.Telescope;
+        import io.github.eschizoid.telescope.conversion.Mapper;
+        record Src(String a) {}
+        record Tgt(String a, String b) {}
+        class Holder {
+          static final Class<Src> SRC = Src.class;
+          static final Mapper<Src, Tgt> M = Telescope.mapper(SRC, Tgt.class);
+        }
+        """
+      );
+      assertTrue(compilation.success(), () -> compilation.errorMessages());
+    }
+
+    @Test
+    @DisplayName("@UncheckedMapping on the enclosing field exempts the site")
+    void uncheckedMappingSuppresses() {
+      final var compilation = verify(
+        """
+        package demo;
+        import io.github.eschizoid.telescope.Telescope;
+        import io.github.eschizoid.telescope.annotations.UncheckedMapping;
+        import io.github.eschizoid.telescope.conversion.Mapper;
+        record Src(String a) {}
+        record Tgt(String a, String b) {}
+        class Holder {
+          @UncheckedMapping("intentionally partial in this test")
+          static final Mapper<Src, Tgt> M = Telescope.mapper(Src.class, Tgt.class);
+        }
+        """
+      );
+      assertTrue(compilation.success(), () -> compilation.errorMessages());
+    }
+
+    @Test
+    @DisplayName("-Atelescope.verify=off disables the verifier")
+    void offFlagDisables() {
+      final var compilation = verify(
+        List.of("-Atelescope.verify=off"),
+        """
+        package demo;
+        import io.github.eschizoid.telescope.Telescope;
+        import io.github.eschizoid.telescope.conversion.Mapper;
+        record Src(String a) {}
+        record Tgt(String a, String b) {}
+        class Holder {
+          static final Mapper<Src, Tgt> M = Telescope.mapper(Src.class, Tgt.class);
+        }
+        """
+      );
+      assertTrue(compilation.success(), () -> compilation.errorMessages());
+    }
+
+    @Test
+    @DisplayName("-Atelescope.verify=warn reports a WARNING and the build stays green")
+    void warnModeWarns() {
+      final var compilation = verify(
+        List.of("-Atelescope.verify=warn"),
+        """
+        package demo;
+        import io.github.eschizoid.telescope.Telescope;
+        import io.github.eschizoid.telescope.conversion.Mapper;
+        record Src(String a) {}
+        record Tgt(String a, String b) {}
+        class Holder {
+          static final Mapper<Src, Tgt> M = Telescope.mapper(Src.class, Tgt.class);
+        }
+        """
+      );
+      assertTrue(compilation.success(), () -> compilation.errorMessages());
+      final var warned = compilation
+        .diagnostics()
+        .stream()
+        .anyMatch(
+          d ->
+            d.getKind() == Diagnostic.Kind.WARNING &&
+            d.getMessage(null) != null &&
+            d.getMessage(null).contains("has no same-name source")
+        );
+      assertTrue(warned, "expected the completeness diagnostic at WARNING severity");
+    }
+  }
+
+  @Nested
+  @DisplayName("WriteHint validation")
+  class WriteHints {
+
+    @Test
+    @DisplayName("writeBean targeting a record errors with the construction-time message")
+    void writeBeanOnRecordErrors() {
+      final var compilation = verify(
+        """
+        package demo;
+        import static io.github.eschizoid.telescope.mapping.WriteHint.WriteStrategy.SETTERS;
+        import static io.github.eschizoid.telescope.mapping.WriteHint.writeBean;
+        import io.github.eschizoid.telescope.Telescope;
+        import io.github.eschizoid.telescope.conversion.Mapper;
+        record Src(String a) {}
+        record Tgt(String a) {}
+        class Holder {
+          static final Mapper<Src, Tgt> M = Telescope.mapper(Src.class, Tgt.class, writeBean(Tgt.class, SETTERS));
+        }
+        """
+      );
+      assertFalse(compilation.success(), () -> compilation.errorMessages());
+      assertTrue(compilation.hasError("writeBean hint targets a record class"), () -> compilation.errorMessages());
+    }
+  }
+
+  @Test
+  @DisplayName("duplicate rows for the same target field error with the construction-time message")
+  void duplicateTargetRowErrors() {
+    final var compilation = verify(
+      """
+      package demo;
+      import io.github.eschizoid.telescope.Telescope;
+      import io.github.eschizoid.telescope.conversion.Mapper;
+      import io.github.eschizoid.telescope.mapping.Mapping;
+      record Src(String a, String b) {}
+      record Tgt(String x) {}
+      class Holder {
+        static final Mapper<Src, Tgt> M = Telescope.mapper(
+          Src.class, Tgt.class, Mapping.to(Src::a, Tgt::x), Mapping.to(Src::b, Tgt::x));
+      }
+      """
+    );
+    assertFalse(compilation.success(), () -> compilation.errorMessages());
+    assertTrue(compilation.hasError("duplicate override row for target field 'x'"), () -> compilation.errorMessages());
+  }
+
+  @Test
+  @DisplayName("exactly one diagnostic per problem — no cascade from a single unmatched field")
+  void singleDiagnosticPerProblem() {
+    final var compilation = verify(
+      """
+      package demo;
+      import io.github.eschizoid.telescope.Telescope;
+      import io.github.eschizoid.telescope.conversion.Mapper;
+      record Src(String a) {}
+      record Tgt(String a, String b) {}
+      class Holder {
+        static final Mapper<Src, Tgt> M = Telescope.mapper(Src.class, Tgt.class);
+      }
+      """
+    );
+    final var errors = compilation
+      .diagnostics()
+      .stream()
+      .filter(d -> d.getKind() == Diagnostic.Kind.ERROR)
+      .count();
+    assertEquals(1, errors, () -> compilation.errorMessages());
+  }
+}

--- a/codegen/src/test/java/io/github/eschizoid/telescope/codegen/MapperVerifierProcessorTest.java
+++ b/codegen/src/test/java/io/github/eschizoid/telescope/codegen/MapperVerifierProcessorTest.java
@@ -361,6 +361,86 @@ class MapperVerifierProcessorTest {
   }
 
   @Test
+  @DisplayName("a when-wrapped constant is permissive exactly like a bare one — no completeness error")
+  void whenWrappedConstantIsPermissive() {
+    final var compilation = verify(
+      """
+      package demo;
+      import io.github.eschizoid.telescope.Telescope;
+      import io.github.eschizoid.telescope.conversion.Mapper;
+      import io.github.eschizoid.telescope.mapping.Mapping;
+      record Src(String a) {}
+      record Tgt(String a, String extra) {}
+      class Holder {
+        static final Mapper<Src, Tgt> M = Telescope.mapper(
+          Src.class, Tgt.class, Mapping.when(s -> true, Mapping.constant(Tgt::extra, "x")));
+      }
+      """
+    );
+    assertTrue(compilation.success(), () -> compilation.errorMessages());
+  }
+
+  @Test
+  @DisplayName("a toOneWay row claims its fields — the renamed pair is not reported unmatched")
+  void toOneWayRowClaims() {
+    final var compilation = verify(
+      """
+      package demo;
+      import io.github.eschizoid.telescope.Telescope;
+      import io.github.eschizoid.telescope.conversion.ForwardMapper;
+      import io.github.eschizoid.telescope.mapping.Mapping;
+      record Src(Integer count) {}
+      record Tgt(String label) {}
+      class Holder {
+        static final ForwardMapper<Src, Tgt> M = Telescope.mapperForward(
+          Src.class, Tgt.class, Mapping.toOneWay(Src::count, Tgt::label, i -> String.valueOf(i)));
+      }
+      """
+    );
+    assertTrue(compilation.success(), () -> compilation.errorMessages());
+  }
+
+  @Test
+  @DisplayName("an identical wildcard-bearing field pair is skipped, not mis-decided")
+  void wildcardIdentitySkips() {
+    final var compilation = verify(
+      """
+      package demo;
+      import io.github.eschizoid.telescope.Telescope;
+      import io.github.eschizoid.telescope.conversion.Mapper;
+      import java.util.List;
+      record Src(List<? extends CharSequence> xs) {}
+      record Tgt(List<? extends CharSequence> xs) {}
+      class Holder {
+        static final Mapper<Src, Tgt> M = Telescope.mapper(Src.class, Tgt.class);
+      }
+      """
+    );
+    assertTrue(compilation.success(), () -> compilation.errorMessages());
+  }
+
+  @Test
+  @DisplayName("rows on a generic source class still claim their fields (erasure-matched owners)")
+  void genericOwnerRowsClaim() {
+    final var compilation = verify(
+      """
+      package demo;
+      import io.github.eschizoid.telescope.Telescope;
+      import io.github.eschizoid.telescope.conversion.Mapper;
+      import io.github.eschizoid.telescope.mapping.Mapping;
+      record Box<T>(String payload) {}
+      record BoxDto(String data) {}
+      class Holder {
+        @SuppressWarnings("rawtypes")
+        static final Mapper<Box, BoxDto> M = Telescope.mapper(
+          Box.class, BoxDto.class, Mapping.<Box, BoxDto, String>to(Box::payload, BoxDto::data));
+      }
+      """
+    );
+    assertTrue(compilation.success(), () -> compilation.errorMessages());
+  }
+
+  @Test
   @DisplayName("duplicate rows for the same target field error with the construction-time message")
   void duplicateTargetRowErrors() {
     final var compilation = verify(
@@ -379,10 +459,19 @@ class MapperVerifierProcessorTest {
     );
     assertFalse(compilation.success(), () -> compilation.errorMessages());
     assertTrue(compilation.hasError("duplicate override row for target field 'x'"), () -> compilation.errorMessages());
-    // The duplicate-target error is the only diagnostic — 'b' must not cascade as "unmatched source"
+    // The duplicate-target error is the only diagnostic — 'b' must not cascade as "unmatched
+    // source"
     // because the duplicate row still consumes 'b' from the source side.
-    final var errors = compilation.diagnostics().stream().filter(d -> d.getKind() == Diagnostic.Kind.ERROR).count();
-    assertEquals(1, errors, () -> compilation.errorMessages());
+    final var errors = compilation
+      .diagnostics()
+      .stream()
+      .filter(d -> d.getKind() == Diagnostic.Kind.ERROR)
+      .count();
+    assertEquals(
+      1,
+      errors,
+      () -> "the duplicate must not cascade into unmatched-field errors:\n" + compilation.errorMessages()
+    );
   }
 
   @Test

--- a/codegen/src/test/java/io/github/eschizoid/telescope/codegen/MapperVerifierProcessorTest.java
+++ b/codegen/src/test/java/io/github/eschizoid/telescope/codegen/MapperVerifierProcessorTest.java
@@ -379,6 +379,10 @@ class MapperVerifierProcessorTest {
     );
     assertFalse(compilation.success(), () -> compilation.errorMessages());
     assertTrue(compilation.hasError("duplicate override row for target field 'x'"), () -> compilation.errorMessages());
+    // The duplicate-target error is the only diagnostic — 'b' must not cascade as "unmatched source"
+    // because the duplicate row still consumes 'b' from the source side.
+    final var errors = compilation.diagnostics().stream().filter(d -> d.getKind() == Diagnostic.Kind.ERROR).count();
+    assertEquals(1, errors, () -> compilation.errorMessages());
   }
 
   @Test

--- a/codegen/src/testFixtures/java/io/github/eschizoid/telescope/codegen/ProcessorHarness.java
+++ b/codegen/src/testFixtures/java/io/github/eschizoid/telescope/codegen/ProcessorHarness.java
@@ -47,6 +47,41 @@ public final class ProcessorHarness {
    * round.
    */
   public static Compilation compile(final List<? extends Processor> processors, final JavaFileObject... sources) {
+    return compile(processors, List.of(), sources);
+  }
+
+  /**
+   * Same as {@link #compile(List, JavaFileObject...)} with extra compiler options appended — e.g.
+   * {@code -Atelescope.verify=warn} to exercise a processor's option handling.
+   */
+  public static Compilation compile(
+    final List<? extends Processor> processors,
+    final List<String> extraOptions,
+    final JavaFileObject... sources
+  ) {
+    return run(processors, extraOptions, true, sources);
+  }
+
+  /**
+   * Compile through the FULL javac pipeline (parse → process → analyze → generate), with class
+   * output captured in memory and discarded. Needed for processors that do their work from a
+   * post-analysis task listener rather than in the processing rounds — under {@code -proc:only} the
+   * analyze phase never runs, so such processors would be silent.
+   */
+  public static Compilation compileFully(
+    final List<? extends Processor> processors,
+    final List<String> extraOptions,
+    final JavaFileObject... sources
+  ) {
+    return run(processors, extraOptions, false, sources);
+  }
+
+  private static Compilation run(
+    final List<? extends Processor> processors,
+    final List<String> extraOptions,
+    final boolean procOnly,
+    final JavaFileObject... sources
+  ) {
     final JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
     if (compiler == null) {
       throw new IllegalStateException("no system Java compiler available (need a JDK, not a JRE)");
@@ -58,12 +93,17 @@ public final class ProcessorHarness {
     );
 
     // -proc:only runs annotation processing without emitting .class files (nothing leaks into the
-    // working tree, no read-back compile round). The -Xlint flags mirror the build.
+    // working tree, no read-back compile round); the full pipeline routes class output into the
+    // capturing manager's in-memory sink instead. The -Xlint flags mirror the build.
+    final var options = new ArrayList<>(
+      procOnly ? List.of("-proc:only", "-Xlint:all,-processing") : List.of("-Xlint:all,-processing")
+    );
+    options.addAll(extraOptions);
     final JavaCompiler.CompilationTask task = compiler.getTask(
       null,
       capturing,
       diagnostics,
-      List.of("-proc:only", "-Xlint:all,-processing"),
+      options,
       null,
       List.of(sources)
     );
@@ -156,6 +196,11 @@ public final class ProcessorHarness {
         captured.put(className, sourceFile);
         return sourceFile;
       }
+      // Full-pipeline compiles route class output here — sink it in memory so nothing lands in
+      // the working tree.
+      if (location == StandardLocation.CLASS_OUTPUT && kind == JavaFileObject.Kind.CLASS) {
+        return new DiscardedClass(className);
+      }
       return super.getJavaFileForOutput(location, className, kind, sibling);
     }
 
@@ -212,6 +257,19 @@ public final class ProcessorHarness {
   }
 
   /** In-memory sink for a single generated source file. */
+  /** In-memory sink for class output in full-pipeline compiles — the bytes are discarded. */
+  private static final class DiscardedClass extends SimpleJavaFileObject {
+
+    DiscardedClass(final String className) {
+      super(URI.create("mem:///" + className.replace('.', '/') + Kind.CLASS.extension), Kind.CLASS);
+    }
+
+    @Override
+    public OutputStream openOutputStream() {
+      return new ByteArrayOutputStream();
+    }
+  }
+
   private static final class CapturedSource extends SimpleJavaFileObject {
 
     private final ByteArrayOutputStream bytes = new ByteArrayOutputStream();

--- a/codegen/src/testFixtures/java/io/github/eschizoid/telescope/codegen/ProcessorHarness.java
+++ b/codegen/src/testFixtures/java/io/github/eschizoid/telescope/codegen/ProcessorHarness.java
@@ -256,7 +256,6 @@ public final class ProcessorHarness {
     }
   }
 
-  /** In-memory sink for a single generated source file. */
   /** In-memory sink for class output in full-pipeline compiles — the bytes are discarded. */
   private static final class DiscardedClass extends SimpleJavaFileObject {
 
@@ -270,6 +269,7 @@ public final class ProcessorHarness {
     }
   }
 
+  /** In-memory sink for a single generated source file. */
   private static final class CapturedSource extends SimpleJavaFileObject {
 
     private final ByteArrayOutputStream bytes = new ByteArrayOutputStream();

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -29,6 +29,13 @@ tasks.withType<JavaCompile>().configureEach {
     options.compilerArgs.addAll(listOf("-Xlint:all,-processing", "-Werror", "-parameters"))
 }
 
+tasks.named<JavaCompile>("compileTestJava") {
+    // This suite deliberately constructs invalid mappers to pin the construction-time rejections;
+    // the compile-time verifier would (correctly) refuse to compile them. The module under test IS
+    // the construction-time validator, so compile-time verification is off for its own tests.
+    options.compilerArgs.add("-Atelescope.verify=off")
+}
+
 tasks.withType<Test>().configureEach {
     useJUnitPlatform()
     testLogging {

--- a/core/src/main/java/io/github/eschizoid/telescope/DeepMap.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/DeepMap.java
@@ -197,16 +197,9 @@ public final class DeepMap {
     for (final var hint : hints) {
       if (hint instanceof WriteHint.DefaultWriteHint) continue; // handled by extractDefaultStrategy
       final var cls = hint.targetClass();
-      if (cls.isRecord()) throw new IllegalArgumentException(
-        "writeBean hint targets a record class (" +
-          cls.getName() +
-          "). Records are always reconstructed via the canonical constructor; the hint cannot apply. " +
-          "Remove the writeBean(...) row, or move it to the bean side of the mapping."
-      );
+      if (cls.isRecord()) throw new IllegalArgumentException(PairingMessages.writeBeanTargetsRecord(cls.getName()));
       if (map.containsKey(cls)) throw new IllegalArgumentException(
-        "Duplicate writeBean hint for " +
-          cls.getName() +
-          ". Each target class may declare at most one writeBean(...) row per Telescope.map(...) call."
+        PairingMessages.duplicateWriteBeanHint(cls.getName())
       );
       map.put(cls, writerFor(hint));
     }

--- a/core/src/main/java/io/github/eschizoid/telescope/DeepMap.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/DeepMap.java
@@ -6,6 +6,11 @@ import io.github.eschizoid.telescope.internal.NullDefaults;
 import io.github.eschizoid.telescope.internal.Records;
 import io.github.eschizoid.telescope.internal.Reflective;
 import io.github.eschizoid.telescope.internal.optics.Iso;
+import io.github.eschizoid.telescope.internal.pairing.ContainerView;
+import io.github.eschizoid.telescope.internal.pairing.PairDecision;
+import io.github.eschizoid.telescope.internal.pairing.PairingMessages;
+import io.github.eschizoid.telescope.internal.pairing.PairingRules;
+import io.github.eschizoid.telescope.internal.pairing.ReflectionProps;
 import io.github.eschizoid.telescope.mapping.Compute;
 import io.github.eschizoid.telescope.mapping.Conditional;
 import io.github.eschizoid.telescope.mapping.Constant;
@@ -24,7 +29,6 @@ import io.github.eschizoid.telescope.mapping.WriteHint;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
-import java.time.temporal.Temporal;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -39,16 +43,11 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.PriorityQueue;
-import java.util.Queue;
 import java.util.Set;
-import java.util.SortedMap;
-import java.util.SortedSet;
 import java.util.Stack;
 import java.util.TreeMap;
 import java.util.TreeSet;
-import java.util.UUID;
 import java.util.Vector;
 import java.util.WeakHashMap;
 import java.util.concurrent.ConcurrentHashMap;
@@ -95,6 +94,14 @@ import java.util.function.Supplier;
 public final class DeepMap {
 
   private DeepMap() {}
+
+  /**
+   * The shared pairing decision spec, adapted to the reflection world. Every per-pair conversion
+   * decision and every pairing diagnostic routes through this one rule set — the compile-time
+   * verifier consumes the same rules through a {@code TypeMirror} adapter, so what constructs here
+   * and what compiles there cannot drift.
+   */
+  private static final PairingRules<Type> PAIRING = new PairingRules<>(new ReflectionProps());
 
   // ---------- Package-private entries (called from Telescope.map / Telescope.mapper) ----------
 
@@ -453,13 +460,7 @@ public final class DeepMap {
         // strict source-must-be-claimed pass below when one side carries fields the other doesn't.
         if (row instanceof Drop<?, ?, ?>) {
           if (!claimedSrc.add(srcField)) throw new IllegalArgumentException(
-            "Deep map " +
-              source.getSimpleName() +
-              " → " +
-              target.getSimpleName() +
-              ": duplicate override row for source field '" +
-              srcField +
-              "'. Each (source, target) type pair may declare at most one row per source field."
+            PairingMessages.duplicateSourceRow(source.getSimpleName(), target.getSimpleName(), srcField)
           );
           // Register a backward-only step under the source name so the source-reconstructor
           // (assembleIso's bySourceName loop) produces a placeholder value (null) for the dropped
@@ -473,13 +474,7 @@ public final class DeepMap {
         // overwrite each other in byTargetName and could produce non-bijective forward/backward
         // (each direction using a different correspondence).
         if (!claimedTgt.add(tgtField)) throw new IllegalArgumentException(
-          "Deep map " +
-            source.getSimpleName() +
-            " → " +
-            target.getSimpleName() +
-            ": duplicate override row for target field '" +
-            tgtField +
-            "'. Each (source, target) type pair may declare at most one row per target field."
+          PairingMessages.duplicateTargetRow(source.getSimpleName(), target.getSimpleName(), tgtField)
         );
         // Same-source fan-out IS permitted: one source field feeding multiple target fields is a
         // common enterprise pattern (e.g. `businessUnit → cretnUserId AND lastUpdtdUserId` on
@@ -564,19 +559,13 @@ public final class DeepMap {
             continue;
           }
           throw new IllegalStateException(
-            "Deep map " +
-              source.getSimpleName() +
-              " → " +
-              target.getSimpleName() +
-              ": target " +
-              slot(tgtRefl) +
-              " '" +
-              name +
-              "' has no same-name source " +
-              slot(srcRefl) +
-              ". Add a rename row to(sourceAccessor, targetAccessor) that maps to '" +
-              name +
-              "'."
+            PairingMessages.noSameNameSource(
+              source.getSimpleName(),
+              target.getSimpleName(),
+              slot(tgtRefl),
+              slot(srcRefl),
+              name
+            )
           );
         }
         final var step = new FieldStep(
@@ -616,19 +605,13 @@ public final class DeepMap {
           continue;
         }
         throw new IllegalStateException(
-          "Deep map " +
-            source.getSimpleName() +
-            " → " +
-            target.getSimpleName() +
-            ": source " +
-            slot(srcRefl) +
-            " '" +
-            name +
-            "' has no same-name target " +
-            slot(tgtRefl) +
-            ". Add a rename row to(sourceAccessor, targetAccessor) that consumes '" +
-            name +
-            "'."
+          PairingMessages.noSameNameTarget(
+            source.getSimpleName(),
+            target.getSimpleName(),
+            slot(srcRefl),
+            slot(tgtRefl),
+            name
+          )
         );
       }
 
@@ -894,69 +877,45 @@ public final class DeepMap {
     final Set<TypePair> cyclicPairs,
     final Deque<TypePair> inProgress
   ) {
+    // Every branch DECISION routes through the shared pairing spec — this method only maps each
+    // decision to its runtime Iso. Branch rationale (kind discriminators, scalar exclusions,
+    // ordering) lives on PairingRules#decidePair, consumed identically by the compile-time
+    // verifier so what constructs here and what compiles there cannot drift.
+    final var decision = PAIRING.decidePair(srcType, tgtType, componentName);
+
     // (a) Same generic type → identity Iso.
-    if (srcType.equals(tgtType)) return Iso.identity();
+    if (decision instanceof PairDecision.Identity) return Iso.identity();
 
     // (a.1) Primitive ↔ wrapper pair → autobox / unbox via JLS-default-safe Iso. Forward
     // unboxes (null-safe — substitutes the primitive default to avoid NPE on the wrapper-to-
     // primitive setter); backward boxes via the wrapper's static valueOf. Matches MapStruct's
     // behaviour for these pairs (it silently autoboxes and uses 0/false/etc. for null).
-    if (
-      srcType instanceof Class<?> srcClsAB &&
-      tgtType instanceof Class<?> tgtClsAB &&
-      isPrimitiveWrapperPair(srcClsAB, tgtClsAB)
-    ) {
-      return primitiveWrapperIso(srcClsAB, tgtClsAB);
+    if (decision instanceof PairDecision.PrimitiveWrapper) {
+      return primitiveWrapperIso((Class<?>) srcType, (Class<?>) tgtType);
     }
 
-    // (a.2) Collection / Map subtype pair. Common in legacy bean codebases: `class
-    //       ImageUrls extends ArrayList<ImageUrl>` and `class ImageUrlsBO extends
-    //       ArrayList<ImageUrl>` on opposite sides. Neither is identity (different concrete
-    //       classes), neither is a parameterised raw `List` / `Map` (so ContainerShape skips
-    //       them), and trying to bean-decompose would hit
-    //       `MethodHandles.privateLookupIn(ArrayList.class)` rejection. Copy elements via the
-    //       target's no-arg constructor + `addAll` / `putAll`.
-    //
-    //       Collection side is gated on same kind (List↔List, Set↔Set, Queue↔Queue). Copying a
-    //       `LinkedList` into a `HashSet` would silently deduplicate; an `ArrayList` into a
-    //       `PriorityQueue` would silently reorder by natural ordering. Users who genuinely want
-    //       a kind change must declare an explicit `Mapping.via(...)` row.
-    //
-    //       Map side uses a SortedMap-vs-non-Sorted axis (mirrors the SortedSet split): a
-    //       `HashMap ↔ TreeMap` pair over non-Comparable keys would CCE at putAll. Within each
-    //       side, iteration-order, comparator, and thread-safety guarantees may still shift
-    //       when the concrete kinds differ (e.g. `LinkedHashMap → HashMap` reorders;
-    //       `ConcurrentHashMap → HashMap` drops the concurrency contract). The Iso copies
-    //       entries verbatim — users with semantic dependencies on the source's concrete type
-    //       should declare an explicit row.
-    if (srcType instanceof Class<?> srcCC && tgtType instanceof Class<?> tgtCC) {
-      if (sameKindCollection(srcCC, tgtCC)) {
-        final var iso = collectionCopyIso(srcCC, tgtCC);
-        if (iso != null) return iso;
-      }
-      if (sameKindMap(srcCC, tgtCC)) {
-        final var iso = mapCopyIso(srcCC, tgtCC);
-        if (iso != null) return iso;
-      }
+    // (a.2) Same-kind Collection / Map subtype pair (raw container subclasses like `class
+    //       ImageUrls extends ArrayList<ImageUrl>` on both sides) — copy elements via the target's
+    //       no-arg constructor + `addAll` / `putAll`. The kind-discriminator and allocability
+    //       gates live on the shared spec; the decision only fires when the copy is buildable.
+    if (decision instanceof PairDecision.CollectionCopy) {
+      return collectionCopyIso((Class<?>) srcType, (Class<?>) tgtType);
+    }
+    if (decision instanceof PairDecision.MapCopy) {
+      return mapCopyIso((Class<?>) srcType, (Class<?>) tgtType);
     }
 
     // (b) Both reflectable (record or bean) → recurse, return cache-reading Iso so cycles work.
-    if (srcType instanceof Class<?> srcCls && tgtType instanceof Class<?> tgtCls) {
-      if (isReflectable(srcCls) && isReflectable(tgtCls)) {
-        // Nested recursion — `isNested` (inProgress.size() > 1) already triggers the lenient gate
-        // for unmatched fields regardless of the outer call's strictness. Pass `false` here so the
-        // lenient flag's meaning stays anchored to the user-facing top-level call (mapperForward).
-        populateIso(srcCls, tgtCls, overrides, beanRefl, cache, null, nullStrategy, cyclicPairs, inProgress, false);
-        final var subKey = new TypePair(srcCls, tgtCls);
-        return lazyCacheIso(cache, subKey, !cyclicPairs.contains(subKey));
-      }
+    if (decision instanceof PairDecision.RecursePair) {
+      final var srcCls = (Class<?>) srcType;
+      final var tgtCls = (Class<?>) tgtType;
+      // Nested recursion — `isNested` (inProgress.size() > 1) already triggers the lenient gate
+      // for unmatched fields regardless of the outer call's strictness. Pass `false` here so the
+      // lenient flag's meaning stays anchored to the user-facing top-level call (mapperForward).
+      populateIso(srcCls, tgtCls, overrides, beanRefl, cache, null, nullStrategy, cyclicPairs, inProgress, false);
+      final var subKey = new TypePair(srcCls, tgtCls);
+      return lazyCacheIso(cache, subKey, !cyclicPairs.contains(subKey));
     }
-
-    // (c) Both same-kind containers → recurse on the element TYPE so nested containers work
-    //     (List<Optional<X>>, Optional<List<X>>, Map<K, List<X>>, etc.). Scalar/record/container
-    //     elements all dispatch through this same autoIso recursion.
-    final var srcShape = ContainerShape.of(srcType);
-    final var tgtShape = ContainerShape.of(tgtType);
 
     // (c.1) Cross-paradigm Optional bridge — one side is Optional<X>, the other is a possibly-null
     //       scalar/record/bean. Common case: record uses Optional<Address> while the JPA-mapped
@@ -969,10 +928,10 @@ public final class DeepMap {
     //       corrupt the {@code .reverse()} on the second branch — coalesceForward's documented
     //       non-bijection at the null/default boundary would land on the BACKWARD direction post-
     //       reverse. Field-level wrap fires once at the outer autoIso return; that's enough.
-    if (srcShape != null && srcShape.kind == ContainerShape.Kind.OPTIONAL && tgtShape == null) {
+    if (decision instanceof PairDecision.OptionalToNullable<Type> d) {
       final var elementIso = autoIso(
-        srcShape.elementType,
-        tgtType,
+        d.elementSrc(),
+        d.elementTgt(),
         componentName + "[*]",
         overrides,
         beanRefl,
@@ -983,10 +942,10 @@ public final class DeepMap {
       );
       return Iso.liftOptionalToNullable(eraseIso(elementIso));
     }
-    if (tgtShape != null && tgtShape.kind == ContainerShape.Kind.OPTIONAL && srcShape == null) {
+    if (decision instanceof PairDecision.NullableToOptional<Type> d) {
       final var elementIso = autoIso(
-        srcType,
-        tgtShape.elementType,
+        d.elementSrc(),
+        d.elementTgt(),
         componentName + "[*]",
         overrides,
         beanRefl,
@@ -998,27 +957,14 @@ public final class DeepMap {
       return Iso.liftOptionalToNullable(eraseIso(elementIso)).reverse();
     }
 
-    if (srcShape != null && tgtShape != null && srcShape.kind == tgtShape.kind) {
-      // Map<K, X> ↔ Map<K, Y>: keys must match exactly; Iso.liftMapValues preserves source keys.
-      if (srcShape.kind == ContainerShape.Kind.MAP_VALUES && !srcShape.keyClass.equals(tgtShape.keyClass)) {
-        throw new IllegalStateException(
-          "Deep map: component '" +
-            componentName +
-            "' has incompatible Map key types — source " +
-            srcShape.keyClass.getName() +
-            " vs target " +
-            tgtShape.keyClass.getName() +
-            ". Key types must match exactly; auto-lifting preserves the source keys."
-        );
-      }
-      // Element-level recursion passes PROPAGATE — see the cross-Optional branch above for the
-      // rationale. NullStrategy.DEFAULT is a field-level semantic and the outer autoIso wraps the
-      // lifted result once; double-wrapping the element-level would over-substitute null elements
-      // inside the collection (per MapStruct's SET_TO_DEFAULT the gate is at the field, not the
-      // element).
+    // (c) Both same-kind containers → recurse on the element TYPE so nested containers work
+    //     (List<Optional<X>>, Optional<List<X>>, Map<K, List<X>>, etc.). Scalar/record/container
+    //     elements all dispatch through this same autoIso recursion. Element-level recursion
+    //     passes PROPAGATE — see the cross-Optional branch above for the rationale.
+    if (decision instanceof PairDecision.LiftContainer<Type> d) {
       final var elementIso = autoIso(
-        srcShape.elementType,
-        tgtShape.elementType,
+        d.src().elementType(),
+        d.tgt().elementType(),
         componentName + "[*]",
         overrides,
         beanRefl,
@@ -1027,25 +973,28 @@ public final class DeepMap {
         cyclicPairs,
         inProgress
       );
-      return switch (srcShape.kind) {
-        case LIST -> liftListIntoTargetRaw(eraseIso(elementIso), srcShape.rawClass, tgtShape.rawClass);
-        case SET -> liftSetIntoTargetRaw(eraseIso(elementIso), srcShape.rawClass, tgtShape.rawClass);
-        case MAP_VALUES -> liftMapIntoTargetRaw(eraseIso(elementIso), srcShape.rawClass, tgtShape.rawClass);
+      return switch (d.src().kind()) {
+        case LIST -> liftListIntoTargetRaw(
+          eraseIso(elementIso),
+          (Class<?>) d.src().rawType(),
+          (Class<?>) d.tgt().rawType()
+        );
+        case SET -> liftSetIntoTargetRaw(
+          eraseIso(elementIso),
+          (Class<?>) d.src().rawType(),
+          (Class<?>) d.tgt().rawType()
+        );
+        case MAP_VALUES -> liftMapIntoTargetRaw(
+          eraseIso(elementIso),
+          (Class<?>) d.src().rawType(),
+          (Class<?>) d.tgt().rawType()
+        );
         // Optional is final; no subclasses, no allocator needed.
         case OPTIONAL -> Iso.liftOptional(eraseIso(elementIso));
       };
     }
 
-    throw new IllegalStateException(
-      "Deep map: component '" +
-        componentName +
-        "' has incompatible source/target shapes — " +
-        srcType.getTypeName() +
-        " vs " +
-        tgtType.getTypeName() +
-        ". Shapes must match: same scalar, both records/beans, or both same-kind container. For " +
-        "differing scalar types, add a to(src, tgt, forward, backward) row to supply the conversion."
-    );
+    throw new IllegalStateException(((PairDecision.Incompatible<Type>) decision).message());
   }
 
   /**
@@ -1148,28 +1097,40 @@ public final class DeepMap {
     final var elementIso = Iso.of(raw::forward, raw::backward);
     final var mapperSrc = raw.sourceClass();
     final var mapperTgt = raw.targetClass();
-    final var srcShape = ContainerShape.of(srcType);
-    final var tgtShape = ContainerShape.of(tgtType);
+    final var srcShape = PAIRING.containerViewOf(srcType);
+    final var tgtShape = PAIRING.containerViewOf(tgtType);
     if (
       srcShape != null &&
       tgtShape != null &&
-      srcShape.kind == tgtShape.kind &&
-      elementTypeMatches(srcShape.elementType, mapperSrc) &&
-      elementTypeMatches(tgtShape.elementType, mapperTgt)
+      srcShape.kind() == tgtShape.kind() &&
+      elementTypeMatches(srcShape.elementType(), mapperSrc) &&
+      elementTypeMatches(tgtShape.elementType(), mapperTgt)
     ) {
-      if (srcShape.kind == ContainerShape.Kind.MAP_VALUES && !srcShape.keyClass.equals(tgtShape.keyClass)) {
+      if (srcShape.kind() == ContainerView.Kind.MAP_VALUES && !srcShape.keyType().equals(tgtShape.keyType())) {
         throw new IllegalStateException(
           "Deep map via(...): Map key types must match exactly — source " +
-            srcShape.keyClass.getName() +
+            ((Class<?>) srcShape.keyType()).getName() +
             " vs target " +
-            tgtShape.keyClass.getName() +
+            ((Class<?>) tgtShape.keyType()).getName() +
             ". Key types must match exactly; auto-lifting preserves the source keys."
         );
       }
-      return switch (srcShape.kind) {
-        case LIST -> liftListIntoTargetRaw(eraseIso(elementIso), srcShape.rawClass, tgtShape.rawClass);
-        case SET -> liftSetIntoTargetRaw(eraseIso(elementIso), srcShape.rawClass, tgtShape.rawClass);
-        case MAP_VALUES -> liftMapIntoTargetRaw(eraseIso(elementIso), srcShape.rawClass, tgtShape.rawClass);
+      return switch (srcShape.kind()) {
+        case LIST -> liftListIntoTargetRaw(
+          eraseIso(elementIso),
+          (Class<?>) srcShape.rawType(),
+          (Class<?>) tgtShape.rawType()
+        );
+        case SET -> liftSetIntoTargetRaw(
+          eraseIso(elementIso),
+          (Class<?>) srcShape.rawType(),
+          (Class<?>) tgtShape.rawType()
+        );
+        case MAP_VALUES -> liftMapIntoTargetRaw(
+          eraseIso(elementIso),
+          (Class<?>) srcShape.rawType(),
+          (Class<?>) tgtShape.rawType()
+        );
         // Optional is final; no subclasses, no allocator needed.
         case OPTIONAL -> Iso.liftOptional(eraseIso(elementIso));
       };
@@ -1249,48 +1210,6 @@ public final class DeepMap {
         return fresh;
       }
     );
-  }
-
-  private static boolean sameKindCollection(final Class<?> a, final Class<?> b) {
-    if (!Collection.class.isAssignableFrom(a) || !Collection.class.isAssignableFrom(b)) return false;
-    // Require both sides to AGREE on every kind discriminator so the Iso doesn't silently
-    // re-interpret container semantics OR throw ClassCastException at addAll time. Without
-    // these symmetric checks:
-    //   - `LinkedList ↔ ArrayDeque` would match the Queue branch (LinkedList is both List and
-    //     Queue) and turn random-access list semantics into FIFO queue semantics.
-    //   - `PriorityQueue ↔ ArrayDeque` would match the Queue branch and turn heap-ordered
-    //     dequeue into FIFO (or vice-versa).
-    //   - `HashSet ↔ TreeSet` over a non-Comparable element type would CCE at forward() time
-    //     because the fresh TreeSet's addAll falls through to compareTo on a Comparable-less
-    //     element. The SortedSet discriminator rejects that pair before the Iso runs.
-    // If either side is a List the other must be one too; same for Set's SortedSet axis; and
-    // within the Queue residual, both must agree on whether they're also Deque.
-    final var aList = List.class.isAssignableFrom(a);
-    final var bList = List.class.isAssignableFrom(b);
-    if (aList != bList) return false;
-    if (aList) return true;
-    final var aSet = Set.class.isAssignableFrom(a);
-    final var bSet = Set.class.isAssignableFrom(b);
-    if (aSet != bSet) return false;
-    if (aSet) return SortedSet.class.isAssignableFrom(a) == SortedSet.class.isAssignableFrom(b);
-    if (!Queue.class.isAssignableFrom(a) || !Queue.class.isAssignableFrom(b)) return false;
-    return Deque.class.isAssignableFrom(a) == Deque.class.isAssignableFrom(b);
-  }
-
-  private static boolean sameKindMap(final Class<?> a, final Class<?> b) {
-    if (!Map.class.isAssignableFrom(a) || !Map.class.isAssignableFrom(b)) return false;
-    // Same SortedMap discriminator as the Set side: a `HashMap ↔ TreeMap` pair over non-
-    // Comparable keys would CCE at putAll time when the fresh TreeMap calls compareTo on the
-    // first inserted key. Reject the Sorted/non-Sorted crossing before the Iso runs. Within
-    // each side (HashMap ↔ LinkedHashMap ↔ ConcurrentHashMap on non-Sorted; TreeMap ↔
-    // ConcurrentSkipListMap on Sorted), differences are iteration-order or thread-safety
-    // attribute drops — silent, but documented at the call site.
-    //
-    // Edge cases the gate intentionally accepts (silent but recoverable via an explicit
-    // `Mapping.via(...)` row): `IdentityHashMap ↔ HashMap` (the IdentityHashMap side de-dups
-    // equal-but-distinct-reference keys); `WeakHashMap ↔ HashMap` (WeakHashMap GCs keys
-    // without strong references).
-    return SortedMap.class.isAssignableFrom(a) == SortedMap.class.isAssignableFrom(b);
   }
 
   /**
@@ -1460,29 +1379,6 @@ public final class DeepMap {
   }
 
   /**
-   * True when {@code src} and {@code tgt} are a primitive ↔ wrapper pair (in either direction)
-   * referring to the same underlying scalar — e.g. {@code int} / {@code Integer}, {@code boolean} /
-   * {@code Boolean}. Same-scalar same-side pairs (already covered by the identity branch) are not
-   * matched here.
-   */
-  private static boolean isPrimitiveWrapperPair(final Class<?> src, final Class<?> tgt) {
-    return (src.isPrimitive() && wrap(src) == tgt) || (tgt.isPrimitive() && wrap(tgt) == src);
-  }
-
-  /** Wrap a primitive to its boxed class; non-primitives are returned unchanged. */
-  private static Class<?> wrap(final Class<?> cls) {
-    if (cls == int.class) return Integer.class;
-    if (cls == long.class) return Long.class;
-    if (cls == double.class) return Double.class;
-    if (cls == float.class) return Float.class;
-    if (cls == boolean.class) return Boolean.class;
-    if (cls == short.class) return Short.class;
-    if (cls == byte.class) return Byte.class;
-    if (cls == char.class) return Character.class;
-    return cls;
-  }
-
-  /**
    * Build the per-field Iso for a primitive ↔ wrapper pair. The Iso's {@code to} (forward)
    * substitutes the primitive default when the source value is null, so a wrapper-to-primitive
    * write never NPEs at the setter. {@code from} (backward) is symmetric.
@@ -1491,22 +1387,6 @@ public final class DeepMap {
     final var fwdDefault = tgt.isPrimitive() ? primitiveDefault(tgt) : null;
     final var bwdDefault = src.isPrimitive() ? primitiveDefault(src) : null;
     return Iso.of(v -> v == null ? fwdDefault : v, v -> v == null ? bwdDefault : v);
-  }
-
-  /** A record or any non-scalar class — anything Reflective can drive. */
-  private static boolean isReflectable(final Class<?> cls) {
-    if (cls.isRecord()) return true;
-    if (cls.isPrimitive()) return false;
-    if (cls.isArray()) return false;
-    if (cls.isEnum()) return false;
-    if (cls.isInterface()) return false;
-    // Common scalars that should NOT be treated as reflectable beans. CharSequence covers String,
-    // StringBuilder, StringBuffer, and any other implementation — assignableFrom catches subtypes.
-    if (CharSequence.class.isAssignableFrom(cls)) return false;
-    if (Number.class.isAssignableFrom(cls)) return false;
-    if (cls == Boolean.class || cls == Character.class) return false;
-    if (Temporal.class.isAssignableFrom(cls)) return false;
-    return !UUID.class.isAssignableFrom(cls);
   }
 
   // ---------- Iso assembly (lattice-routed) ----------
@@ -1879,41 +1759,4 @@ public final class DeepMap {
    * mapping a {@code Map<String, X>} to a {@code Map<Long, Y>} target would silently produce a
    * {@code Map<String, Y>} at runtime, which violates the target's declared key type.
    */
-  private record ContainerShape(Kind kind, Type elementType, Class<?> keyClass, Class<?> rawClass) {
-    enum Kind {
-      LIST,
-      SET,
-      MAP_VALUES,
-      OPTIONAL,
-    }
-
-    static ContainerShape of(final Type t) {
-      if (!(t instanceof ParameterizedType pt)) return null;
-      if (!(pt.getRawType() instanceof Class<?> raw)) return null;
-      // Optional is final; no subtypes possible — keep exact-match.
-      if (raw == Optional.class) return new ContainerShape(Kind.OPTIONAL, pt.getActualTypeArguments()[0], null, raw);
-      // List / Set / Map: accept any subtype of the interface. The raw class is carried so the
-      // autoIso lift can allocate the target's concrete class (e.g. `List<X>` ↔ `ArrayList<Y>`
-      // — both shapes match LIST, but the lifted Iso has to write into a fresh ArrayList<Y>
-      // when the target field is `ArrayList<Y>`).
-      if (List.class.isAssignableFrom(raw)) return new ContainerShape(
-        Kind.LIST,
-        pt.getActualTypeArguments()[0],
-        null,
-        raw
-      );
-      if (Set.class.isAssignableFrom(raw)) return new ContainerShape(
-        Kind.SET,
-        pt.getActualTypeArguments()[0],
-        null,
-        raw
-      );
-      if (Map.class.isAssignableFrom(raw)) {
-        final var keyArg = pt.getActualTypeArguments()[0];
-        if (!(keyArg instanceof Class<?> keyCls)) return null;
-        return new ContainerShape(Kind.MAP_VALUES, pt.getActualTypeArguments()[1], keyCls, raw);
-      }
-      return null;
-    }
-  }
 }

--- a/core/src/main/java/io/github/eschizoid/telescope/annotations/UncheckedMapping.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/annotations/UncheckedMapping.java
@@ -1,0 +1,22 @@
+package io.github.eschizoid.telescope.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Exempts the annotated element's {@code Telescope.map} / {@code mapper} / {@code mapperForward}
+ * call sites from compile-time mapping verification. The construction-time validation still runs —
+ * this only silences the compile-time twin, for sites whose rows or classes are assembled
+ * dynamically and can't be statically analyzed anyway.
+ *
+ * <p>The {@code value} is a required, human-readable reason ("rows built from config", "classes
+ * resolved at runtime") so every exemption documents itself at the site.
+ */
+@Retention(RetentionPolicy.SOURCE)
+@Target({ ElementType.TYPE, ElementType.METHOD, ElementType.FIELD, ElementType.CONSTRUCTOR })
+public @interface UncheckedMapping {
+  /** Why this site can't (or shouldn't) be statically verified. */
+  String value();
+}

--- a/internal/src/main/java/io/github/eschizoid/telescope/internal/pairing/ContainerView.java
+++ b/internal/src/main/java/io/github/eschizoid/telescope/internal/pairing/ContainerView.java
@@ -1,0 +1,20 @@
+package io.github.eschizoid.telescope.internal.pairing;
+
+/**
+ * A parameterized container as the pairing rules see it: its kind, its element (or map-value) type,
+ * the map key type when applicable, and the raw class handle (carried so lifted conversions can
+ * allocate the declared concrete class). The world-agnostic twin of the runtime's private
+ * container-shape probe — built exclusively by {@link PairingRules#containerViewOf} so the kind
+ * selection rules live once.
+ *
+ * @param <T> the world's type handle
+ */
+public record ContainerView<T>(ContainerView.Kind kind, T elementType, T keyType, T rawType) {
+  /** Container families the auto-lift understands. */
+  public enum Kind {
+    LIST,
+    SET,
+    MAP_VALUES,
+    OPTIONAL,
+  }
+}

--- a/internal/src/main/java/io/github/eschizoid/telescope/internal/pairing/ContainerView.java
+++ b/internal/src/main/java/io/github/eschizoid/telescope/internal/pairing/ContainerView.java
@@ -17,4 +17,12 @@ public record ContainerView<T>(ContainerView.Kind kind, T elementType, T keyType
     MAP_VALUES,
     OPTIONAL,
   }
+
+  public ContainerView {
+    if ((keyType != null) != (kind == Kind.MAP_VALUES)) {
+      throw new IllegalArgumentException(
+        "keyType is required for MAP_VALUES and forbidden otherwise (kind=" + kind + ")"
+      );
+    }
+  }
 }

--- a/internal/src/main/java/io/github/eschizoid/telescope/internal/pairing/PairDecision.java
+++ b/internal/src/main/java/io/github/eschizoid/telescope/internal/pairing/PairDecision.java
@@ -1,0 +1,38 @@
+package io.github.eschizoid.telescope.internal.pairing;
+
+/**
+ * The outcome of {@link PairingRules#decidePair} for one (source type, target type) field pair —
+ * the world-agnostic decision the runtime turns into an {@code Iso} and the compile-time verifier
+ * turns into a diagnostic (or a recursion). Exactly one decision per pair; {@link Incompatible}
+ * carries the final diagnostic text so both worlds report identical messages.
+ *
+ * @param <T> the world's type handle
+ */
+public sealed interface PairDecision<T> {
+  /** Same type on both sides — identity conversion. */
+  record Identity<T>() implements PairDecision<T> {}
+
+  /** Primitive ↔ wrapper pair over the same scalar — null-safe box/unbox. */
+  record PrimitiveWrapper<T>() implements PairDecision<T> {}
+
+  /** Same-kind {@code Collection} subtype pair — element copy into a fresh target instance. */
+  record CollectionCopy<T>() implements PairDecision<T> {}
+
+  /** Same-kind {@code Map} subtype pair — entry copy into a fresh target instance. */
+  record MapCopy<T>() implements PairDecision<T> {}
+
+  /** Both sides reflectable (record or bean) — recurse into the nested pair. */
+  record RecursePair<T>() implements PairDecision<T> {}
+
+  /** Source {@code Optional<X>} to nullable target — element pair {@code (X, target)}. */
+  record OptionalToNullable<T>(T elementSrc, T elementTgt) implements PairDecision<T> {}
+
+  /** Nullable source to target {@code Optional<Y>} — element pair {@code (source, Y)}. */
+  record NullableToOptional<T>(T elementSrc, T elementTgt) implements PairDecision<T> {}
+
+  /** Same-kind containers — lift the element pair through the container. */
+  record LiftContainer<T>(ContainerView<T> src, ContainerView<T> tgt) implements PairDecision<T> {}
+
+  /** No compatible conversion — {@code message} is the diagnostic both worlds emit verbatim. */
+  record Incompatible<T>(String message) implements PairDecision<T> {}
+}

--- a/internal/src/main/java/io/github/eschizoid/telescope/internal/pairing/PairingMessages.java
+++ b/internal/src/main/java/io/github/eschizoid/telescope/internal/pairing/PairingMessages.java
@@ -1,0 +1,118 @@
+package io.github.eschizoid.telescope.internal.pairing;
+
+/**
+ * The single source of truth for every pairing diagnostic. The runtime throws these strings at
+ * mapper construction; the compile-time verifier reports the same strings as compiler errors —
+ * byte-identical, so a user who has seen one recognizes the other. Wording changes happen here and
+ * nowhere else.
+ */
+public final class PairingMessages {
+
+  private PairingMessages() {}
+
+  /** Duplicate override row claiming an already-claimed source field. */
+  public static String duplicateSourceRow(final String source, final String target, final String srcField) {
+    return (
+      "Deep map " +
+      source +
+      " → " +
+      target +
+      ": duplicate override row for source field '" +
+      srcField +
+      "'. Each (source, target) type pair may declare at most one row per source field."
+    );
+  }
+
+  /** Duplicate override row claiming an already-claimed target field. */
+  public static String duplicateTargetRow(final String source, final String target, final String tgtField) {
+    return (
+      "Deep map " +
+      source +
+      " → " +
+      target +
+      ": duplicate override row for target field '" +
+      tgtField +
+      "'. Each (source, target) type pair may declare at most one row per target field."
+    );
+  }
+
+  /** Strict-bijection failure: a target field has no same-name source and no row. */
+  public static String noSameNameSource(
+    final String source,
+    final String target,
+    final String tgtSlot,
+    final String srcSlot,
+    final String name
+  ) {
+    return (
+      "Deep map " +
+      source +
+      " → " +
+      target +
+      ": target " +
+      tgtSlot +
+      " '" +
+      name +
+      "' has no same-name source " +
+      srcSlot +
+      ". Add a rename row to(sourceAccessor, targetAccessor) that maps to '" +
+      name +
+      "'."
+    );
+  }
+
+  /** Strict-bijection failure: a source field has no same-name target and no row. */
+  public static String noSameNameTarget(
+    final String source,
+    final String target,
+    final String srcSlot,
+    final String tgtSlot,
+    final String name
+  ) {
+    return (
+      "Deep map " +
+      source +
+      " → " +
+      target +
+      ": source " +
+      srcSlot +
+      " '" +
+      name +
+      "' has no same-name target " +
+      tgtSlot +
+      ". Add a rename row to(sourceAccessor, targetAccessor) that consumes '" +
+      name +
+      "'."
+    );
+  }
+
+  /**
+   * Map-valued pair whose key types differ — auto-lifting preserves source keys, so keys must
+   * match.
+   */
+  public static String incompatibleMapKeys(final String componentName, final String srcKey, final String tgtKey) {
+    return (
+      "Deep map: component '" +
+      componentName +
+      "' has incompatible Map key types — source " +
+      srcKey +
+      " vs target " +
+      tgtKey +
+      ". Key types must match exactly; auto-lifting preserves the source keys."
+    );
+  }
+
+  /** Terminal shape mismatch — no branch of the compatibility lattice applies. */
+  public static String incompatibleShapes(final String componentName, final String srcType, final String tgtType) {
+    return (
+      "Deep map: component '" +
+      componentName +
+      "' has incompatible source/target shapes — " +
+      srcType +
+      " vs " +
+      tgtType +
+      ". Shapes must match: same scalar, both records/beans, or both same-kind container. For " +
+      "differing scalar types, add a to(src, tgt, forward, backward) row to supply the conversion."
+    );
+  }
+}

--- a/internal/src/main/java/io/github/eschizoid/telescope/internal/pairing/PairingMessages.java
+++ b/internal/src/main/java/io/github/eschizoid/telescope/internal/pairing/PairingMessages.java
@@ -1,14 +1,33 @@
 package io.github.eschizoid.telescope.internal.pairing;
 
 /**
- * The single source of truth for every pairing diagnostic. The runtime throws these strings at
- * mapper construction; the compile-time verifier reports the same strings as compiler errors —
- * byte-identical, so a user who has seen one recognizes the other. Wording changes happen here and
- * nowhere else.
+ * The single source of truth for every diagnostic the shared pairing decisions emit. The runtime
+ * throws these strings at mapper construction; the compile-time verifier reports the same strings
+ * as compiler errors — byte-identical, so a user who has seen one recognizes the other. Wording
+ * changes happen here and nowhere else.
  */
 public final class PairingMessages {
 
   private PairingMessages() {}
+
+  /** A {@code writeBean} hint targeting a record — the hint can never apply. */
+  public static String writeBeanTargetsRecord(final String binaryName) {
+    return (
+      "writeBean hint targets a record class (" +
+      binaryName +
+      "). Records are always reconstructed via the canonical constructor; the hint cannot apply. " +
+      "Remove the writeBean(...) row, or move it to the bean side of the mapping."
+    );
+  }
+
+  /** Two {@code writeBean} hints for the same target class. */
+  public static String duplicateWriteBeanHint(final String binaryName) {
+    return (
+      "Duplicate writeBean hint for " +
+      binaryName +
+      ". Each target class may declare at most one writeBean(...) row per Telescope.map(...) call."
+    );
+  }
 
   /** Duplicate override row claiming an already-claimed source field. */
   public static String duplicateSourceRow(final String source, final String target, final String srcField) {

--- a/internal/src/main/java/io/github/eschizoid/telescope/internal/pairing/PairingRules.java
+++ b/internal/src/main/java/io/github/eschizoid/telescope/internal/pairing/PairingRules.java
@@ -1,0 +1,205 @@
+package io.github.eschizoid.telescope.internal.pairing;
+
+import io.github.eschizoid.telescope.internal.pairing.PropertySystem.WellKnown;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * The shared pairing decision rules — one implementation, two consumers. The runtime mapper
+ * construction and the compile-time verifier both delegate every pairing decision here: which
+ * conversion a (source, target) field-type pair takes ({@link #decidePair}), which fields of a type
+ * pair match by name ({@link #matchFields}), and which container view a parameterized type presents
+ * ({@link #containerViewOf}). Only the type-system <em>primitives</em> differ per world — supplied
+ * through {@link PropertySystem} — so the rules cannot drift between compile time and construction
+ * time.
+ *
+ * <p>Decision order in {@link #decidePair} is load-bearing and mirrors the runtime lattice exactly:
+ * identity → primitive/wrapper → same-kind subtype copy → reflectable recursion → cross-{@code
+ * Optional} bridge → same-kind container lift → incompatible.
+ *
+ * @param <T> the world's type handle
+ */
+public final class PairingRules<T> {
+
+  private final PropertySystem<T> props;
+
+  public PairingRules(final PropertySystem<T> props) {
+    this.props = props;
+  }
+
+  /** Decide the conversion for one (source type, target type) field pair. Never returns null. */
+  public PairDecision<T> decidePair(final T srcType, final T tgtType, final String componentName) {
+    // (a) Same type → identity.
+    if (props.sameType(srcType, tgtType)) return new PairDecision.Identity<>();
+
+    if (props.isClassType(srcType) && props.isClassType(tgtType)) {
+      // (a.1) Primitive ↔ wrapper over the same scalar — null-safe box/unbox.
+      if (primitiveWrapperPair(srcType, tgtType)) return new PairDecision.PrimitiveWrapper<>();
+
+      // (a.2) Same-kind Collection / Map subtype pair (raw container subclasses on both sides) —
+      // element copy, gated on kind-discriminator agreement AND allocability so an infeasible copy
+      // falls through to the remaining branches exactly like the runtime.
+      if (sameKindCollection(srcType, tgtType) && props.copyAllocable(srcType, tgtType)) {
+        return new PairDecision.CollectionCopy<>();
+      }
+      if (sameKindMap(srcType, tgtType) && props.copyAllocable(srcType, tgtType)) {
+        return new PairDecision.MapCopy<>();
+      }
+
+      // (b) Both reflectable (record or bean) → recurse into the nested pair.
+      if (reflectable(srcType) && reflectable(tgtType)) return new PairDecision.RecursePair<>();
+    }
+
+    // (c) Container views. Cross-Optional bridge first, then same-kind lift.
+    final var srcView = containerViewOf(srcType);
+    final var tgtView = containerViewOf(tgtType);
+
+    // (c.1) Optional<X> ↔ nullable scalar/record/bean, either direction.
+    if (srcView != null && srcView.kind() == ContainerView.Kind.OPTIONAL && tgtView == null) {
+      return new PairDecision.OptionalToNullable<>(srcView.elementType(), tgtType);
+    }
+    if (tgtView != null && tgtView.kind() == ContainerView.Kind.OPTIONAL && srcView == null) {
+      return new PairDecision.NullableToOptional<>(srcType, tgtView.elementType());
+    }
+
+    if (srcView != null && tgtView != null && srcView.kind() == tgtView.kind()) {
+      // Map<K, X> ↔ Map<K, Y>: keys must match exactly; lifting preserves the source keys.
+      if (srcView.kind() == ContainerView.Kind.MAP_VALUES && !props.sameType(srcView.keyType(), tgtView.keyType())) {
+        return new PairDecision.Incompatible<>(
+          PairingMessages.incompatibleMapKeys(
+            componentName,
+            props.typeName(srcView.keyType()),
+            props.typeName(tgtView.keyType())
+          )
+        );
+      }
+      return new PairDecision.LiftContainer<>(srcView, tgtView);
+    }
+
+    return new PairDecision.Incompatible<>(
+      PairingMessages.incompatibleShapes(componentName, props.typeName(srcType), props.typeName(tgtType))
+    );
+  }
+
+  /**
+   * The container view of {@code t}, or {@code null} when {@code t} is not a parameterized
+   * container the auto-lift understands. Selection rules: {@code Optional} (final, exact) →
+   * OPTIONAL; any {@code List} / {@code Set} subtype → LIST / SET; any {@code Map} subtype whose
+   * key argument is a plain class handle → MAP_VALUES (a wildcard or variable key defeats the
+   * key-equality guarantee, so the type is not treated as a liftable container).
+   */
+  public ContainerView<T> containerViewOf(final T t) {
+    final var args = props.typeArguments(t);
+    if (args.isEmpty()) return null;
+    final var raw = props.rawType(t);
+    if (props.isSubtypeOf(raw, WellKnown.OPTIONAL)) {
+      return new ContainerView<>(ContainerView.Kind.OPTIONAL, args.get(0), null, raw);
+    }
+    if (props.isSubtypeOf(raw, WellKnown.LIST)) {
+      return new ContainerView<>(ContainerView.Kind.LIST, args.get(0), null, raw);
+    }
+    if (props.isSubtypeOf(raw, WellKnown.SET)) {
+      return new ContainerView<>(ContainerView.Kind.SET, args.get(0), null, raw);
+    }
+    if (props.isSubtypeOf(raw, WellKnown.MAP)) {
+      final var key = args.get(0);
+      if (!props.isClassType(key)) return null;
+      return new ContainerView<>(ContainerView.Kind.MAP_VALUES, args.get(1), key, raw);
+    }
+    return null;
+  }
+
+  /**
+   * A record, or any class the reflective bean machinery can decompose — everything except
+   * primitives, arrays, enums, interfaces, and the common scalar families ({@code CharSequence},
+   * {@code Number}, {@code Boolean}/{@code Character}, {@code Temporal}, {@code UUID}).
+   */
+  public boolean reflectable(final T t) {
+    if (props.isRecordType(t)) return true;
+    if (props.isPrimitive(t)) return false;
+    if (props.isArrayType(t)) return false;
+    if (props.isEnumType(t)) return false;
+    if (props.isInterfaceType(t)) return false;
+    if (props.isSubtypeOf(t, WellKnown.CHAR_SEQUENCE)) return false;
+    if (props.isSubtypeOf(t, WellKnown.NUMBER)) return false;
+    if (props.isSubtypeOf(t, WellKnown.BOOLEAN_WRAPPER) || props.isSubtypeOf(t, WellKnown.CHARACTER_WRAPPER)) {
+      return false;
+    }
+    if (props.isSubtypeOf(t, WellKnown.TEMPORAL)) return false;
+    return !props.isSubtypeOf(t, WellKnown.UUID);
+  }
+
+  /** Primitive ↔ wrapper pair over the same scalar, in either direction. */
+  public boolean primitiveWrapperPair(final T src, final T tgt) {
+    return (
+      (props.isPrimitive(src) && props.sameType(props.boxed(src), tgt)) ||
+      (props.isPrimitive(tgt) && props.sameType(props.boxed(tgt), src))
+    );
+  }
+
+  /**
+   * Both sides are {@code Collection} subtypes that agree on every kind discriminator: the List
+   * axis, the Set / SortedSet axis, and (within the Queue residual) the Deque axis. Disagreement on
+   * any axis would silently re-interpret container semantics — or throw at copy time — so the pair
+   * is rejected here and the user declares an explicit conversion row instead.
+   */
+  public boolean sameKindCollection(final T a, final T b) {
+    if (!props.isSubtypeOf(a, WellKnown.COLLECTION) || !props.isSubtypeOf(b, WellKnown.COLLECTION)) return false;
+    final var aList = props.isSubtypeOf(a, WellKnown.LIST);
+    final var bList = props.isSubtypeOf(b, WellKnown.LIST);
+    if (aList != bList) return false;
+    if (aList) return true;
+    final var aSet = props.isSubtypeOf(a, WellKnown.SET);
+    final var bSet = props.isSubtypeOf(b, WellKnown.SET);
+    if (aSet != bSet) return false;
+    if (aSet) return props.isSubtypeOf(a, WellKnown.SORTED_SET) == props.isSubtypeOf(b, WellKnown.SORTED_SET);
+    if (!props.isSubtypeOf(a, WellKnown.QUEUE) || !props.isSubtypeOf(b, WellKnown.QUEUE)) return false;
+    return props.isSubtypeOf(a, WellKnown.DEQUE) == props.isSubtypeOf(b, WellKnown.DEQUE);
+  }
+
+  /** Both sides are {@code Map} subtypes agreeing on the SortedMap axis. */
+  public boolean sameKindMap(final T a, final T b) {
+    if (!props.isSubtypeOf(a, WellKnown.MAP) || !props.isSubtypeOf(b, WellKnown.MAP)) return false;
+    return props.isSubtypeOf(a, WellKnown.SORTED_MAP) == props.isSubtypeOf(b, WellKnown.SORTED_MAP);
+  }
+
+  /**
+   * Same-name field matching over the two sides' property names, honoring claims already made by
+   * explicit rows. Pure set logic — the strictness gates (what happens to the unmatched leftovers)
+   * are the caller's policy; the matches and leftovers themselves are decided here, identically in
+   * both worlds. Iteration order follows the target side, matching construction order.
+   */
+  public static MatchResult matchFields(
+    final List<String> sourceNames,
+    final List<String> targetNames,
+    final Set<String> claimedSource,
+    final Set<String> claimedTarget
+  ) {
+    final var srcNameSet = new LinkedHashSet<>(sourceNames);
+    final var matched = new ArrayList<String>();
+    final var unmatchedTargets = new ArrayList<String>();
+    final var claimedSrcNow = new LinkedHashSet<>(claimedSource);
+    for (final var name : targetNames) {
+      if (claimedTarget.contains(name)) continue;
+      if (srcNameSet.contains(name)) {
+        matched.add(name);
+        claimedSrcNow.add(name);
+      } else {
+        unmatchedTargets.add(name);
+      }
+    }
+    final var unmatchedSources = new ArrayList<String>();
+    for (final var name : sourceNames) {
+      if (!claimedSrcNow.contains(name)) unmatchedSources.add(name);
+    }
+    return new MatchResult(List.copyOf(matched), List.copyOf(unmatchedTargets), List.copyOf(unmatchedSources));
+  }
+
+  /**
+   * Outcome of {@link #matchFields}: field names paired by same-name auto-match (in target order),
+   * target names with no source counterpart, and source names with no consumer.
+   */
+  public record MatchResult(List<String> matched, List<String> unmatchedTargets, List<String> unmatchedSources) {}
+}

--- a/internal/src/main/java/io/github/eschizoid/telescope/internal/pairing/PairingRules.java
+++ b/internal/src/main/java/io/github/eschizoid/telescope/internal/pairing/PairingRules.java
@@ -15,9 +15,12 @@ import java.util.Set;
  * through {@link PropertySystem} — so the rules cannot drift between compile time and construction
  * time.
  *
- * <p>Decision order in {@link #decidePair} is load-bearing and mirrors the runtime lattice exactly:
- * identity → primitive/wrapper → same-kind subtype copy → reflectable recursion → cross-{@code
- * Optional} bridge → same-kind container lift → incompatible.
+ * <p>Decision order in {@link #decidePair} is load-bearing — it IS the runtime lattice: identity →
+ * primitive/wrapper → same-kind subtype copy → reflectable recursion → cross-{@code Optional}
+ * bridge → same-kind container lift → incompatible. Subtype copy must precede reflectable
+ * recursion: a raw container subclass ({@code class ImageUrls extends ArrayList<ImageUrl>}) counts
+ * as reflectable, and bean-decomposing it would fail at the JDK boundary (private lookup into
+ * {@code java.base} is rejected) — the copy branch intercepts those pairs first.
  *
  * @param <T> the world's type handle
  */
@@ -39,12 +42,21 @@ public final class PairingRules<T> {
       if (primitiveWrapperPair(srcType, tgtType)) return new PairDecision.PrimitiveWrapper<>();
 
       // (a.2) Same-kind Collection / Map subtype pair (raw container subclasses on both sides) —
-      // element copy, gated on kind-discriminator agreement AND allocability so an infeasible copy
-      // falls through to the remaining branches exactly like the runtime.
-      if (sameKindCollection(srcType, tgtType) && props.copyAllocable(srcType, tgtType)) {
+      // element copy, gated on kind-discriminator agreement AND allocability so a provably
+      // infeasible copy falls through to the remaining branches exactly like the runtime. UNKNOWN
+      // allocability (the compile-time world can't probe allocators) resolves in the ACCEPTING
+      // direction here: CollectionCopy/MapCopy are terminal accepts, so optimism can only defer an
+      // error to the construction backstop, never invent one.
+      if (
+        sameKindCollection(srcType, tgtType) &&
+        props.copyAllocability(srcType, tgtType) != PropertySystem.Allocability.NOT_ALLOCABLE
+      ) {
         return new PairDecision.CollectionCopy<>();
       }
-      if (sameKindMap(srcType, tgtType) && props.copyAllocable(srcType, tgtType)) {
+      if (
+        sameKindMap(srcType, tgtType) &&
+        props.copyAllocability(srcType, tgtType) != PropertySystem.Allocability.NOT_ALLOCABLE
+      ) {
         return new PairDecision.MapCopy<>();
       }
 
@@ -87,8 +99,9 @@ public final class PairingRules<T> {
    * The container view of {@code t}, or {@code null} when {@code t} is not a parameterized
    * container the auto-lift understands. Selection rules: {@code Optional} (final, exact) →
    * OPTIONAL; any {@code List} / {@code Set} subtype → LIST / SET; any {@code Map} subtype whose
-   * key argument is a plain class handle → MAP_VALUES (a wildcard or variable key defeats the
-   * key-equality guarantee, so the type is not treated as a liftable container).
+   * key argument is a plain class handle → MAP_VALUES (a non-class key — wildcard, type variable,
+   * or parameterized type — defeats the key-equality guarantee, so the type is not treated as a
+   * liftable container).
    */
   public ContainerView<T> containerViewOf(final T t) {
     final var args = props.typeArguments(t);
@@ -159,7 +172,12 @@ public final class PairingRules<T> {
     return props.isSubtypeOf(a, WellKnown.DEQUE) == props.isSubtypeOf(b, WellKnown.DEQUE);
   }
 
-  /** Both sides are {@code Map} subtypes agreeing on the SortedMap axis. */
+  /**
+   * Both sides are {@code Map} subtypes agreeing on the SortedMap axis — a {@code HashMap ↔
+   * TreeMap} pair over non-Comparable keys would throw at copy time when the fresh sorted map calls
+   * {@code compareTo} on the first inserted key, so the crossing is rejected before any conversion
+   * runs.
+   */
   public boolean sameKindMap(final T a, final T b) {
     if (!props.isSubtypeOf(a, WellKnown.MAP) || !props.isSubtypeOf(b, WellKnown.MAP)) return false;
     return props.isSubtypeOf(a, WellKnown.SORTED_MAP) == props.isSubtypeOf(b, WellKnown.SORTED_MAP);

--- a/internal/src/main/java/io/github/eschizoid/telescope/internal/pairing/PropertySystem.java
+++ b/internal/src/main/java/io/github/eschizoid/telescope/internal/pairing/PropertySystem.java
@@ -50,8 +50,9 @@ public interface PropertySystem<T> {
   boolean sameType(T a, T b);
 
   /**
-   * True when {@code t} is a raw class handle — a primitive, or a non-parameterized, non-wildcard
-   * reference the rules may probe for record-ness, bean-ness, or subtype-copy pairing.
+   * True when {@code t} is a raw class handle — a primitive, an array, or a non-parameterized,
+   * non-wildcard reference the rules may probe for record-ness, bean-ness, or subtype-copy pairing.
+   * (In the reflection world all three are {@code Class} instances; the mirror world must agree.)
    * Parameterized container types answer {@code false} and flow to {@link
    * PairingRules#containerViewOf} instead.
    */

--- a/internal/src/main/java/io/github/eschizoid/telescope/internal/pairing/PropertySystem.java
+++ b/internal/src/main/java/io/github/eschizoid/telescope/internal/pairing/PropertySystem.java
@@ -1,0 +1,77 @@
+package io.github.eschizoid.telescope.internal.pairing;
+
+import java.util.List;
+
+/**
+ * The type-system primitives {@link PairingRules} is parameterized over. Two worlds implement it: a
+ * reflection-backed adapter over {@code java.lang.reflect.Type} (runtime mapper construction) and a
+ * {@code javax.lang.model}-backed adapter over {@code TypeMirror} (compile-time verification).
+ * Every method is a <em>primitive</em> — a single type-system fact with no policy — so all pairing
+ * policy (branch ordering, kind discriminators, scalar exclusions, matching) lives once, in {@link
+ * PairingRules}, and cannot drift between the two worlds.
+ *
+ * @param <T> the world's type handle ({@code Type} or {@code TypeMirror})
+ */
+public interface PropertySystem<T> {
+  /** Well-known JDK types the pairing rules discriminate on. */
+  enum WellKnown {
+    COLLECTION,
+    LIST,
+    SET,
+    SORTED_SET,
+    QUEUE,
+    DEQUE,
+    MAP,
+    SORTED_MAP,
+    OPTIONAL,
+    CHAR_SEQUENCE,
+    NUMBER,
+    TEMPORAL,
+    UUID,
+    BOOLEAN_WRAPPER,
+    CHARACTER_WRAPPER,
+  }
+
+  /** Structural type equality — {@code Type#equals} / {@code Types#isSameType} semantics. */
+  boolean sameType(T a, T b);
+
+  /**
+   * True when {@code t} is a raw class handle — a non-parameterized, non-wildcard reference the
+   * rules may probe for record-ness, bean-ness, or subtype-copy pairing. Parameterized container
+   * types answer {@code false} and flow to {@link PairingRules#containerViewOf} instead.
+   */
+  boolean isClassType(T t);
+
+  boolean isPrimitive(T t);
+
+  /** The boxed counterpart of a primitive handle; non-primitives are returned unchanged. */
+  T boxed(T t);
+
+  boolean isRecordType(T t);
+
+  boolean isArrayType(T t);
+
+  boolean isEnumType(T t);
+
+  boolean isInterfaceType(T t);
+
+  /** Subtype test against a well-known JDK type. Final well-knowns make this an exact match. */
+  boolean isSubtypeOf(T t, WellKnown wellKnown);
+
+  /** Type arguments when {@code t} is parameterized; empty list otherwise. */
+  List<T> typeArguments(T t);
+
+  /** The raw/erased class handle of {@code t} ({@code List<X>} → {@code List}). */
+  T rawType(T t);
+
+  /**
+   * True when a same-kind collection/map subtype pair can actually be element-copied — both sides
+   * allocable. The reflection world probes the real intermediate allocator; the compile-time world
+   * answers optimistically ({@code true} when uncertain) so an infeasible copy surfaces at the
+   * construction-time backstop rather than as a speculative compile error.
+   */
+  boolean copyAllocable(T src, T tgt);
+
+  /** Human-readable type name for diagnostics — {@code Type#getTypeName} semantics. */
+  String typeName(T t);
+}

--- a/internal/src/main/java/io/github/eschizoid/telescope/internal/pairing/PropertySystem.java
+++ b/internal/src/main/java/io/github/eschizoid/telescope/internal/pairing/PropertySystem.java
@@ -32,13 +32,28 @@ public interface PropertySystem<T> {
     CHARACTER_WRAPPER,
   }
 
+  /** Whether both sides of a same-kind subtype copy can actually be allocated. */
+  enum Allocability {
+    /** Both sides allocable — the copy is buildable. */
+    ALLOCABLE,
+    /** At least one side provably not allocable — the pair falls through to the next branch. */
+    NOT_ALLOCABLE,
+    /**
+     * This world can't tell (the compile-time adapter). {@link PairingRules} resolves the
+     * uncertainty in the accepting direction — an infeasible copy then surfaces at the
+     * construction-time backstop rather than as a speculative compile error.
+     */
+    UNKNOWN,
+  }
+
   /** Structural type equality — {@code Type#equals} / {@code Types#isSameType} semantics. */
   boolean sameType(T a, T b);
 
   /**
-   * True when {@code t} is a raw class handle — a non-parameterized, non-wildcard reference the
-   * rules may probe for record-ness, bean-ness, or subtype-copy pairing. Parameterized container
-   * types answer {@code false} and flow to {@link PairingRules#containerViewOf} instead.
+   * True when {@code t} is a raw class handle — a primitive, or a non-parameterized, non-wildcard
+   * reference the rules may probe for record-ness, bean-ness, or subtype-copy pairing.
+   * Parameterized container types answer {@code false} and flow to {@link
+   * PairingRules#containerViewOf} instead.
    */
   boolean isClassType(T t);
 
@@ -65,12 +80,12 @@ public interface PropertySystem<T> {
   T rawType(T t);
 
   /**
-   * True when a same-kind collection/map subtype pair can actually be element-copied — both sides
-   * allocable. The reflection world probes the real intermediate allocator; the compile-time world
-   * answers optimistically ({@code true} when uncertain) so an infeasible copy surfaces at the
-   * construction-time backstop rather than as a speculative compile error.
+   * Whether a same-kind collection/map subtype pair can actually be element-copied. A pure fact per
+   * world: the reflection adapter probes the real intermediate allocator; the compile-time adapter
+   * answers {@link Allocability#UNKNOWN}. The uncertainty POLICY (proceed as copyable) lives in
+   * {@link PairingRules}, not here.
    */
-  boolean copyAllocable(T src, T tgt);
+  Allocability copyAllocability(T src, T tgt);
 
   /** Human-readable type name for diagnostics — {@code Type#getTypeName} semantics. */
   String typeName(T t);

--- a/internal/src/main/java/io/github/eschizoid/telescope/internal/pairing/ReflectionProps.java
+++ b/internal/src/main/java/io/github/eschizoid/telescope/internal/pairing/ReflectionProps.java
@@ -1,0 +1,124 @@
+package io.github.eschizoid.telescope.internal.pairing;
+
+import io.github.eschizoid.telescope.internal.Beans;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.time.temporal.Temporal;
+import java.util.Collection;
+import java.util.Deque;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Queue;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.SortedSet;
+import java.util.UUID;
+
+/**
+ * The reflection-world {@link PropertySystem}: type handles are {@link Type}, class handles are
+ * {@link Class}, and allocability probes the real intermediate allocator. Used by the runtime
+ * mapper construction; the compile-time verifier supplies the {@code javax.lang.model} twin.
+ */
+public final class ReflectionProps implements PropertySystem<Type> {
+
+  @Override
+  public boolean sameType(final Type a, final Type b) {
+    return a.equals(b);
+  }
+
+  @Override
+  public boolean isClassType(final Type t) {
+    return t instanceof Class<?>;
+  }
+
+  @Override
+  public boolean isPrimitive(final Type t) {
+    return t instanceof Class<?> c && c.isPrimitive();
+  }
+
+  @Override
+  public Type boxed(final Type t) {
+    if (!(t instanceof Class<?> c) || !c.isPrimitive()) return t;
+    if (c == int.class) return Integer.class;
+    if (c == long.class) return Long.class;
+    if (c == double.class) return Double.class;
+    if (c == float.class) return Float.class;
+    if (c == boolean.class) return Boolean.class;
+    if (c == short.class) return Short.class;
+    if (c == byte.class) return Byte.class;
+    if (c == char.class) return Character.class;
+    return t;
+  }
+
+  @Override
+  public boolean isRecordType(final Type t) {
+    return t instanceof Class<?> c && c.isRecord();
+  }
+
+  @Override
+  public boolean isArrayType(final Type t) {
+    return t instanceof Class<?> c && c.isArray();
+  }
+
+  @Override
+  public boolean isEnumType(final Type t) {
+    return t instanceof Class<?> c && c.isEnum();
+  }
+
+  @Override
+  public boolean isInterfaceType(final Type t) {
+    return t instanceof Class<?> c && c.isInterface();
+  }
+
+  @Override
+  public boolean isSubtypeOf(final Type t, final WellKnown wellKnown) {
+    return t instanceof Class<?> c && classOf(wellKnown).isAssignableFrom(c);
+  }
+
+  @Override
+  public List<Type> typeArguments(final Type t) {
+    return t instanceof ParameterizedType pt ? List.of(pt.getActualTypeArguments()) : List.of();
+  }
+
+  @Override
+  public Type rawType(final Type t) {
+    if (t instanceof ParameterizedType pt && pt.getRawType() instanceof Class<?> raw) return raw;
+    return t;
+  }
+
+  @Override
+  public boolean copyAllocable(final Type src, final Type tgt) {
+    return (
+      src instanceof Class<?> srcCls &&
+      tgt instanceof Class<?> tgtCls &&
+      Beans.intermediateAllocator(srcCls).get() != null &&
+      Beans.intermediateAllocator(tgtCls).get() != null
+    );
+  }
+
+  @Override
+  public String typeName(final Type t) {
+    return t.getTypeName();
+  }
+
+  private static Class<?> classOf(final WellKnown wellKnown) {
+    return switch (wellKnown) {
+      case COLLECTION -> Collection.class;
+      case LIST -> List.class;
+      case SET -> Set.class;
+      case SORTED_SET -> SortedSet.class;
+      case QUEUE -> Queue.class;
+      case DEQUE -> Deque.class;
+      case MAP -> Map.class;
+      case SORTED_MAP -> SortedMap.class;
+      case OPTIONAL -> Optional.class;
+      case CHAR_SEQUENCE -> CharSequence.class;
+      case NUMBER -> Number.class;
+      case TEMPORAL -> Temporal.class;
+      case UUID -> UUID.class;
+      case BOOLEAN_WRAPPER -> Boolean.class;
+      case CHARACTER_WRAPPER -> Character.class;
+    };
+  }
+}

--- a/internal/src/main/java/io/github/eschizoid/telescope/internal/pairing/ReflectionProps.java
+++ b/internal/src/main/java/io/github/eschizoid/telescope/internal/pairing/ReflectionProps.java
@@ -88,13 +88,13 @@ public final class ReflectionProps implements PropertySystem<Type> {
   }
 
   @Override
-  public boolean copyAllocable(final Type src, final Type tgt) {
-    return (
+  public Allocability copyAllocability(final Type src, final Type tgt) {
+    final var allocable =
       src instanceof Class<?> srcCls &&
       tgt instanceof Class<?> tgtCls &&
       Beans.intermediateAllocator(srcCls).get() != null &&
-      Beans.intermediateAllocator(tgtCls).get() != null
-    );
+      Beans.intermediateAllocator(tgtCls).get() != null;
+    return allocable ? Allocability.ALLOCABLE : Allocability.NOT_ALLOCABLE;
   }
 
   @Override

--- a/internal/src/main/java/module-info.java
+++ b/internal/src/main/java/module-info.java
@@ -39,4 +39,8 @@ module io.github.eschizoid.telescope.internal {
   exports io.github.eschizoid.telescope.internal to io.github.eschizoid.telescope;
   exports io.github.eschizoid.telescope.internal.optics to io.github.eschizoid.telescope;
   exports io.github.eschizoid.telescope.internal.optics.collections to io.github.eschizoid.telescope;
+  // The shared pairing decision spec: the runtime (:core) and the compile-time verifier (:codegen)
+  // consume one rule set so construction-time and compile-time diagnostics cannot drift.
+  exports io.github.eschizoid.telescope.internal.pairing
+    to io.github.eschizoid.telescope, io.github.eschizoid.telescope.codegen;
 }


### PR DESCRIPTION
## What

Compile-time mapper verification (ADR-0012, spec #208) — closes the last "MapStruct is safer by default" concession: *"if it compiles, every mapping is complete"* now holds on the ergonomic `Telescope.map` / `mapper` / `mapperForward` API, with zero new user ceremony.

Two commit stages, as spec'd:

### Stage 1 — `refactor(core)`: the shared pairing spec

`DeepMap`'s pairing **decisions** move to `:internal/pairing` — `PairingRules` (the compat lattice `decidePair`, container-view selection, kind discriminators, reflectable exclusions, primitive/wrapper rule, same-name `matchFields`), `PairingMessages` (every diagnostic string, single source of truth), `PropertySystem` (per-world type primitives), `ReflectionProps` (the reflection adapter). `DeepMap` now maps decisions to Isos; the dead private twins are deleted. **Zero behavior change — the full `:internal` + `:core` suites pass unchanged (the parity pin).** JPMS: `internal.pairing` qualified-exports to `:core` and `:codegen`.

### Stage 2 — `feat(codegen)`: `MapperVerifierProcessor`

Consumes the same spec through a `TypeMirror` adapter (`MirrorProps`), so compile-time and construction-time rules **cannot drift, by construction**. Reports the runtime's own diagnostic text as compile errors anchored on the offending row expression.

**Architecture note (learned the hard way):** scanning runs from a **post-ANALYZE `JavacTask` listener**, not in the processing rounds — attributing method bodies mid-round corrupts javac's anonymous-class symbol bookkeeping when the final compile re-attributes (`:internal`'s own test suite caught this). The listener is armored: any exception skips the unit with a NOTE; the verifier can never break a build except through its own diagnostics.

**Coverage:** completeness (strict bijection) + shape checks for `map`/`mapper`; rows-only for the lenient `mapperForward`; 2-arg `to()` renames replay the shared decision (the LUB-hole check at compile time); nested pairs recurse shape-checked but lenient (mirroring the runtime); rows keyed to **nested** pairs (grouped by their accessors' classes, exactly like `groupOverridesByPair`) claim nothing at the call's pair; `writeBean` record-target + duplicate eager checks. Anything dynamic defers silently to the construction backstop — the invariant is *the verifier only fires where construction would reject*.

**Controls:** on by default with the processor present; `-Atelescope.verify=error|warn|off`; per-site `@UncheckedMapping(reason)` (new `annotations/` type). `:core`'s own test compile sets `verify=off` — that suite deliberately constructs invalid mappers to pin the construction-time rejections.

## Deviations from the #208 spec (flagged, not silent)

- **`fromMap` verification deferred** — its runtime validation semantics (duplicate extract targets, key rules) need pinning before mirroring them; guessing risked false positives. Tracked in #208.
- **Write-strategy ladder feasibility** (BUILDER-on-no-builder etc.) deferred with it; `writeBean` record-target + duplicate checks shipped.
- **toOrElse/toOrElseGet are claims-only**: the runtime constructs them without a shape gate today, and the verifier never fires where construction succeeds. (Routing them through `autoIso` at runtime is the right follow-up; then the verifier inherits it for free.)

## Verification

- 17 harness tests — completeness, shapes (scalar/nested/container-lifted), degradation (dynamic rows, non-literal classes, `@UncheckedMapping`, `off`/`warn` flags), duplicate rows, `writeBean`, single-diagnostic-per-problem. Via the new `ProcessorHarness.compileFully` (full javac pipeline; post-analysis listeners never fire under `-proc:only`; class output sinks in memory).
- **Full repo build green with the verifier live in every module** — examples, benchmarks, starters, lombok. Real dogfood: the demos' nested-keyed rows exposed the pair-scoping bug during development; fixed and covered.

Closes #208.
