### PR TITLE
build!: raise the compile baseline to Java 21 and restore the reverted language features

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ keeps going where MapStruct structurally stops — deep navigation, effectful up
 merge, JPA-cycle and Hibernate-`LAZY` handling, all from one `Telescope<S, A>` type. Same speed, compile safety
 MapStruct can't give you, and a strictly larger surface. [See it row by row →](#how-it-compares-to-mapstruct)
 
-[![JVM 17+](https://img.shields.io/badge/JVM-17%2B-brightgreen.svg?&logo=openjdk)](https://openjdk.org/projects/jdk/17/)
+[![JVM 21+](https://img.shields.io/badge/JVM-21%2B-brightgreen.svg?&logo=openjdk)](https://openjdk.org/projects/jdk/21/)
 [![Build](https://github.com/eschizoid/telescope/actions/workflows/ci.yaml/badge.svg)](https://github.com/eschizoid/telescope/actions/workflows/ci.yaml)
 [![Codecov](https://codecov.io/gh/eschizoid/telescope/graph/badge.svg?token=a235ea8b-e6dc-45c6-8fea-e5050940c5d4)](https://codecov.io/gh/eschizoid/telescope)
 [![Maven Central](https://img.shields.io/maven-central/v/io.github.eschizoid/telescope-core.svg?label=Maven%20Central)](https://central.sonatype.com/artifact/io.github.eschizoid/telescope-core)

--- a/benchmarks/build.gradle.kts
+++ b/benchmarks/build.gradle.kts
@@ -23,7 +23,7 @@ dependencies {
 }
 
 tasks.withType<JavaCompile>().configureEach {
-    options.release = 17
+    options.release = 21
     options.encoding = "UTF-8"
     modularity.inferModulePath = true
 }

--- a/codegen/build.gradle.kts
+++ b/codegen/build.gradle.kts
@@ -25,7 +25,7 @@ java {
 }
 
 tasks.withType<JavaCompile>().configureEach {
-    options.release = 17
+    options.release = 21
     options.encoding = "UTF-8"
     options.compilerArgs.addAll(listOf("-Xlint:all,-processing", "-parameters"))
 }

--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/AbstractTelescopeProcessor.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/AbstractTelescopeProcessor.java
@@ -924,7 +924,7 @@ public abstract class AbstractTelescopeProcessor extends AbstractProcessor {
     if (props.isEmpty()) {
       out.println("    return Map.of();");
     } else if (props.size() == 1) {
-      final var onlyName = props.get(0).name();
+      final var onlyName = props.getFirst().name();
       out.println("    return Map.of(\"" + onlyName + "\", " + onlyName + ");");
     } else {
       out.println("    return Map.ofEntries(");

--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BeanFocusProcessor.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BeanFocusProcessor.java
@@ -20,7 +20,7 @@ import javax.lang.model.element.TypeElement;
  * setters — see {@link AbstractTelescopeProcessor#emitBeanNavigator}.
  */
 @SupportedAnnotationTypes("io.github.eschizoid.telescope.annotations.BeanFocus")
-@SupportedSourceVersion(SourceVersion.RELEASE_17)
+@SupportedSourceVersion(SourceVersion.RELEASE_21)
 public final class BeanFocusProcessor extends AbstractTelescopeProcessor {
 
   /**

--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
@@ -1788,9 +1788,9 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
 
   // Sealed-source bridge: dispatch on the permits clause and delegate each case to the per-case
   // bridge that the user already declared with @Bridge on the subtype. The emitted forward/backward
-  // are pattern-match switches over the sealed permits; no field walking, no rebuild — just one
-  // dispatch arm per case. Requires every permit case to be @Bridge-annotated and its target to be
-  // a permit of the sealed target.
+  // dispatch through the Match.of(...).when(...).exhaustive() fluent over the sealed permits; no
+  // field walking, no rebuild — just one dispatch arm per case. Requires every permit case to be
+  // @Bridge-annotated and its target to be a permit of the sealed target.
   private void generateSealed(
     final TypeElement source,
     final TypeElement target,

--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
@@ -64,7 +64,7 @@ import javax.tools.StandardLocation;
 @SupportedAnnotationTypes(
   { "io.github.eschizoid.telescope.annotations.Bridge", "io.github.eschizoid.telescope.annotations.Bridges" }
 )
-@SupportedSourceVersion(SourceVersion.RELEASE_17)
+@SupportedSourceVersion(SourceVersion.RELEASE_21)
 public final class BridgeProcessor extends AbstractTelescopeProcessor {
 
   /**
@@ -1850,7 +1850,7 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
           );
         } else if (caseBridges.size() == 1) {
           // Single @Bridge whose target isn't in the sealed-target permits — name it explicitly.
-          final var only = rawTargetValueFromMirror(caseBridges.get(0));
+          final var only = rawTargetValueFromMirror(caseBridges.getFirst());
           if (!(only instanceof DeclaredType decl)) continue;
           final var onlyEl = (TypeElement) decl.asElement();
           error(
@@ -2170,13 +2170,13 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
     if (!(type instanceof DeclaredType dt)) return null;
     final var args = dt.getTypeArguments();
     if (assignableToRaw(type, "java.util.Optional")) {
-      return args.size() == 1 ? new ContainerShape(FieldPlan.Kind.OPTIONAL, args.get(0), null) : null;
+      return args.size() == 1 ? new ContainerShape(FieldPlan.Kind.OPTIONAL, args.getFirst(), null) : null;
     }
     if (args.size() == 1 && assignableToRaw(type, "java.util.List")) {
-      return new ContainerShape(FieldPlan.Kind.LIST, args.get(0), null);
+      return new ContainerShape(FieldPlan.Kind.LIST, args.getFirst(), null);
     }
     if (args.size() == 1 && assignableToRaw(type, "java.util.Set")) {
-      return new ContainerShape(FieldPlan.Kind.SET, args.get(0), null);
+      return new ContainerShape(FieldPlan.Kind.SET, args.getFirst(), null);
     }
     if (args.size() == 2 && assignableToRaw(type, "java.util.Map")) {
       return new ContainerShape(FieldPlan.Kind.MAP_VALUES, args.get(1), args.get(0));
@@ -2194,11 +2194,11 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
     if (!(type instanceof DeclaredType dt) || !dt.getTypeArguments().isEmpty()) return null;
     if (assignableToRaw(type, "java.util.List")) {
       final var args = containerViewArgs(type, "java.util.List");
-      return args.size() == 1 ? new ContainerShape(FieldPlan.Kind.LIST, args.get(0), null) : null;
+      return args.size() == 1 ? new ContainerShape(FieldPlan.Kind.LIST, args.getFirst(), null) : null;
     }
     if (assignableToRaw(type, "java.util.Set")) {
       final var args = containerViewArgs(type, "java.util.Set");
-      return args.size() == 1 ? new ContainerShape(FieldPlan.Kind.SET, args.get(0), null) : null;
+      return args.size() == 1 ? new ContainerShape(FieldPlan.Kind.SET, args.getFirst(), null) : null;
     }
     if (assignableToRaw(type, "java.util.Map")) {
       final var args = containerViewArgs(type, "java.util.Map");
@@ -2930,7 +2930,7 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
       return "new " + implFqn + "<" + args.get(0) + ", " + args.get(1) + ">()";
     }
     final var args = containerViewArgs(container, kind == FieldPlan.Kind.SET ? "java.util.Set" : "java.util.List");
-    return "new " + implFqn + "<" + args.get(0) + ">()";
+    return "new " + implFqn + "<" + args.getFirst() + ">()";
   }
 
   private void emitListHelper(
@@ -2941,8 +2941,8 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
     final String subBridge,
     final String direction
   ) {
-    final var srcElement = ((DeclaredType) srcContainer).getTypeArguments().get(0);
-    final var tgtElement = ((DeclaredType) tgtContainer).getTypeArguments().get(0);
+    final var srcElement = ((DeclaredType) srcContainer).getTypeArguments().getFirst();
+    final var tgtElement = ((DeclaredType) tgtContainer).getTypeArguments().getFirst();
     final var returnRaw = simpleName(containerRawFqn(tgtContainer));
     final var paramRaw = simpleName(containerRawFqn(srcContainer));
     final var implFqn = concreteImplFqn(tgtContainer, FieldPlan.Kind.LIST);
@@ -2977,8 +2977,8 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
     final String subBridge,
     final String direction
   ) {
-    final var srcElement = ((DeclaredType) srcContainer).getTypeArguments().get(0);
-    final var tgtElement = ((DeclaredType) tgtContainer).getTypeArguments().get(0);
+    final var srcElement = ((DeclaredType) srcContainer).getTypeArguments().getFirst();
+    final var tgtElement = ((DeclaredType) tgtContainer).getTypeArguments().getFirst();
     final var returnRaw = simpleName(containerRawFqn(tgtContainer));
     final var paramRaw = simpleName(containerRawFqn(srcContainer));
     final var implFqn = concreteImplFqn(tgtContainer, FieldPlan.Kind.SET);

--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/FocusProcessor.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/FocusProcessor.java
@@ -44,7 +44,7 @@ import javax.lang.model.element.TypeElement;
  * </ul>
  */
 @SupportedAnnotationTypes("io.github.eschizoid.telescope.annotations.Focus")
-@SupportedSourceVersion(SourceVersion.RELEASE_17)
+@SupportedSourceVersion(SourceVersion.RELEASE_21)
 public final class FocusProcessor extends AbstractTelescopeProcessor {
 
   /**
@@ -231,7 +231,7 @@ public final class FocusProcessor extends AbstractTelescopeProcessor {
     if (components.isEmpty()) {
       out.println("    return Map.of();");
     } else if (components.size() == 1) {
-      final var onlyName = components.get(0).getSimpleName();
+      final var onlyName = components.getFirst().getSimpleName();
       out.println("    return Map.of(\"" + onlyName + "\", " + onlyName + ");");
     } else {
       out.println("    return Map.ofEntries(");

--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/FromMapProcessor.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/FromMapProcessor.java
@@ -27,7 +27,7 @@ import javax.lang.model.type.TypeMirror;
  * generated code is GraalVM native-image clean.
  */
 @SupportedAnnotationTypes("io.github.eschizoid.telescope.annotations.FromMap")
-@SupportedSourceVersion(SourceVersion.RELEASE_17)
+@SupportedSourceVersion(SourceVersion.RELEASE_21)
 public final class FromMapProcessor extends AbstractTelescopeProcessor {
 
   private static final String ANNOTATION = "io.github.eschizoid.telescope.annotations.FromMap";
@@ -375,7 +375,7 @@ public final class FromMapProcessor extends AbstractTelescopeProcessor {
   private TypeMirror singleArgOf(final DeclaredType type, final String rawFqn) {
     if (!isErasure(type, rawFqn)) return null;
     final var args = type.getTypeArguments();
-    return args.size() == 1 ? args.get(0) : null;
+    return args.size() == 1 ? args.getFirst() : null;
   }
 
   /** Whether {@code type}'s erasure is exactly the raw type named {@code rawFqn}. */

--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/MapperVerifierProcessor.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/MapperVerifierProcessor.java
@@ -439,7 +439,7 @@ public final class MapperVerifierProcessor extends AbstractProcessor {
       final Set<String> hintTargets
     ) {
       if (!"writeBean".contentEquals(rowExec.getSimpleName())) return;
-      final var target = row.getArguments().isEmpty() ? null : classLiteral(row.getArguments().get(0));
+      final var target = row.getArguments().isEmpty() ? null : classLiteral(row.getArguments().getFirst());
       final var targetEl = target == null ? null : props.elementOf(target);
       if (targetEl == null) {
         note(

--- a/codegen/src/test/java/io/github/eschizoid/telescope/codegen/BridgeProcessorTest.java
+++ b/codegen/src/test/java/io/github/eschizoid/telescope/codegen/BridgeProcessorTest.java
@@ -1440,7 +1440,9 @@ class BridgeProcessorTest {
   class SealedRoots {
 
     @Test
-    @DisplayName("sealed interface ↔ sealed interface emits a switch over permits that delegates to per-case bridges")
+    @DisplayName(
+      "sealed interface ↔ sealed interface emits an exhaustive Match over permits that delegates to per-case bridges"
+    )
     void sealedToSealed() {
       final var compilation = compile(
         source(

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -24,7 +24,7 @@ java {
 }
 
 tasks.withType<JavaCompile>().configureEach {
-    options.release = 17
+    options.release = 21
     options.encoding = "UTF-8"
     options.compilerArgs.addAll(listOf("-Xlint:all,-processing", "-Werror", "-parameters"))
 }

--- a/core/src/main/java/io/github/eschizoid/telescope/DeepMap.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/DeepMap.java
@@ -262,11 +262,11 @@ public final class DeepMap {
   private static WriteHint.WriteStrategy extractDefaultStrategy(final List<WriteHint<?>> hints) {
     WriteHint.WriteStrategy defaultStrategy = null;
     for (final var hint : hints) {
-      if (!(hint instanceof WriteHint.DefaultWriteHint defaultHint)) continue;
+      if (!(hint instanceof WriteHint.DefaultWriteHint(final WriteHint.WriteStrategy strat))) continue;
       if (defaultStrategy != null) throw new IllegalArgumentException(
         "Duplicate writeBeans(...) default — at most one default write strategy per Telescope.map(...) call."
       );
-      defaultStrategy = defaultHint.strategy();
+      defaultStrategy = strat;
     }
     return defaultStrategy;
   }
@@ -1161,53 +1161,56 @@ public final class DeepMap {
     // Inline the contributed leaf-level Iso for each row variant. Reading the public components
     // directly keeps Iso (internal) out of the mapping types' public signatures — so the mapping
     // types stay portable across packages without needing @SuppressWarnings("exports").
-    // SameTypedTo carries no conversion; populateIso resolves it through autoIso (identity /
-    // primitive-wrapper / container lifting / incompatible-shape rejection), so it must not reach
-    // here. The guard surfaces a routing regression with a clear class name, like the rows below.
-    if (row instanceof SameTypedTo<?, ?, ?>) throw new IllegalStateException(
-      "SameTypedTo row should be resolved via autoIso, not fieldIsoOf"
-    );
-    if (row instanceof TypedTransformTo<?, ?, ?, ?> r) return Iso.of((Function) r.forward(), (Function) r.backward());
-    if (row instanceof ForwardOnlyTransformTo<?, ?, ?, ?> r) {
-      // DEAD-BRANCH-DEFENSIVE: this throwingBackward lambda is unreachable via the public API.
-      // Both factory entries Telescope.map(...) and Telescope.mapper(...) call
-      // rejectForwardOnlyRows
-      // up front; Telescope.mapperForward(...) accepts the row but never invokes the backward leg.
-      // The guard remains so a future cross-package construction path that bypasses
-      // rejectForwardOnlyRows produces a precise field-naming error rather than silent corruption.
-      // NOT a coverage target.
-      final String fieldName = r.sourceField();
-      final Function<Object, Object> throwingBackward = y -> {
-        throw new UnsupportedOperationException(
-          "Mapping.toOneWay is forward-only — backward direction is undefined for field '" +
-            fieldName +
-            "'. Use Telescope.mapperForward(...) for a forward-only mapper, or Mapping.to(src, " +
-            "tgt, forward, backward) for an explicit bidirectional row."
-        );
-      };
-      return Iso.of((Function) r.forward(), throwingBackward);
-    }
-    if (row instanceof Via<?, ?> r) return liftViaIfNeeded(r, srcType, tgtType);
-    // DEAD-BRANCH-DEFENSIVE block (rows below): every permit of the sealed Mapping hierarchy that
-    // is NOT a per-field leaf Iso is filtered out by populateIso BEFORE this method is called. The
-    // checks remain solely as a compile-time exhaustiveness backstop — if a future permit is added
-    // to Mapping and populateIso forgets to short-circuit, the corresponding throw here surfaces
-    // the routing bug with a clear class name. NOT coverage targets — these can only fire when a
-    // routing change in populateIso introduces a regression, at which point the test failure is in
-    // populateIso, not here.
-    if (row instanceof Drop<?, ?, ?>) throw new IllegalStateException("Drop row should not reach fieldIsoOf");
-    if (row instanceof TelescopeTo<?, ?, ?>) throw new IllegalStateException(
-      "TelescopeTo row should not reach fieldIsoOf"
-    );
-    if (row instanceof FromTelescopeTo<?, ?, ?>) throw new IllegalStateException(
-      "FromTelescopeTo row should not reach fieldIsoOf"
-    );
-    if (row instanceof TelescopeToTelescope<?, ?, ?>) throw new IllegalStateException(
-      "TelescopeToTelescope row should not reach fieldIsoOf"
-    );
-    if (row instanceof Constant<?, ?, ?>) throw new IllegalStateException("Constant row should not reach fieldIsoOf");
-    if (row instanceof Compute<?, ?, ?>) throw new IllegalStateException("Compute row should not reach fieldIsoOf");
-    throw new IllegalStateException("unreachable: Mapping is sealed");
+    return switch (row) {
+      // SameTypedTo carries no conversion; populateIso resolves it through autoIso (identity /
+      // primitive-wrapper / container lifting / incompatible-shape rejection), so it must not reach
+      // here. The guard surfaces a routing regression with a clear class name, like the cases
+      // below.
+      case SameTypedTo<?, ?, ?> __ -> throw new IllegalStateException(
+        "SameTypedTo row should be resolved via autoIso, not fieldIsoOf"
+      );
+      case TypedTransformTo<?, ?, ?, ?> r -> Iso.of((Function) r.forward(), (Function) r.backward());
+      case ForwardOnlyTransformTo<?, ?, ?, ?> r -> {
+        // DEAD-BRANCH-DEFENSIVE: this throwingBackward lambda is unreachable via the public API.
+        // Both factory entries Telescope.map(...) and Telescope.mapper(...) call
+        // rejectForwardOnlyRows
+        // up front; Telescope.mapperForward(...) accepts the row but never invokes the backward
+        // leg. The guard remains so a future cross-package construction path that bypasses
+        // rejectForwardOnlyRows produces a precise field-naming error rather than silent
+        // corruption. NOT a coverage target.
+        final String fieldName = r.sourceField();
+        final Function<Object, Object> throwingBackward = y -> {
+          throw new UnsupportedOperationException(
+            "Mapping.toOneWay is forward-only — backward direction is undefined for field '" +
+              fieldName +
+              "'. Use Telescope.mapperForward(...) for a forward-only mapper, or Mapping.to(src, " +
+              "tgt, forward, backward) for an explicit bidirectional row."
+          );
+        };
+        yield Iso.of((Function) r.forward(), throwingBackward);
+      }
+      case Via<?, ?> r -> liftViaIfNeeded(r, srcType, tgtType);
+      // DEAD-BRANCH-DEFENSIVE block (cases below): every permit of the sealed Mapping hierarchy
+      // that is NOT a per-field leaf Iso is filtered out by populateIso BEFORE this method is
+      // called. The cases exist only because the sealed switch must stay exhaustive — if a future
+      // permit is added to Mapping and populateIso forgets to short-circuit, the compiler forces a
+      // case here whose throw surfaces the routing bug with a clear class name. NOT coverage
+      // targets — these can only fire when a routing change in populateIso introduces a
+      // regression, at which point the test failure is in populateIso, not here.
+      case Drop<?, ?, ?> __ -> throw new IllegalStateException("Drop row should not reach fieldIsoOf");
+      case TelescopeTo<?, ?, ?> __ -> throw new IllegalStateException("TelescopeTo row should not reach fieldIsoOf");
+      case FromTelescopeTo<?, ?, ?> __ -> throw new IllegalStateException(
+        "FromTelescopeTo row should not reach fieldIsoOf"
+      );
+      case TelescopeToTelescope<?, ?, ?> __ -> throw new IllegalStateException(
+        "TelescopeToTelescope row should not reach fieldIsoOf"
+      );
+      case Constant<?, ?, ?> __ -> throw new IllegalStateException("Constant row should not reach fieldIsoOf");
+      case Compute<?, ?, ?> __ -> throw new IllegalStateException("Compute row should not reach fieldIsoOf");
+      case Conditional<?, ?> __ -> throw new IllegalStateException(
+        "Conditional row should be unwrapped by populateIso before fieldIsoOf"
+      );
+    };
   }
 
   /**

--- a/core/src/main/java/io/github/eschizoid/telescope/Telescope.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/Telescope.java
@@ -1980,12 +1980,9 @@ public sealed class Telescope<
    * literal upper bound on in-flight operations.
    *
    * <pre>{@code
-   * final var pool = Executors.newFixedThreadPool(10);
-   * try {
+   * try (final var pool = Executors.newFixedThreadPool(10)) {
    *   final CompletableFuture<Batch> done = path.updateAsync(batch, this::fetch, pool);
    *   done.join();
-   * } finally {
-   *   pool.shutdown();
    * }
    * }</pre>
    */
@@ -2307,7 +2304,7 @@ public sealed class Telescope<
   // fn.backward in one virtual hop. The Iso is still the underlying optic — composition (.then,
   // .field, .each, .as, etc.) returns a regular Telescope and keeps lattice semantics intact; the
   // fast path applies only when a terminal is invoked directly on the bridge constant.
-  static final class BridgeTelescope<S, T> extends Telescope<S, T> {
+  private static final class BridgeTelescope<S, T> extends Telescope<S, T> {
 
     private final BridgeFn<S, T> fn;
 

--- a/core/src/main/java/io/github/eschizoid/telescope/effects/Either.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/effects/Either.java
@@ -93,13 +93,12 @@ public sealed interface Either<L, R> {
    * }</pre>
    */
   default <T> T fold(final Function<? super L, ? extends T> onLeft, final Function<? super R, ? extends T> onRight) {
-    // Sealed-aware dispatch: a single instanceof + a guaranteed-safe cast on the other branch.
-    // Avoids the dead "second instanceof always true" branch the explicit double-instanceof pattern
-    // produces (which JaCoCo flags as a partial and a defensive throw line as unreachable). Every
-    // other default method on Either delegates here so the sealed-dispatch logic lives in one
-    // place.
-    if (this instanceof Left<L, R> l) return onLeft.apply(l.value());
-    return onRight.apply(((Right<L, R>) this).value());
+    // Every other default method on Either delegates here, so the sealed-dispatch logic lives in
+    // one place. Exhaustiveness over the sealed hierarchy is compiler-checked.
+    return switch (this) {
+      case Left<L, R> l -> onLeft.apply(l.value());
+      case Right<L, R> r -> onRight.apply(r.value());
+    };
   }
 
   /**

--- a/core/src/main/java/io/github/eschizoid/telescope/effects/Validated.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/effects/Validated.java
@@ -119,12 +119,12 @@ public sealed interface Validated<E, A> {
     final Function<? super List<E>, ? extends T> onInvalid,
     final Function<? super A, ? extends T> onValid
   ) {
-    // Sealed-aware dispatch: a single instanceof + a guaranteed-safe cast on the other branch.
     // Every other default method on Validated delegates here, so the sealed-dispatch logic lives
-    // in one place and the partial-coverage / dead-throw branches the explicit double-instanceof
-    // pattern produces don't multiply across each method.
-    if (this instanceof Invalid<E, A> inv) return onInvalid.apply(inv.errors());
-    return onValid.apply(((Valid<E, A>) this).value());
+    // in one place. Exhaustiveness over the sealed hierarchy is compiler-checked.
+    return switch (this) {
+      case Invalid<E, A> inv -> onInvalid.apply(inv.errors());
+      case Valid<E, A> v -> onValid.apply(v.value());
+    };
   }
 
   /**
@@ -261,10 +261,9 @@ public sealed interface Validated<E, A> {
     final var values = new ArrayList<A>(inputs.size());
     final var errors = new ArrayList<E>();
     for (final var v : inputs) {
-      if (v instanceof Valid<E, A> ok) {
-        values.add(ok.value());
-      } else if (v instanceof Invalid<E, A> bad) {
-        errors.addAll(bad.errors());
+      switch (v) {
+        case Valid<E, A> ok -> values.add(ok.value());
+        case Invalid<E, A> bad -> errors.addAll(bad.errors());
       }
     }
     if (!errors.isEmpty()) return new Invalid<>(errors);
@@ -288,16 +287,14 @@ public sealed interface Validated<E, A> {
     final Validated<E, B> right,
     final BiFunction<? super A, ? super B, ? extends C> f
   ) {
-    if (left instanceof Invalid<E, A> leftInvalid && right instanceof Invalid<E, B> rightInvalid) {
-      final var leftErrors = leftInvalid.errors();
-      final var rightErrors = rightInvalid.errors();
+    if (left instanceof Invalid<E, A>(List<E> leftErrors) && right instanceof Invalid<E, B>(List<E> rightErrors)) {
       final var combined = new ArrayList<E>(leftErrors.size() + rightErrors.size());
       combined.addAll(leftErrors);
       combined.addAll(rightErrors);
       return new Invalid<>(combined);
     }
-    if (left instanceof Invalid<E, A> leftInvalid) return new Invalid<>(leftInvalid.errors());
-    if (right instanceof Invalid<E, B> rightInvalid) return new Invalid<>(rightInvalid.errors());
+    if (left instanceof Invalid<E, A>(List<E> errors)) return new Invalid<>(errors);
+    if (right instanceof Invalid<E, B>(List<E> errors)) return new Invalid<>(errors);
     final var l = ((Valid<E, A>) left).value();
     final var r = ((Valid<E, B>) right).value();
     return new Valid<>(f.apply(l, r));

--- a/core/src/main/java/io/github/eschizoid/telescope/effects/Validated.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/effects/Validated.java
@@ -287,14 +287,17 @@ public sealed interface Validated<E, A> {
     final Validated<E, B> right,
     final BiFunction<? super A, ? super B, ? extends C> f
   ) {
-    if (left instanceof Invalid<E, A>(List<E> leftErrors) && right instanceof Invalid<E, B>(List<E> rightErrors)) {
+    if (
+      left instanceof Invalid<E, A>(final List<E> leftErrors) &&
+      right instanceof Invalid<E, B>(final List<E> rightErrors)
+    ) {
       final var combined = new ArrayList<E>(leftErrors.size() + rightErrors.size());
       combined.addAll(leftErrors);
       combined.addAll(rightErrors);
       return new Invalid<>(combined);
     }
-    if (left instanceof Invalid<E, A>(List<E> errors)) return new Invalid<>(errors);
-    if (right instanceof Invalid<E, B>(List<E> errors)) return new Invalid<>(errors);
+    if (left instanceof Invalid<E, A>(final List<E> errors)) return new Invalid<>(errors);
+    if (right instanceof Invalid<E, B>(final List<E> errors)) return new Invalid<>(errors);
     final var l = ((Valid<E, A>) left).value();
     final var r = ((Valid<E, B>) right).value();
     return new Valid<>(f.apply(l, r));

--- a/core/src/main/java/io/github/eschizoid/telescope/effects/Validated.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/effects/Validated.java
@@ -262,6 +262,7 @@ public sealed interface Validated<E, A> {
     final var errors = new ArrayList<E>();
     for (final var v : inputs) {
       switch (v) {
+        case null -> throw new NullPointerException("combineAll: null Validated element in inputs");
         case Valid<E, A> ok -> values.add(ok.value());
         case Invalid<E, A> bad -> errors.addAll(bad.errors());
       }

--- a/core/src/main/java/io/github/eschizoid/telescope/runtime/instances/EitherK.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/runtime/instances/EitherK.java
@@ -56,10 +56,14 @@ public final class EitherK<L> implements Kind.Witness {
         final Kind<EitherK<L>, B> fb,
         final BiFunction<? super A, ? super B, ? extends C> f
       ) {
-        // Sealed-aware nested dispatch through `fold` — short-circuits on the first Left and
-        // collapses the explicit double-instanceof chain (which left dead branches that JaCoCo
-        // flagged as partials / defensive throw lines).
-        return box(unbox(fa).flatMap(a -> unbox(fb).map(b -> f.apply(a, b))));
+        // Short-circuits on the first Left: fb is only inspected once fa is known to be a Right.
+        return switch (unbox(fa)) {
+          case Either.Left<L, A> la -> box(Either.left(la.value()));
+          case Either.Right<L, A> ra -> switch (unbox(fb)) {
+            case Either.Left<L, B> lb -> box(Either.left(lb.value()));
+            case Either.Right<L, B> rb -> box(Either.right(f.apply(ra.value(), rb.value())));
+          };
+        };
       }
 
       @Override

--- a/core/src/main/java/io/github/eschizoid/telescope/runtime/instances/ValidatedK.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/runtime/instances/ValidatedK.java
@@ -65,16 +65,16 @@ public final class ValidatedK<E> implements Kind.Witness {
         final var va = unbox(fa);
         final var vb = unbox(fb);
         if (
-          va instanceof Validated.Invalid<E, A>(List<E> errorsA) &&
-          vb instanceof Validated.Invalid<E, B>(List<E> errorsB)
+          va instanceof Validated.Invalid<E, A>(final List<E> errorsA) &&
+          vb instanceof Validated.Invalid<E, B>(final List<E> errorsB)
         ) {
           final var combined = new ArrayList<E>(errorsA.size() + errorsB.size());
           combined.addAll(errorsA);
           combined.addAll(errorsB);
           return box(Validated.invalid(combined));
         }
-        if (va instanceof Validated.Invalid<E, A>(List<E> errors)) return box(Validated.invalid(errors));
-        if (vb instanceof Validated.Invalid<E, B>(List<E> errors)) return box(Validated.invalid(errors));
+        if (va instanceof Validated.Invalid<E, A>(final List<E> errors)) return box(Validated.invalid(errors));
+        if (vb instanceof Validated.Invalid<E, B>(final List<E> errors)) return box(Validated.invalid(errors));
         final var a = ((Validated.Valid<E, A>) va).value();
         final var b = ((Validated.Valid<E, B>) vb).value();
         return box(Validated.valid(f.apply(a, b)));

--- a/core/src/main/java/io/github/eschizoid/telescope/runtime/instances/ValidatedK.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/runtime/instances/ValidatedK.java
@@ -4,6 +4,7 @@ import io.github.eschizoid.telescope.effects.Validated;
 import io.github.eschizoid.telescope.internal.optics.Applicative;
 import io.github.eschizoid.telescope.internal.optics.Kind;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
@@ -63,16 +64,17 @@ public final class ValidatedK<E> implements Kind.Witness {
       ) {
         final var va = unbox(fa);
         final var vb = unbox(fb);
-        if (va instanceof Validated.Invalid<E, A> invA && vb instanceof Validated.Invalid<E, B> invB) {
-          final var errors1 = invA.errors();
-          final var errors2 = invB.errors();
-          final var combined = new ArrayList<E>(errors1.size() + errors2.size());
-          combined.addAll(errors1);
-          combined.addAll(errors2);
+        if (
+          va instanceof Validated.Invalid<E, A>(List<E> errorsA) &&
+          vb instanceof Validated.Invalid<E, B>(List<E> errorsB)
+        ) {
+          final var combined = new ArrayList<E>(errorsA.size() + errorsB.size());
+          combined.addAll(errorsA);
+          combined.addAll(errorsB);
           return box(Validated.invalid(combined));
         }
-        if (va instanceof Validated.Invalid<E, A> invA) return box(Validated.invalid(invA.errors()));
-        if (vb instanceof Validated.Invalid<E, B> invB) return box(Validated.invalid(invB.errors()));
+        if (va instanceof Validated.Invalid<E, A>(List<E> errors)) return box(Validated.invalid(errors));
+        if (vb instanceof Validated.Invalid<E, B>(List<E> errors)) return box(Validated.invalid(errors));
         final var a = ((Validated.Valid<E, A>) va).value();
         final var b = ((Validated.Valid<E, B>) vb).value();
         return box(Validated.valid(f.apply(a, b)));

--- a/core/src/test/java/io/github/eschizoid/telescope/BoundedAsyncTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/BoundedAsyncTest.java
@@ -63,8 +63,7 @@ class BoundedAsyncTest {
         )
       );
 
-      final var pool = Executors.newFixedThreadPool(2);
-      try {
+      try (final var pool = Executors.newFixedThreadPool(2)) {
         final var done = USERS.updateAsync(
           team,
           user -> {
@@ -85,8 +84,6 @@ class BoundedAsyncTest {
         assertEquals(6, result.users().size());
         assertTrue(maxObserved.get() <= 2, "max concurrent invocations should be ≤ 2, was " + maxObserved.get());
         assertTrue(maxObserved.get() >= 1, "must have at least 1 in-flight at peak");
-      } finally {
-        pool.shutdown();
       }
     }
 
@@ -95,8 +92,7 @@ class BoundedAsyncTest {
     void rebuilds() throws Exception {
       final var team = new Team("eng", List.of(new User("alice", ""), new User("bob", "")));
 
-      final var pool = Executors.newFixedThreadPool(2);
-      try {
+      try (final var pool = Executors.newFixedThreadPool(2)) {
         final var done = USERS.updateAsync(
           team,
           user -> CompletableFuture.completedFuture(new User(user.name(), "x")),
@@ -104,8 +100,6 @@ class BoundedAsyncTest {
         );
         final var result = done.get(5, TimeUnit.SECONDS);
         assertEquals(List.of("x", "x"), result.users().stream().map(User::bio).toList());
-      } finally {
-        pool.shutdown();
       }
     }
   }

--- a/core/src/test/java/io/github/eschizoid/telescope/DeepMapBranchTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/DeepMapBranchTest.java
@@ -16,15 +16,15 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 /**
- * Pins the instanceof / record-pattern branches in {@link DeepMap} that the Java 17 cross-compile
- * (PR #80) rewrote — specifically the post-fixup row routing inside {@code applyForward} / {@code
- * applyBackward} (covering {@code Constant}, {@code Compute}, {@code TelescopeToTelescope} zip /
- * broadcast, and {@code FromTelescopeTo}), and the {@code DefaultWriteHint} record-pattern site in
- * {@code extractDefaultStrategy}.
+ * Pins the row-routing branches in {@link DeepMap}'s post-fixup passes — {@code applyForward} /
+ * {@code applyBackward} (covering {@code Constant}, {@code Compute}, {@code TelescopeToTelescope}
+ * zip / broadcast, and {@code FromTelescopeTo}) — and the {@code DefaultWriteHint} record-pattern
+ * site in {@code extractDefaultStrategy}.
  *
  * <p>The base {@code TelescopeTest} / {@code MappingTest} fixtures cover the common rows; this file
- * targets the specific branches whose codecov coverage degraded when the sealed-switch
- * exhaustiveness check moved from compile-time (pre-#80) to runtime-fallthrough (post-#80).
+ * targets the branches that route sequentially through instanceof chains (no compiler-checked
+ * exhaustiveness there, unlike the sealed switch in {@code fieldIsoOf}), so each arm needs an
+ * explicit pin.
  */
 class DeepMapBranchTest {
 

--- a/core/src/test/java/io/github/eschizoid/telescope/effects/SealedEffectsBranchTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/effects/SealedEffectsBranchTest.java
@@ -3,10 +3,12 @@ package io.github.eschizoid.telescope.effects;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.github.eschizoid.telescope.runtime.instances.EitherK;
 import io.github.eschizoid.telescope.runtime.instances.ValidatedK;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -273,6 +275,14 @@ class SealedEffectsBranchTest {
     @DisplayName("empty input → Valid(empty list)")
     void emptyInputs() {
       assertEquals(Validated.valid(List.of()), Validated.<String, Integer>combineAll(List.of()));
+    }
+
+    @Test
+    @DisplayName("a null element fails loudly with a message naming the API, never a silent drop")
+    void nullElementFailsLoudly() {
+      final var inputs = Arrays.asList(Validated.<String, Integer>valid(1), null);
+      final var thrown = assertThrows(NullPointerException.class, () -> Validated.combineAll(inputs));
+      assertEquals("combineAll: null Validated element in inputs", thrown.getMessage());
     }
   }
 

--- a/core/src/test/java/io/github/eschizoid/telescope/introspection/MapperLoggingTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/introspection/MapperLoggingTest.java
@@ -107,7 +107,7 @@ class MapperLoggingTest {
     });
     // Exactly one record: the construction explain. No per-forward value trace leaks in at DEBUG.
     assertEquals(1, records.size(), () -> "expected only the construction explain at DEBUG; got " + messages(records));
-    assertEquals(Level.FINE, records.get(0).getLevel(), "the construction log must be at DEBUG (JUL FINE)");
+    assertEquals(Level.FINE, records.getFirst().getLevel(), "the construction log must be at DEBUG (JUL FINE)");
     assertTrue(any(records, "Mapped:"), () -> "expected the explain structure; got " + messages(records));
     assertFalse(any(records, "\"Ada\""), () -> "the value trace must not appear at DEBUG; got " + messages(records));
   }

--- a/examples/library/build.gradle.kts
+++ b/examples/library/build.gradle.kts
@@ -15,7 +15,7 @@ java {
 }
 
 tasks.withType<JavaCompile>().configureEach {
-    options.release = 17
+    options.release = 21
     options.encoding = "UTF-8"
     // -parameters lets WriteHint.CONSTRUCTOR match args by parameter name on the immutable POJO demo.
     options.compilerArgs.addAll(listOf("-Xlint:all,-processing", "-parameters"))

--- a/examples/library/src/main/java/io/github/eschizoid/telescope/examples/DeepMappingDemo.java
+++ b/examples/library/src/main/java/io/github/eschizoid/telescope/examples/DeepMappingDemo.java
@@ -142,9 +142,9 @@ final class DeepMappingDemo {
     final CompanyDto dto = mapper.read(entity);
     System.out.println("[map] founded→since         : " + dto.since());
     System.out.println(
-      "[map] name→fullName (deep)  : " + dto.departments().get(0).teams().get(0).users().get(0).fullName()
+      "[map] name→fullName (deep)  : " + dto.departments().getFirst().teams().getFirst().users().getFirst().fullName()
     );
-    System.out.println("[map] Optional<User> head   : " + dto.departments().get(0).head().orElseThrow().fullName());
+    System.out.println("[map] Optional<User> head   : " + dto.departments().getFirst().head().orElseThrow().fullName());
     System.out.println("[map] Map<String,Address>   : " + dto.officesByRegion().get("EU").city());
   }
 

--- a/examples/library/src/main/java/io/github/eschizoid/telescope/examples/MultiEditDemo.java
+++ b/examples/library/src/main/java/io/github/eschizoid/telescope/examples/MultiEditDemo.java
@@ -72,10 +72,10 @@ final class MultiEditDemo {
 
     System.out.println("[all/over] dept names trimmed: " + out.departments().stream().map(Department::name).toList());
     System.out.println(
-      "[all/over] team names trimmed: " + out.departments().get(0).teams().stream().map(Team::name).toList()
+      "[all/over] team names trimmed: " + out.departments().getFirst().teams().stream().map(Team::name).toList()
     );
     System.out.println(
-      "[all/over] first user email  : " + out.departments().get(0).teams().get(0).users().get(0).email()
+      "[all/over] first user email  : " + out.departments().getFirst().teams().getFirst().users().getFirst().email()
     );
 
     // The same normalizer is reusable on a different source.
@@ -85,7 +85,8 @@ final class MultiEditDemo {
     );
     final var another2 = normalize.apply(another);
     System.out.println(
-      "[all/over] reused on another : " + another2.departments().get(0).teams().get(0).users().get(0).email()
+      "[all/over] reused on another : " +
+        another2.departments().getFirst().teams().getFirst().users().getFirst().email()
     );
   }
 }

--- a/examples/mapstruct-vs-telescope/build.gradle.kts
+++ b/examples/mapstruct-vs-telescope/build.gradle.kts
@@ -16,7 +16,7 @@ java {
 }
 
 tasks.withType<JavaCompile>().configureEach {
-    options.release = 17
+    options.release = 21
     options.encoding = "UTF-8"
     // -processing keeps MapStruct's own processor notes out of -Xlint; -parameters lets MapStruct
     // and telescope match constructor args by name on the domain records.

--- a/examples/mapstruct-vs-telescope/src/test/java/io/github/eschizoid/telescope/example/mapstruct/MapStructVsTelescopeTest.java
+++ b/examples/mapstruct-vs-telescope/src/test/java/io/github/eschizoid/telescope/example/mapstruct/MapStructVsTelescopeTest.java
@@ -104,12 +104,12 @@ class MapStructVsTelescopeTest {
 
     final var taxed = TelescopeMappings.applyRate(order, new BigDecimal("2"));
 
-    assertEquals(new BigDecimal("20.00"), taxed.lines().get(0).price(), "every line price doubled");
+    assertEquals(new BigDecimal("20.00"), taxed.lines().getFirst().price(), "every line price doubled");
     assertEquals(new BigDecimal("10.00"), taxed.lines().get(1).price(), "every line price doubled");
     assertNotSame(order, taxed, "a new Order graph is returned");
     assertEquals(
       new BigDecimal("10.00"),
-      order.lines().get(0).price(),
+      order.lines().getFirst().price(),
       "the original Order is unchanged — immutable update"
     );
     log(

--- a/examples/springboot/invoicing/build.gradle.kts
+++ b/examples/springboot/invoicing/build.gradle.kts
@@ -38,7 +38,7 @@ dependencies {
 }
 
 tasks.withType<JavaCompile>().configureEach {
-    options.release = 17
+    options.release = 21
     options.encoding = "UTF-8"
     options.compilerArgs.addAll(listOf("-Xlint:all,-processing,-serial", "-parameters"))
 }

--- a/examples/springboot/invoicing/src/test/java/io/github/eschizoid/telescope/demo/invoicing/InvoiceBridgeFlowTest.java
+++ b/examples/springboot/invoicing/src/test/java/io/github/eschizoid/telescope/demo/invoicing/InvoiceBridgeFlowTest.java
@@ -70,9 +70,9 @@ class InvoiceBridgeFlowTest {
     assertThat(entity).isNotNull();
     assertThat(entity.getNumber()).isEqualTo("INV-200");
     assertThat(entity.getLines()).hasSize(2);
-    assertThat(entity.getLines().get(0).getSku()).isEqualTo("SKU-X");
-    assertThat(entity.getLines().get(0).getQty()).isEqualTo(2);
-    assertThat(entity.getLines().get(0).getUnitPrice()).isEqualByComparingTo("11.50");
+    assertThat(entity.getLines().getFirst().getSku()).isEqualTo("SKU-X");
+    assertThat(entity.getLines().getFirst().getQty()).isEqualTo(2);
+    assertThat(entity.getLines().getFirst().getUnitPrice()).isEqualByComparingTo("11.50");
     assertThat(entity.getLines().get(1).getSku()).isEqualTo("SKU-Y");
     assertThat(entity.getLines().get(1).getQty()).isEqualTo(7);
     assertThat(entity.getLines().get(1).getUnitPrice()).isEqualByComparingTo("0.99");

--- a/examples/springboot/order-jpa/build.gradle.kts
+++ b/examples/springboot/order-jpa/build.gradle.kts
@@ -4,8 +4,8 @@ plugins {
     id("io.spring.dependency-management") version "1.1.7"
 }
 
-// Spring Boot 4.0.1 — the latest GA at the time of this demo. Brings Spring Framework 7.0,
-// Jakarta EE 10 (`jakarta.persistence.*`), Hibernate 7, and Java 17 baseline. We compile to 25.
+// Spring Boot 4.x — brings Spring Framework 7.0, Jakarta EE 10 (`jakarta.persistence.*`), and
+// Hibernate 7. This module compiles with --release 21 on the Java 25 toolchain.
 
 group = "io.github.eschizoid.telescope.demo"
 version = "0.0.1-SNAPSHOT"

--- a/examples/springboot/order-jpa/build.gradle.kts
+++ b/examples/springboot/order-jpa/build.gradle.kts
@@ -54,7 +54,7 @@ dependencies {
 }
 
 tasks.withType<JavaCompile>().configureEach {
-    options.release = 17
+    options.release = 21
     options.encoding = "UTF-8"
     // -parameters lets Spring's @PathVariable / @RequestParam resolve by name without
     // explicit annotation values, and helps Jackson's record-creator detection.

--- a/examples/springboot/order-jpa/src/main/java/io/github/eschizoid/telescope/demo/spring/api/ValidatedOrderController.java
+++ b/examples/springboot/order-jpa/src/main/java/io/github/eschizoid/telescope/demo/spring/api/ValidatedOrderController.java
@@ -34,15 +34,10 @@ public class ValidatedOrderController {
           : Validated.valid(quantity)
       );
 
-    // Sealed-dispatch via fold — the canonical shape, single source of truth for Valid/Invalid
-    // routing. Returns the OK response on Valid; throws on Invalid (the throw needs an `unchecked
-    // cast` of the fold's T inference back to `ResponseEntity<Order>`).
-    return result.fold(
-      errors -> {
-        throw new InvalidOrderException(new Validated.Invalid<>(errors));
-      },
-      ResponseEntity::ok
-    );
+    return switch (result) {
+      case Validated.Valid<LineItemValidationError, Order>(final Order accepted) -> ResponseEntity.ok(accepted);
+      case Validated.Invalid<LineItemValidationError, Order> bad -> throw new InvalidOrderException(bad);
+    };
   }
 
   // Recover the SKU of the first line item with this quantity for error context. The validator

--- a/examples/springboot/org-chart/build.gradle.kts
+++ b/examples/springboot/org-chart/build.gradle.kts
@@ -43,7 +43,7 @@ dependencies {
 }
 
 tasks.withType<JavaCompile>().configureEach {
-    options.release = 17
+    options.release = 21
     options.encoding = "UTF-8"
     options.compilerArgs.addAll(listOf("-Xlint:all,-processing,-serial", "-parameters"))
 }

--- a/examples/springboot/product-starter/build.gradle.kts
+++ b/examples/springboot/product-starter/build.gradle.kts
@@ -49,7 +49,7 @@ dependencies {
 }
 
 tasks.withType<JavaCompile>().configureEach {
-    options.release = 17
+    options.release = 21
     options.encoding = "UTF-8"
     options.compilerArgs.addAll(listOf("-Xlint:all,-processing,-serial", "-parameters"))
 }

--- a/internal/build.gradle.kts
+++ b/internal/build.gradle.kts
@@ -24,7 +24,7 @@ java {
 }
 
 tasks.withType<JavaCompile>().configureEach {
-    options.release = 17
+    options.release = 21
     options.encoding = "UTF-8"
     // -Xlint:-module suppresses the "qualified-export target module not found" warning that fires
     // because :core (io.github.eschizoid.telescope) requires :internal, not the other way around,

--- a/lombok/build.gradle.kts
+++ b/lombok/build.gradle.kts
@@ -24,7 +24,7 @@ java {
 }
 
 tasks.withType<JavaCompile>().configureEach {
-    options.release = 17
+    options.release = 21
     options.encoding = "UTF-8"
     options.compilerArgs.addAll(listOf("-Xlint:all,-processing", "-parameters"))
 }

--- a/lombok/src/main/java/io/github/eschizoid/telescope/codegen/lombok/LombokFocusProcessor.java
+++ b/lombok/src/main/java/io/github/eschizoid/telescope/codegen/lombok/LombokFocusProcessor.java
@@ -34,7 +34,7 @@ import javax.lang.model.element.TypeElement;
  * guaranteed done patching.
  */
 @SupportedAnnotationTypes({ "lombok.Data", "lombok.Value", "lombok.Builder" })
-@SupportedSourceVersion(SourceVersion.RELEASE_17)
+@SupportedSourceVersion(SourceVersion.RELEASE_21)
 public final class LombokFocusProcessor extends AbstractTelescopeProcessor {
 
   /**

--- a/quarkus/build.gradle.kts
+++ b/quarkus/build.gradle.kts
@@ -41,7 +41,7 @@ java {
 }
 
 tasks.withType<JavaCompile>().configureEach {
-    options.release = 17
+    options.release = 21
     options.encoding = "UTF-8"
     options.compilerArgs.addAll(listOf("-Xlint:all,-processing", "-parameters"))
 }

--- a/spring-boot-starter/build.gradle.kts
+++ b/spring-boot-starter/build.gradle.kts
@@ -24,7 +24,7 @@ java {
 }
 
 tasks.withType<JavaCompile>().configureEach {
-    options.release = 17
+    options.release = 21
     options.encoding = "UTF-8"
     options.compilerArgs.addAll(listOf("-Xlint:all,-processing", "-parameters"))
 }


### PR DESCRIPTION
Closes #217. Raises the compile baseline from Java 17 to **Java 21 (LTS)** across all modules — toolchain stays at 25 — and restores every language feature the Java 17 downgrade (#80) stripped, except unnamed `_` (JEP 456 needs 22+; deliberately out of scope at an LTS floor).

## What's restored
- **Pattern-match `switch`** over the sealed hierarchies in `Either`, `Validated`, `EitherK`, `ValidatedK`, `DeepMap` (the `fieldIsoOf` dispatch and `extractDefaultStrategy`; the sequential `applyForward`/`applyBackward` routing passes intentionally stay as chains), `ValidatedOrderController` — the `"unreachable"` fallthrough throws are deleted (exhaustiveness is compiler-checked now).
- **Record patterns** in `Validated.combine`, `ValidatedK.map2`, `DeepMap`.
- **Sequenced Collections** — `getFirst()` across codegen processors, demos, tests. Positional `get(0)`/`get(1)` pairs (Map key/value type args) intentionally stay indexed.
- **try-with-resources on `ExecutorService`** in `BoundedAsyncTest` + the `Telescope` javadoc example.
- **`Telescope.BridgeTelescope` back to `private`** — Java 21 accepts a private permitted subclass in the same compilation unit, so #80's accessibility workaround goes away.
- `options.release = 21` in all 14 module build files, `@SupportedSourceVersion(RELEASE_21)` on the 5 processors, README JVM badge → 21+.

## Correction vs the issue text
#217 listed "restore `BridgeProcessor` switch emission" — that item is **moot**: the sealed-bridge dispatch emission was independently rewritten (after #80) to the lattice-routed `Match.of(…).when(…).exhaustive()` runtime builder, which is source-level-agnostic. Generated navigators/bridges therefore do **not** impose a `-source 21` requirement on consumers; the only consumer-facing constraint is the runtime floor below.

## Breaking change (release-notes callout)
- Consumers on **Java 17–20 can no longer run telescope** — artifacts are compiled at `--release 21` (class-file 65), so the runtime floor is **Java 21**.

## Deliberate behavior change (found in review)
`Validated.combineAll` now throws `NullPointerException` on a null list element where the old `instanceof` chain silently **dropped** it (producing a `Valid` with a shorter list — silent corruption). Loud failure over silent element loss; no caller or test relied on the old behavior.

This should ride the next **minor-at-least** version bump with the baseline called out in the release notes.

## Test
Full `./gradlew spotlessApply build` green across all 14 modules.

## Note on codecov/patch
The exhaustive `fieldIsoOf` switch carries eight explicitly-dead throwing arms (documented in-source as DEAD-BRANCH-DEFENSIVE, "NOT coverage targets"): they exist so a future `Mapping` permit forces a compile error instead of silently mis-routing. codecov/patch counts those never-executed lines against the patch — that red is the deliberate price of compile-checked exhaustiveness, not a coverage gap; every reachable branch is pinned by a named test (see the review-fleet coverage report).
