### PR TITLE
fix(ci): unblock release verifyRelease under config cache + sweep stale Path→Telescope docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1089,10 +1089,11 @@ final Telescope<OrderRecord, OrderPojo> conv = Telescope.map(
 
 Validation is eager: a misconfigured hint (`BUILDER` on a no-builder class, hint targeting a record, duplicate hint,
 unused hint) throws at `Telescope.map(...)` time — not on first `iso.to()` deep in production. And with
-`telescope-codegen` on the annotation-processor path, the same validation moves up to **compile time**:
-statically-visible `map(...)` / `mapper(...)` call sites are replayed by the verifier and violations surface as compile
-errors with the identical diagnostic text
-([details in `telescope-codegen`](codegen/README.md#compile-time-mapper-verification)).
+`telescope-codegen` on the annotation-processor path, the structural rejections that don't need the live classpath — a
+hint targeting a record, a duplicate hint — move up to **compile time**: statically-visible `map(...)` / `mapper(...)`
+call sites are replayed by the verifier and those violations surface as compile errors with the identical diagnostic
+text ([details in `telescope-codegen`](codegen/README.md#compile-time-mapper-verification)). The builder-feasibility and
+unused-hint checks stay at construction time (both still eager and loud).
 
 **`writeBeans(STRATEGY)` — one default for every bean target.** When every entity in the recursion shares the same
 construction shape (the common JPA case: every `@Entity` needs `SETTERS` so Hibernate's identity assignment fires), one
@@ -1251,7 +1252,7 @@ Telescope.of(Company.class)
   .update(company, String::toLowerCase);
 
 // Compile-time, reflection-free — same Telescope, generator-built
-CompanyPath.of()
+CompanyTelescope.of()
   .departments().each().teams().each()
   .users().each().email()
   .update(company, String::toLowerCase);
@@ -1265,38 +1266,39 @@ import io.github.eschizoid.telescope.annotations.Focus;
 @Focus record Team(String name, List<User> users) {}
 @Focus record Company(String name, List<Team> teams) {}
 
-// Generated: <X>Path<R> per annotated type plus a step class per collection-shaped component.
+// Generated: <X>Telescope<R> per annotated type plus a step class per collection-shaped component.
 // Usage reads like the reflective DSL — but every hop is type-checked by javac and every read /
 // rebuild is a direct method-ref + constructor call (no reflection):
-final Telescope<Company, String> userNames = CompanyPath.of()
-  .teams().each()        // step over List<Team> → TeamPath<Company>
-  .users().each()        // step over List<User> → UserPath<Company>
+final Telescope<Company, String> userNames = CompanyTelescope.of()
+  .teams().each()        // step over List<Team> → TeamTelescope<Company>
+  .users().each()        // step over List<User> → UserTelescope<Company>
   .name();               // terminal Telescope<Company, String>
 
 final Company shouted = userNames.update(company, String::toUpperCase);
 
 // Single fields are just as direct:
-UserPath.of().address().city().update(alice, String::toUpperCase);
+UserTelescope.of().address().city().update(alice, String::toUpperCase);
 ```
 
 Each scalar component yields a terminal `Telescope<R, T>`; each sub-record component (also `@Focus`-annotated) yields a
-`<Sub>Path<R>` to keep navigating; each container component yields a small step class whose `.each()` (List/Set/
-Iterable), `.eachValue()` (Map values, keys preserved), or `.whenPresent()` (Optional) returns the element's `Path` when
-the element is itself annotated, or a terminal `Telescope` otherwise. At any hop, `.get()` returns the current
-`Telescope` — so a step or path _is_ a navigator, but every leaf is the same `Telescope<R, X>` value the reflective DSL
-gives you.
+`<Sub>Telescope<R>` navigator to keep navigating; each container component yields a small step class whose `.each()`
+(List/Set/Iterable), `.eachValue()` (Map values, keys preserved), or `.whenPresent()` (Optional) returns the element's
+navigator when the element is itself annotated, or a terminal `Telescope` otherwise. At any hop, `.get()` returns the
+current `Telescope` — so a step or navigator _is_ a navigator, but every leaf is the same `Telescope<R, X>` value the
+reflective DSL gives you.
 
-**Ops at every hop, effects included.** Every generated `Path` and `Step` also forwards the full `Telescope` operation
-surface — `read` / `find` / `toList` / `count` / `exists` / `set` / `update` / `updateIndexed` / `toListIndexed` /
-`then` plus the four effect methods `updateAsync` (with or without `Executor`) / `updateOptional` / `updateEither` /
-`updateValidated`. You don't need to terminate with `.get()` first; the navigator stands in for the wrapped Telescope at
-any intermediate hop. So `CompanyPath.of().teams().each().users().each().updateAsync(company, svc::lookup, pool)`
-returns a `CompletableFuture<Company>` directly, with the effect threaded through the generated chain.
+**Ops at every hop, effects included.** Every generated navigator and `Step` also forwards the full `Telescope`
+operation surface — `read` / `find` / `toList` / `count` / `exists` / `set` / `update` / `updateIndexed` /
+`toListIndexed` / `then` plus the four effect methods `updateAsync` (with or without `Executor`) / `updateOptional` /
+`updateEither` / `updateValidated`. You don't need to terminate with `.get()` first; the navigator stands in for the
+wrapped Telescope at any intermediate hop. So
+`CompanyTelescope.of().teams().each().users().each().updateAsync(company, svc::lookup, pool)` returns a
+`CompletableFuture<Company>` directly, with the effect threaded through the generated chain.
 
-**Bridge hops — conversion as a navigator step.** If a type carries both `@Focus`/`@BeanFocus` (so it has a `*Path`) and
-`@Bridge(Target.class)` (so it has a `*Bridge.BRIDGE`), the navigator gains a fluent **`as<Target>()`** method that
-chains the bridge in. The navigator becomes a single compile-checked surface for _both_ navigation _and_ conversion,
-crossing paradigms naturally (record↔record, record↔POJO, POJO↔POJO):
+**Bridge hops — conversion as a navigator step.** If a type carries both `@Focus`/`@BeanFocus` (so it has a `*Telescope`
+navigator) and `@Bridge(Target.class)` (so it has a `*Bridge.BRIDGE`), the navigator gains a fluent **`as<Target>()`**
+method that chains the bridge in. The navigator becomes a single compile-checked surface for _both_ navigation _and_
+conversion, crossing paradigms naturally (record↔record, record↔POJO, POJO↔POJO):
 
 ```java
 @Focus
@@ -1308,15 +1310,15 @@ record UserDto(String id, String email) {}
 
 // Navigate through the bridge into a target field, then update. The Iso round-trips, so the
 // result is a new UserEntity:
-final UserEntity lowered = UserEntityPath.of()
-  .asUserDto() // → UserDtoPath<UserEntity>
+final UserEntity lowered = UserEntityTelescope.of()
+  .asUserDto() // → UserDtoTelescope<UserEntity>
   .email() // → Telescope<UserEntity, String>
   .update(entity, String::toLowerCase);
 ```
 
 The return type degrades to a terminal `Telescope<R, Target>` when the target isn't itself annotated (so there's no
-`<Target>Path` to chain into). The reverse direction (target's Path getting `.asSource()`) still goes through
-`.then(SourceBridge.BRIDGE.reverse())` for now — forward only at the navigator level.
+`<Target>Telescope` navigator to chain into). The reverse direction (target's navigator getting `.asSource()`) still
+goes through `.then(SourceBridge.BRIDGE.reverse())` for now — forward only at the navigator level.
 
 Gradle wiring:
 
@@ -1340,8 +1342,8 @@ import io.github.eschizoid.telescope.annotations.BeanFocus;
 
 @BeanFocus public class UserBean { /* getId/getEmail + setters, or a static builder() */ }
 
-// Generated alongside: UserBeanPath<R> with the same fluent surface as a record navigator.
-UserBeanPath.of().email().update(user, String::toLowerCase);   // no reflection
+// Generated alongside: UserBeanTelescope<R> with the same fluent surface as a record navigator.
+UserBeanTelescope.of().email().update(user, String::toLowerCase);   // no reflection
 ```
 
 ---
@@ -1561,7 +1563,7 @@ return afterUsers.flatMapAsync(ok -> enrichPath.updateAsync(ok, this::enrich));
      can't verify the name exists or that the inferred type matches the actual field. Wrong name → runtime error.
 
    For zero runtime-check points, use the **`@Focus` / `@BeanFocus` / `@Bridge` annotation processors** — they generate
-   a typed `<X>Path<R>` navigator at compile time, with every step a typed method call.
+   a typed `<X>Telescope<R>` navigator at compile time, with every step a typed method call.
 
 7. **Versioning policy — semver.** Source and binary compatibility across minor versions; breaks only on majors.
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,7 @@
 import com.diffplug.gradle.spotless.SpotlessExtension
 import org.jreleaser.model.Active.ALWAYS
 import org.jreleaser.model.Active.NEVER
+import pl.allegro.tech.build.axion.release.VerifyReleaseTask
 
 plugins {
     base
@@ -52,6 +53,16 @@ scmVersion {
 allprojects {
     group = "io.github.eschizoid"
     version = rootProject.scmVersion.version
+}
+
+// The snapshot-dependency scan resolves every subproject's configurations from the root
+// verifyRelease task; the GraalVM native-buildtools plugin (:examples:graphql) forbids that
+// cross-project resolution ("attempted without an exclusive lock"), failing every release run at
+// configuration-cache store time. Replacing the convention provider with an empty set neutralizes
+// only the scan — the task's uncommitted-changes / ahead-of-remote guards keep running. Safe here:
+// every dependency is a catalog-pinned release version, so the SNAPSHOT guard has nothing to catch.
+tasks.withType<VerifyReleaseTask>().configureEach {
+    snapshotDependencies.empty()
 }
 
 // Single source of truth for which subprojects ship to Maven Central. Used below to drive both

--- a/codegen/README.md
+++ b/codegen/README.md
@@ -1,6 +1,6 @@
 # telescope-codegen
 
-Annotation processors that emit a fluent typed `<X>Path<R>` navigator at compile time, eliminating the runtime
+Annotation processors that emit a fluent typed `<X>Telescope<R>` navigator at compile time, eliminating the runtime
 reflection cost of the [core DSL](../README.md). Same end-state values as the reflective
 `Telescope.of(Class).field(...)` path; different price tag.
 
@@ -12,7 +12,7 @@ Telescope.of(Company.class)             // runtime path (~262 ns/op for a 3-leve
     .field(User::email)
     .update(company, String::toLowerCase);
 
-CompanyPath.of()                      // codegen path (~45 ns/op — 5.8× faster)
+CompanyTelescope.of()                 // codegen path (~45 ns/op — 5.8× faster)
     .departments().each()
     .teams().each()
     .users().each()
@@ -23,10 +23,10 @@ CompanyPath.of()                      // codegen path (~45 ns/op — 5.8× faste
 
 - **Hot paths.** The codegen navigator emits direct method-reference + canonical-constructor bytecode at every hop. Zero
   `SerializedLambda` decode, zero `Records.fieldLens(String)` lookup, zero `Beans.lens(...)` reflection.
-- **Compile-time path validation.** A typo on `CompanyPath.of().teams()` is a `javac` error. The reflective
+- **Compile-time path validation.** A typo on `CompanyTelescope.of().teams()` is a `javac` error. The reflective
   `.field(Company::teamz)` blows up at construction time.
 - **Cross-paradigm bridges.** `@Bridge(UserDto.class)` on a `UserEntity` POJO generates
-  `UserEntityPath.of().asUserDto().email()` — one fluent chain hops from bean to record.
+  `UserEntityTelescope.of().asUserDto().email()` — one fluent chain hops from bean to record.
 
 Skip codegen for prototype / glue code that doesn't sit in a tight loop. The reflective path is sub-microsecond and
 still build-time-validated for method references.
@@ -35,7 +35,7 @@ still build-time-validated for method references.
 
 | Annotation              | Target                                        | Emits                                                                              |
 | ----------------------- | --------------------------------------------- | ---------------------------------------------------------------------------------- |
-| `@Focus`                | records                                       | `<R>Path<R>` navigator with one method per component                               |
+| `@Focus`                | records                                       | `<R>Telescope<R>` navigator with one method per component                          |
 | `@BeanFocus`            | POJOs with public getters / setters / builder | same shape as `@Focus`                                                             |
 | `@Bridge(Target.class)` | record or POJO                                | `<S>Bridge.BRIDGE : Iso<S, Target>` constant + `as<Target>()` hop on the navigator |
 
@@ -106,16 +106,16 @@ For a record `User`:
 public record User(String id, String email, Address address) {}
 ```
 
-The processor emits `UserPath<R>` next to it:
+The processor emits `UserTelescope<R>` next to it:
 
 ```java
-public final class UserPath<R> {
-  public static UserPath<User> start() { /* identity */ }
+public final class UserTelescope<R> {
+  public static UserTelescope<User> of() { /* identity */ }
 
   public Telescope<R, User>    get()     { /* current chain */ }
   public Telescope<R, String>  id()      { /* lens to id */ }
   public Telescope<R, String>  email()   { /* lens to email */ }
-  public AddressPath<R>        address() { /* sub-record → continue navigation */ }
+  public AddressTelescope<R>   address() { /* sub-record → continue navigation */ }
 
   // forwarders so any hop can read/update/etc without .get()
   public User read(R source)                                              { ... }
@@ -126,7 +126,8 @@ public final class UserPath<R> {
 ```
 
 Container components yield a `<X><Cap>Step<R>` whose `.each()` / `.eachValue()` / `.whenPresent()` returns the element's
-`Path<R>` when the element type is itself annotated, or a terminal `Telescope<R, T>` when it is not.
+`<Element>Telescope<R>` navigator when the element type is itself annotated, or a terminal `Telescope<R, T>` when it is
+not.
 
 ## Lombok bean classes
 

--- a/codegen/src/test/java/io/github/eschizoid/telescope/codegen/BeanFocusProcessorTest.java
+++ b/codegen/src/test/java/io/github/eschizoid/telescope/codegen/BeanFocusProcessorTest.java
@@ -13,9 +13,10 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Drives {@link BeanFocusProcessor} through the shared {@link ProcessorHarness}. Asserts on the
- * shape of the generated fluent navigator: {@code <Pojo>Telescope<R>} with {@code start()}, {@code
- * get()}, and per-property methods (scalar terminal / sub-bean-Path / container step), for both
- * rebuild strategies (static {@code builder()} and no-arg constructor + setters), plus the guards.
+ * shape of the generated fluent navigator: {@code <Pojo>Telescope<R>} with {@code of()}, {@code
+ * get()}, and per-property methods (scalar terminal / sub-bean navigator / container step), for
+ * both rebuild strategies (static {@code builder()} and no-arg constructor + setters), plus the
+ * guards.
  */
 class BeanFocusProcessorTest {
 
@@ -58,7 +59,7 @@ class BeanFocusProcessorTest {
 
       assertTrue(compilation.success(), () -> "compilation failed: " + compilation.errorMessages());
       final var generated = compilation.generated().get("demo.BuilderPojoTelescope");
-      assertNotNull(generated, () -> "BuilderPojoPath not generated; saw " + compilation.generated().keySet());
+      assertNotNull(generated, () -> "BuilderPojoTelescope not generated; saw " + compilation.generated().keySet());
 
       assertTrue(generated.contains("public final class BuilderPojoTelescope<R>"), generated);
       assertTrue(generated.contains("public static BuilderPojoTelescope<BuilderPojo> of()"), generated);
@@ -99,7 +100,7 @@ class BeanFocusProcessorTest {
 
       assertTrue(compilation.success(), () -> "compilation failed: " + compilation.errorMessages());
       final var generated = compilation.generated().get("demo.SetterPojoTelescope");
-      assertNotNull(generated, () -> "SetterPojoPath not generated; saw " + compilation.generated().keySet());
+      assertNotNull(generated, () -> "SetterPojoTelescope not generated; saw " + compilation.generated().keySet());
 
       assertTrue(generated.contains("public final class SetterPojoTelescope<R>"), generated);
       assertTrue(generated.contains("new SetterPojo()"), generated);
@@ -133,7 +134,7 @@ class BeanFocusProcessorTest {
 
       assertTrue(compilation.success(), () -> "compilation failed: " + compilation.errorMessages());
       final var generated = compilation.generated().get("demo.CounterTelescope");
-      assertNotNull(generated, () -> "CounterPath not generated; saw " + compilation.generated().keySet());
+      assertNotNull(generated, () -> "CounterTelescope not generated; saw " + compilation.generated().keySet());
 
       assertTrue(generated.contains("public Telescope<R, Integer> count()"), generated);
       assertFalse(generated.contains("Telescope<R, int>"), generated);
@@ -201,7 +202,7 @@ class BeanFocusProcessorTest {
 
       assertTrue(compilation.success(), () -> "compilation failed: " + compilation.errorMessages());
       final var generated = compilation.generated().get("demo.UserBeanTelescope");
-      assertNotNull(generated, () -> "UserBeanPath not generated; saw " + compilation.generated().keySet());
+      assertNotNull(generated, () -> "UserBeanTelescope not generated; saw " + compilation.generated().keySet());
 
       // Target is not @Focus'd (just a record) → terminal Telescope.
       assertTrue(generated.contains("public Telescope<R, demo.UserDto> asUserDto()"), generated);
@@ -390,7 +391,7 @@ class BeanFocusProcessorTest {
       assertTrue(holder.contains("public static final Telescope<Person, Integer> age"), holder);
 
       // Each constant uses Telescope.lens(...) with the same no-arg-ctor + setX rebuild expression
-      // the Path navigator would emit.
+      // the navigator would emit.
       assertTrue(holder.contains("Telescope.lens(Person::getName,"), holder);
       assertTrue(holder.contains("Telescope.lens(Person::getAge,"), holder);
       assertTrue(holder.contains("new Person()"), holder);
@@ -403,7 +404,7 @@ class BeanFocusProcessorTest {
     }
 
     @Test
-    @DisplayName("builder() POJO: constants rebuild via the builder chain (same as the Path navigator)")
+    @DisplayName("builder() POJO: constants rebuild via the builder chain (same as the navigator)")
     void telescopeHolderForBuilderBean() {
       final var compilation = compile(
         source(
@@ -464,9 +465,10 @@ class BeanFocusProcessorTest {
 
       assertTrue(compilation.success(), () -> "compilation failed: " + compilation.errorMessages());
       final var holder = compilation.generated().get("demo.BagFieldOptics");
-      assertNotNull(holder, () -> "BagTelescope not generated; saw " + compilation.generated().keySet());
+      assertNotNull(holder, () -> "BagFieldOptics not generated; saw " + compilation.generated().keySet());
 
-      // Raw container lens on the holder — the Path's container step lifts; the holder does not.
+      // Raw container lens on the holder — the navigator's container step lifts; the holder does
+      // not.
       // Consumers compose via .then(...) if they want element-level navigation.
       assertTrue(holder.contains("public static final Telescope<Bag, List<String>> tags"), holder);
       assertTrue(holder.contains("import java.util.List;"), holder);

--- a/codegen/src/test/java/io/github/eschizoid/telescope/codegen/BeanFocusProcessorTest.java
+++ b/codegen/src/test/java/io/github/eschizoid/telescope/codegen/BeanFocusProcessorTest.java
@@ -351,11 +351,11 @@ class BeanFocusProcessorTest {
   }
 
   @Nested
-  @DisplayName("Metadata holder emission — sibling <X>Telescope")
+  @DisplayName("Metadata holder emission — sibling <X>FieldOptics")
   class MetadataHolder {
 
     @Test
-    @DisplayName("emits a sibling <X>Telescope holder with one typed Telescope constant per property")
+    @DisplayName("emits a sibling <X>FieldOptics holder with one typed Telescope constant per property")
     void generatesTelescopeHolderForBean() {
       final var compilation = compile(
         source(
@@ -379,7 +379,7 @@ class BeanFocusProcessorTest {
 
       assertTrue(compilation.success(), () -> "compilation failed: " + compilation.errorMessages());
       final var holder = compilation.generated().get("demo.PersonFieldOptics");
-      assertNotNull(holder, () -> "PersonTelescope not generated; saw " + compilation.generated().keySet());
+      assertNotNull(holder, () -> "PersonFieldOptics not generated; saw " + compilation.generated().keySet());
 
       // Holder is a top-level public final class in the user's package, no instances permitted.
       assertTrue(holder.contains("public final class PersonFieldOptics"), holder);

--- a/codegen/src/test/java/io/github/eschizoid/telescope/codegen/FocusProcessorTest.java
+++ b/codegen/src/test/java/io/github/eschizoid/telescope/codegen/FocusProcessorTest.java
@@ -145,7 +145,7 @@ class FocusProcessorTest {
       );
       assertFalse(
         compilation.generated().containsKey("demo.NotARecordTelescope"),
-        "no Path class should be generated for a rejected type"
+        "no Telescope class should be generated for a rejected type"
       );
     }
 
@@ -239,12 +239,12 @@ class FocusProcessorTest {
       assertNotNull(step, () -> "TeamMembersStep not generated; saw " + compilation.generated().keySet());
       assertTrue(step.contains("public final class TeamMembersStep<R>"), step);
       assertTrue(step.contains("public Telescope<R, List<demo.Member>> get()"), step);
-      // each() returns the element's Path (Member is a record). The body uses the typed
+      // each() returns the element's navigator (Member is a record). The body uses the typed
       // Telescope.asList(path).each() factory — no runtime container dispatch, all lattice.
       assertTrue(step.contains("public demo.MemberTelescope<R> each()"), step);
       assertTrue(step.contains("Telescope.<R, demo.Member>asList(path).each()"), step);
 
-      // The Path itself routes the members() method to the Step.
+      // The navigator itself routes the members() method to the Step.
       final var path = compilation.generated().get("demo.TeamTelescope");
       assertNotNull(path, () -> "TeamTelescope not generated; saw " + compilation.generated().keySet());
       assertTrue(path.contains("public TeamMembersStep<R> members()"), path);
@@ -269,7 +269,7 @@ class FocusProcessorTest {
       assertTrue(compilation.success(), () -> "compilation failed: " + compilation.errorMessages());
       final var step = compilation.generated().get("demo.BagTagsStep");
       assertNotNull(step, () -> "BagTagsStep not generated; saw " + compilation.generated().keySet());
-      // Scalar element → terminal Telescope<R, String>, not a Path.
+      // Scalar element → terminal Telescope<R, String>, not a generated navigator.
       assertTrue(step.contains("public Telescope<R, String> each()"), step);
     }
 
@@ -332,13 +332,13 @@ class FocusProcessorTest {
       final var generated = compilation.generated().get("demo.EntityTelescope");
       assertNotNull(generated, () -> "EntityTelescope not generated; saw " + compilation.generated().keySet());
 
-      // Target is itself navigable (@Focus'd) → return its Path.
+      // Target is itself navigable (@Focus'd) → return its navigator.
       assertTrue(generated.contains("public demo.DtoTelescope<R> asDto()"), generated);
       assertTrue(generated.contains("new demo.DtoTelescope<>(path.then(EntityBridge.BRIDGE))"), generated);
     }
 
     @Test
-    @DisplayName("Bridge hop across packages: target's Path is in a different package and still constructible")
+    @DisplayName("Bridge hop across packages: target's navigator is in a different package and still constructible")
     void bridgeHopCrossPackage() {
       final var compilation = compile(
         source(
@@ -366,10 +366,11 @@ class FocusProcessorTest {
       assertTrue(compilation.success(), () -> "compilation failed: " + compilation.errorMessages());
       final var generated = compilation.generated().get("src.EntityTelescope");
       assertNotNull(generated, () -> "EntityTelescope not generated; saw " + compilation.generated().keySet());
-      // The bridge hop must instantiate a navigator from a different package — DtoPath's ctor
+      // The bridge hop must instantiate a navigator from a different package — DtoTelescope's ctor
       // must therefore be visible (public) for this to compile.
       assertTrue(generated.contains("new tgt.DtoTelescope<>(path.then(EntityBridge.BRIDGE))"), generated);
-      // Confirm the foreign target's Path emits a public ctor so the cross-package `new` resolves.
+      // Confirm the foreign target's navigator emits a public ctor so the cross-package `new`
+      // resolves.
       final var dtoPath = compilation.generated().get("tgt.DtoTelescope");
       assertNotNull(dtoPath, () -> "DtoTelescope not generated; saw " + compilation.generated().keySet());
       assertTrue(dtoPath.contains("public DtoTelescope(final Telescope<R, Dto> path)"), dtoPath);
@@ -403,7 +404,7 @@ class FocusProcessorTest {
       final var generated = compilation.generated().get("demo.EntityTelescope");
       assertNotNull(generated, () -> "EntityTelescope not generated; saw " + compilation.generated().keySet());
 
-      // Target isn't @Focus'd → return terminal Telescope, not a Path.
+      // Target isn't @Focus'd → return terminal Telescope, not a generated navigator.
       assertTrue(generated.contains("public Telescope<R, demo.Plain> asPlain()"), generated);
       assertTrue(generated.contains("return path.then(EntityBridge.BRIDGE);"), generated);
       assertFalse(generated.contains("PlainTelescope"), generated);
@@ -433,7 +434,7 @@ class FocusProcessorTest {
     }
 
     @Test
-    @DisplayName("emits a sibling <X>Telescope holder with one typed Telescope constant per component")
+    @DisplayName("emits a sibling <X>FieldOptics holder with one typed Telescope constant per component")
     void generatesTelescopeHolder() {
       final var compilation = compile(
         source(
@@ -460,7 +461,7 @@ class FocusProcessorTest {
       assertTrue(holder.contains("public static final Telescope<Person, String> name"), holder);
       assertTrue(holder.contains("public static final Telescope<Person, Integer> age"), holder);
 
-      // Each constant uses Telescope.lens(...) with the same canonical-setter expression the Path
+      // Each constant uses Telescope.lens(...) with the same canonical-setter expression the
       // navigator would emit.
       assertTrue(holder.contains("Telescope.lens(Person::name,"), holder);
       assertTrue(holder.contains("Telescope.lens(Person::age,"), holder);
@@ -490,7 +491,8 @@ class FocusProcessorTest {
       final var holder = compilation.generated().get("demo.BagFieldOptics");
       assertNotNull(holder, () -> "BagTelescope not generated; saw " + compilation.generated().keySet());
 
-      // Raw container lens on the holder — the Path's container step lifts; the holder does not.
+      // Raw container lens on the holder — the navigator's container step lifts; the holder does
+      // not.
       // Consumers compose via .then(...) if they want element-level navigation.
       assertTrue(holder.contains("public static final Telescope<Bag, List<String>> tags"), holder);
       assertTrue(holder.contains("import java.util.List;"), holder);

--- a/codegen/src/test/java/io/github/eschizoid/telescope/codegen/FocusProcessorTest.java
+++ b/codegen/src/test/java/io/github/eschizoid/telescope/codegen/FocusProcessorTest.java
@@ -13,10 +13,10 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Drives {@link FocusProcessor} through the shared {@link ProcessorHarness}. Asserts on the shape
- * of the generated fluent navigator: a {@code <Record>Telescope<R>} class with a {@code start()}
- * factory, a {@code get()} terminal, and one method per component (scalar terminal /
- * sub-record-Path / container step), plus the container step classes for {@code List}/{@code
- * Map}/{@code Optional} components.
+ * of the generated fluent navigator: a {@code <Record>Telescope<R>} class with an {@code of()}
+ * factory, a {@code get()} terminal, and one method per component (scalar terminal / sub-record
+ * navigator / container step), plus the container step classes for {@code List}/{@code Map}/{@code
+ * Optional} components.
  */
 class FocusProcessorTest {
 
@@ -29,7 +29,7 @@ class FocusProcessorTest {
   class HappyPath {
 
     @Test
-    @DisplayName("generates a <Record>Telescope<R> class with start(), get(), and one method per component")
+    @DisplayName("generates a <Record>Telescope<R> class with of(), get(), and one method per component")
     void generatesPathClass() {
       final var compilation = compile(
         source(
@@ -93,7 +93,7 @@ class FocusProcessorTest {
 
       assertTrue(compilation.success(), () -> "compilation failed: " + compilation.errorMessages());
       final var generated = compilation.generated().get("demo.ComboTelescope");
-      assertNotNull(generated, () -> "ComboPath not generated; saw " + compilation.generated().keySet());
+      assertNotNull(generated, () -> "ComboTelescope not generated; saw " + compilation.generated().keySet());
 
       // Off-path component reads are null-guarded so the lens rebuilds a fresh record when it
       // writes
@@ -195,7 +195,7 @@ class FocusProcessorTest {
 
       assertTrue(compilation.success(), () -> "compilation failed: " + compilation.errorMessages());
       final var generated = compilation.generated().get("demo.AgeTelescope");
-      assertNotNull(generated, () -> "AgePath not generated; saw " + compilation.generated().keySet());
+      assertNotNull(generated, () -> "AgeTelescope not generated; saw " + compilation.generated().keySet());
 
       assertTrue(generated.contains("public Telescope<R, Integer> age()"), generated);
       // The primitive name must not leak into the reference-typed Telescope parameter.
@@ -246,7 +246,7 @@ class FocusProcessorTest {
 
       // The Path itself routes the members() method to the Step.
       final var path = compilation.generated().get("demo.TeamTelescope");
-      assertNotNull(path, () -> "TeamPath not generated; saw " + compilation.generated().keySet());
+      assertNotNull(path, () -> "TeamTelescope not generated; saw " + compilation.generated().keySet());
       assertTrue(path.contains("public TeamMembersStep<R> members()"), path);
     }
 
@@ -330,7 +330,7 @@ class FocusProcessorTest {
 
       assertTrue(compilation.success(), () -> "compilation failed: " + compilation.errorMessages());
       final var generated = compilation.generated().get("demo.EntityTelescope");
-      assertNotNull(generated, () -> "EntityPath not generated; saw " + compilation.generated().keySet());
+      assertNotNull(generated, () -> "EntityTelescope not generated; saw " + compilation.generated().keySet());
 
       // Target is itself navigable (@Focus'd) → return its Path.
       assertTrue(generated.contains("public demo.DtoTelescope<R> asDto()"), generated);
@@ -365,13 +365,13 @@ class FocusProcessorTest {
 
       assertTrue(compilation.success(), () -> "compilation failed: " + compilation.errorMessages());
       final var generated = compilation.generated().get("src.EntityTelescope");
-      assertNotNull(generated, () -> "EntityPath not generated; saw " + compilation.generated().keySet());
+      assertNotNull(generated, () -> "EntityTelescope not generated; saw " + compilation.generated().keySet());
       // The bridge hop must instantiate a navigator from a different package — DtoPath's ctor
       // must therefore be visible (public) for this to compile.
       assertTrue(generated.contains("new tgt.DtoTelescope<>(path.then(EntityBridge.BRIDGE))"), generated);
       // Confirm the foreign target's Path emits a public ctor so the cross-package `new` resolves.
       final var dtoPath = compilation.generated().get("tgt.DtoTelescope");
-      assertNotNull(dtoPath, () -> "DtoPath not generated; saw " + compilation.generated().keySet());
+      assertNotNull(dtoPath, () -> "DtoTelescope not generated; saw " + compilation.generated().keySet());
       assertTrue(dtoPath.contains("public DtoTelescope(final Telescope<R, Dto> path)"), dtoPath);
     }
 
@@ -401,7 +401,7 @@ class FocusProcessorTest {
 
       assertTrue(compilation.success(), () -> "compilation failed: " + compilation.errorMessages());
       final var generated = compilation.generated().get("demo.EntityTelescope");
-      assertNotNull(generated, () -> "EntityPath not generated; saw " + compilation.generated().keySet());
+      assertNotNull(generated, () -> "EntityTelescope not generated; saw " + compilation.generated().keySet());
 
       // Target isn't @Focus'd → return terminal Telescope, not a Path.
       assertTrue(generated.contains("public Telescope<R, demo.Plain> asPlain()"), generated);
@@ -426,7 +426,7 @@ class FocusProcessorTest {
 
       assertTrue(compilation.success(), () -> "compilation failed: " + compilation.errorMessages());
       final var generated = compilation.generated().get("demo.PlainRecTelescope");
-      assertNotNull(generated, () -> "PlainRecPath not generated; saw " + compilation.generated().keySet());
+      assertNotNull(generated, () -> "PlainRecTelescope not generated; saw " + compilation.generated().keySet());
 
       // No @Bridge → no bridge hop (no reference to a <Source>Bridge.BRIDGE constant).
       assertFalse(generated.contains("Bridge.BRIDGE"), () -> "unexpected bridge hop in: " + generated);

--- a/docs/adr/0006-codegen-runtime-1-1-lookup-via-metadata-holder.md
+++ b/docs/adr/0006-codegen-runtime-1-1-lookup-via-metadata-holder.md
@@ -21,7 +21,7 @@ and getter/setter resolution. Those probes:
   architecture diagram.
 
 [ADR-0004](0004-runtime-and-codegen-strategy-separate.md) deliberately kept runtime and codegen as **separate
-strategies**. Users who annotate switch their call sites to `UserPath.of().name()` — different API entry. Users who
+strategies**. Users who annotate switch their call sites to `UserTelescope.of().name()` — different API entry. Users who
 don't, stay on `Telescope.of(User.class).field(User::name)` with the reflective metadata probe.
 
 The drawback of that split: a user who **wants** codegen ergonomics (no reflection) **and** the runtime entry point
@@ -36,8 +36,8 @@ generalises.
 ## Decision
 
 `FocusProcessor` and `BeanFocusProcessor` (and `LombokFocusProcessor` via the round-deferred emission pattern) **also**
-emit a sibling metadata holder class — `<X>Telescope` — alongside the existing `<X>Path<R>`. The holder exposes one
-`public static final Telescope<X, FieldType>` constant per record component / bean property.
+emit a sibling metadata holder class — `<X>FieldOptics` — alongside the generated `<X>Telescope<R>` navigator. The
+holder exposes one `public static final Telescope<X, FieldType>` constant per record component / bean property.
 
 At runtime, the dispatch sites that consume metadata (`Telescope.of(Class).field(Accessor)`,
 `Telescope.fieldByName(String)`, `Telescope.map(Class, Class, ...)`) consult a `ClassValue<Optional<HolderRef>>` cache
@@ -51,29 +51,29 @@ becomes a constant lookup rather than a reflective probe + LMF dispatch.
 
 Phased rollout (each phase is a discrete PR, no public API change):
 
-- **Phase A — emit `<X>Telescope`.** `FocusProcessor` and `BeanFocusProcessor` emit the sibling holder. Lombok
+- **Phase A — emit `<X>FieldOptics`.** `FocusProcessor` and `BeanFocusProcessor` emit the sibling holder. Lombok
   piggybacks on the existing `processingOver()` deferral. Pure additive: no runtime consumer yet.
 - **Phase B — runtime probe.** `ClassValue<Optional<HolderRef>>` short-circuit added to the dispatch sites in
   `Records.fieldLens(...)` / `Beans.lens(...)`. Holder-present types navigate via constants; holder-absent types fall
   through to today's LMF path unchanged.
-- **Phase C — deep-mapping uses constants.** `Reflective#structuralIso(cls)` probes for a sibling `<X>Telescope` and,
+- **Phase C — deep-mapping uses constants.** `Reflective#structuralIso(cls)` probes for a sibling `<X>FieldOptics` and,
   when present, pre-resolves a per-component `Lens` table. The backward branch (instance → name-keyed `Map`) reads via
   those lenses instead of routing through `Records.read` / `Beans.readProperty`. Holder-absent types and partial holders
   fall through to the reflective `read` path unchanged. The forward branch (`construct`) is untouched — the holder
   doesn't expose a constructor primitive, so canonical-ctor / `BeanWriter` dispatch remains. Net effect: for type pairs
   where both sides are annotated, every per-component value read during deep-mapping decomposition uses a pre-baked
   lens.
-- **Phase D — holder construct(...) closes the forward branch.** The `<X>Telescope` holder gains a
+- **Phase D — holder construct(...) closes the forward branch.** The `<X>FieldOptics` holder gains a
   `public static <X> construct(Function<String, Object> values)` method that mirrors the same write strategy the
-  `<X>Path<R>` lenses use (canonical constructor for records; builder chain or no-arg ctor + setters for beans). The
-  `MetadataHolderProbe.HolderRef` adds an optional `Function<Function<String, Object>, Object> constructor` field bound
-  once via `LambdaMetafactory` at probe time. `Reflective#structuralIso(cls)`'s forward branch routes through it when
-  present, bypassing the reflective `Records.construct` / `Beans.BeanWriter` path; older holders that predate Phase D
-  surface a `null` constructor and the engine falls back to today's reflective path unchanged. Net effect: for type
-  pairs where both sides are annotated, both the forward (construct) and the backward (read) branches of `structuralIso`
-  are reflection-free in the hot path; the only remaining runtime reflection is `SerializedLambda` decode on the user's
-  accessor method references.
-- **Phase E — holder constants() eliminates the probe's field scan.** The `<X>Telescope` holder gains a
+  `<X>Telescope<R>` navigator uses (canonical constructor for records; builder chain or no-arg ctor + setters for
+  beans). The `MetadataHolderProbe.HolderRef` adds an optional `Function<Function<String, Object>, Object> constructor`
+  field bound once via `LambdaMetafactory` at probe time. `Reflective#structuralIso(cls)`'s forward branch routes
+  through it when present, bypassing the reflective `Records.construct` / `Beans.BeanWriter` path; older holders that
+  predate Phase D surface a `null` constructor and the engine falls back to today's reflective path unchanged. Net
+  effect: for type pairs where both sides are annotated, both the forward (construct) and the backward (read) branches
+  of `structuralIso` are reflection-free in the hot path; the only remaining runtime reflection is `SerializedLambda`
+  decode on the user's accessor method references.
+- **Phase E — holder constants() eliminates the probe's field scan.** The `<X>FieldOptics` holder gains a
   `public static Map<String, Telescope<?, ?>> constants()` method that returns the name → lens map directly.
   `MetadataHolderProbe.probe(...)` calls this method as the only path; a holder that's missing the method (out-of-date
   codegen on the classpath) trips a precise `IllegalStateException` rather than silently falling back. Net effect on the
@@ -88,14 +88,14 @@ Phased rollout (each phase is a discrete PR, no public API change):
 The scout report surfaced ten open design questions; each is resolved here so the implementation has no remaining
 ambiguity:
 
-1. **Holder location.** Top-level `public final class <X>Telescope` in the user's package, alongside `<X>Path` and
-   `<X>Bridge`. Same shape as `@Bridge` output.
-   `Class.forName(cls.getName() + "Telescope", false, cls.getClassLoader())` is the runtime probe.
+1. **Holder location.** Top-level `public final class <X>FieldOptics` in the user's package, alongside `<X>Telescope`
+   and `<X>Bridge`. Same shape as `@Bridge` output.
+   `Class.forName(cls.getName() + "FieldOptics", false, cls.getClassLoader())` is the runtime probe.
 2. **What the holder exposes.** Typed `public static final Telescope<X, FieldType>` constants per field. **No** `Type[]`
    or `Class<?>[]` metadata arrays — container detection happens at codegen time when the constant is emitted,
    sidestepping generic-erasure questions. The constant _is_ the typed lens.
-3. **Holder naming.** Suffix convention `<X>Telescope` (e.g. `UserTelescope`). Matches `<X>Bridge` / `<X>Path`. No `$`
-   prefix.
+3. **Holder naming.** Suffix convention `<X>FieldOptics` (e.g. `UserFieldOptics`). Matches the generated `<X>Telescope`
+   / `<X>Bridge` pair. No `$` prefix.
 4. **`@Bridge` interaction.** `BridgeProcessor` stays as-is. The whole-record `BRIDGE` constant is already
    zero-reflection; composing it from per-field holder constants is a circuitous path with no perf gain.
 5. **`Reflective` interface.** Unchanged. Phase B adds a probe **before** the `Reflective.of(cls)` dispatch, two-tier;
@@ -109,8 +109,8 @@ ambiguity:
    `@MapTo(Target.class)` annotation or extending `@Bridge` semantics.
 9. **Lookup miss.** Throws `IllegalStateException` with a precise diagnostic ("Component 'name' not found in `User`'s
    metadata holder. Re-run the @Focus processor."). Silent fallback would mask stale codegen or accessor mismatches.
-10. **Lombok integration.** Holder emission uses the same `processingOver()` deferral the existing `<X>Path` emission
-    already uses — Lombok AST patches arrive lazily; early emission would see un-patched members.
+10. **Lombok integration.** Holder emission uses the same `processingOver()` deferral the existing `<X>Telescope`
+    emission already uses — Lombok AST patches arrive lazily; early emission would see un-patched members.
 
 ## Consequences
 
@@ -120,8 +120,8 @@ ambiguity:
   no other type info; the JDK requires this probe regardless of substrate.
 - **For non-annotated types, zero behavior change.** Phase B's short-circuit is opt-in via the holder's presence on the
   classpath.
-- **Codegen output grows.** One additional `<X>Telescope.class` per annotated type, alongside `<X>Path.class` and any
-  `<X><Comp>Step.class` files. Bounded by the surface of types the user explicitly annotates.
+- **Codegen output grows.** One additional `<X>FieldOptics.class` per annotated type, alongside `<X>Telescope.class` and
+  any `<X><Comp>Step.class` files. Bounded by the surface of types the user explicitly annotates.
 - **The `Telescope.map(A.class, B.class, ...)` path benefits most.** Today's reflective per-component name scan +
   per-component LMF bind per type pair becomes a per-pair `Iso<A, B>` composition from constants. This is where the
   hybrid's quantitative win is largest; the per-call navigation (`.field(...)`) is already at LMF parity with codegen
@@ -144,9 +144,9 @@ ambiguity:
   metadata reflection in `Reflective.java` / `Records.componentNames` / `Beans.propertyNames` — visible enough that the
   user flagged it during the v1.0 readiness pass. Leaving it would mean shipping 1.0 with the "reflection still in the
   runtime" caveat and pushing the resolution to v1.1; user explicitly pulled the resolution into 1.0.
-- **`<X>Telescope` as a nested class on `<X>Path`.** Rejected. Couples metadata to navigator presence at runtime; would
-  break for consumers who have the holder on the classpath but stripped the Path class. Top-level is cheaper to reason
-  about.
+- **`<X>FieldOptics` as a nested class on `<X>Telescope`.** Rejected. Couples metadata to navigator presence at runtime;
+  would break for consumers who have the holder on the classpath but stripped the navigator class. Top-level is cheaper
+  to reason about.
 - **Expose `Type[]` / `Class<?>[]` metadata on the holder instead of typed `Telescope` constants.** Rejected. Forces the
   runtime to interpret reflection types again; the typed-constant shape sidesteps generic erasure entirely by moving
   container detection to codegen time.

--- a/docs/adr/0007-cross-module-bridge-carrier.md
+++ b/docs/adr/0007-cross-module-bridge-carrier.md
@@ -55,8 +55,8 @@ cross-module setups.
   carries a `source = ...` attribute → carrier path (read source + target from the annotation, emit
   `<Carrier>Bridge.BRIDGE` in the carrier's package); else → existing model-anchored path. The downstream emit pipeline
   is otherwise unchanged.
-- **`as<Target>()` Path hop is only generated for the model-anchored form.** Carrier-anchored bridges don't have a
-  source-class `<Source>Path<R>` to hang the hop off of, by design — the source class is annotation-free in the
+- **`as<Target>()` navigator hop is only generated for the model-anchored form.** Carrier-anchored bridges don't have a
+  source-class `<Source>Telescope<R>` to hang the hop off of, by design — the source class is annotation-free in the
   cross-module case. Adopters use the carrier's `<Carrier>Bridge.BRIDGE` constant directly via
   `Telescope.from(...).to(...).using(BRIDGE)` or `Telescope.of(Source.class).then(BRIDGE)`. Documented limitation;
   symmetric with the reality that the source module can't see the carrier class either.

--- a/docs/adr/0012-compile-time-mapper-verification.md
+++ b/docs/adr/0012-compile-time-mapper-verification.md
@@ -23,10 +23,12 @@ drift, and with error-severity diagnostics a drifted rule is a user's build brok
 Two coupled decisions, one feature.
 
 **1. A call-site verifier in `:codegen`, built on JSR-269 + the Compiler Tree API.** `MapperVerifierProcessor` claims
-`"*"`, obtains `Trees.instance(processingEnv)`, and walks every root element's tree for invocations of the four
-factories. From class-literal arguments and statically-recognizable `Mapping` / `WriteHint` row factories (method
-references resolve to real `ExecutableElement`s — the compile-time twin of the `SerializedLambda` decode), it replays
-the construction-time pairing decisions and reports violations as **compile errors anchored on the offending row
+`"*"`, obtains `Trees.instance(processingEnv)`, and walks every root element's tree for invocations of the three
+verified factories — `Telescope.map` / `Telescope.mapper` (strict) and `Telescope.mapperForward` (lenient).
+(`Telescope.fromMap` verification is descoped to a tracked follow-up: its untyped `Map` source has no compile-time field
+set to pair against.) From class-literal arguments and statically-recognizable `Mapping` / `WriteHint` row factories
+(method references resolve to real `ExecutableElement`s — the compile-time twin of the `SerializedLambda` decode), it
+replays the construction-time pairing decisions and reports violations as **compile errors anchored on the offending row
 expression**, with the same diagnostic text the runtime throws. On a non-javac compiler (`Trees` unavailable) the
 processor prints one NOTE and no-ops: verification is additive, never load-bearing — the construction-time check remains
 the backstop, so a skipped site is exactly as safe as today.

--- a/lombok/README.md
+++ b/lombok/README.md
@@ -1,6 +1,6 @@
 # telescope-lombok
 
-Compile-time `<X>Path<R>` navigator emission for Lombok-annotated POJOs. Sibling of
+Compile-time `<X>Telescope<R>` navigator emission for Lombok-annotated POJOs. Sibling of
 [`telescope-codegen`](../codegen/README.md), out-of-tree consumer of the same `AbstractTelescopeProcessor` base — split
 because Lombok's lazy AST patching breaks the in-memory test harness `:codegen` uses, and round-deferred emission means
 a different processor lifecycle.
@@ -25,7 +25,7 @@ public class User {
 You want the same compile-checked navigator as `@Focus`/`@BeanFocus`:
 
 ```java
-UserPath.of()
+UserTelescope.of()
     .address().city()
     .update(user, city -> city.toLowerCase());
 ```
@@ -87,8 +87,8 @@ synthesised getters / setters / builder), causing a "no readable properties" err
 
 ## Generated output
 
-Same `<X>Path<R>` shape as [`telescope-codegen`'s](../codegen/README.md) emission — see that module's README for the
-full structure. The processor uses the Lombok-synthesised getter / setter / builder where present:
+Same `<X>Telescope<R>` shape as [`telescope-codegen`'s](../codegen/README.md) emission — see that module's README for
+the full structure. The processor uses the Lombok-synthesised getter / setter / builder where present:
 
 - `@Data` / `@Value` → read via `getFoo()` / `isFoo()`, rebuild via no-arg ctor + setters
 - `@Builder` → rebuild via the generated `Builder.foo(value).build()` chain
@@ -96,16 +96,16 @@ full structure. The processor uses the Lombok-synthesised getter / setter / buil
 If a class carries both `@Data` and `@Builder`, the builder rebuild path wins (higher fidelity for field-renamed builder
 methods).
 
-## Caveat: same-module main code can't reference the emitted Path
+## Caveat: same-module main code can't reference the emitted navigator
 
-Lombok-emitted `<Pojo>Path<R>` is emitted in `processingOver()` — the final processor round, after main-source symbol
-resolution. Same-module main code that directly references `<Pojo>Path` won't compile, since the symbol isn't visible
-until after main resolution finishes.
+Lombok-emitted `<Pojo>Telescope<R>` is emitted in `processingOver()` — the final processor round, after main-source
+symbol resolution. Same-module main code that directly references `<Pojo>Telescope` won't compile, since the symbol
+isn't visible until after main resolution finishes.
 
 Workarounds:
 
-- Reference the Path from test code (works — test compilation is a separate phase)
-- Reference from downstream modules (works — they're compiled later, the jar carries the emitted Path)
+- Reference the navigator from test code (works — test compilation is a separate phase)
+- Reference from downstream modules (works — they're compiled later, the jar carries the emitted navigator)
 - For same-module main code, use the reflective `Telescope.ofBean(Pojo.class).field(Pojo::getFoo)` path instead.
   Slightly slower; gets the same end-state.
 

--- a/lombok/src/test/java/io/github/eschizoid/telescope/codegen/lombok/LombokFocusProcessorTest.java
+++ b/lombok/src/test/java/io/github/eschizoid/telescope/codegen/lombok/LombokFocusProcessorTest.java
@@ -81,7 +81,8 @@ class LombokFocusProcessorTest {
       // compilation pass with LombokFocusProcessor on the annotation-processor classpath. The
       // consumer references DataUserTelescope directly — if this class were loaded at all (it is,
       // by
-      // this test), the consumer compiled, meaning the Path symbol resolved during the consumer's
+      // this test), the consumer compiled, meaning the navigator symbol resolved during the
+      // consumer's
       // own binding phase. That's the regression guard against re-introducing the
       // processingOver()-only emission pattern.
       final var result = SameRoundConsumer.shoutEmail(new DataUser("u-1", "alice@example.com"));
@@ -90,11 +91,12 @@ class LombokFocusProcessorTest {
     }
 
     @Test
-    @DisplayName("Nested static @Data class yields a flattened-name Path at package level")
+    @DisplayName("Nested static @Data class yields a flattened-name navigator at package level")
     void nestedStaticDataClassEmitsFlattenedPath() throws Exception {
-      // OuterWithNested holds a nested static @Data Inner. The processor should emit the Path /
+      // OuterWithNested holds a nested static @Data Inner. The processor should emit the navigator
+      // /
       // metadata holder at package level with the outer's name folded in to avoid colliding with
-      // a hypothetical top-level Inner. Path identifies the nested Inner via a dotted type
+      // a hypothetical top-level Inner. The navigator identifies the nested Inner via a dotted type
       // reference inside its own source.
       final var pathClass = Class.forName(
         "io.github.eschizoid.telescope.codegen.lombok.fixtures.OuterWithNestedInnerTelescope"
@@ -106,7 +108,8 @@ class LombokFocusProcessorTest {
       );
       assertNotNull(holder);
 
-      // Path's method signatures must reference the nested type, not a hypothetical top-level one.
+      // The navigator's method signatures must reference the nested type, not a hypothetical
+      // top-level one.
       final var nestedType = Class.forName(
         "io.github.eschizoid.telescope.codegen.lombok.fixtures.OuterWithNested$Inner"
       );
@@ -117,7 +120,7 @@ class LombokFocusProcessorTest {
     }
 
     @Test
-    @DisplayName("@Data POJO with List<@Data> emits a container step whose each() returns the element's Path")
+    @DisplayName("@Data POJO with List<@Data> emits a container step whose each() returns the element's navigator")
     void containerStepDescendsIntoSubPath() throws Exception {
       final var teamPath = Class.forName("io.github.eschizoid.telescope.codegen.lombok.fixtures.DataTeamTelescope");
       assertNotNull(teamPath);
@@ -139,12 +142,12 @@ class LombokFocusProcessorTest {
   }
 
   @Nested
-  @DisplayName("Sibling <X>Telescope metadata holders are emitted (ADR-0006)")
+  @DisplayName("Sibling <X>FieldOptics metadata holders are emitted (ADR-0006)")
   class MetadataHolder {
 
     @Test
     @DisplayName(
-      "@Data POJO yields a DataUserTelescope holder with public static final Telescope constants per property"
+      "@Data POJO yields a DataUserFieldOptics holder with public static final Telescope constants per property"
     )
     void dataHolder() throws Exception {
       final var holder = Class.forName("io.github.eschizoid.telescope.codegen.lombok.fixtures.DataUserFieldOptics");
@@ -291,7 +294,7 @@ class LombokFocusProcessorTest {
   }
 
   @Nested
-  @DisplayName("Runtime behaviour — generated paths actually work end-to-end")
+  @DisplayName("Runtime behaviour — generated navigators actually work end-to-end")
   class Runtime {
 
     @Test

--- a/lombok/src/test/java/io/github/eschizoid/telescope/codegen/lombok/LombokFocusProcessorTest.java
+++ b/lombok/src/test/java/io/github/eschizoid/telescope/codegen/lombok/LombokFocusProcessorTest.java
@@ -38,7 +38,7 @@ class LombokFocusProcessorTest {
   class Generated {
 
     @Test
-    @DisplayName("@Data POJO yields a DataUserTelescope with start(), get(), and per-property methods")
+    @DisplayName("@Data POJO yields a DataUserTelescope with of(), get(), and per-property methods")
     void dataPath() throws Exception {
       final var pathClass = Class.forName("io.github.eschizoid.telescope.codegen.lombok.fixtures.DataUserTelescope");
       assertNotNull(pathClass);
@@ -50,7 +50,7 @@ class LombokFocusProcessorTest {
     }
 
     @Test
-    @DisplayName("@Builder POJO yields a BuilderUserTelescope with start(), get(), and per-property methods")
+    @DisplayName("@Builder POJO yields a BuilderUserTelescope with of(), get(), and per-property methods")
     void builderPath() throws Exception {
       final var pathClass = Class.forName("io.github.eschizoid.telescope.codegen.lombok.fixtures.BuilderUserTelescope");
       assertNotNull(pathClass);
@@ -328,9 +328,9 @@ class LombokFocusProcessorTest {
   }
 
   private static void assertHasFocusMethod(final Class<?> pathClass) throws Exception {
-    final var start = pathClass.getDeclaredMethod("of");
-    assertTrue(Modifier.isStatic(start.getModifiers()), "start() must be static");
-    assertEquals(pathClass, start.getReturnType(), () -> "start() should return " + pathClass.getSimpleName());
+    final var of = pathClass.getDeclaredMethod("of");
+    assertTrue(Modifier.isStatic(of.getModifiers()), "of() must be static");
+    assertEquals(pathClass, of.getReturnType(), () -> "of() should return " + pathClass.getSimpleName());
   }
 
   private static void assertHasGetMethod(final Class<?> pathClass) throws Exception {

--- a/lombok/src/test/java/io/github/eschizoid/telescope/codegen/lombok/fixtures/DataTeam.java
+++ b/lombok/src/test/java/io/github/eschizoid/telescope/codegen/lombok/fixtures/DataTeam.java
@@ -7,8 +7,8 @@ import lombok.NoArgsConstructor;
 
 /**
  * Fixture: {@code @Data} POJO with a container component whose element type ({@link DataUser}) is
- * itself {@code @Data}-annotated. Drives the cross-fixture "container step returns sub-Path" emit
- * path.
+ * itself {@code @Data}-annotated. Drives the cross-fixture "container step returns sub-navigator"
+ * emit path.
  */
 @Data
 @NoArgsConstructor

--- a/lombok/src/test/java/io/github/eschizoid/telescope/codegen/lombok/fixtures/OuterWithNested.java
+++ b/lombok/src/test/java/io/github/eschizoid/telescope/codegen/lombok/fixtures/OuterWithNested.java
@@ -6,18 +6,19 @@ import lombok.NoArgsConstructor;
 
 /**
  * Fixture: outer class holds a nested static {@code @Data} POJO. Pins that {@code
- * LombokFocusProcessor} emits a Path for the nested class, with the outer's name folded into the
- * Path's class name to avoid collision with any top-level sibling of the same simple name.
+ * LombokFocusProcessor} emits a navigator for the nested class, with the outer's name folded into
+ * the generated class name to avoid collision with any top-level sibling of the same simple name.
  *
  * <p>Expected emissions:
  *
  * <ul>
  *   <li>{@code OuterWithNestedInnerTelescope} — at package level (not nested inside
  *       OuterWithNested).
- *   <li>{@code OuterWithNestedInnerTelescope} — the metadata holder, also flattened.
+ *   <li>{@code OuterWithNestedInnerFieldOptics} — the metadata holder, also flattened.
  * </ul>
  *
- * The outer class itself is not annotated with a Lombok bean trigger so no Path is emitted for it.
+ * The outer class itself is not annotated with a Lombok bean trigger so no navigator is emitted for
+ * it.
  */
 public class OuterWithNested {
 

--- a/lombok/src/test/java/io/github/eschizoid/telescope/codegen/lombok/fixtures/SameRoundConsumer.java
+++ b/lombok/src/test/java/io/github/eschizoid/telescope/codegen/lombok/fixtures/SameRoundConsumer.java
@@ -2,10 +2,10 @@ package io.github.eschizoid.telescope.codegen.lombok.fixtures;
 
 /**
  * Fixture: a same-package, same-compilation-pass consumer of a Lombok-emitted {@code <X>Telescope}
- * navigator. Pins that the Path is visible to user code in the SAME module's source compilation —
- * the failure mode this guards against is the round-deferred emission that used to land the Path
- * only on {@code processingOver()}, after the compiler had already finished symbol resolution for
- * round-1 sources like this one.
+ * navigator. Pins that the navigator is visible to user code in the SAME module's source
+ * compilation — the failure mode this guards against is the round-deferred emission that used to
+ * land the navigator only on {@code processingOver()}, after the compiler had already finished
+ * symbol resolution for round-1 sources like this one.
  *
  * <p>If this class compiles, the same-module-main-code constraint is gone. If it doesn't, the
  * timing of {@link io.github.eschizoid.telescope.codegen.lombok.LombokFocusProcessor}'s emission


### PR DESCRIPTION
## Why

Two things, both surfaced by the recent `actions/upload-artifact` v4→v7 sweep and the fleet review of #211:

### 1. The Release action was failing

[Run 28679807746](https://github.com/eschizoid/telescope/actions/runs/28679807746) died at **Update Version and Create Tag** (`./gradlew release`). Root cause is not the action bump itself — it's `verifyRelease` under the configuration cache:

```
Configuration cache state could not be cached: field `__snapshotDependencies__` of task
`:verifyRelease` ... error writing value of type 'DefaultSetProperty'
> Resolution of the configuration ':examples:graphql:nativeImageTestClasspathInternal'
  was attempted without an exclusive lock. This is unsafe and not allowed.
```

axion-release's snapshot-dependency scan resolves **every** subproject's configurations from the root `verifyRelease` task. The GraalVM `native-buildtools` plugin (added to `:examples:graphql` in #204) forbids that cross-project resolution, so the scan throws at config-cache store time and aborts the release.

**Fix:** empty the task's `snapshotDependencies` provider. Only the SNAPSHOT scan is neutralized — the uncommitted-changes and ahead-of-remote guards still run. Safe here because every dependency is a catalog-pinned release version, so the SNAPSHOT guard has nothing to catch.

Verified locally: `./gradlew verifyRelease -Prelease.disableChecks` now passes **with the configuration cache on** (previously failed).

### 2. Stale `Path` → `Telescope` doc drift

The codegen navigator was renamed from `<X>Path<R>` / `start()` to `<X>Telescope<R>` / `of()` long ago, and the ADR-0006 metadata holder is `<X>FieldOptics` — but several docs and test strings never got swept. A reviewer fresh-eyes pass on #211 surfaced them. None of the README snippets compiled against the shipped generator.

Corrected across `README.md`, `codegen/README.md`, `lombok/README.md`, and the codegen/lombok processor test javadocs / `@DisplayName`s / stale `"...Path not generated"` failure messages (which named classes the processor never emits).

Also folded in two accuracy overhangs the #211 review flagged:
- **ADR-0012** said the verifier walks "the four factories" — it scans **three** (`map`/`mapper`/`mapperForward`); `fromMap` verification is descoped to a tracked follow-up (#208).
- The root README **writeBean** paragraph over-claimed — only the record-target and duplicate-hint rejections replay at compile time; builder-feasibility and unused-hint stay construction-time (both still eager and loud).

## Verification

- `./gradlew build` — green.
- `./gradlew :codegen:test :lombok:test spotlessCheck --rerun-tasks` — green (the test-string edits).
- `./gradlew verifyRelease -Prelease.disableChecks` — green with config cache on (the actual release-workflow gate).
- Every doc claim re-checked against the processor sources (`FocusProcessor` `pathName = ... + "Telescope"`, factory `of()`, holder `... + "FieldOptics"`, three-factory scan).

`.claude/CLAUDE.md` carried the same drift and was corrected locally, but it's gitignored so it's not in this diff.
