### PR TITLE
perf(runtime): MethodHandle-combinator leaf Iso for records — 57.95→12.22 ns (~4.7x), array+boxing eliminated

### DIFF
--- a/benchmarks/src/jmh/java/io/github/eschizoid/telescope/benchmarks/MethodHandleChainSpikeBenchmark.java
+++ b/benchmarks/src/jmh/java/io/github/eschizoid/telescope/benchmarks/MethodHandleChainSpikeBenchmark.java
@@ -35,8 +35,9 @@ import org.openjdk.jmh.infra.Blackhole;
  * </ul>
  *
  * <p>If {@code mhChain} lands near {@code handWritten} and well below {@code currentMapper}, the
- * lattice-legal structural win (a MH-combinator leaf {@code Iso}) is real. If {@code mhChain} tracks
- * {@code currentMapper}, the runtime floor is confirmed and hot loops belong on {@code @Bridge}.
+ * lattice-legal structural win (a MH-combinator leaf {@code Iso}) is real. If {@code mhChain}
+ * tracks {@code currentMapper}, the runtime floor is confirmed and hot loops belong on
+ * {@code @Bridge}.
  */
 @State(Scope.Benchmark)
 @BenchmarkMode(Mode.AverageTime)
@@ -60,8 +61,9 @@ public class MethodHandleChainSpikeBenchmark {
     final MethodHandles.Lookup lk = MethodHandles.lookup();
 
     // Raw, primitive-typed constructor handle: (int, long, String, double, boolean) -> Dst.
-    final MethodHandle ctor =
-      lk.unreflectConstructor(Dst.class.getDeclaredConstructor(int.class, long.class, String.class, double.class, boolean.class));
+    final MethodHandle ctor = lk.unreflectConstructor(
+      Dst.class.getDeclaredConstructor(int.class, long.class, String.class, double.class, boolean.class)
+    );
 
     // Raw, primitive-typed component accessors: each (Src) -> Ti.
     final MethodHandle a = lk.unreflect(Src.class.getMethod("a")); // (Src) -> int
@@ -81,14 +83,13 @@ public class MethodHandleChainSpikeBenchmark {
     // forward would pay (Iso.to -> captured forward.apply). A productionized MH-combinator leaf Iso
     // lands between mhChain (bare) and currentMapper.
     final MethodHandle h = mhChain;
-    mhFn =
-      s -> {
-        try {
-          return (Dst) h.invokeExact(s);
-        } catch (final Throwable t) {
-          throw new RuntimeException(t);
-        }
-      };
+    mhFn = s -> {
+      try {
+        return (Dst) h.invokeExact(s);
+      } catch (final Throwable t) {
+        throw new RuntimeException(t);
+      }
+    };
   }
 
   @Benchmark

--- a/benchmarks/src/jmh/java/io/github/eschizoid/telescope/benchmarks/MethodHandleChainSpikeBenchmark.java
+++ b/benchmarks/src/jmh/java/io/github/eschizoid/telescope/benchmarks/MethodHandleChainSpikeBenchmark.java
@@ -1,0 +1,113 @@
+package io.github.eschizoid.telescope.benchmarks;
+
+import io.github.eschizoid.telescope.Telescope;
+import io.github.eschizoid.telescope.conversion.Mapper;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.infra.Blackhole;
+
+/**
+ * SPIKE (not a permanent benchmark): does a MethodHandle-combinator-composed {@code (Src) -> Dst}
+ * forward — no {@code Object[]} intermediate, no boxing for primitive fields — beat the current
+ * array-based reflective {@code Telescope.mapper(...).forward(...)} path, and how close does it get
+ * to a hand-written constructor call (the MapStruct-equivalent unboxed ceiling)?
+ *
+ * <p>The fixture is a flat 5-field record pair with mixed primitives + a reference type, so boxing
+ * is actually exercised. Three paths convert the SAME {@code Src} to a {@code Dst}:
+ *
+ * <ul>
+ *   <li>{@code handWritten} — direct {@code new Dst(src.a(), ...)}; the unboxed ceiling.
+ *   <li>{@code mhChain} — {@code filterArguments}(raw primitive accessors into raw ctor) {@code ->
+ *       permuteArguments -> } one {@code (Src) -> Dst} handle, {@code invokeExact} through a {@code
+ *       final} field. No array, no boxing.
+ *   <li>{@code currentMapper} — {@code Telescope.mapper(...).forward(...)}; the {@code Object[]} +
+ *       boxing baseline.
+ * </ul>
+ *
+ * <p>If {@code mhChain} lands near {@code handWritten} and well below {@code currentMapper}, the
+ * lattice-legal structural win (a MH-combinator leaf {@code Iso}) is real. If {@code mhChain} tracks
+ * {@code currentMapper}, the runtime floor is confirmed and hot loops belong on {@code @Bridge}.
+ */
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+public class MethodHandleChainSpikeBenchmark {
+
+  public record Src(int a, long b, String c, double d, boolean e) {}
+
+  public record Dst(int a, long b, String c, double d, boolean e) {}
+
+  private Src src;
+  private Mapper<Src, Dst> currentMapper;
+  private MethodHandle mhChain; // (Src) -> Dst, fully composed, invokeExact through final field
+  private Function<Src, Dst> mhFn; // the same handle behind one SAM hop — production-representative
+
+  @Setup
+  public void setup() throws Throwable {
+    src = new Src(7, 42L, "telescope", 3.14, true);
+    currentMapper = Telescope.mapper(Src.class, Dst.class);
+
+    final MethodHandles.Lookup lk = MethodHandles.lookup();
+
+    // Raw, primitive-typed constructor handle: (int, long, String, double, boolean) -> Dst.
+    final MethodHandle ctor =
+      lk.unreflectConstructor(Dst.class.getDeclaredConstructor(int.class, long.class, String.class, double.class, boolean.class));
+
+    // Raw, primitive-typed component accessors: each (Src) -> Ti.
+    final MethodHandle a = lk.unreflect(Src.class.getMethod("a")); // (Src) -> int
+    final MethodHandle b = lk.unreflect(Src.class.getMethod("b")); // (Src) -> long
+    final MethodHandle c = lk.unreflect(Src.class.getMethod("c")); // (Src) -> String
+    final MethodHandle d = lk.unreflect(Src.class.getMethod("d")); // (Src) -> double
+    final MethodHandle e = lk.unreflect(Src.class.getMethod("e")); // (Src) -> boolean
+
+    // Feed each constructor argument through its accessor: (Src, Src, Src, Src, Src) -> Dst.
+    final MethodHandle filtered = MethodHandles.filterArguments(ctor, 0, a, b, c, d, e);
+
+    // Collapse the five Src slots to a single input: (Src) -> Dst. All primitive-typed end to end —
+    // no Object[], no boxing.
+    mhChain = MethodHandles.permuteArguments(filtered, MethodType.methodType(Dst.class, Src.class), 0, 0, 0, 0, 0);
+
+    // Same handle, but reached through one Function SAM hop — approximates what a real leaf Iso.of
+    // forward would pay (Iso.to -> captured forward.apply). A productionized MH-combinator leaf Iso
+    // lands between mhChain (bare) and currentMapper.
+    final MethodHandle h = mhChain;
+    mhFn =
+      s -> {
+        try {
+          return (Dst) h.invokeExact(s);
+        } catch (final Throwable t) {
+          throw new RuntimeException(t);
+        }
+      };
+  }
+
+  @Benchmark
+  public void handWritten(final Blackhole bh) {
+    bh.consume(new Dst(src.a(), src.b(), src.c(), src.d(), src.e()));
+  }
+
+  @Benchmark
+  public void mhChain(final Blackhole bh) throws Throwable {
+    bh.consume((Dst) mhChain.invokeExact(src));
+  }
+
+  @Benchmark
+  public void mhChainViaFunction(final Blackhole bh) {
+    bh.consume(mhFn.apply(src));
+  }
+
+  @Benchmark
+  public void currentMapper(final Blackhole bh) {
+    bh.consume(currentMapper.forward(src));
+  }
+}

--- a/core/src/main/java/io/github/eschizoid/telescope/DeepMap.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/DeepMap.java
@@ -3,6 +3,7 @@ package io.github.eschizoid.telescope;
 import io.github.eschizoid.telescope.conversion.ForwardMapper;
 import io.github.eschizoid.telescope.conversion.Mapper;
 import io.github.eschizoid.telescope.internal.Beans;
+import io.github.eschizoid.telescope.internal.MhIso;
 import io.github.eschizoid.telescope.internal.NullDefaults;
 import io.github.eschizoid.telescope.internal.Records;
 import io.github.eschizoid.telescope.internal.Reflective;
@@ -1596,11 +1597,30 @@ public final class DeepMap {
     // path (matches the prior dispatch-shape invariant: one branch outside the Iso, not N
     // branches inside).
     final var srcNames = srcRefl.names(source);
-    final var srcHolderReaders = Telescope.holderReadersFor(source, srcNames);
-    final var srcHolderConstructor = Telescope.holderConstructorFor(source);
     final var tgtNames = tgtRefl.names(target);
-    final var tgtHolderReaders = Telescope.holderReadersFor(target, tgtNames);
-    final var tgtHolderConstructor = Telescope.holderConstructorFor(target);
+    final var slotMaps = buildSlotMaps(byTargetName, bySourceName, srcNames, tgtNames);
+    final Iso<Object, Object> identity = Iso.identity();
+
+    // Composed-handle leaf for record↔record pairs: the whole conversion is one (S)→T / (T)→S
+    // MethodHandle — no Object[] intermediate, no boxing on same-type fields (identity slots read
+    // primitive-to-primitive straight into the canonical constructor). Non-identity slots (rename
+    // with conversion, nested pair, container lift) still route through their per-slot Iso. This is
+    // a build-time shape decision (see MhIso.supports), not a runtime fallback; it stays lattice-
+    // routed — the composed handles are the leaf Iso's transforms.
+    if (MhIso.supports(source, target)) {
+      return MhIso.recordPair(
+        source,
+        target,
+        slotMaps.fwdSrcPos(),
+        slotMaps.fwdIso(),
+        slotMaps.bwdTgtPos(),
+        slotMaps.bwdIso(),
+        identity
+      );
+    }
+
+    // Array leaf for bean-involving pairs: bean construction is setter/builder-based rather than a
+    // single canonical constructor, so its composed-handle assembly is a separate shape.
     // Fused-source-and-remap: bypass the source-side Object[] intermediate. The previous shape
     // ran S → Object[srcArity] (srcReader) → Object[tgtArity] (remap) → T (tgtBuilder) — two
     // intermediate arrays + three Iso.then virtual dispatches per call. The fused body inlines
@@ -1608,12 +1628,14 @@ public final class DeepMap {
     // value directly from srcReaders[fwdSrcPos[i]].apply(s) and apply the per-slot Iso. Saves one
     // alloc + 5 array writes + 5 array reads + 2 virtual Iso.then hops per call. Identity-Iso
     // short-circuit preserved against the cached singleton from Iso.identity().
+    final var srcHolderReaders = Telescope.holderReadersFor(source, srcNames);
+    final var srcHolderConstructor = Telescope.holderConstructorFor(source);
+    final var tgtHolderReaders = Telescope.holderReadersFor(target, tgtNames);
+    final var tgtHolderConstructor = Telescope.holderConstructorFor(target);
     final var srcReaders = srcRefl.positionalReaders(source, srcHolderReaders);
     final var tgtReaders = tgtRefl.positionalReaders(target, tgtHolderReaders);
     final var tgtBuilderFn = tgtRefl.positionalBuilder(target, tgtHolderReaders, tgtHolderConstructor);
     final var srcBuilderFn = srcRefl.positionalBuilder(source, srcHolderReaders, srcHolderConstructor);
-    final var slotMaps = buildSlotMaps(byTargetName, bySourceName, srcNames, tgtNames);
-    final Iso<Object, Object> identity = Iso.identity();
     return Iso.of(
       s -> {
         if (s == null) return null;

--- a/internal/src/main/java/io/github/eschizoid/telescope/internal/MhIso.java
+++ b/internal/src/main/java/io/github/eschizoid/telescope/internal/MhIso.java
@@ -13,11 +13,11 @@ import java.util.function.Function;
  * and boxes every primitive component (its readers are typed {@code Function<Object, Object>} and
  * its builder spreads an {@code Object[]}). This assembler instead composes the whole conversion
  * into a single {@code (S) -> T} handle: each constructor argument is produced by running the
- * source's raw, primitive-typed accessor handle, piped straight into the target's raw
- * constructor handle via {@link MethodHandles#filterArguments} + {@link
- * MethodHandles#permuteArguments}. On same-name/same-type ("identity") fields the value flows
- * primitive-to-primitive with no box and no array; only fields carrying a real per-field {@link Iso}
- * (rename with conversion, nested pair, container lift) route through that Iso, exactly as before.
+ * source's raw, primitive-typed accessor handle, piped straight into the target's raw constructor
+ * handle via {@link MethodHandles#filterArguments} + {@link MethodHandles#permuteArguments}. On
+ * same-name/same-type ("identity") fields the value flows primitive-to-primitive with no box and no
+ * array; only fields carrying a real per-field {@link Iso} (rename with conversion, nested pair,
+ * container lift) route through that Iso, exactly as before.
  *
  * <p><b>Lattice.</b> The result is an ordinary {@link Iso#of(Function, Function)} — the composed
  * handles <em>are</em> the leaf Iso's forward/backward transforms. Composition above this leaf
@@ -26,7 +26,9 @@ import java.util.function.Function;
  */
 public final class MhIso {
 
-  /** Constructor-parameter ceiling for {@code filterArguments}/{@code permuteArguments} composition. */
+  /**
+   * Constructor-parameter ceiling for {@code filterArguments}/{@code permuteArguments} composition.
+   */
   private static final int MAX_ARITY = 250;
 
   private MhIso() {}
@@ -37,10 +39,12 @@ public final class MhIso {
    * over the array leaf — a shape decision, not a runtime fallback.
    */
   public static boolean supports(final Class<?> source, final Class<?> target) {
-    return source.isRecord()
-      && target.isRecord()
-      && source.getRecordComponents().length <= MAX_ARITY
-      && target.getRecordComponents().length <= MAX_ARITY;
+    return (
+      source.isRecord() &&
+      target.isRecord() &&
+      source.getRecordComponents().length <= MAX_ARITY &&
+      target.getRecordComponents().length <= MAX_ARITY
+    );
   }
 
   // (Iso, Object) -> Object  ==  iso.to(v) / iso.from(v). Bound per non-identity field.
@@ -79,12 +83,26 @@ public final class MhIso {
     // Erase both directions to (Object) -> Object so the Function SAM call site can invokeExact
     // them — the boundary casts (Object -> record on entry, record -> Object on exit) are cheap
     // reference casts; the primitive fields inside stay unboxed.
-    final MethodHandle fwd =
-      compose(source, target, srcInfo.accessorHandles(), tgtInfo.ctorHandle(), fwdSrcPos, fwdIso, ISO_TO, identity)
-        .asType(MethodType.methodType(Object.class, Object.class));
-    final MethodHandle bwd =
-      compose(target, source, tgtInfo.accessorHandles(), srcInfo.ctorHandle(), bwdTgtPos, bwdIso, ISO_FROM, identity)
-        .asType(MethodType.methodType(Object.class, Object.class));
+    final MethodHandle fwd = compose(
+      source,
+      target,
+      srcInfo.accessorHandles(),
+      tgtInfo.ctorHandle(),
+      fwdSrcPos,
+      fwdIso,
+      ISO_TO,
+      identity
+    ).asType(MethodType.methodType(Object.class, Object.class));
+    final MethodHandle bwd = compose(
+      target,
+      source,
+      tgtInfo.accessorHandles(),
+      srcInfo.ctorHandle(),
+      bwdTgtPos,
+      bwdIso,
+      ISO_FROM,
+      identity
+    ).asType(MethodType.methodType(Object.class, Object.class));
 
     final Function<S, T> forward = s -> {
       if (s == null) return null;
@@ -132,30 +150,35 @@ public final class MhIso {
       final int sp = slotSrcPos[i];
       final boolean isIdentity = slotIso[i] == identity;
       if (isIdentity && sp >= 0) {
-        // Plain passthrough: raw accessor straight into the constructor slot, primitive-to-primitive,
+        // Plain passthrough: raw accessor straight into the constructor slot,
+        // primitive-to-primitive,
         // no box. This is the fast path the whole assembler exists for.
         filters[i] = srcAccessors[sp].asType(MethodType.methodType(pt, srcCls));
       } else if (isIdentity) {
         // Identity Iso but no source field: yield null. asType into a primitive slot unboxes null →
         // NPE at call time, identical to the array path's `ctorFn.apply(nullSlot)`.
-        filters[i] =
-          MethodHandles.dropArguments(MethodHandles.constant(Object.class, null), 0, srcCls)
-            .asType(MethodType.methodType(pt, srcCls));
+        filters[i] = MethodHandles.dropArguments(MethodHandles.constant(Object.class, null), 0, srcCls).asType(
+          MethodType.methodType(pt, srcCls)
+        );
       } else {
         // Non-identity Iso (rename-with-conversion, nested pair, container lift, constant, compute,
-        // when-gate): mirror the array path's `iso.to(v)`, where v is the read value or null when the
+        // when-gate): mirror the array path's `iso.to(v)`, where v is the read value or null when
+        // the
         // slot has no source. isoStep : (Object) -> Object.
         final MethodHandle isoStep = isoDir.bindTo(slotIso[i]);
         if (sp < 0) {
           // v == null: constant / compute / gated rows produce their value from a null input.
-          filters[i] =
-            MethodHandles.dropArguments(MethodHandles.insertArguments(isoStep, 0, (Object) null), 0, srcCls)
-              .asType(MethodType.methodType(pt, srcCls));
+          filters[i] = MethodHandles.dropArguments(
+            MethodHandles.insertArguments(isoStep, 0, (Object) null),
+            0,
+            srcCls
+          ).asType(MethodType.methodType(pt, srcCls));
         } else {
           final Class<?> readType = srcAccessors[sp].type().returnType();
-          filters[i] =
-            MethodHandles.filterReturnValue(srcAccessors[sp], isoStep.asType(MethodType.methodType(Object.class, readType)))
-              .asType(MethodType.methodType(pt, srcCls));
+          filters[i] = MethodHandles.filterReturnValue(
+            srcAccessors[sp],
+            isoStep.asType(MethodType.methodType(Object.class, readType))
+          ).asType(MethodType.methodType(pt, srcCls));
         }
       }
     }

--- a/internal/src/main/java/io/github/eschizoid/telescope/internal/MhIso.java
+++ b/internal/src/main/java/io/github/eschizoid/telescope/internal/MhIso.java
@@ -1,0 +1,171 @@
+package io.github.eschizoid.telescope.internal;
+
+import io.github.eschizoid.telescope.internal.optics.Iso;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.util.function.Function;
+
+/**
+ * MethodHandle-combinator assembly of a record&harr;record conversion {@link Iso}.
+ *
+ * <p>The array-based assembly in {@code DeepMap.assembleIso} allocates an {@code Object[]} per call
+ * and boxes every primitive component (its readers are typed {@code Function<Object, Object>} and
+ * its builder spreads an {@code Object[]}). This assembler instead composes the whole conversion
+ * into a single {@code (S) -> T} handle: each constructor argument is produced by running the
+ * source's raw, primitive-typed accessor handle, piped straight into the target's raw
+ * constructor handle via {@link MethodHandles#filterArguments} + {@link
+ * MethodHandles#permuteArguments}. On same-name/same-type ("identity") fields the value flows
+ * primitive-to-primitive with no box and no array; only fields carrying a real per-field {@link Iso}
+ * (rename with conversion, nested pair, container lift) route through that Iso, exactly as before.
+ *
+ * <p><b>Lattice.</b> The result is an ordinary {@link Iso#of(Function, Function)} — the composed
+ * handles <em>are</em> the leaf Iso's forward/backward transforms. Composition above this leaf
+ * (nested pairs, {@code liftList}/{@code liftMapValues}, {@code .then(...)}) is unchanged and still
+ * routes through the optic lattice. This sharpens the leaf; it does not bypass the lattice.
+ */
+public final class MhIso {
+
+  /** Constructor-parameter ceiling for {@code filterArguments}/{@code permuteArguments} composition. */
+  private static final int MAX_ARITY = 250;
+
+  private MhIso() {}
+
+  /**
+   * Whether {@code source} and {@code target} are both records within the arity this assembler can
+   * compose. {@code DeepMap} consults this once, at build time, to choose the composed-handle leaf
+   * over the array leaf — a shape decision, not a runtime fallback.
+   */
+  public static boolean supports(final Class<?> source, final Class<?> target) {
+    return source.isRecord()
+      && target.isRecord()
+      && source.getRecordComponents().length <= MAX_ARITY
+      && target.getRecordComponents().length <= MAX_ARITY;
+  }
+
+  // (Iso, Object) -> Object  ==  iso.to(v) / iso.from(v). Bound per non-identity field.
+  private static final MethodHandle ISO_TO;
+  private static final MethodHandle ISO_FROM;
+
+  static {
+    try {
+      final MethodHandles.Lookup lk = MethodHandles.lookup();
+      ISO_TO = lk.findVirtual(Iso.class, "to", MethodType.methodType(Object.class, Object.class));
+      ISO_FROM = lk.findVirtual(Iso.class, "from", MethodType.methodType(Object.class, Object.class));
+    } catch (final ReflectiveOperationException e) {
+      throw new ExceptionInInitializerError(e);
+    }
+  }
+
+  /**
+   * Build the record&harr;record conversion as an {@link Iso} whose forward/backward are single
+   * composed handles. The slot arrays are the same ones {@code DeepMap.buildSlotMaps} produces:
+   * {@code fwdSrcPos[i]} is the source position feeding target slot {@code i} ({@code -1} = no
+   * source), and {@code fwdIso[i]} is that slot's per-field Iso ({@code == identity} for a plain
+   * same-name/same-type passthrough). Backward is symmetric.
+   */
+  public static <S, T> Iso<S, T> recordPair(
+    final Class<S> source,
+    final Class<T> target,
+    final int[] fwdSrcPos,
+    final Iso<Object, Object>[] fwdIso,
+    final int[] bwdTgtPos,
+    final Iso<Object, Object>[] bwdIso,
+    final Iso<Object, Object> identity
+  ) {
+    final Records.RecordInfo srcInfo = Records.info(source);
+    final Records.RecordInfo tgtInfo = Records.info(target);
+
+    // Erase both directions to (Object) -> Object so the Function SAM call site can invokeExact
+    // them — the boundary casts (Object -> record on entry, record -> Object on exit) are cheap
+    // reference casts; the primitive fields inside stay unboxed.
+    final MethodHandle fwd =
+      compose(source, target, srcInfo.accessorHandles(), tgtInfo.ctorHandle(), fwdSrcPos, fwdIso, ISO_TO, identity)
+        .asType(MethodType.methodType(Object.class, Object.class));
+    final MethodHandle bwd =
+      compose(target, source, tgtInfo.accessorHandles(), srcInfo.ctorHandle(), bwdTgtPos, bwdIso, ISO_FROM, identity)
+        .asType(MethodType.methodType(Object.class, Object.class));
+
+    final Function<S, T> forward = s -> {
+      if (s == null) return null;
+      try {
+        @SuppressWarnings("unchecked")
+        final T out = (T) fwd.invokeExact((Object) s);
+        return out;
+      } catch (final Throwable e) {
+        throw rethrow(source, target, e);
+      }
+    };
+    final Function<T, S> backward = t -> {
+      if (t == null) return null;
+      try {
+        @SuppressWarnings("unchecked")
+        final S out = (S) bwd.invokeExact((Object) t);
+        return out;
+      } catch (final Throwable e) {
+        throw rethrow(target, source, e);
+      }
+    };
+    return Iso.of(forward, backward);
+  }
+
+  /**
+   * Compose {@code (srcCls) -> tgtCls}: for each target constructor parameter, a filter handle
+   * {@code (srcCls) -> paramType} produced from the source accessor (and the slot's per-field Iso
+   * when it is not the identity), then {@code filterArguments} into the constructor and {@code
+   * permuteArguments} to feed the single source instance to every filter.
+   */
+  private static MethodHandle compose(
+    final Class<?> srcCls,
+    final Class<?> tgtCls,
+    final MethodHandle[] srcAccessors,
+    final MethodHandle tgtCtor,
+    final int[] slotSrcPos,
+    final Iso<Object, Object>[] slotIso,
+    final MethodHandle isoDir,
+    final Iso<Object, Object> identity
+  ) {
+    final Class<?>[] paramTypes = tgtCtor.type().parameterArray();
+    final MethodHandle[] filters = new MethodHandle[paramTypes.length];
+    for (var i = 0; i < paramTypes.length; i++) {
+      final Class<?> pt = paramTypes[i];
+      final int sp = slotSrcPos[i];
+      final boolean isIdentity = slotIso[i] == identity;
+      if (isIdentity && sp >= 0) {
+        // Plain passthrough: raw accessor straight into the constructor slot, primitive-to-primitive,
+        // no box. This is the fast path the whole assembler exists for.
+        filters[i] = srcAccessors[sp].asType(MethodType.methodType(pt, srcCls));
+      } else if (isIdentity) {
+        // Identity Iso but no source field: yield null. asType into a primitive slot unboxes null →
+        // NPE at call time, identical to the array path's `ctorFn.apply(nullSlot)`.
+        filters[i] =
+          MethodHandles.dropArguments(MethodHandles.constant(Object.class, null), 0, srcCls)
+            .asType(MethodType.methodType(pt, srcCls));
+      } else {
+        // Non-identity Iso (rename-with-conversion, nested pair, container lift, constant, compute,
+        // when-gate): mirror the array path's `iso.to(v)`, where v is the read value or null when the
+        // slot has no source. isoStep : (Object) -> Object.
+        final MethodHandle isoStep = isoDir.bindTo(slotIso[i]);
+        if (sp < 0) {
+          // v == null: constant / compute / gated rows produce their value from a null input.
+          filters[i] =
+            MethodHandles.dropArguments(MethodHandles.insertArguments(isoStep, 0, (Object) null), 0, srcCls)
+              .asType(MethodType.methodType(pt, srcCls));
+        } else {
+          final Class<?> readType = srcAccessors[sp].type().returnType();
+          filters[i] =
+            MethodHandles.filterReturnValue(srcAccessors[sp], isoStep.asType(MethodType.methodType(Object.class, readType)))
+              .asType(MethodType.methodType(pt, srcCls));
+        }
+      }
+    }
+    final MethodHandle filtered = MethodHandles.filterArguments(tgtCtor, 0, filters);
+    final int[] toSingleInput = new int[paramTypes.length]; // all zeros: every filter reads slot 0
+    return MethodHandles.permuteArguments(filtered, MethodType.methodType(tgtCls, srcCls), toSingleInput);
+  }
+
+  private static RuntimeException rethrow(final Class<?> from, final Class<?> to, final Throwable e) {
+    if (e instanceof RuntimeException re) return re;
+    return new RuntimeException("Failed to convert " + from.getSimpleName() + " -> " + to.getSimpleName(), e);
+  }
+}

--- a/internal/src/main/java/io/github/eschizoid/telescope/internal/Records.java
+++ b/internal/src/main/java/io/github/eschizoid/telescope/internal/Records.java
@@ -288,7 +288,14 @@ public final class Records {
     RecordComponent[] components,
     Function<Object, Object>[] readers,
     Constructor<?> ctor,
-    Function<Object, Object> ctorFn
+    Function<Object, Object> ctorFn,
+    // Raw, primitive-typed handles for the MethodHandle-combinator assembly path (MhIso). Unlike
+    // `readers` / `ctorFn` — which are typed Function<Object, Object> and therefore box every
+    // primitive component — these keep the actual component/constructor signatures, so a composed
+    // (S) -> T handle stays unboxed end to end. `accessorHandles[i]` has type `(cls) -> compType[i]`;
+    // `ctorHandle` has type `(compType[0], ..., compType[n]) -> cls`.
+    MethodHandle[] accessorHandles,
+    MethodHandle ctorHandle
   ) {
     static RecordInfo of(final Class<?> cls) {
       if (!cls.isRecord()) throw new IllegalArgumentException("Not a record: " + cls.getName());
@@ -302,9 +309,49 @@ public final class Records {
         final var lookup = privateLookupIn(cls);
         final var readers = buildReaders(cls, comps, lookup);
         final var ctorFn = buildCtorFn(cls, ctor, lookup);
-        return new RecordInfo(comps, readers, ctor, ctorFn);
+        final var accessorHandles = buildAccessorHandles(cls, comps, lookup);
+        final var ctorHandle = buildCtorHandle(cls, ctor, lookup);
+        return new RecordInfo(comps, readers, ctor, ctorFn, accessorHandles, ctorHandle);
       } catch (final NoSuchMethodException e) {
         throw new IllegalStateException("Cannot find canonical constructor for " + cls.getName(), e);
+      }
+    }
+
+    /**
+     * Raw, primitive-typed component accessor handles — {@code (cls) -> componentType[i]}, no boxing.
+     * The {@link #readers} counterpart is forced to {@code Function<Object, Object>} (Function's only
+     * SAM) and boxes; these keep the component's real type so {@link MhIso} can compose them into an
+     * unboxed {@code (S) -> T} constructor call.
+     */
+    private static MethodHandle[] buildAccessorHandles(
+      final Class<?> cls,
+      final RecordComponent[] comps,
+      final MethodHandles.Lookup lookup
+    ) {
+      final var handles = new MethodHandle[comps.length];
+      for (var i = 0; i < comps.length; i++) {
+        try {
+          handles[i] = lookup.unreflect(comps[i].getAccessor());
+        } catch (final IllegalAccessException e) {
+          throw new IllegalStateException(
+            "Failed to build accessor handle for " + cls.getName() + "." + comps[i].getName(),
+            e
+          );
+        }
+      }
+      return handles;
+    }
+
+    /** Raw canonical-constructor handle {@code (compType[0], ..., compType[n]) -> cls}, unboxed. */
+    private static MethodHandle buildCtorHandle(
+      final Class<?> cls,
+      final Constructor<?> ctor,
+      final MethodHandles.Lookup lookup
+    ) {
+      try {
+        return lookup.unreflectConstructor(ctor);
+      } catch (final IllegalAccessException e) {
+        throw new IllegalStateException("Failed to build constructor handle for " + cls.getName(), e);
       }
     }
 

--- a/internal/src/main/java/io/github/eschizoid/telescope/internal/Records.java
+++ b/internal/src/main/java/io/github/eschizoid/telescope/internal/Records.java
@@ -292,7 +292,8 @@ public final class Records {
     // Raw, primitive-typed handles for the MethodHandle-combinator assembly path (MhIso). Unlike
     // `readers` / `ctorFn` — which are typed Function<Object, Object> and therefore box every
     // primitive component — these keep the actual component/constructor signatures, so a composed
-    // (S) -> T handle stays unboxed end to end. `accessorHandles[i]` has type `(cls) -> compType[i]`;
+    // (S) -> T handle stays unboxed end to end. `accessorHandles[i]` has type `(cls) ->
+    // compType[i]`;
     // `ctorHandle` has type `(compType[0], ..., compType[n]) -> cls`.
     MethodHandle[] accessorHandles,
     MethodHandle ctorHandle
@@ -318,10 +319,10 @@ public final class Records {
     }
 
     /**
-     * Raw, primitive-typed component accessor handles — {@code (cls) -> componentType[i]}, no boxing.
-     * The {@link #readers} counterpart is forced to {@code Function<Object, Object>} (Function's only
-     * SAM) and boxes; these keep the component's real type so {@link MhIso} can compose them into an
-     * unboxed {@code (S) -> T} constructor call.
+     * Raw, primitive-typed component accessor handles — {@code (cls) -> componentType[i]}, no
+     * boxing. The {@link #readers} counterpart is forced to {@code Function<Object, Object>}
+     * (Function's only SAM) and boxes; these keep the component's real type so {@link MhIso} can
+     * compose them into an unboxed {@code (S) -> T} constructor call.
      */
     private static MethodHandle[] buildAccessorHandles(
       final Class<?> cls,


### PR DESCRIPTION
## What

Replaces the `Object[]`-plus-boxing array assembly with a **single composed `(S)→T` MethodHandle** for record↔record conversions. Each constructor argument is produced by the source's raw primitive-typed accessor handle piped straight into the target's raw canonical-constructor handle via `filterArguments` + `permuteArguments`; on same-name/same-type ("identity") slots the value flows **primitive-to-primitive with no box and no array**. Non-identity slots (rename-with-conversion, nested pair, container lift, constant, compute, `when`-gate) route through their per-field `Iso` exactly as before — including `sp<0` slots where the value is `iso.to(null)`.

## Results (canonical CI, 3 forks + gc profiler)

| path | main (array) | this branch |
|---|---:|---:|
| `Telescope.mapper(rec,rec).forward` | 57.95 ns / **104 B/op** | **12.22 ns / 40 B/op** |
| hand-written ceiling (≈ MapStruct) | — | 3.49 ns / 40 B/op |

**~4.7× faster; allocation cut from 104 → 40 B/op** — the array and every primitive box eliminated, down to the irreducible result-object allocation (identical to a hand-written constructor call). The `gc.alloc.rate.norm` drop is the mechanism, not a timing artifact.

## Lattice

The result is an ordinary `Iso.of(forward, backward)` — the composed handles **are** the leaf Iso's transforms. Composition above the leaf (nested pairs, `liftList`/`liftMapValues`, `.then`) is unchanged and still lattice-routed. This sharpens the leaf; it does not bypass the lattice. `MhIso.supports` is a **build-time shape decision** (record pairs within the `filterArguments` arity ceiling), not a runtime fallback — the same records-vs-beans split `Reflective` has always had.

## Scope

- **In:** record↔record (both directions), all field shapes the suite exercises — scalar, rename, transform, nested, container, constant, compute, `when`-gate.
- **Next PR:** bean↔record / bean↔bean via a setter-fold MH assembler (beans construct via no-arg-ctor + setters, a different combinator shape). Won't hit the same ~4.7× — a stateful setter sequence can't be a single unboxed constructor handle — but kills the array there too.
- **Follow-on:** drop the redundant double-`Iso.of` wrap in `Mapper` (the ~5.6 ns between the 12.2 ns production path and the 6.6 ns bare MH core).

## Tests

Full `:core` / `:internal` / `:codegen` / `:lombok` / starters / examples suite green — **optic laws included**. The suite caught one real bug during development (`sp<0` constant/compute/`when` slots must apply `iso.to(null)`), now fixed.

No public API change.
