### PR TITLE
fix(core): fail fast when Mapping rows bind to a type pair the mapper never visits

### DIFF
--- a/core/src/main/java/io/github/eschizoid/telescope/DeepMap.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/DeepMap.java
@@ -358,21 +358,13 @@ public final class DeepMap {
         if (!(r instanceof Drop)) rows.add(r.sourceField() + " -> " + r.targetField());
       }
       if (rows.isEmpty()) continue;
-      dead.add(
-        "(" +
-          pair.source.getSimpleName() +
-          " -> " +
-          pair.target.getSimpleName() +
-          "): [" +
-          String.join(", ", rows) +
-          "]"
-      );
+      dead.add("(" + pair.source.getName() + " -> " + pair.target.getName() + "): [" + String.join(", ", rows) + "]");
     }
     if (!dead.isEmpty()) throw new IllegalArgumentException(
       "Mapping rows bound to a type pair the mapper (" +
-        topSource.getSimpleName() +
+        topSource.getName() +
         " -> " +
-        topTarget.getSimpleName() +
+        topTarget.getName() +
         ") never visits — they would be silently ignored: " +
         String.join("; ", dead) +
         ". Bind the rows to a type pair this mapper's recursion actually reaches, or remove them."

--- a/core/src/main/java/io/github/eschizoid/telescope/DeepMap.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/DeepMap.java
@@ -205,6 +205,7 @@ public final class DeepMap {
       trail
     );
     validateAllHintsConsumed(hintMap, cache);
+    validateAllOverridesConsumed(overrideTable, cache, source, target);
     final var iso = (Iso<A, B>) Objects.requireNonNull(cache.get(new TypePair(source, target)));
     final var patchTable = new LinkedHashMap<String, Mapper.PatchEntry>();
     topSteps.forEach((tgtName, step) ->
@@ -327,6 +328,54 @@ public final class DeepMap {
       "Unused writeBean hints — classes never encountered during deep-mapping recursion: " +
         String.join(", ", unused) +
         ". Remove the row, or verify the class is actually reached by the source/target structure."
+    );
+  }
+
+  /**
+   * Reject any {@code Mapping} row bucket whose (source, target) type pair the recursion never
+   * visited — the rows could only ever be silently ignored. The classic trip-wire is reusing a row
+   * group declared against one DTO variant inside a mapper for a different variant: the rows are
+   * keyed by the accessors' declaring classes, so the foreign pair's bucket would sit unvisited
+   * while same-name auto-mapping masks the loss. Failing loudly here keeps explicit rows on the
+   * same footing as the unmatched-field and writeBean-hint validations.
+   */
+  private static void validateAllOverridesConsumed(
+    final Map<TypePair, List<Mapping<?, ?>>> overrideTable,
+    final Map<TypePair, Iso<?, ?>> cache,
+    final Class<?> topSource,
+    final Class<?> topTarget
+  ) {
+    if (overrideTable.isEmpty()) return;
+    final var dead = new ArrayList<String>();
+    for (final var entry : overrideTable.entrySet()) {
+      final var pair = entry.getKey();
+      if (cache.containsKey(pair)) continue;
+      // Drop rows are exempt: an unreachable drop is a harmless no-op (nested pairs are lenient
+      // already), and the one-arg form deliberately buckets a nested source class with the top
+      // target. Only rows that promise a mapping effect can be silently lost.
+      final var rows = new ArrayList<String>();
+      for (final var r : entry.getValue()) {
+        if (!(r instanceof Drop)) rows.add(r.sourceField() + " -> " + r.targetField());
+      }
+      if (rows.isEmpty()) continue;
+      dead.add(
+        "(" +
+          pair.source.getSimpleName() +
+          " -> " +
+          pair.target.getSimpleName() +
+          "): [" +
+          String.join(", ", rows) +
+          "]"
+      );
+    }
+    if (!dead.isEmpty()) throw new IllegalArgumentException(
+      "Mapping rows bound to a type pair the mapper (" +
+        topSource.getSimpleName() +
+        " -> " +
+        topTarget.getSimpleName() +
+        ") never visits — they would be silently ignored: " +
+        String.join("; ", dead) +
+        ". Bind the rows to a type pair this mapper's recursion actually reaches, or remove them."
     );
   }
 

--- a/core/src/main/java/io/github/eschizoid/telescope/conversion/MapperBuilder.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/conversion/MapperBuilder.java
@@ -15,10 +15,10 @@ import java.util.Objects;
  *
  * <pre>{@code
  * private static final MapStep[] AUDIT_COLUMNS = {
- *     to(Entity::createdAt, Dto::createdAt),
- *     to(Entity::createdBy, Dto::createdBy),
- *     to(Entity::updatedAt, Dto::updatedAt),
- *     to(Entity::updatedBy, Dto::updatedBy)};
+ *     to(UserEntity::createdAt, UserDto::createdAt),
+ *     to(UserEntity::createdBy, UserDto::createdBy),
+ *     to(UserEntity::updatedAt, UserDto::updatedAt),
+ *     to(UserEntity::updatedBy, UserDto::updatedBy)};
  *
  * private static final MapStep[] DEFAULTS = {
  *     nullSourceValues(DEFAULT),
@@ -31,11 +31,18 @@ import java.util.Objects;
  *     .add(constant(UserDto::tenant, "us-east"))
  *     .build();
  *
- * final Mapper<UserEntity, AdminUserDto> adminMapper = Telescope.mapperBuilder(UserEntity.class, AdminUserDto.class)
- *     .inherit(AUDIT_COLUMNS)                                 // same audit rules
- *     .add(constant(AdminUserDto::role, "ADMIN"))
+ * final Mapper<UserEntity, UserDto> projectionMapper = Telescope.mapperBuilder(UserEntity.class, UserDto.class)
+ *     .inherit(AUDIT_COLUMNS)                                 // same audit rules, second mapper
+ *     .add(constant(UserDto::tenant, "eu-west"))
  *     .build();
  * }</pre>
+ *
+ * <p><b>Row groups bind to their type pair.</b> Each {@code Mapping} row is keyed by its accessors'
+ * declaring classes, so a group declared against {@code (UserEntity, UserDto)} reuses across any
+ * number of mappers of that same pair (or of pairs whose recursion visits it). Inheriting it into a
+ * mapper of a different pair — say {@code (UserEntity, AdminUserDto)} — cannot apply, and {@code
+ * build()} fails fast with an error naming the unreachable pair and its rows; declare a per-variant
+ * group typed against the variant instead.
  *
  * <p><b>Equivalent to varargs spread, more declarative.</b> The builder is mechanically equivalent
  * to spreading a {@code MapStep[]} constant into {@link Telescope#mapper(Class, Class,

--- a/core/src/main/java/io/github/eschizoid/telescope/conversion/MapperBuilder.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/conversion/MapperBuilder.java
@@ -40,9 +40,10 @@ import java.util.Objects;
  * <p><b>Row groups bind to their type pair.</b> Each {@code Mapping} row is keyed by its accessors'
  * declaring classes, so a group declared against {@code (UserEntity, UserDto)} reuses across any
  * number of mappers of that same pair (or of pairs whose recursion visits it). Inheriting it into a
- * mapper of a different pair — say {@code (UserEntity, AdminUserDto)} — cannot apply, and {@code
- * build()} fails fast with an error naming the unreachable pair and its rows; declare a per-variant
- * group typed against the variant instead.
+ * mapper of a different pair — say {@code (UserEntity, AdminUserDto)} — cannot apply, and mapper
+ * construction fails fast (through {@code build()} here, or directly through {@link
+ * Telescope#mapper(Class, Class, MapStep...)}) with an error naming the unreachable pair and its
+ * rows; declare a per-variant group typed against the variant instead.
  *
  * <p><b>Equivalent to varargs spread, more declarative.</b> The builder is mechanically equivalent
  * to spreading a {@code MapStep[]} constant into {@link Telescope#mapper(Class, Class,

--- a/core/src/test/java/io/github/eschizoid/telescope/MapperBuilderTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/MapperBuilderTest.java
@@ -67,6 +67,42 @@ class MapperBuilderTest {
   }
 
   @Nested
+  @DisplayName("Cross-pair inherit fails fast — rows bound to a foreign type pair cannot be silently dropped")
+  class CrossPairInherit {
+
+    @Test
+    @DisplayName("inheriting a Dto-typed row group into an AdminDto mapper throws at build, naming both pairs")
+    void crossPairInheritThrowsAtBuild() {
+      // AUDIT_COLUMNS rows decode to the (Entity, Dto) pair; an (Entity, AdminDto) mapper never
+      // visits that pair, so the rows could only ever be silently ignored (same-name auto masks
+      // the loss). The builder must refuse instead.
+      // constant(role) satisfies the strict check, so pre-guard this mapper built cleanly and the
+      // inherited rows were dead — the exact silent loss the guard now surfaces.
+      final var builder = Telescope.mapperBuilder(Entity.class, AdminDto.class)
+        .inherit(AUDIT_COLUMNS)
+        .add(constant(AdminDto::role, "ADMIN"));
+      final var ex = assertThrows(IllegalArgumentException.class, builder::build);
+      assertTrue(ex.getMessage().contains("Entity -> AdminDto"), ex.getMessage());
+      assertTrue(ex.getMessage().contains("Entity -> Dto"), ex.getMessage());
+      assertTrue(ex.getMessage().contains("createdAt"), ex.getMessage());
+    }
+
+    @Test
+    @DisplayName("the same dead-row guard fires through the plain varargs factory, not just the builder")
+    void crossPairRowsThrowViaVarargsFactory() {
+      final var ex = assertThrows(IllegalArgumentException.class, () ->
+        Telescope.mapper(
+          Entity.class,
+          AdminDto.class,
+          to(Entity::createdAt, Dto::createdAt),
+          constant(AdminDto::role, "ADMIN")
+        )
+      );
+      assertTrue(ex.getMessage().contains("never visits"), ex.getMessage());
+    }
+  }
+
+  @Nested
   @DisplayName("Different mappers reusing the same shared group")
   class SharedAcrossMappers {
 

--- a/core/src/test/java/io/github/eschizoid/telescope/MapperBuilderTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/MapperBuilderTest.java
@@ -82,8 +82,9 @@ class MapperBuilderTest {
         .inherit(AUDIT_COLUMNS)
         .add(constant(AdminDto::role, "ADMIN"));
       final var ex = assertThrows(IllegalArgumentException.class, builder::build);
-      assertTrue(ex.getMessage().contains("Entity -> AdminDto"), ex.getMessage());
-      assertTrue(ex.getMessage().contains("Entity -> Dto"), ex.getMessage());
+      // Stable tokens only — the class names (fully qualified in the message) and one dead row.
+      assertTrue(ex.getMessage().contains("AdminDto"), ex.getMessage());
+      assertTrue(ex.getMessage().contains("never visits"), ex.getMessage());
       assertTrue(ex.getMessage().contains("createdAt"), ex.getMessage());
     }
 

--- a/docs/mapstruct-migration.md
+++ b/docs/mapstruct-migration.md
@@ -98,9 +98,9 @@ cheapest possible safety net, and you delete it together with the old interface.
   mapper often _surfaces_ fields MapStruct was silently nulling — that's the point, not a regression.
 - **Multiple source parameters** go through `Telescope.merge(...)` with a `Sources` bag — the source-class check happens
   at `forward(...)` time, not at the method signature (see the matrix row for details).
-- **Row-group reuse** (`MapperBuilder.inherit`) currently applies only across mappers of the **same** (source, target)
-  pair — a group inherited into a different pair is silently dropped
-  ([#223](https://github.com/eschizoid/telescope/issues/223)).
+- **Row-group reuse** (`MapperBuilder.inherit`) applies across mappers of the **same** (source, target) pair; a group
+  inherited into a different pair fails fast at `build()` with an error naming the unreachable pair
+  ([#223](https://github.com/eschizoid/telescope/issues/223)) — declare a per-variant group instead.
 - **Multi-constructor immutables** (MapStruct's `@Default`) aren't disambiguated — records and single-constructor
   classes are the supported shapes.
 - **Hot loops:** the runtime path is reflective (fast enough outside hot paths); annotate the pair with

--- a/docs/mapstruct-parity.md
+++ b/docs/mapstruct-parity.md
@@ -929,9 +929,10 @@ Entity back = mapper.backward(mapper.forward(entity));
 ```
 
 Row groups reuse cleanly across mappers of the SAME (source, target) pair, and the inverse half is free (backward()
-derives from the same rows). Verified limitation: a group inherited into a DIFFERENT type pair is silently dropped (rows
-are bucketed by their decoded type pair; never-visited buckets are ignored) — cross-DTO-variant reuse per
-MapperBuilder's javadoc example does not currently apply the shared rows. Tracked as a bug (#223).
+derives from the same rows). Remaining limitation: rows bind to their decoded type pair, so a group cannot be reused
+across DTO variants of different pairs — but a group inherited into a foreign pair now fails fast at build with an error
+naming the unreachable pair and its rows (#223), instead of being silently dropped. Declare a per-variant group typed
+against the variant.
 
 <sub>Evidence: core/src/main/java/io/github/eschizoid/telescope/conversion/MapperBuilder.java:10-14 (javadoc: "Closes
 MapStruct's @InheritConfiguration"), :106-109 (inherit), :150-152 (build delegates to Telescope.mapper);


### PR DESCRIPTION
Closes #223.

## What

`Mapping` rows are bucketed by their accessors' decoded (source, target) type pair; never-visited buckets were **silently ignored**. Following `MapperBuilder`'s own javadoc example — inheriting a row group declared against one DTO variant into a mapper for a different variant — built without error and quietly lost the renamed/transformed mappings, with same-name auto-mapping masking the hole.

## Fix

Resolution now validates row buckets exactly the way it already validates `writeBean` hints: after recursion, any bucket whose pair was never visited throws `IllegalArgumentException` naming the mapper's pair, the unreachable pair, and its rows:

```
Mapping rows bound to a type pair the mapper (Entity -> AdminDto) never visits — they would be
silently ignored: (Entity -> Dto): [createdAt -> createdAt, updatedAt -> updatedAt]. Bind the rows
to a type pair this mapper's recursion actually reaches, or remove them.
```

**`Drop` rows are exempt** — an unreachable drop is a harmless no-op (nested pairs are lenient already), and the one-arg form deliberately buckets a nested source class with the top target; the existing drop tests pin that contract and still pass.

## Also

- `MapperBuilder`'s javadoc example previously showed the broken cross-pair inherit as the headline scenario; it now shows same-pair reuse and documents the pair-binding rule.
- Parity matrix + migration guide updated from "silently dropped" to the fail-fast behavior.

## Test

Two new regression tests in `MapperBuilderTest` (builder path + plain varargs path, asserting both pairs and the row list appear in the message); full `./gradlew build` green across all modules — including the pinned `drop()` lenient-bucket contract.
