### PR TITLE
docs(introspection): neutral empty-trace label (follow-up to #213)

### DIFF
--- a/core/src/main/java/io/github/eschizoid/telescope/introspection/Trace.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/introspection/Trace.java
@@ -41,6 +41,9 @@ public record Trace(List<Node> roots) {
 
   @Override
   public String toString() {
+    // Neutral label for an empty trace, mirroring OpticReport's "(empty optic)" — an empty string
+    // would be indistinguishable from a rendering bug.
+    if (roots.isEmpty()) return "(empty optic)";
     final var out = new StringBuilder();
     for (final var root : roots) render(out, root, "");
     return out.toString().stripTrailing();

--- a/core/src/test/java/io/github/eschizoid/telescope/introspection/TraceTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/introspection/TraceTest.java
@@ -1,0 +1,20 @@
+package io.github.eschizoid.telescope.introspection;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Contract tests for {@link Trace}'s render. The tree render itself is pinned end-to-end by {@code
+ * NavigationTraceTest} / {@code MapperTraceTest}; this pins the degenerate empty-roots case.
+ */
+class TraceTest {
+
+  @Test
+  @DisplayName("an empty trace renders a neutral label, mirroring OpticReport, not a blank string")
+  void emptyTraceLabel() {
+    assertEquals("(empty optic)", new Trace(List.of()).toString());
+  }
+}


### PR DESCRIPTION
Follow-up to #213 (ADR-0013 introspectable optics), addressing the final Copilot review observation.

`Trace.toString()` returned an empty string when its `roots` are empty (an empty trace), which is hard to distinguish from a rendering bug and was inconsistent with `OpticReport`, which renders an explicit `(empty optic)` for the empty case. `Trace` now renders the same neutral label.

Pinned by a focused `TraceTest`.
