### PR TITLE
perf(runtime): MethodHandle-combinator path for bean↔record / bean↔bean (unboxed setter-fold)

### DIFF
--- a/core/src/main/java/io/github/eschizoid/telescope/DeepMap.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/DeepMap.java
@@ -1601,14 +1601,16 @@ public final class DeepMap {
     final var slotMaps = buildSlotMaps(byTargetName, bySourceName, srcNames, tgtNames);
     final Iso<Object, Object> identity = Iso.identity();
 
-    // Composed-handle leaf for record↔record pairs: the whole conversion is one (S)→T / (T)→S
+    // Composed-handle leaf for record/bean pairs: the whole conversion is one (S)→T / (T)→S
     // MethodHandle — no Object[] intermediate, no boxing on same-type fields (identity slots read
-    // primitive-to-primitive straight into the canonical constructor). Non-identity slots (rename
-    // with conversion, nested pair, container lift) still route through their per-slot Iso. This is
-    // a build-time shape decision (see MhIso.supports), not a runtime fallback; it stays lattice-
-    // routed — the composed handles are the leaf Iso's transforms.
+    // primitive-to-primitive straight into the canonical constructor, or into the setter fold for a
+    // bean target). Non-identity slots (rename with conversion, nested pair, container lift) still
+    // route through their per-slot Iso. Each side is a record (canonical-ctor rebuild) or a bean
+    // constructible via no-arg ctor + setters; a bean needing a builder or field injection falls to
+    // the array leaf below. This is a build-time shape decision (see MhIso.supports), not a runtime
+    // fallback; it stays lattice-routed — the composed handles are the leaf Iso's transforms.
     if (MhIso.supports(source, target)) {
-      return MhIso.recordPair(
+      return MhIso.pair(
         source,
         target,
         slotMaps.fwdSrcPos(),
@@ -1619,8 +1621,10 @@ public final class DeepMap {
       );
     }
 
-    // Array leaf for bean-involving pairs: bean construction is setter/builder-based rather than a
-    // single canonical constructor, so its composed-handle assembly is a separate shape.
+    // Array leaf for the pairs MhIso.supports declines — a bean side that needs a builder or
+    // field injection (no no-arg constructor, or a mapped property with no setter). Its
+    // construction can't be expressed as the no-arg-ctor + setter-fold combinator, so it stays on
+    // the reflective array shape.
     // Fused-source-and-remap: bypass the source-side Object[] intermediate. The previous shape
     // ran S → Object[srcArity] (srcReader) → Object[tgtArity] (remap) → T (tgtBuilder) — two
     // intermediate arrays + three Iso.then virtual dispatches per call. The fused body inlines

--- a/core/src/test/java/io/github/eschizoid/telescope/MhIsoDifferentialParityTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/MhIsoDifferentialParityTest.java
@@ -29,10 +29,11 @@ import org.junit.jupiter.api.Test;
  * the legacy {@code DeepMap.assembleIso} array leaf.
  *
  * <p>For each source/target shape and every sample instance, the same conversion is built and run
- * twice in a single JVM: once with {@code System.clearProperty(MhIso.DISABLE_PROPERTY)} (the MH leaf) and once with {@code
- * System.setProperty(MhIso.DISABLE_PROPERTY, "true")} (which makes {@code MhIso.supports} return {@code false}, so {@code
- * DeepMap.assembleIso} routes to the array leaf). The two results — forward, backward, patch, and
- * any thrown exception — must be byte-identical. Any divergence is a parity bug.
+ * twice in a single JVM: once with {@code System.clearProperty(MhIso.DISABLE_PROPERTY)} (the MH
+ * leaf) and once with {@code System.setProperty(MhIso.DISABLE_PROPERTY, "true")} (which makes
+ * {@code MhIso.supports} return {@code false}, so {@code DeepMap.assembleIso} routes to the array
+ * leaf). The two results — forward, backward, patch, and any thrown exception — must be
+ * byte-identical. Any divergence is a parity bug.
  */
 @DisplayName("MhIso ↔ array-leaf differential parity")
 final class MhIsoDifferentialParityTest {
@@ -331,10 +332,7 @@ final class MhIsoDifferentialParityTest {
     public boolean equals(final Object o) {
       if (!(o instanceof FluentBean f)) return false;
       return (
-        count == f.count &&
-        active == f.active &&
-        Objects.equals(label, f.label) &&
-        Objects.equals(ratio, f.ratio)
+        count == f.count && active == f.active && Objects.equals(label, f.label) && Objects.equals(ratio, f.ratio)
       );
     }
 
@@ -612,8 +610,8 @@ final class MhIsoDifferentialParityTest {
 
   /**
    * Forward-only variant for {@code mapperForward(...)} cases (constant / compute / when) where the
-   * result is a {@link io.github.eschizoid.telescope.conversion.ForwardMapper} with no backward. The
-   * {@code apply} closure builds the forward mapper under the CURRENT toggle and runs it, so
+   * result is a {@link io.github.eschizoid.telescope.conversion.ForwardMapper} with no backward.
+   * The {@code apply} closure builds the forward mapper under the CURRENT toggle and runs it, so
    * toggling {@code MhIso.DISABLE_PROPERTY} between the two calls selects the leaf.
    */
   private <A, B> void diffForward(final String shape, final Function<A, B> applyUnderToggle, final A sample) {
@@ -669,9 +667,7 @@ final class MhIsoDifferentialParityTest {
       return;
     }
     if (!Objects.equals(mh.value(), arr.value())) {
-      divergences.add(
-        label + ": MH=" + render(mh.value()) + " array=" + render(arr.value()) + " for input=" + input
-      );
+      divergences.add(label + ": MH=" + render(mh.value()) + " array=" + render(arr.value()) + " for input=" + input);
     }
   }
 
@@ -728,33 +724,36 @@ final class MhIsoDifferentialParityTest {
     assertEquals("n", leaf.getName());
 
     // record->bean primitives + wrappers land in the right slots
-    final var pb = Telescope
-      .mapper(FlatRec.class, FluentBean.class)
-      .forward(new FlatRec(42, "hi", true, 3.5));
+    final var pb = Telescope.mapper(FlatRec.class, FluentBean.class).forward(new FlatRec(42, "hi", true, 3.5));
     assertEquals(42, pb.getCount());
     assertEquals("hi", pb.getLabel());
     assertTrue(pb.isActive());
     assertEquals(3.5, pb.getRatio());
 
     // typed transform int->String at the leaf
-    final var yd = Telescope
-      .mapper(YearEntity.class, YearDto.class, to(YearEntity::year, YearDto::year, i -> Integer.toString(i), Integer::parseInt))
-      .forward(new YearEntity("a", 2024));
+    final var yd = Telescope.mapper(
+      YearEntity.class,
+      YearDto.class,
+      to(YearEntity::year, YearDto::year, i -> Integer.toString(i), Integer::parseInt)
+    ).forward(new YearEntity("a", 2024));
     assertEquals("2024", yd.year());
 
     // constant + compute forward-only
-    final var wide = Telescope
-      .mapperForward(SrcNarrow.class, TgtWide.class, constant(TgtWide::tenant, "prod"), compute(TgtWide::seq, () -> 42))
-      .forward(new SrcNarrow("neo"));
+    final var wide = Telescope.mapperForward(
+      SrcNarrow.class,
+      TgtWide.class,
+      constant(TgtWide::tenant, "prod"),
+      compute(TgtWide::seq, () -> 42)
+    ).forward(new SrcNarrow("neo"));
     assertEquals("neo", wide.name());
     assertEquals("prod", wide.tenant());
     assertEquals(42, wide.seq());
 
     // container recursion with rename inside the element is exercised by parity; here pin the
     // list element identity conversion produced a distinct-but-equal element type.
-    final var cont = Telescope
-      .mapper(ContRec.class, ContRec2.class)
-      .forward(new ContRec(List.of(new InnerRec("a", 1)), Set.of(), Map.of(), Optional.of(new InnerRec("o", 3))));
+    final var cont = Telescope.mapper(ContRec.class, ContRec2.class).forward(
+      new ContRec(List.of(new InnerRec("a", 1)), Set.of(), Map.of(), Optional.of(new InnerRec("o", 3)))
+    );
     assertEquals("a", cont.list().get(0).city());
     assertEquals(3, cont.opt().orElseThrow().zip());
   }
@@ -876,11 +875,18 @@ final class MhIsoDifferentialParityTest {
         Double.MAX_VALUE,
         "max"
       ),
-      // null wrappers into a bean (identity slots: array path also carries null through setters)
+      // null wrappers into a bean (identity slots: array path also carries null through
+      // setters)
       bean(3, 4L, (short) 5, (byte) 6, 'q', true, 3.14f, 2.71d, null, null, null, null, null, null, null, null, null)
     );
     for (final var s : samples) {
-      diff("PrimBean->PrimBean", PrimBean.class, PrimBean.class, () -> Telescope.mapper(PrimBean.class, PrimBean.class), s);
+      diff(
+        "PrimBean->PrimBean",
+        PrimBean.class,
+        PrimBean.class,
+        () -> Telescope.mapper(PrimBean.class, PrimBean.class),
+        s
+      );
     }
   }
 
@@ -892,7 +898,13 @@ final class MhIsoDifferentialParityTest {
       new FlatRec(-1, null, false, null) // null String + null Double wrapper
     );
     for (final var r : recs) {
-      diff("FlatRec->FluentBean", FlatRec.class, FluentBean.class, () -> Telescope.mapper(FlatRec.class, FluentBean.class), r);
+      diff(
+        "FlatRec->FluentBean",
+        FlatRec.class,
+        FluentBean.class,
+        () -> Telescope.mapper(FlatRec.class, FluentBean.class),
+        r
+      );
     }
     final List<FluentBean> beans = List.of(
       new FluentBean().setCount(0).setLabel("").setActive(false).setRatio(0.0),
@@ -900,7 +912,13 @@ final class MhIsoDifferentialParityTest {
       new FluentBean().setCount(-3).setLabel(null).setActive(true).setRatio(null)
     );
     for (final var b : beans) {
-      diff("FluentBean->FlatRec", FluentBean.class, FlatRec.class, () -> Telescope.mapper(FluentBean.class, FlatRec.class), b);
+      diff(
+        "FluentBean->FlatRec",
+        FluentBean.class,
+        FlatRec.class,
+        () -> Telescope.mapper(FluentBean.class, FlatRec.class),
+        b
+      );
     }
     // bean <-> bean (both sides fold setters); also stresses the fluent-setter fold
     for (final var b : beans) {
@@ -918,7 +936,13 @@ final class MhIsoDifferentialParityTest {
   private void fuzzInheritedAndFluentBeans() {
     final List<ChildRec> recs = List.of(new ChildRec(0L, ""), new ChildRec(99L, "abc"), new ChildRec(-5L, null));
     for (final var r : recs) {
-      diff("ChildRec->ChildBean", ChildRec.class, ChildBean.class, () -> Telescope.mapper(ChildRec.class, ChildBean.class), r);
+      diff(
+        "ChildRec->ChildBean",
+        ChildRec.class,
+        ChildBean.class,
+        () -> Telescope.mapper(ChildRec.class, ChildBean.class),
+        r
+      );
     }
     final List<ChildBean> beans = new ArrayList<>();
     for (final var r : recs) {
@@ -928,13 +952,29 @@ final class MhIsoDifferentialParityTest {
       beans.add(cb);
     }
     for (final var b : beans) {
-      diff("ChildBean->ChildRec", ChildBean.class, ChildRec.class, () -> Telescope.mapper(ChildBean.class, ChildRec.class), b);
+      diff(
+        "ChildBean->ChildRec",
+        ChildBean.class,
+        ChildRec.class,
+        () -> Telescope.mapper(ChildBean.class, ChildRec.class),
+        b
+      );
     }
 
     // Two-level inheritance (inherited setter AND inherited getter on the deepest bean).
-    final List<LeafRec> leafRecs = List.of(new LeafRec(0L, "", ""), new LeafRec(7L, "t", "n"), new LeafRec(-2L, null, null));
+    final List<LeafRec> leafRecs = List.of(
+      new LeafRec(0L, "", ""),
+      new LeafRec(7L, "t", "n"),
+      new LeafRec(-2L, null, null)
+    );
     for (final var r : leafRecs) {
-      diff("LeafRec->LeafBean", LeafRec.class, LeafBean.class, () -> Telescope.mapper(LeafRec.class, LeafBean.class), r);
+      diff(
+        "LeafRec->LeafBean",
+        LeafRec.class,
+        LeafBean.class,
+        () -> Telescope.mapper(LeafRec.class, LeafBean.class),
+        r
+      );
     }
     final List<LeafBean> leafBeans = new ArrayList<>();
     for (final var r : leafRecs) {
@@ -945,11 +985,23 @@ final class MhIsoDifferentialParityTest {
       leafBeans.add(lb);
     }
     for (final var b : leafBeans) {
-      diff("LeafBean->LeafRec", LeafBean.class, LeafRec.class, () -> Telescope.mapper(LeafBean.class, LeafRec.class), b);
+      diff(
+        "LeafBean->LeafRec",
+        LeafBean.class,
+        LeafRec.class,
+        () -> Telescope.mapper(LeafBean.class, LeafRec.class),
+        b
+      );
     }
     // bean->bean across the two-level hierarchy (both sides fold inherited setters)
     for (final var b : leafBeans) {
-      diff("LeafBean->LeafBean", LeafBean.class, LeafBean.class, () -> Telescope.mapper(LeafBean.class, LeafBean.class), b);
+      diff(
+        "LeafBean->LeafBean",
+        LeafBean.class,
+        LeafBean.class,
+        () -> Telescope.mapper(LeafBean.class, LeafBean.class),
+        b
+      );
     }
   }
 
@@ -961,7 +1013,13 @@ final class MhIsoDifferentialParityTest {
       new OuterRec("x", null) // null nested record
     );
     for (final var r : recs) {
-      diff("OuterRec->OuterRec2", OuterRec.class, OuterRec2.class, () -> Telescope.mapper(OuterRec.class, OuterRec2.class), r);
+      diff(
+        "OuterRec->OuterRec2",
+        OuterRec.class,
+        OuterRec2.class,
+        () -> Telescope.mapper(OuterRec.class, OuterRec2.class),
+        r
+      );
     }
     final List<OuterBean> beans = new ArrayList<>();
     for (final var spec : List.of(new String[] { "t", "NYC", "10001" }, new String[] { null, null, "0" })) {
@@ -979,7 +1037,13 @@ final class MhIsoDifferentialParityTest {
     nullInner.setInner(null);
     beans.add(nullInner);
     for (final var b : beans) {
-      diff("OuterBean->OuterBean", OuterBean.class, OuterBean.class, () -> Telescope.mapper(OuterBean.class, OuterBean.class), b);
+      diff(
+        "OuterBean->OuterBean",
+        OuterBean.class,
+        OuterBean.class,
+        () -> Telescope.mapper(OuterBean.class, OuterBean.class),
+        b
+      );
     }
   }
 
@@ -1010,7 +1074,13 @@ final class MhIsoDifferentialParityTest {
       new ContRec(null, null, null, null)
     );
     for (final var s : samples) {
-      diff("ContRec->ContRec2", ContRec.class, ContRec2.class, () -> Telescope.mapper(ContRec.class, ContRec2.class), s);
+      diff(
+        "ContRec->ContRec2",
+        ContRec.class,
+        ContRec2.class,
+        () -> Telescope.mapper(ContRec.class, ContRec2.class),
+        s
+      );
     }
 
     // scalar containers (no element recursion)
@@ -1035,9 +1105,19 @@ final class MhIsoDifferentialParityTest {
     final Function<Integer, String> fwd = i -> i == null ? null : Integer.toString(i);
     final Function<String, Integer> bwd = str -> str == null ? null : Integer.parseInt(str);
     final MapStep row = to(YearEntity::year, YearDto::year, fwd, bwd);
-    final List<YearEntity> samples = List.of(new YearEntity("a", 2024), new YearEntity(null, 0), new YearEntity("b", -7));
+    final List<YearEntity> samples = List.of(
+      new YearEntity("a", 2024),
+      new YearEntity(null, 0),
+      new YearEntity("b", -7)
+    );
     for (final var s : samples) {
-      diff("YearEntity->YearDto (typed transform)", YearEntity.class, YearDto.class, () -> Telescope.mapper(YearEntity.class, YearDto.class, row), s);
+      diff(
+        "YearEntity->YearDto (typed transform)",
+        YearEntity.class,
+        YearDto.class,
+        () -> Telescope.mapper(YearEntity.class, YearDto.class, row),
+        s
+      );
     }
 
     // Transform that returns null INTO a primitive record slot: both leaves should NPE-on-rebuild
@@ -1135,9 +1215,21 @@ final class MhIsoDifferentialParityTest {
   private void fuzzNullEdges() {
     diff("null PrimRec", PrimRec.class, PrimRec2.class, () -> Telescope.mapper(PrimRec.class, PrimRec2.class), null);
     diff("null PrimBean", PrimBean.class, PrimBean.class, () -> Telescope.mapper(PrimBean.class, PrimBean.class), null);
-    diff("null OuterRec", OuterRec.class, OuterRec2.class, () -> Telescope.mapper(OuterRec.class, OuterRec2.class), null);
+    diff(
+      "null OuterRec",
+      OuterRec.class,
+      OuterRec2.class,
+      () -> Telescope.mapper(OuterRec.class, OuterRec2.class),
+      null
+    );
     diff("null ContRec", ContRec.class, ContRec2.class, () -> Telescope.mapper(ContRec.class, ContRec2.class), null);
-    diff("null FluentBean", FluentBean.class, FlatRec.class, () -> Telescope.mapper(FluentBean.class, FlatRec.class), null);
+    diff(
+      "null FluentBean",
+      FluentBean.class,
+      FlatRec.class,
+      () -> Telescope.mapper(FluentBean.class, FlatRec.class),
+      null
+    );
   }
 
   // ---- helpers ----

--- a/core/src/test/java/io/github/eschizoid/telescope/MhIsoDifferentialParityTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/MhIsoDifferentialParityTest.java
@@ -1,0 +1,1183 @@
+package io.github.eschizoid.telescope;
+
+import static io.github.eschizoid.telescope.mapping.Mapping.compute;
+import static io.github.eschizoid.telescope.mapping.Mapping.constant;
+import static io.github.eschizoid.telescope.mapping.Mapping.to;
+import static io.github.eschizoid.telescope.mapping.Mapping.via;
+import static io.github.eschizoid.telescope.mapping.Mapping.when;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import io.github.eschizoid.telescope.conversion.Mapper;
+import io.github.eschizoid.telescope.internal.MhIso;
+import io.github.eschizoid.telescope.mapping.MapStep;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Differential parity harness for the {@link MhIso} MethodHandle-combinator conversion leaf against
+ * the legacy {@code DeepMap.assembleIso} array leaf.
+ *
+ * <p>For each source/target shape and every sample instance, the same conversion is built and run
+ * twice in a single JVM: once with {@code System.clearProperty(MhIso.DISABLE_PROPERTY)} (the MH leaf) and once with {@code
+ * System.setProperty(MhIso.DISABLE_PROPERTY, "true")} (which makes {@code MhIso.supports} return {@code false}, so {@code
+ * DeepMap.assembleIso} routes to the array leaf). The two results — forward, backward, patch, and
+ * any thrown exception — must be byte-identical. Any divergence is a parity bug.
+ */
+@DisplayName("MhIso ↔ array-leaf differential parity")
+final class MhIsoDifferentialParityTest {
+
+  private int comparisons = 0;
+  private final List<String> divergences = new ArrayList<>();
+
+  @AfterEach
+  void restoreToggle() {
+    System.clearProperty(MhIso.DISABLE_PROPERTY);
+  }
+
+  // ============================ fixtures ============================
+
+  // --- flat records with every primitive + wrapper ---
+  record PrimRec(
+    int i,
+    long l,
+    short s,
+    byte b,
+    char c,
+    boolean bool,
+    float f,
+    double d,
+    Integer wi,
+    Long wl,
+    Short ws,
+    Byte wb,
+    Character wc,
+    Boolean wbool,
+    Float wf,
+    Double wd,
+    String str
+  ) {}
+
+  // same shape, different type (record ↔ record identity conversion, all same-name/same-type)
+  record PrimRec2(
+    int i,
+    long l,
+    short s,
+    byte b,
+    char c,
+    boolean bool,
+    float f,
+    double d,
+    Integer wi,
+    Long wl,
+    Short ws,
+    Byte wb,
+    Character wc,
+    Boolean wbool,
+    Float wf,
+    Double wd,
+    String str
+  ) {}
+
+  // --- flat bean with every primitive + wrapper (no-arg ctor + setters) ---
+  static final class PrimBean {
+
+    private int i;
+    private long l;
+    private short s;
+    private byte b;
+    private char c;
+    private boolean bool;
+    private float f;
+    private double d;
+    private Integer wi;
+    private Long wl;
+    private Short ws;
+    private Byte wb;
+    private Character wc;
+    private Boolean wbool;
+    private Float wf;
+    private Double wd;
+    private String str;
+
+    public int getI() {
+      return i;
+    }
+
+    public void setI(final int v) {
+      this.i = v;
+    }
+
+    public long getL() {
+      return l;
+    }
+
+    public void setL(final long v) {
+      this.l = v;
+    }
+
+    public short getS() {
+      return s;
+    }
+
+    public void setS(final short v) {
+      this.s = v;
+    }
+
+    public byte getB() {
+      return b;
+    }
+
+    public void setB(final byte v) {
+      this.b = v;
+    }
+
+    public char getC() {
+      return c;
+    }
+
+    public void setC(final char v) {
+      this.c = v;
+    }
+
+    public boolean isBool() {
+      return bool;
+    }
+
+    public void setBool(final boolean v) {
+      this.bool = v;
+    }
+
+    public float getF() {
+      return f;
+    }
+
+    public void setF(final float v) {
+      this.f = v;
+    }
+
+    public double getD() {
+      return d;
+    }
+
+    public void setD(final double v) {
+      this.d = v;
+    }
+
+    public Integer getWi() {
+      return wi;
+    }
+
+    public void setWi(final Integer v) {
+      this.wi = v;
+    }
+
+    public Long getWl() {
+      return wl;
+    }
+
+    public void setWl(final Long v) {
+      this.wl = v;
+    }
+
+    public Short getWs() {
+      return ws;
+    }
+
+    public void setWs(final Short v) {
+      this.ws = v;
+    }
+
+    public Byte getWb() {
+      return wb;
+    }
+
+    public void setWb(final Byte v) {
+      this.wb = v;
+    }
+
+    public Character getWc() {
+      return wc;
+    }
+
+    public void setWc(final Character v) {
+      this.wc = v;
+    }
+
+    public Boolean getWbool() {
+      return wbool;
+    }
+
+    public void setWbool(final Boolean v) {
+      this.wbool = v;
+    }
+
+    public Float getWf() {
+      return wf;
+    }
+
+    public void setWf(final Float v) {
+      this.wf = v;
+    }
+
+    public Double getWd() {
+      return wd;
+    }
+
+    public void setWd(final Double v) {
+      this.wd = v;
+    }
+
+    public String getStr() {
+      return str;
+    }
+
+    public void setStr(final String v) {
+      this.str = v;
+    }
+
+    // value equality so forward/backward results compare structurally
+    @Override
+    public boolean equals(final Object o) {
+      if (!(o instanceof PrimBean p)) return false;
+      return (
+        i == p.i &&
+        l == p.l &&
+        s == p.s &&
+        b == p.b &&
+        c == p.c &&
+        bool == p.bool &&
+        Float.compare(f, p.f) == 0 &&
+        Double.compare(d, p.d) == 0 &&
+        Objects.equals(wi, p.wi) &&
+        Objects.equals(wl, p.wl) &&
+        Objects.equals(ws, p.ws) &&
+        Objects.equals(wb, p.wb) &&
+        Objects.equals(wc, p.wc) &&
+        Objects.equals(wbool, p.wbool) &&
+        Objects.equals(wf, p.wf) &&
+        Objects.equals(wd, p.wd) &&
+        Objects.equals(str, p.str)
+      );
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(i, l, s, b, c, bool, f, d, wi, wl, ws, wb, wc, wbool, wf, wd, str);
+    }
+
+    @Override
+    public String toString() {
+      return "PrimBean{i=" + i + ",wi=" + wi + ",str=" + str + ",f=" + f + ",bool=" + bool + "}";
+    }
+  }
+
+  // A second bean shape for bean↔bean, with a fluent (chaining) setter and a boolean isX/setX.
+  static final class FluentBean {
+
+    private int count;
+    private String label;
+    private boolean active;
+    private Double ratio;
+
+    public int getCount() {
+      return count;
+    }
+
+    // fluent/chaining setter returning this (Lombok @Accessors(chain=true) shape)
+    public FluentBean setCount(final int v) {
+      this.count = v;
+      return this;
+    }
+
+    public String getLabel() {
+      return label;
+    }
+
+    public FluentBean setLabel(final String v) {
+      this.label = v;
+      return this;
+    }
+
+    public boolean isActive() {
+      return active;
+    }
+
+    public FluentBean setActive(final boolean v) {
+      this.active = v;
+      return this;
+    }
+
+    public Double getRatio() {
+      return ratio;
+    }
+
+    public FluentBean setRatio(final Double v) {
+      this.ratio = v;
+      return this;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+      if (!(o instanceof FluentBean f)) return false;
+      return (
+        count == f.count &&
+        active == f.active &&
+        Objects.equals(label, f.label) &&
+        Objects.equals(ratio, f.ratio)
+      );
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(count, label, active, ratio);
+    }
+
+    @Override
+    public String toString() {
+      return "FluentBean{count=" + count + ",label=" + label + ",active=" + active + ",ratio=" + ratio + "}";
+    }
+  }
+
+  // Record matching FluentBean's properties for record↔bean cross-paradigm.
+  record FlatRec(int count, String label, boolean active, Double ratio) {}
+
+  // Bean with an inherited setter (setId lives on a superclass).
+  static class BaseBean {
+
+    private long id;
+
+    public long getId() {
+      return id;
+    }
+
+    public void setId(final long v) {
+      this.id = v;
+    }
+  }
+
+  static final class ChildBean extends BaseBean {
+
+    private String name;
+
+    public String getName() {
+      return name;
+    }
+
+    public void setName(final String v) {
+      this.name = v;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+      if (!(o instanceof ChildBean c)) return false;
+      return getId() == c.getId() && Objects.equals(name, c.name);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(getId(), name);
+    }
+
+    @Override
+    public String toString() {
+      return "ChildBean{id=" + getId() + ",name=" + name + "}";
+    }
+  }
+
+  record ChildRec(long id, String name) {}
+
+  // Two-level inheritance: grandparent setId/getId, parent setTag/getTag, leaf setName/getName.
+  static class GrandBean {
+
+    private long id;
+
+    public long getId() {
+      return id;
+    }
+
+    public void setId(final long v) {
+      this.id = v;
+    }
+  }
+
+  static class MidBean extends GrandBean {
+
+    private String tag;
+
+    public String getTag() {
+      return tag;
+    }
+
+    public void setTag(final String v) {
+      this.tag = v;
+    }
+  }
+
+  static final class LeafBean extends MidBean {
+
+    private String name;
+
+    public String getName() {
+      return name;
+    }
+
+    public void setName(final String v) {
+      this.name = v;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+      if (!(o instanceof LeafBean l)) return false;
+      return getId() == l.getId() && Objects.equals(getTag(), l.getTag()) && Objects.equals(name, l.name);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(getId(), getTag(), name);
+    }
+
+    @Override
+    public String toString() {
+      return "LeafBean{id=" + getId() + ",tag=" + getTag() + ",name=" + name + "}";
+    }
+  }
+
+  record LeafRec(long id, String tag, String name) {}
+
+  // --- nested records ---
+  record InnerRec(String city, int zip) {}
+
+  record OuterRec(String tag, InnerRec inner) {}
+
+  record InnerRec2(String city, int zip) {}
+
+  record OuterRec2(String tag, InnerRec2 inner) {}
+
+  // --- nested beans ---
+  static final class InnerBean {
+
+    private String city;
+    private int zip;
+
+    public String getCity() {
+      return city;
+    }
+
+    public void setCity(final String v) {
+      this.city = v;
+    }
+
+    public int getZip() {
+      return zip;
+    }
+
+    public void setZip(final int v) {
+      this.zip = v;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+      if (!(o instanceof InnerBean b)) return false;
+      return zip == b.zip && Objects.equals(city, b.city);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(city, zip);
+    }
+
+    @Override
+    public String toString() {
+      return "InnerBean{city=" + city + ",zip=" + zip + "}";
+    }
+  }
+
+  static final class OuterBean {
+
+    private String tag;
+    private InnerBean inner;
+
+    public String getTag() {
+      return tag;
+    }
+
+    public void setTag(final String v) {
+      this.tag = v;
+    }
+
+    public InnerBean getInner() {
+      return inner;
+    }
+
+    public void setInner(final InnerBean v) {
+      this.inner = v;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+      if (!(o instanceof OuterBean b)) return false;
+      return Objects.equals(tag, b.tag) && Objects.equals(inner, b.inner);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(tag, inner);
+    }
+
+    @Override
+    public String toString() {
+      return "OuterBean{tag=" + tag + ",inner=" + inner + "}";
+    }
+  }
+
+  // --- deep (3 levels) records ---
+  record L3(int v) {}
+
+  record L2(String name, L3 leaf) {}
+
+  record L1(String top, L2 mid) {}
+
+  record L3b(int v) {}
+
+  record L2b(String name, L3b leaf) {}
+
+  record L1b(String top, L2b mid) {}
+
+  // --- containers: List / Set / Map values / Optional of records ---
+  record ContRec(List<InnerRec> list, Set<InnerRec> set, Map<String, InnerRec> byKey, Optional<InnerRec> opt) {}
+
+  record ContRec2(List<InnerRec2> list, Set<InnerRec2> set, Map<String, InnerRec2> byKey, Optional<InnerRec2> opt) {}
+
+  // --- containers of scalars ---
+  record ScalarContRec(List<Integer> ints, Map<String, String> strs, Optional<Long> optLong) {}
+
+  record ScalarContRec2(List<Integer> ints, Map<String, String> strs, Optional<Long> optLong) {}
+
+  // --- rename with type conversion at the leaf ---
+  record YearEntity(String label, int year) {}
+
+  record YearDto(String label, String year) {}
+
+  // --- constant / compute target record (sp<0 slots) ---
+  record SrcNarrow(String name) {}
+
+  record TgtWide(String name, String tenant, int seq) {}
+
+  // ============================ the differential engine ============================
+
+  /**
+   * Build the mapper under the current toggle, then compare forward/backward (and patch when
+   * supported) of the MH leaf against the array leaf for one sample. Both directions of any thrown
+   * exception must match by type.
+   */
+  private <A, B> void diff(
+    final String shape,
+    final Class<A> src,
+    final Class<B> tgt,
+    final Supplier<Mapper<A, B>> build,
+    final A sample
+  ) {
+    // MH leaf
+    System.clearProperty(MhIso.DISABLE_PROPERTY);
+    final Outcome<B> mhFwd = capture(() -> build.get().forward(sample));
+    // Array leaf
+    System.setProperty(MhIso.DISABLE_PROPERTY, "true");
+    final Outcome<B> arrFwd = capture(() -> build.get().forward(sample));
+
+    comparisons++;
+    compareOutcome(shape + " forward", sample, mhFwd, arrFwd);
+
+    // Backward: only meaningful when both forward directions produced an equal, non-null value.
+    if (mhFwd.ok() && arrFwd.ok() && mhFwd.value() != null && Objects.equals(mhFwd.value(), arrFwd.value())) {
+      final B b = mhFwd.value();
+      System.clearProperty(MhIso.DISABLE_PROPERTY);
+      final Outcome<A> mhBwd = capture(() -> build.get().backward(b));
+      System.setProperty(MhIso.DISABLE_PROPERTY, "true");
+      final Outcome<A> arrBwd = capture(() -> build.get().backward(b));
+      comparisons++;
+      compareOutcome(shape + " backward", b, mhBwd, arrBwd);
+    }
+  }
+
+  /**
+   * Forward-only variant for {@code mapperForward(...)} cases (constant / compute / when) where the
+   * result is a {@link io.github.eschizoid.telescope.conversion.ForwardMapper} with no backward. The
+   * {@code apply} closure builds the forward mapper under the CURRENT toggle and runs it, so
+   * toggling {@code MhIso.DISABLE_PROPERTY} between the two calls selects the leaf.
+   */
+  private <A, B> void diffForward(final String shape, final Function<A, B> applyUnderToggle, final A sample) {
+    System.clearProperty(MhIso.DISABLE_PROPERTY);
+    final Outcome<B> mhFwd = capture(() -> applyUnderToggle.apply(sample));
+    System.setProperty(MhIso.DISABLE_PROPERTY, "true");
+    final Outcome<B> arrFwd = capture(() -> applyUnderToggle.apply(sample));
+    comparisons++;
+    compareOutcome(shape + " forward", sample, mhFwd, arrFwd);
+  }
+
+  private record Outcome<T>(boolean ok, T value, Class<?> exType) {}
+
+  private static <T> Outcome<T> capture(final Supplier<T> op) {
+    try {
+      return new Outcome<>(true, op.get(), null);
+    } catch (final Throwable t) {
+      Throwable cause = t;
+      // The MH leaf wraps checked throwables in RuntimeException("Failed to convert ...");
+      // the array leaf surfaces reflection failures differently. Compare the deepest cause type
+      // so a wrapper mismatch on the SAME underlying failure doesn't read as a divergence.
+      while (cause.getCause() != null && cause.getCause() != cause) cause = cause.getCause();
+      return new Outcome<>(false, null, cause.getClass());
+    }
+  }
+
+  private void compareOutcome(final String label, final Object input, final Outcome<?> mh, final Outcome<?> arr) {
+    if (mh.ok() != arr.ok()) {
+      divergences.add(
+        label +
+          ": MH " +
+          (mh.ok() ? "succeeded" : "threw " + mh.exType()) +
+          " but array " +
+          (arr.ok() ? "succeeded" : "threw " + arr.exType()) +
+          " for input=" +
+          input
+      );
+      return;
+    }
+    if (!mh.ok()) {
+      // both threw — require the same deepest cause type
+      if (!Objects.equals(mh.exType(), arr.exType())) {
+        divergences.add(
+          label +
+            ": both threw but different types — MH=" +
+            mh.exType() +
+            " array=" +
+            arr.exType() +
+            " for input=" +
+            input
+        );
+      }
+      return;
+    }
+    if (!Objects.equals(mh.value(), arr.value())) {
+      divergences.add(
+        label + ": MH=" + render(mh.value()) + " array=" + render(arr.value()) + " for input=" + input
+      );
+    }
+  }
+
+  private static String render(final Object o) {
+    if (o == null) return "null";
+    if (o instanceof PrimBean || o instanceof FluentBean) return o.toString();
+    return String.valueOf(o) + " (" + o.getClass().getSimpleName() + ")";
+  }
+
+  // ============================ the fuzz corpus ============================
+
+  @Test
+  @DisplayName("MH leaf is byte-identical to the array leaf across a wide shape/instance fuzz")
+  void differentialParity() {
+    fuzzFlatRecords();
+    fuzzFlatBeans();
+    fuzzCrossParadigm();
+    fuzzInheritedAndFluentBeans();
+    fuzzNested();
+    fuzzDeep();
+    fuzzContainers();
+    fuzzRenameWithConversion();
+    fuzzConstantComputeGated();
+    fuzzViaNestedMapper();
+    fuzzNullEdges();
+
+    // Anchor a handful of absolute-correctness checks under the MH leaf so a "both leaves wrong
+    // the same way" scenario can't pass as parity. These pin the ACTUAL converted values.
+    assertCorrectness();
+
+    if (!divergences.isEmpty()) {
+      fail(
+        "DIFFERENTIAL PARITY FAILURES (" +
+          divergences.size() +
+          " of " +
+          comparisons +
+          " comparisons):\n" +
+          String.join("\n", divergences)
+      );
+    }
+    // Guardrail: the harness actually exercised a substantial corpus.
+    assertTrue(comparisons > 90, "expected >90 comparisons, ran " + comparisons);
+    System.out.println("[MhIso parity] CLEAN — " + comparisons + " comparisons byte-identical");
+  }
+
+  // ---- absolute-value anchors (MH leaf), so "both leaves wrong identically" can't pass ----
+  private void assertCorrectness() {
+    System.clearProperty(MhIso.DISABLE_PROPERTY);
+
+    // inherited two-level bean: id/tag/name all populated through inherited setters
+    final var leaf = Telescope.mapper(LeafRec.class, LeafBean.class).forward(new LeafRec(7L, "t", "n"));
+    assertEquals(7L, leaf.getId());
+    assertEquals("t", leaf.getTag());
+    assertEquals("n", leaf.getName());
+
+    // record->bean primitives + wrappers land in the right slots
+    final var pb = Telescope
+      .mapper(FlatRec.class, FluentBean.class)
+      .forward(new FlatRec(42, "hi", true, 3.5));
+    assertEquals(42, pb.getCount());
+    assertEquals("hi", pb.getLabel());
+    assertTrue(pb.isActive());
+    assertEquals(3.5, pb.getRatio());
+
+    // typed transform int->String at the leaf
+    final var yd = Telescope
+      .mapper(YearEntity.class, YearDto.class, to(YearEntity::year, YearDto::year, i -> Integer.toString(i), Integer::parseInt))
+      .forward(new YearEntity("a", 2024));
+    assertEquals("2024", yd.year());
+
+    // constant + compute forward-only
+    final var wide = Telescope
+      .mapperForward(SrcNarrow.class, TgtWide.class, constant(TgtWide::tenant, "prod"), compute(TgtWide::seq, () -> 42))
+      .forward(new SrcNarrow("neo"));
+    assertEquals("neo", wide.name());
+    assertEquals("prod", wide.tenant());
+    assertEquals(42, wide.seq());
+
+    // container recursion with rename inside the element is exercised by parity; here pin the
+    // list element identity conversion produced a distinct-but-equal element type.
+    final var cont = Telescope
+      .mapper(ContRec.class, ContRec2.class)
+      .forward(new ContRec(List.of(new InnerRec("a", 1)), Set.of(), Map.of(), Optional.of(new InnerRec("o", 3))));
+    assertEquals("a", cont.list().get(0).city());
+    assertEquals(3, cont.opt().orElseThrow().zip());
+  }
+
+  // ---- flat records: every primitive + wrapper, null wrappers, min/max/0 ----
+  private void fuzzFlatRecords() {
+    final List<PrimRec> samples = List.of(
+      new PrimRec(0, 0L, (short) 0, (byte) 0, '\0', false, 0f, 0d, 0, 0L, (short) 0, (byte) 0, 'a', false, 0f, 0d, ""),
+      new PrimRec(
+        Integer.MAX_VALUE,
+        Long.MAX_VALUE,
+        Short.MAX_VALUE,
+        Byte.MAX_VALUE,
+        Character.MAX_VALUE,
+        true,
+        Float.MAX_VALUE,
+        Double.MAX_VALUE,
+        Integer.MAX_VALUE,
+        Long.MAX_VALUE,
+        Short.MAX_VALUE,
+        Byte.MAX_VALUE,
+        Character.MAX_VALUE,
+        true,
+        Float.MAX_VALUE,
+        Double.MAX_VALUE,
+        "max"
+      ),
+      new PrimRec(
+        Integer.MIN_VALUE,
+        Long.MIN_VALUE,
+        Short.MIN_VALUE,
+        Byte.MIN_VALUE,
+        Character.MIN_VALUE,
+        false,
+        Float.MIN_VALUE,
+        Double.MIN_VALUE,
+        Integer.MIN_VALUE,
+        Long.MIN_VALUE,
+        Short.MIN_VALUE,
+        Byte.MIN_VALUE,
+        Character.MIN_VALUE,
+        false,
+        -0.0f,
+        -0.0d,
+        "min"
+      ),
+      // all wrapper fields null
+      new PrimRec(
+        7,
+        8L,
+        (short) 9,
+        (byte) 10,
+        'z',
+        true,
+        1.5f,
+        2.5d,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null
+      ),
+      // NaN / infinities in the floating wrappers and primitives
+      new PrimRec(
+        1,
+        1L,
+        (short) 1,
+        (byte) 1,
+        'x',
+        true,
+        Float.NaN,
+        Double.POSITIVE_INFINITY,
+        1,
+        1L,
+        (short) 1,
+        (byte) 1,
+        'x',
+        true,
+        Float.NEGATIVE_INFINITY,
+        Double.NaN,
+        "nan"
+      )
+    );
+    for (final var s : samples) {
+      diff(
+        "PrimRec->PrimRec2",
+        PrimRec.class,
+        PrimRec2.class,
+        () -> Telescope.mapper(PrimRec.class, PrimRec2.class),
+        s
+      );
+    }
+  }
+
+  // ---- flat beans: same primitive matrix, plus null-wrapper edges ----
+  private void fuzzFlatBeans() {
+    final List<PrimBean> samples = List.of(
+      bean(0, 0L, (short) 0, (byte) 0, '\0', false, 0f, 0d, 0, 0L, (short) 0, (byte) 0, 'a', false, 0f, 0d, ""),
+      bean(
+        Integer.MAX_VALUE,
+        Long.MAX_VALUE,
+        Short.MAX_VALUE,
+        Byte.MAX_VALUE,
+        Character.MAX_VALUE,
+        true,
+        Float.MAX_VALUE,
+        Double.MAX_VALUE,
+        Integer.MAX_VALUE,
+        Long.MAX_VALUE,
+        Short.MAX_VALUE,
+        Byte.MAX_VALUE,
+        Character.MAX_VALUE,
+        true,
+        Float.MAX_VALUE,
+        Double.MAX_VALUE,
+        "max"
+      ),
+      // null wrappers into a bean (identity slots: array path also carries null through setters)
+      bean(3, 4L, (short) 5, (byte) 6, 'q', true, 3.14f, 2.71d, null, null, null, null, null, null, null, null, null)
+    );
+    for (final var s : samples) {
+      diff("PrimBean->PrimBean", PrimBean.class, PrimBean.class, () -> Telescope.mapper(PrimBean.class, PrimBean.class), s);
+    }
+  }
+
+  // ---- cross-paradigm: record<->bean, bean<->record ----
+  private void fuzzCrossParadigm() {
+    final List<FlatRec> recs = List.of(
+      new FlatRec(0, "", false, 0.0),
+      new FlatRec(42, "hi", true, 3.5),
+      new FlatRec(-1, null, false, null) // null String + null Double wrapper
+    );
+    for (final var r : recs) {
+      diff("FlatRec->FluentBean", FlatRec.class, FluentBean.class, () -> Telescope.mapper(FlatRec.class, FluentBean.class), r);
+    }
+    final List<FluentBean> beans = List.of(
+      new FluentBean().setCount(0).setLabel("").setActive(false).setRatio(0.0),
+      new FluentBean().setCount(9).setLabel("x").setActive(true).setRatio(1.25),
+      new FluentBean().setCount(-3).setLabel(null).setActive(true).setRatio(null)
+    );
+    for (final var b : beans) {
+      diff("FluentBean->FlatRec", FluentBean.class, FlatRec.class, () -> Telescope.mapper(FluentBean.class, FlatRec.class), b);
+    }
+    // bean <-> bean (both sides fold setters); also stresses the fluent-setter fold
+    for (final var b : beans) {
+      diff(
+        "FluentBean->FluentBean",
+        FluentBean.class,
+        FluentBean.class,
+        () -> Telescope.mapper(FluentBean.class, FluentBean.class),
+        b
+      );
+    }
+  }
+
+  // ---- inherited setter bean + record cross-paradigm ----
+  private void fuzzInheritedAndFluentBeans() {
+    final List<ChildRec> recs = List.of(new ChildRec(0L, ""), new ChildRec(99L, "abc"), new ChildRec(-5L, null));
+    for (final var r : recs) {
+      diff("ChildRec->ChildBean", ChildRec.class, ChildBean.class, () -> Telescope.mapper(ChildRec.class, ChildBean.class), r);
+    }
+    final List<ChildBean> beans = new ArrayList<>();
+    for (final var r : recs) {
+      final var cb = new ChildBean();
+      cb.setId(r.id());
+      cb.setName(r.name());
+      beans.add(cb);
+    }
+    for (final var b : beans) {
+      diff("ChildBean->ChildRec", ChildBean.class, ChildRec.class, () -> Telescope.mapper(ChildBean.class, ChildRec.class), b);
+    }
+
+    // Two-level inheritance (inherited setter AND inherited getter on the deepest bean).
+    final List<LeafRec> leafRecs = List.of(new LeafRec(0L, "", ""), new LeafRec(7L, "t", "n"), new LeafRec(-2L, null, null));
+    for (final var r : leafRecs) {
+      diff("LeafRec->LeafBean", LeafRec.class, LeafBean.class, () -> Telescope.mapper(LeafRec.class, LeafBean.class), r);
+    }
+    final List<LeafBean> leafBeans = new ArrayList<>();
+    for (final var r : leafRecs) {
+      final var lb = new LeafBean();
+      lb.setId(r.id());
+      lb.setTag(r.tag());
+      lb.setName(r.name());
+      leafBeans.add(lb);
+    }
+    for (final var b : leafBeans) {
+      diff("LeafBean->LeafRec", LeafBean.class, LeafRec.class, () -> Telescope.mapper(LeafBean.class, LeafRec.class), b);
+    }
+    // bean->bean across the two-level hierarchy (both sides fold inherited setters)
+    for (final var b : leafBeans) {
+      diff("LeafBean->LeafBean", LeafBean.class, LeafBean.class, () -> Telescope.mapper(LeafBean.class, LeafBean.class), b);
+    }
+  }
+
+  // ---- nested record-in-record, bean-in-bean ----
+  private void fuzzNested() {
+    final List<OuterRec> recs = List.of(
+      new OuterRec("t", new InnerRec("NYC", 10001)),
+      new OuterRec(null, new InnerRec(null, 0)),
+      new OuterRec("x", null) // null nested record
+    );
+    for (final var r : recs) {
+      diff("OuterRec->OuterRec2", OuterRec.class, OuterRec2.class, () -> Telescope.mapper(OuterRec.class, OuterRec2.class), r);
+    }
+    final List<OuterBean> beans = new ArrayList<>();
+    for (final var spec : List.of(new String[] { "t", "NYC", "10001" }, new String[] { null, null, "0" })) {
+      final var ob = new OuterBean();
+      ob.setTag(spec[0]);
+      final var ib = new InnerBean();
+      ib.setCity(spec[1]);
+      ib.setZip(Integer.parseInt(spec[2]));
+      ob.setInner(ib);
+      beans.add(ob);
+    }
+    // bean with null nested bean
+    final var nullInner = new OuterBean();
+    nullInner.setTag("solo");
+    nullInner.setInner(null);
+    beans.add(nullInner);
+    for (final var b : beans) {
+      diff("OuterBean->OuterBean", OuterBean.class, OuterBean.class, () -> Telescope.mapper(OuterBean.class, OuterBean.class), b);
+    }
+  }
+
+  // ---- deep 3-level records ----
+  private void fuzzDeep() {
+    final List<L1> samples = List.of(
+      new L1("root", new L2("mid", new L3(7))),
+      new L1(null, new L2(null, new L3(0))),
+      new L1("r", new L2("m", null)) // null at the deepest boundary
+    );
+    for (final var s : samples) {
+      diff("L1->L1b", L1.class, L1b.class, () -> Telescope.mapper(L1.class, L1b.class), s);
+    }
+  }
+
+  // ---- containers: List/Set/Map values/Optional of records, empty + null + multi ----
+  private void fuzzContainers() {
+    final List<ContRec> samples = List.of(
+      new ContRec(
+        List.of(new InnerRec("a", 1), new InnerRec("b", 2)),
+        Set.of(new InnerRec("s", 9)),
+        Map.of("k1", new InnerRec("m1", 11), "k2", new InnerRec("m2", 12)),
+        Optional.of(new InnerRec("o", 3))
+      ),
+      // empty containers + empty optional
+      new ContRec(List.of(), Set.of(), Map.of(), Optional.empty()),
+      // null containers + null optional-holder
+      new ContRec(null, null, null, null)
+    );
+    for (final var s : samples) {
+      diff("ContRec->ContRec2", ContRec.class, ContRec2.class, () -> Telescope.mapper(ContRec.class, ContRec2.class), s);
+    }
+
+    // scalar containers (no element recursion)
+    final List<ScalarContRec> scalars = List.of(
+      new ScalarContRec(List.of(1, 2, 3), Map.of("a", "x", "b", "y"), Optional.of(5L)),
+      new ScalarContRec(List.of(), Map.of(), Optional.empty()),
+      new ScalarContRec(null, null, null)
+    );
+    for (final var s : scalars) {
+      diff(
+        "ScalarContRec->ScalarContRec2",
+        ScalarContRec.class,
+        ScalarContRec2.class,
+        () -> Telescope.mapper(ScalarContRec.class, ScalarContRec2.class),
+        s
+      );
+    }
+  }
+
+  // ---- rename with type conversion (int<->String), including transform returning null ----
+  private void fuzzRenameWithConversion() {
+    final Function<Integer, String> fwd = i -> i == null ? null : Integer.toString(i);
+    final Function<String, Integer> bwd = str -> str == null ? null : Integer.parseInt(str);
+    final MapStep row = to(YearEntity::year, YearDto::year, fwd, bwd);
+    final List<YearEntity> samples = List.of(new YearEntity("a", 2024), new YearEntity(null, 0), new YearEntity("b", -7));
+    for (final var s : samples) {
+      diff("YearEntity->YearDto (typed transform)", YearEntity.class, YearDto.class, () -> Telescope.mapper(YearEntity.class, YearDto.class, row), s);
+    }
+
+    // Transform that returns null INTO a primitive record slot: both leaves should NPE-on-rebuild
+    // identically (record canonical ctor cannot take null for an int). Target record has a
+    // primitive int fed by a null-returning transform.
+    final MapStep nullIntoPrimRecordRow = to(
+      YearDto::year,
+      YearEntity::year,
+      (String str) -> (Integer) null,
+      (Integer i) -> i == null ? null : i.toString()
+    );
+    final List<YearDto> dtoSamples = List.of(new YearDto("a", "2024"));
+    for (final var s : dtoSamples) {
+      diff(
+        "YearDto->YearEntity (null into primitive record slot)",
+        YearDto.class,
+        YearEntity.class,
+        () -> Telescope.mapper(YearDto.class, YearEntity.class, nullIntoPrimRecordRow),
+        s
+      );
+    }
+
+    // Transform returning null INTO a primitive BEAN slot: SettersWriter skips → JLS default; the
+    // MH fold null-guards → same JLS default. Target bean FluentBean.count is int.
+    final MapStep nullIntoPrimBeanRow = to(
+      FlatRec::label,
+      FluentBean::getCount,
+      (String str) -> (Integer) null,
+      (Integer i) -> i == null ? null : i.toString()
+    );
+    final List<FlatRec> recSamples = List.of(new FlatRec(1, "ignored", true, 1.0));
+    for (final var s : recSamples) {
+      diff(
+        "FlatRec->FluentBean (null into primitive bean slot)",
+        FlatRec.class,
+        FluentBean.class,
+        () -> Telescope.mapper(FlatRec.class, FluentBean.class, nullIntoPrimBeanRow),
+        s
+      );
+    }
+  }
+
+  // ---- constant / compute / when-gated rows (sp<0 slots) ----
+  private void fuzzConstantComputeGated() {
+    final List<SrcNarrow> samples = List.of(new SrcNarrow("neo"), new SrcNarrow(null));
+
+    // constant into a reference slot + compute into a primitive int slot (sp<0 slots on target)
+    final MapStep constRow = constant(TgtWide::tenant, "prod");
+    final MapStep computeRow = compute(TgtWide::seq, () -> 42);
+    for (final var s : samples) {
+      diffForward(
+        "SrcNarrow->TgtWide (constant + compute)",
+        src -> Telescope.mapperForward(SrcNarrow.class, TgtWide.class, constRow, computeRow).forward(src),
+        s
+      );
+    }
+
+    // when-gated row: predicate on the source decides whether the inner mapping fires. seq stays a
+    // constant so the primitive int slot is fed. when(...) only wraps telescope-based rows, so the
+    // inner correspondence is a source-Telescope → target-accessor row.
+    final MapStep gated = when(
+      (SrcNarrow src) -> src != null && src.name() != null,
+      to(Telescope.of(SrcNarrow.class).field(SrcNarrow::name), TgtWide::tenant)
+    );
+    final MapStep seqConst = constant(TgtWide::seq, 0);
+    for (final var s : samples) {
+      diffForward(
+        "SrcNarrow->TgtWide (when-gated)",
+        src -> Telescope.mapperForward(SrcNarrow.class, TgtWide.class, gated, seqConst).forward(src),
+        s
+      );
+    }
+  }
+
+  // ---- via nested Mapper on a container of records ----
+  private void fuzzViaNestedMapper() {
+    final Mapper<InnerRec, InnerRec2> elem = Telescope.mapper(InnerRec.class, InnerRec2.class);
+    final MapStep viaRow = via(ContRec::list, ContRec2::list, elem);
+    final List<ContRec> samples = List.of(
+      new ContRec(List.of(new InnerRec("a", 1)), Set.of(), Map.of(), Optional.empty()),
+      new ContRec(List.of(), Set.of(), Map.of(), Optional.empty())
+    );
+    for (final var s : samples) {
+      diff(
+        "ContRec->ContRec2 (via nested list mapper)",
+        ContRec.class,
+        ContRec2.class,
+        () -> Telescope.mapper(ContRec.class, ContRec2.class, viaRow),
+        s
+      );
+    }
+  }
+
+  // ---- null source; null everything ----
+  private void fuzzNullEdges() {
+    diff("null PrimRec", PrimRec.class, PrimRec2.class, () -> Telescope.mapper(PrimRec.class, PrimRec2.class), null);
+    diff("null PrimBean", PrimBean.class, PrimBean.class, () -> Telescope.mapper(PrimBean.class, PrimBean.class), null);
+    diff("null OuterRec", OuterRec.class, OuterRec2.class, () -> Telescope.mapper(OuterRec.class, OuterRec2.class), null);
+    diff("null ContRec", ContRec.class, ContRec2.class, () -> Telescope.mapper(ContRec.class, ContRec2.class), null);
+    diff("null FluentBean", FluentBean.class, FlatRec.class, () -> Telescope.mapper(FluentBean.class, FlatRec.class), null);
+  }
+
+  // ---- helpers ----
+  private static PrimBean bean(
+    final int i,
+    final long l,
+    final short s,
+    final byte b,
+    final char c,
+    final boolean bool,
+    final float f,
+    final double d,
+    final Integer wi,
+    final Long wl,
+    final Short ws,
+    final Byte wb,
+    final Character wc,
+    final Boolean wbool,
+    final Float wf,
+    final Double wd,
+    final String str
+  ) {
+    final var p = new PrimBean();
+    p.setI(i);
+    p.setL(l);
+    p.setS(s);
+    p.setB(b);
+    p.setC(c);
+    p.setBool(bool);
+    p.setF(f);
+    p.setD(d);
+    p.setWi(wi);
+    p.setWl(wl);
+    p.setWs(ws);
+    p.setWb(wb);
+    p.setWc(wc);
+    p.setWbool(wbool);
+    p.setWf(wf);
+    p.setWd(wd);
+    p.setStr(str);
+    return p;
+  }
+}

--- a/core/src/test/java/io/github/eschizoid/telescope/MhLeafMapperSurfaceTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/MhLeafMapperSurfaceTest.java
@@ -1,0 +1,324 @@
+package io.github.eschizoid.telescope;
+
+import static io.github.eschizoid.telescope.mapping.Mapping.compute;
+import static io.github.eschizoid.telescope.mapping.Mapping.to;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Objects;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Interaction tests between the MethodHandle-combinator leaf {@code Iso} (chosen at build time for
+ * record/bean pairs via {@code MhIso.supports}) and the rest of the {@code Mapper} public surface.
+ *
+ * <p>The first review round validated the leaf in isolation ({@code MhIsoTest}). This suite pins
+ * the surfaces that do <em>more</em> than {@code forward}/{@code backward} — patch, into,
+ * explain/trace, hooks, lift* — over exactly the record/bean shapes the MH leaf now owns, so a leaf
+ * change that diverged from the array-leaf semantics on those surfaces would be caught here.
+ */
+class MhLeafMapperSurfaceTest {
+
+  // record source + bean target with no-arg ctor + full setters => MH-eligible (record->bean).
+  record OrderDto(String id, String customerName, int quantity) {}
+
+  static class OrderEntity {
+
+    private String id;
+    private String customerName;
+    private int quantity;
+
+    public OrderEntity() {}
+
+    public String getId() {
+      return id;
+    }
+
+    public void setId(final String id) {
+      this.id = id;
+    }
+
+    public String getCustomerName() {
+      return customerName;
+    }
+
+    public void setCustomerName(final String customerName) {
+      this.customerName = customerName;
+    }
+
+    public int getQuantity() {
+      return quantity;
+    }
+
+    public void setQuantity(final int quantity) {
+      this.quantity = quantity;
+    }
+  }
+
+  // bean source + bean target, both no-arg ctor + setters => MH-eligible (bean->bean).
+  static class PersonBean {
+
+    private String name;
+    private int age;
+
+    public PersonBean() {}
+
+    public PersonBean(final String name, final int age) {
+      this.name = name;
+      this.age = age;
+    }
+
+    public String getName() {
+      return name;
+    }
+
+    public void setName(final String name) {
+      this.name = name;
+    }
+
+    public int getAge() {
+      return age;
+    }
+
+    public void setAge(final int age) {
+      this.age = age;
+    }
+  }
+
+  static class PersonDtoBean {
+
+    private String name;
+    private int age;
+
+    public PersonDtoBean() {}
+
+    public String getName() {
+      return name;
+    }
+
+    public void setName(final String name) {
+      this.name = name;
+    }
+
+    public int getAge() {
+      return age;
+    }
+
+    public void setAge(final int age) {
+      this.age = age;
+    }
+  }
+
+  @Nested
+  @DisplayName("patch(base, partial) — patch table (per-field step Iso), NOT the composed MH leaf")
+  class PatchSurface {
+
+    @Test
+    @DisplayName("record source rebuilt from a bean partial's non-null fields (record<-bean patch table)")
+    void patchRecordSourceFromBeanTargetPartial() {
+      final var mapper = Telescope.mapper(OrderDto.class, OrderEntity.class);
+      final var base = new OrderDto("id-1", "Alice", 7);
+
+      // partial: only customerName set (quantity default 0, id null). Patch overlays customerName;
+      // quantity 0 IS a value on a bean partial and overlays too (the patch table only skips nulls,
+      // and a primitive can't be null) — so the round-trip mirrors the array-leaf contract exactly.
+      final var partial = new OrderEntity();
+      partial.setCustomerName("Bob");
+
+      final var patched = mapper.patch(base, partial);
+      assertEquals("id-1", patched.id(), "null partial.id → base id preserved");
+      assertEquals("Bob", patched.customerName(), "non-null partial.customerName overlaid");
+      assertEquals(0, patched.quantity(), "primitive quantity is never null → always overlaid (=0)");
+    }
+
+    @Test
+    @DisplayName("bean->bean patch overlays only non-null target fields; base identity is fresh")
+    void patchBeanToBean() {
+      final var mapper = Telescope.mapper(PersonBean.class, PersonDtoBean.class);
+      final var base = new PersonBean("Alice", 30);
+      final var partial = new PersonDtoBean();
+      partial.setName("Bob"); // age left 0
+
+      final var patched = mapper.patch(base, partial);
+      assertEquals("Bob", patched.getName());
+      // age is a primitive on the partial (0, never null) → overlaid, matching the array-leaf path.
+      assertEquals(0, patched.getAge());
+    }
+  }
+
+  @Nested
+  @DisplayName("into(target, source) — reuses forward()'s MH-built value, writes onto a live target")
+  class IntoSurface {
+
+    @Test
+    @DisplayName("record->bean into() mutates the passed target and returns the same reference")
+    void intoBeanTarget() {
+      final var mapper = Telescope.mapper(OrderDto.class, OrderEntity.class);
+      final var managed = new OrderEntity();
+      managed.setId("old");
+      managed.setCustomerName("old");
+      managed.setQuantity(99);
+
+      final var out = mapper.into(managed, new OrderDto("new-id", "NewName", 5));
+      assertSame(managed, out, "same reference returned");
+      assertEquals("new-id", managed.getId());
+      assertEquals("NewName", managed.getCustomerName());
+      assertEquals(5, managed.getQuantity(), "primitive quantity carried unboxed through the MH leaf");
+    }
+
+    @Test
+    @DisplayName("into() equals forward() field-for-field on an MH-eligible bean target")
+    void intoEqualsForward() {
+      final var mapper = Telescope.mapper(PersonBean.class, PersonDtoBean.class);
+      final var src = new PersonBean("Carol", 41);
+
+      final var viaForward = mapper.forward(src);
+      final var viaInto = mapper.into(new PersonDtoBean(), src);
+      assertEquals(viaForward.getName(), viaInto.getName());
+      assertEquals(viaForward.getAge(), viaInto.getAge());
+    }
+  }
+
+  @Nested
+  @DisplayName("null transform into a primitive bean slot — MH leaf must match array-leaf skip")
+  class PrimitiveNullSkipThroughForward {
+
+    // compute(...) returns null into the primitive `quantity` slot: the array leaf's SettersWriter
+    // skips the setter (JLS default 0); the MH leaf's setterFromSource guards the same way. This
+    // exercises that parity through the *full Mapper.forward*, not the raw MhIso leaf.
+    @Test
+    @DisplayName("compute yielding null into an int bean slot leaves the JLS default (0), via Mapper.forward")
+    void nullComputeIntoPrimitiveBeanSlot() {
+      final var mapper = Telescope.mapper(
+        OrderDto.class,
+        OrderEntity.class,
+        to(OrderDto::id, OrderEntity::getId),
+        to(OrderDto::customerName, OrderEntity::getCustomerName),
+        compute(OrderEntity::getQuantity, () -> (Integer) null)
+      );
+
+      final var out = mapper.forward(new OrderDto("id-9", "Dan", 123));
+      assertEquals("id-9", out.getId());
+      assertEquals("Dan", out.getCustomerName());
+      assertEquals(0, out.getQuantity(), "null into primitive setter is skipped → JLS default 0");
+    }
+  }
+
+  @Nested
+  @DisplayName("explain()/trace() — built from the resolution trail, independent of leaf assembly")
+  class ExplainTraceSurface {
+
+    @Test
+    @DisplayName("trace() runs the actual MH forward and the field trail still lines up")
+    void traceOverMhLeaf() {
+      final var mapper = Telescope.mapper(PersonBean.class, PersonDtoBean.class);
+      final var trace = mapper.trace(new PersonBean("Eve", 22));
+      assertNotNull(trace);
+      // explain() is the static structure; must enumerate both mapped fields regardless of leaf.
+      final var report = mapper.explain().toString();
+      assertTrue(report.contains("name"), "explain lists name");
+      assertTrue(report.contains("age"), "explain lists age");
+    }
+  }
+
+  @Nested
+  @DisplayName("hooks — beforeForward/afterForward wrap the MH leaf, not bypass it")
+  class HooksSurface {
+
+    @Test
+    @DisplayName("beforeForward normalises the source before the MH leaf reads it")
+    void beforeForwardComposesWithMhLeaf() {
+      final var mapper = Telescope.mapper(PersonBean.class, PersonDtoBean.class).beforeForward(p ->
+        new PersonBean(p.getName().toUpperCase(), p.getAge() + 1)
+      );
+
+      final var out = mapper.forward(new PersonBean("frank", 10));
+      assertEquals("FRANK", out.getName());
+      assertEquals(11, out.getAge(), "afterForward-free hook still threads the primitive through the leaf");
+    }
+
+    @Test
+    @DisplayName("afterForward post-processes the MH-built target")
+    void afterForwardComposesWithMhLeaf() {
+      final var mapper = Telescope.mapper(PersonBean.class, PersonDtoBean.class).afterForward(dto -> {
+        dto.setName(dto.getName() + "!");
+        return dto;
+      });
+      final var out = mapper.forward(new PersonBean("Grace", 33));
+      assertEquals("Grace!", out.getName());
+      assertEquals(33, out.getAge());
+    }
+  }
+
+  @Nested
+  @DisplayName("lift* — lifting the MH-built leaf Iso through a container shape")
+  class LiftSurface {
+
+    @Test
+    @DisplayName("liftList over an MH-eligible bean mapper converts a List<Bean> element-wise")
+    void liftListOverMhBeanMapper() {
+      final var mapper = Telescope.mapper(PersonBean.class, PersonDtoBean.class);
+      final var listMapper = mapper.liftList();
+
+      final var out = listMapper.forward(List.of(new PersonBean("H", 1), new PersonBean("I", 2)));
+      assertEquals(2, out.size());
+      assertEquals("H", out.get(0).getName());
+      assertEquals(1, out.get(0).getAge());
+      assertEquals("I", out.get(1).getName());
+      assertEquals(2, out.get(1).getAge());
+
+      // backward through the lifted MH leaf too.
+      final var back = listMapper.backward(out);
+      assertEquals("H", back.get(0).getName());
+      assertEquals(2, back.get(1).getAge());
+    }
+  }
+
+  @Nested
+  @DisplayName("asTelescope()/toForwardMapper() — route through forward/backward over the MH leaf")
+  class TelescopeAndForwardProjection {
+
+    @Test
+    @DisplayName("asTelescope().set converts A->B through the MH leaf")
+    void asTelescopeOverMhLeaf() {
+      final var mapper = Telescope.mapper(PersonBean.class, PersonDtoBean.class);
+      final var t = mapper.asTelescope();
+      final var dto = t.read(new PersonBean("Jo", 44));
+      assertEquals("Jo", dto.getName());
+      assertEquals(44, dto.getAge());
+    }
+
+    @Test
+    @DisplayName("toForwardMapper().forward converts through the MH leaf")
+    void toForwardMapperOverMhLeaf() {
+      final var fwd = Telescope.mapper(PersonBean.class, PersonDtoBean.class).toForwardMapper();
+      final var dto = fwd.forward(new PersonBean("Kim", 55));
+      assertEquals("Kim", dto.getName());
+      assertEquals(55, dto.getAge());
+    }
+  }
+
+  @Nested
+  @DisplayName("byte-identical to the array leaf — forward output equals a hand-copy")
+  class ByteIdentical {
+
+    @Test
+    @DisplayName("MH bean->bean forward matches a manual field copy exactly")
+    void mhForwardMatchesManualCopy() {
+      final var mapper = Telescope.mapper(PersonBean.class, PersonDtoBean.class);
+      final var src = new PersonBean("Liam", 66);
+      final var out = mapper.forward(src);
+      assertTrue(Objects.equals(out.getName(), src.getName()));
+      assertEquals(src.getAge(), out.getAge());
+      assertFalse(out == null);
+      assertNull(mapper.forward(null), "null-in null-out preserved");
+    }
+  }
+}

--- a/core/src/test/java/io/github/eschizoid/telescope/MhLeafMapperSurfaceTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/MhLeafMapperSurfaceTest.java
@@ -194,7 +194,7 @@ class MhLeafMapperSurfaceTest {
     // skips the setter (JLS default 0); the MH leaf's setterFromSource guards the same way. This
     // exercises that parity through the *full Mapper.forward*, not the raw MhIso leaf.
     @Test
-    @DisplayName("compute yielding null into an int bean slot leaves the JLS default (0), via Mapper.forward")
+    @DisplayName("compute yielding null into an int bean slot leaves the JLS default (0), via" + " Mapper.forward")
     void nullComputeIntoPrimitiveBeanSlot() {
       final var mapper = Telescope.mapper(
         OrderDto.class,

--- a/internal/src/main/java/io/github/eschizoid/telescope/internal/Beans.java
+++ b/internal/src/main/java/io/github/eschizoid/telescope/internal/Beans.java
@@ -101,6 +101,20 @@ public final class Beans {
     }
   };
 
+  // Raw, primitive-typed handles for the MethodHandle-combinator assembly path (MhIso) — the bean
+  // mirror of Records.RecordInfo's accessorHandles / ctorHandle. Unlike GETTER_INVOKERS /
+  // SETTER_INVOKERS (typed Function / BiConsumer, which box every primitive), these keep the real
+  // getter/setter/constructor signatures so a composed (S) -> BeanT handle stays unboxed end to
+  // end.
+  // Same ClassValue rationale as the sibling caches — the value strongly references reflective
+  // members; ClassValue keeps it off-heap from the Class so the key can still unload.
+  private static final ClassValue<BeanMhInfo> BEAN_MH_INFO = new ClassValue<>() {
+    @Override
+    protected BeanMhInfo computeValue(final Class<?> type) {
+      return BeanMhInfo.of(type);
+    }
+  };
+
   /**
    * Per-class cached {@link Supplier} that returns a fresh allocation of {@code cls}: tries a
    * public no-arg constructor first, then a public static {@code builder().build()} pair, and
@@ -737,6 +751,54 @@ public final class Beans {
   /** The bean's property names (getter-derived), in discovery order. */
   public static String[] propertyNames(final Class<?> beanClass) {
     return getters(beanClass).keySet().toArray(String[]::new);
+  }
+
+  /**
+   * Raw, primitive-typed getter handles for {@code beanClass}, one per property in {@link
+   * #propertyNames} order — the read-side input the MethodHandle-combinator assembly path ({@code
+   * MhIso}) needs. {@code handles[i]} has type {@code (beanClass) -> propertyType[i]}, unboxed,
+   * mirroring {@code Records.RecordInfo.accessorHandles}. The {@link #GETTER_INVOKERS} counterpart
+   * is forced to {@code Function<Object, Object>} and boxes; these keep the getter's real return
+   * type so a composed conversion stays box-free on same-type slots.
+   */
+  public static MethodHandle[] beanAccessorHandles(final Class<?> beanClass) {
+    return BEAN_MH_INFO.get(beanClass).accessorHandles();
+  }
+
+  /**
+   * Raw no-arg constructor handle {@code () -> beanClass} for the MethodHandle-combinator setter
+   * fold. Present only when {@code beanClass} has a no-arg constructor — {@code MhIso.supports}
+   * gates on {@link #isSetterConstructible} first, so callers never reach here for a bean without
+   * one.
+   */
+  public static MethodHandle beanNoArgCtorHandle(final Class<?> beanClass) {
+    return BEAN_MH_INFO.get(beanClass).noArgCtorHandle();
+  }
+
+  /**
+   * Raw setter handle {@code (beanClass, propertyType) -> void} for the property named {@code
+   * name}, or {@code null} when the property has no public single-arg {@code setX} setter. Used by
+   * the MethodHandle-combinator setter fold on a bean-target conversion; the value keeps the
+   * setter's real parameter type so a same-type slot writes unboxed.
+   */
+  public static MethodHandle beanSetterHandle(final Class<?> beanClass, final String name) {
+    return BEAN_MH_INFO.get(beanClass).setterHandle(name);
+  }
+
+  /**
+   * Whether {@code beanClass} can be constructed by the MethodHandle-combinator setter fold: it has
+   * a no-arg constructor and a public single-arg {@code setX} setter for every property in {@code
+   * requiredProperties}. Consulted by {@code MhIso.supports} as a build-time shape decision — a
+   * bean that needs a builder or field injection (no no-arg ctor, or a mapped property with no
+   * setter) returns {@code false} and routes to the array leaf instead. No runtime fallback.
+   */
+  public static boolean isSetterConstructible(final Class<?> beanClass, final String[] requiredProperties) {
+    if (!hasNoArgConstructor(beanClass)) return false;
+    final var info = BEAN_MH_INFO.get(beanClass);
+    for (final var name : requiredProperties) {
+      if (info.setterHandle(name) == null) return false;
+    }
+    return true;
   }
 
   /**
@@ -1602,6 +1664,84 @@ public final class Beans {
       } catch (final Throwable t) {
         throw new RuntimeException("Failed to set '" + name + "' on " + cls.getName(), t);
       }
+    }
+  }
+
+  /**
+   * Cached raw, primitive-typed handles for the MethodHandle-combinator conversion path — the bean
+   * mirror of {@code Records.RecordInfo}. {@code accessorHandles[i]} is the getter for property
+   * {@code i} (in {@link #propertyNames} order), typed {@code (beanClass) -> propertyType[i]} with
+   * no boxing; {@code setterHandles} maps a property name to its {@code (beanClass, propertyType)
+   * -> void} setter handle (absent when the property is getter-only); {@code noArgCtorHandle} is
+   * the raw {@code () -> beanClass} no-arg constructor handle, or {@code null} when the bean has no
+   * no-arg constructor (never reached by the fold — {@code MhIso.supports} gates it out).
+   *
+   * <p>Getter and setter dispatch each go {@code invokevirtual}, so a subtype instance still reads
+   * and writes correctly through a handle bound to the declared {@code beanClass}. The handles keep
+   * the member's actual signature so {@code MhIso} composes them into an unboxed {@code (S) ->
+   * BeanT} fold; the primitive-setter null guard {@link SettersWriter} applies is intentionally
+   * absent here — the combinator's per-slot Iso already substitutes primitive defaults before the
+   * value reaches the setter, exactly as the array leaf does.
+   */
+  record BeanMhInfo(
+    String[] names,
+    MethodHandle[] accessorHandles,
+    Map<String, MethodHandle> setterHandles,
+    MethodHandle noArgCtorHandle
+  ) {
+    static BeanMhInfo of(final Class<?> cls) {
+      final var props = propertyNames(cls);
+      final var getterMethods = getters(cls);
+      final var accessors = new MethodHandle[props.length];
+      final var lookupByDeclaringClass = new LinkedHashMap<Class<?>, MethodHandles.Lookup>();
+      for (var i = 0; i < props.length; i++) {
+        final var getter = getterMethods.get(props[i]);
+        final var declaringClass = getter.getDeclaringClass();
+        final var lookup = lookupByDeclaringClass.computeIfAbsent(declaringClass, dc ->
+          privateLookupOrThrow(dc, cls, "getter")
+        );
+        try {
+          accessors[i] = lookup.unreflect(getter);
+        } catch (final IllegalAccessException e) {
+          throw new IllegalStateException("Failed to build accessor handle for " + cls.getName() + "." + props[i], e);
+        }
+      }
+      final var setters = new LinkedHashMap<String, MethodHandle>();
+      for (final var name : props) {
+        final var setter = findSetter(cls, name);
+        if (setter == null) continue;
+        final var declaringClass = setter.getDeclaringClass();
+        final var lookup = lookupByDeclaringClass.computeIfAbsent(declaringClass, dc ->
+          privateLookupOrThrow(dc, cls, "setter")
+        );
+        try {
+          setters.put(name, lookup.unreflect(setter));
+        } catch (final IllegalAccessException e) {
+          throw new IllegalStateException("Failed to build setter handle for " + cls.getName() + "." + name, e);
+        }
+      }
+      MethodHandle ctorHandle = null;
+      try {
+        final var ctor = cls.getDeclaredConstructor();
+        final var lookup = privateLookupOrThrow(cls, cls, "no-arg constructor");
+        ctorHandle = lookup.unreflectConstructor(ctor);
+      } catch (final NoSuchMethodException | IllegalAccessException ignored) {
+        // No accessible no-arg constructor — the setter fold is unavailable for this bean, and
+        // MhIso.supports gates it out before the fold runs. Leave the handle null.
+      }
+      return new BeanMhInfo(props, accessors, setters, ctorHandle);
+    }
+
+    private static Method findSetter(final Class<?> cls, final String name) {
+      final var set = "set" + capitalize(name);
+      for (final var m : cls.getMethods()) {
+        if (m.getParameterCount() == 1 && m.getName().equals(set)) return m;
+      }
+      return null;
+    }
+
+    MethodHandle setterHandle(final String name) {
+      return setterHandles.get(name);
     }
   }
 }

--- a/internal/src/main/java/io/github/eschizoid/telescope/internal/Beans.java
+++ b/internal/src/main/java/io/github/eschizoid/telescope/internal/Beans.java
@@ -840,15 +840,18 @@ public final class Beans {
     throw new IllegalStateException(
       "No name-based write strategy for " +
         cls.getName() +
-        " — needs a static builder(), a no-arg constructor with setters, a no-arg constructor (field injection), " +
-        "or exactly one public constructor whose arity matches the property count (" +
+        " — needs a static builder(), a no-arg constructor with setters, a no-arg constructor" +
+        " (field injection), or exactly one public constructor whose arity matches the" +
+        " property count (" +
         props.length +
-        "), was compiled with -parameters, and whose parameter names line up with the getter-derived properties. " +
-        "Primary fix: recompile the target class with javac -parameters so its constructor arguments can be " +
-        "matched by name. The writeBean(targetClass, CONSTRUCTOR) hint at the Telescope.map(...) call site is " +
-        "an escape hatch, but note it falls back to POSITIONAL argument matching when -parameters is absent — " +
-        "argument order is then the getter-discovery order (not a stable, user-defined canonical order), so " +
-        "the hint should still be paired with -parameters to be safe."
+        "), was compiled with -parameters, and whose parameter names line up with the" +
+        " getter-derived properties. Primary fix: recompile the target class with javac" +
+        " -parameters so its constructor arguments can be matched by name. The" +
+        " writeBean(targetClass, CONSTRUCTOR) hint at the Telescope.map(...) call site is an" +
+        " escape hatch, but note it falls back to POSITIONAL argument matching when" +
+        " -parameters is absent — argument order is then the getter-discovery order (not a" +
+        " stable, user-defined canonical order), so the hint should still be paired with" +
+        " -parameters to be safe."
     );
   }
 
@@ -1128,10 +1131,10 @@ public final class Beans {
             cls.getName() +
             " for the FIELDS strategy. Add 'opens " +
             cls.getPackageName() +
-            " to io.github.eschizoid.telescope;' to that module's module-info.java. " +
-            "Switching the writeBean hint to CONSTRUCTOR / BUILDER / SETTERS reaches the bean " +
-            "through privateLookupIn rather than raw setAccessible, but the JPMS gate is the same " +
-            "— the open directive is the real fix for a fully closed package.",
+            " to io.github.eschizoid.telescope;' to that module's module-info.java. Switching" +
+            " the writeBean hint to CONSTRUCTOR / BUILDER / SETTERS reaches the bean through" +
+            " privateLookupIn rather than raw setAccessible, but the JPMS gate is the same —" +
+            " the open directive is the real fix for a fully closed package.",
           e
         );
       }
@@ -1161,7 +1164,7 @@ public final class Beans {
         // Diagnose the most likely root cause so the adopter doesn't have to read the JDK source
         // to figure out which of [final, JPMS-closed, missing opens] applies.
         final var finalHint = Modifier.isFinal(field.getModifiers())
-          ? " — field is final; switch the writeBean hint to SETTERS or BUILDER, or remove final"
+          ? " — field is final; switch the writeBean hint to SETTERS or BUILDER, or remove" + " final"
           : "";
         throw new RuntimeException(
           "Failed to bind setter for field '" + field.getName() + "' on " + cls.getName() + finalHint,
@@ -1226,7 +1229,8 @@ public final class Beans {
           cls.getName() +
           ", CONSTRUCTOR) requires a constructor with " +
           arity +
-          " parameters (parameters are matched by name when compiled with -parameters, otherwise positionally)."
+          " parameters (parameters are matched by name when compiled with -parameters," +
+          " otherwise positionally)."
       );
       // No raw setAccessible — buildCtorFn acquires private access through privateLookupOrThrow,
       // which is consistent with the FIELDS strategy and routes JPMS failures through the same

--- a/internal/src/main/java/io/github/eschizoid/telescope/internal/Beans.java
+++ b/internal/src/main/java/io/github/eschizoid/telescope/internal/Beans.java
@@ -1678,10 +1678,11 @@ public final class Beans {
    *
    * <p>Getter and setter dispatch each go {@code invokevirtual}, so a subtype instance still reads
    * and writes correctly through a handle bound to the declared {@code beanClass}. The handles keep
-   * the member's actual signature so {@code MhIso} composes them into an unboxed {@code (S) ->
-   * BeanT} fold; the primitive-setter null guard {@link SettersWriter} applies is intentionally
-   * absent here — the combinator's per-slot Iso already substitutes primitive defaults before the
-   * value reaches the setter, exactly as the array leaf does.
+   * the member's actual signature, so {@code MhIso} composes them into a mostly-unboxed {@code (S)
+   * -> BeanT} fold. This holder carries only the <em>raw</em> handles; the primitive-setter null
+   * guard that {@link SettersWriter} applies (skip a null into a primitive setter, leaving the JLS
+   * default) is layered on top in {@code MhIso.setterFromSource} for a primitive setter fed by a
+   * value-producing Iso — not here.
    */
   record BeanMhInfo(
     String[] names,

--- a/internal/src/main/java/io/github/eschizoid/telescope/internal/MhIso.java
+++ b/internal/src/main/java/io/github/eschizoid/telescope/internal/MhIso.java
@@ -7,17 +7,27 @@ import java.lang.invoke.MethodType;
 import java.util.function.Function;
 
 /**
- * MethodHandle-combinator assembly of a record&harr;record conversion {@link Iso}.
+ * MethodHandle-combinator assembly of a structural conversion {@link Iso} where each side is a
+ * record (canonical-constructor rebuild) or a JavaBean (no-arg constructor + setters).
  *
  * <p>The array-based assembly in {@code DeepMap.assembleIso} allocates an {@code Object[]} per call
  * and boxes every primitive component (its readers are typed {@code Function<Object, Object>} and
  * its builder spreads an {@code Object[]}). This assembler instead composes the whole conversion
- * into a single {@code (S) -> T} handle: each constructor argument is produced by running the
- * source's raw, primitive-typed accessor handle, piped straight into the target's raw constructor
- * handle via {@link MethodHandles#filterArguments} + {@link MethodHandles#permuteArguments}. On
- * same-name/same-type ("identity") fields the value flows primitive-to-primitive with no box and no
- * array; only fields carrying a real per-field {@link Iso} (rename with conversion, nested pair,
- * container lift) route through that Iso, exactly as before.
+ * into a single {@code (S) -> T} handle. Both directions have two independent halves:
+ *
+ * <ul>
+ *   <li><b>Read side (source).</b> A raw, primitive-typed accessor handle per property in {@code
+ *       names(...)} order — {@code Records.RecordInfo.accessorHandles} for a record, {@code
+ *       Beans.beanAccessorHandles} for a bean. Same-name/same-type ("identity") slots read
+ *       primitive-to-primitive with no box; only slots carrying a real per-field {@link Iso}
+ *       (rename with conversion, nested pair, container lift, constant, compute, when-gate) route
+ *       through that Iso.
+ *   <li><b>Construct side (target).</b> A record target pipes the per-slot filters straight into
+ *       the raw canonical-constructor handle via {@link MethodHandles#filterArguments} + {@link
+ *       MethodHandles#permuteArguments}. A bean target folds the raw no-arg constructor handle with
+ *       one raw setter per slot via {@link MethodHandles#foldArguments} — the setter runs as a void
+ *       side effect and the bean instance carries through, all unboxed.
+ * </ul>
  *
  * <p><b>Lattice.</b> The result is an ordinary {@link Iso#of(Function, Function)} — the composed
  * handles <em>are</em> the leaf Iso's forward/backward transforms. Composition above this leaf
@@ -27,24 +37,37 @@ import java.util.function.Function;
 public final class MhIso {
 
   /**
-   * Constructor-parameter ceiling for {@code filterArguments}/{@code permuteArguments} composition.
+   * Constructor-parameter ceiling for {@code filterArguments}/{@code permuteArguments} composition
+   * of a record target. Bean targets fold one setter per slot and have no comparable arity limit,
+   * but the source read side of a bean is still bounded by the number of properties, well under
+   * this ceiling in practice.
    */
   private static final int MAX_ARITY = 250;
 
   private MhIso() {}
 
   /**
-   * Whether {@code source} and {@code target} are both records within the arity this assembler can
-   * compose. {@code DeepMap} consults this once, at build time, to choose the composed-handle leaf
-   * over the array leaf — a shape decision, not a runtime fallback.
+   * Whether the {@code source} &harr; {@code target} conversion can be composed by this assembler:
+   * each side must be a record within the arity ceiling, or a bean constructible via a no-arg
+   * constructor plus a public {@code setX} setter for every property this conversion writes. {@code
+   * DeepMap} consults this once, at build time, to choose the composed-handle leaf over the array
+   * leaf — a shape decision, not a runtime fallback. A bean that needs a builder or field injection
+   * (no no-arg constructor, or a mapped property with no setter) returns {@code false} and routes
+   * to the array leaf.
    */
   public static boolean supports(final Class<?> source, final Class<?> target) {
-    return (
-      source.isRecord() &&
-      target.isRecord() &&
-      source.getRecordComponents().length <= MAX_ARITY &&
-      target.getRecordComponents().length <= MAX_ARITY
-    );
+    return constructibleBy(source) && constructibleBy(target);
+  }
+
+  private static boolean constructibleBy(final Class<?> cls) {
+    if (cls.isRecord()) return cls.getRecordComponents().length <= MAX_ARITY;
+    // A bean side is composable only when it has a no-arg constructor and every one of its
+    // properties is writable via a setter. Requiring a setter for every property (not only the
+    // mapped ones) is the conservative gate — it keeps `supports` a pure per-class question, and a
+    // bean with a getter-only property is exactly the field-injection shape the array leaf must own
+    // for correctness. Records rebuild every component through the canonical constructor
+    // regardless.
+    return Beans.isSetterConstructible(cls, Beans.propertyNames(cls));
   }
 
   // (Iso, Object) -> Object  ==  iso.to(v) / iso.from(v). Bound per non-identity field.
@@ -62,13 +85,14 @@ public final class MhIso {
   }
 
   /**
-   * Build the record&harr;record conversion as an {@link Iso} whose forward/backward are single
-   * composed handles. The slot arrays are the same ones {@code DeepMap.buildSlotMaps} produces:
-   * {@code fwdSrcPos[i]} is the source position feeding target slot {@code i} ({@code -1} = no
-   * source), and {@code fwdIso[i]} is that slot's per-field Iso ({@code == identity} for a plain
-   * same-name/same-type passthrough). Backward is symmetric.
+   * Build the {@code source} &harr; {@code target} conversion as an {@link Iso} whose
+   * forward/backward are single composed handles. Each side is dispatched by shape (record vs bean)
+   * on both the read half and the construct half. The slot arrays are the same ones {@code
+   * DeepMap.buildSlotMaps} produces: {@code fwdSrcPos[i]} is the source position feeding target
+   * slot {@code i} ({@code -1} = no source), and {@code fwdIso[i]} is that slot's per-field Iso
+   * ({@code == identity} for a plain same-name/same-type passthrough). Backward is symmetric.
    */
-  public static <S, T> Iso<S, T> recordPair(
+  public static <S, T> Iso<S, T> pair(
     final Class<S> source,
     final Class<T> target,
     final int[] fwdSrcPos,
@@ -77,32 +101,15 @@ public final class MhIso {
     final Iso<Object, Object>[] bwdIso,
     final Iso<Object, Object> identity
   ) {
-    final Records.RecordInfo srcInfo = Records.info(source);
-    final Records.RecordInfo tgtInfo = Records.info(target);
-
     // Erase both directions to (Object) -> Object so the Function SAM call site can invokeExact
-    // them — the boundary casts (Object -> record on entry, record -> Object on exit) are cheap
+    // them — the boundary casts (Object -> instance on entry, instance -> Object on exit) are cheap
     // reference casts; the primitive fields inside stay unboxed.
-    final MethodHandle fwd = compose(
-      source,
-      target,
-      srcInfo.accessorHandles(),
-      tgtInfo.ctorHandle(),
-      fwdSrcPos,
-      fwdIso,
-      ISO_TO,
-      identity
-    ).asType(MethodType.methodType(Object.class, Object.class));
-    final MethodHandle bwd = compose(
-      target,
-      source,
-      tgtInfo.accessorHandles(),
-      srcInfo.ctorHandle(),
-      bwdTgtPos,
-      bwdIso,
-      ISO_FROM,
-      identity
-    ).asType(MethodType.methodType(Object.class, Object.class));
+    final MethodHandle fwd = compose(source, target, fwdSrcPos, fwdIso, ISO_TO, identity).asType(
+      MethodType.methodType(Object.class, Object.class)
+    );
+    final MethodHandle bwd = compose(target, source, bwdTgtPos, bwdIso, ISO_FROM, identity).asType(
+      MethodType.methodType(Object.class, Object.class)
+    );
 
     final Function<S, T> forward = s -> {
       if (s == null) return null;
@@ -128,63 +135,156 @@ public final class MhIso {
   }
 
   /**
-   * Compose {@code (srcCls) -> tgtCls}: for each target constructor parameter, a filter handle
-   * {@code (srcCls) -> paramType} produced from the source accessor (and the slot's per-field Iso
-   * when it is not the identity), then {@code filterArguments} into the constructor and {@code
-   * permuteArguments} to feed the single source instance to every filter.
+   * Compose {@code (srcCls) -> tgtCls}. First build one filter handle {@code (srcCls) -> slotType}
+   * per target property (identity slot => raw source accessor; else route through the slot's
+   * per-field Iso), then hand those filters to the record-constructor combinator or the bean
+   * setter-fold combinator depending on the target's shape.
    */
   private static MethodHandle compose(
     final Class<?> srcCls,
     final Class<?> tgtCls,
-    final MethodHandle[] srcAccessors,
-    final MethodHandle tgtCtor,
     final int[] slotSrcPos,
     final Iso<Object, Object>[] slotIso,
     final MethodHandle isoDir,
     final Iso<Object, Object> identity
   ) {
-    final Class<?>[] paramTypes = tgtCtor.type().parameterArray();
-    final MethodHandle[] filters = new MethodHandle[paramTypes.length];
-    for (var i = 0; i < paramTypes.length; i++) {
-      final Class<?> pt = paramTypes[i];
-      final int sp = slotSrcPos[i];
-      final boolean isIdentity = slotIso[i] == identity;
-      if (isIdentity && sp >= 0) {
-        // Plain passthrough: raw accessor straight into the constructor slot,
-        // primitive-to-primitive,
-        // no box. This is the fast path the whole assembler exists for.
-        filters[i] = srcAccessors[sp].asType(MethodType.methodType(pt, srcCls));
-      } else if (isIdentity) {
-        // Identity Iso but no source field: yield null. asType into a primitive slot unboxes null →
-        // NPE at call time, identical to the array path's `ctorFn.apply(nullSlot)`.
-        filters[i] = MethodHandles.dropArguments(MethodHandles.constant(Object.class, null), 0, srcCls).asType(
-          MethodType.methodType(pt, srcCls)
-        );
-      } else {
-        // Non-identity Iso (rename-with-conversion, nested pair, container lift, constant, compute,
-        // when-gate): mirror the array path's `iso.to(v)`, where v is the read value or null when
-        // the
-        // slot has no source. isoStep : (Object) -> Object.
-        final MethodHandle isoStep = isoDir.bindTo(slotIso[i]);
-        if (sp < 0) {
-          // v == null: constant / compute / gated rows produce their value from a null input.
-          filters[i] = MethodHandles.dropArguments(
-            MethodHandles.insertArguments(isoStep, 0, (Object) null),
-            0,
-            srcCls
-          ).asType(MethodType.methodType(pt, srcCls));
-        } else {
-          final Class<?> readType = srcAccessors[sp].type().returnType();
-          filters[i] = MethodHandles.filterReturnValue(
-            srcAccessors[sp],
-            isoStep.asType(MethodType.methodType(Object.class, readType))
-          ).asType(MethodType.methodType(pt, srcCls));
-        }
-      }
+    final MethodHandle[] srcAccessors = accessorHandlesFor(srcCls);
+    if (tgtCls.isRecord()) {
+      final MethodHandle tgtCtor = Records.info(tgtCls).ctorHandle();
+      final Class<?>[] slotTypes = tgtCtor.type().parameterArray();
+      final MethodHandle[] filters = buildFilters(
+        srcCls,
+        slotTypes,
+        srcAccessors,
+        slotSrcPos,
+        slotIso,
+        isoDir,
+        identity
+      );
+      final MethodHandle filtered = MethodHandles.filterArguments(tgtCtor, 0, filters);
+      final int[] toSingleInput = new int[slotTypes.length]; // all zeros: every filter reads slot 0
+      return MethodHandles.permuteArguments(filtered, MethodType.methodType(tgtCls, srcCls), toSingleInput);
     }
-    final MethodHandle filtered = MethodHandles.filterArguments(tgtCtor, 0, filters);
-    final int[] toSingleInput = new int[paramTypes.length]; // all zeros: every filter reads slot 0
-    return MethodHandles.permuteArguments(filtered, MethodType.methodType(tgtCls, srcCls), toSingleInput);
+    return beanSetterFold(srcCls, tgtCls, srcAccessors, slotSrcPos, slotIso, isoDir, identity);
+  }
+
+  /** Raw, primitive-typed accessor handles for {@code cls} in {@code names(...)} order. */
+  private static MethodHandle[] accessorHandlesFor(final Class<?> cls) {
+    return cls.isRecord() ? Records.info(cls).accessorHandles() : Beans.beanAccessorHandles(cls);
+  }
+
+  /**
+   * One filter handle {@code (srcCls) -> slotType[i]} per target slot. Identity slots with a source
+   * read the raw accessor straight through, primitive-to-primitive, no box — the fast path this
+   * assembler exists for. Every other slot mirrors the array path's {@code iso.to(v)} / {@code
+   * iso.from(v)}, including the {@code sp < 0} case where {@code v == null} (constant / compute /
+   * gated rows produce their value from a null input — this rule is load-bearing; do not drop it).
+   */
+  private static MethodHandle[] buildFilters(
+    final Class<?> srcCls,
+    final Class<?>[] slotTypes,
+    final MethodHandle[] srcAccessors,
+    final int[] slotSrcPos,
+    final Iso<Object, Object>[] slotIso,
+    final MethodHandle isoDir,
+    final Iso<Object, Object> identity
+  ) {
+    final MethodHandle[] filters = new MethodHandle[slotTypes.length];
+    for (var i = 0; i < slotTypes.length; i++) {
+      filters[i] = buildFilter(srcCls, slotTypes[i], srcAccessors, slotSrcPos[i], slotIso[i], isoDir, identity);
+    }
+    return filters;
+  }
+
+  /** The single-slot filter — factored out so the record ctor path and bean fold path share it. */
+  private static MethodHandle buildFilter(
+    final Class<?> srcCls,
+    final Class<?> slotType,
+    final MethodHandle[] srcAccessors,
+    final int sp,
+    final Iso<Object, Object> slotIso,
+    final MethodHandle isoDir,
+    final Iso<Object, Object> identity
+  ) {
+    final boolean isIdentity = slotIso == identity;
+    if (isIdentity && sp >= 0) {
+      // Plain passthrough: raw accessor straight into the slot, primitive-to-primitive, no box.
+      return srcAccessors[sp].asType(MethodType.methodType(slotType, srcCls));
+    } else if (isIdentity) {
+      // Identity Iso but no source field: yield null. asType into a primitive slot unboxes null →
+      // NPE at call time, identical to the array path's null value flowing into the slot.
+      return MethodHandles.dropArguments(MethodHandles.constant(Object.class, null), 0, srcCls).asType(
+        MethodType.methodType(slotType, srcCls)
+      );
+    }
+    // Non-identity Iso (rename-with-conversion, nested pair, container lift, constant, compute,
+    // when-gate): mirror the array path's iso.to(v), where v is the read value or null when the
+    // slot has no source. isoStep : (Object) -> Object.
+    final MethodHandle isoStep = isoDir.bindTo(slotIso);
+    if (sp < 0) {
+      // v == null: constant / compute / gated rows produce their value from a null input.
+      return MethodHandles.dropArguments(MethodHandles.insertArguments(isoStep, 0, (Object) null), 0, srcCls).asType(
+        MethodType.methodType(slotType, srcCls)
+      );
+    }
+    final Class<?> readType = srcAccessors[sp].type().returnType();
+    return MethodHandles.filterReturnValue(
+      srcAccessors[sp],
+      isoStep.asType(MethodType.methodType(Object.class, readType))
+    ).asType(MethodType.methodType(slotType, srcCls));
+  }
+
+  /**
+   * Compose {@code (srcCls) -> beanCls} as a setter fold. Start from {@code mk : (srcCls) ->
+   * beanCls} that drops its source argument and runs the no-arg constructor. For each writable
+   * property {@code i} (its setter {@code set_i : (beanCls, Pi) -> void} and the same per-slot
+   * filter {@code readVal_i : (srcCls) -> Pi} the record path builds):
+   *
+   * <ol>
+   *   <li>{@code set_i_fromS = filterArguments(set_i, 1, readVal_i)} : {@code (beanCls, srcCls) ->
+   *       void} — the setter now takes the source instance in place of the raw value.
+   *   <li>{@code populate_i = foldArguments(dropArguments(identity(beanCls), 1, srcCls),
+   *       set_i_fromS)} : {@code (beanCls, srcCls) -> beanCls} — runs the void setter as a side
+   *       effect, then returns arg0 (the bean).
+   *   <li>{@code mk = foldArguments(populate_i, mk)} : {@code (srcCls) -> beanCls} — feeds the bean
+   *       built so far and the source into the populate step.
+   * </ol>
+   *
+   * <p>Properties in {@code names(...)} order are folded in turn; {@code MhIso.supports} guarantees
+   * a setter for every one of them, so no slot is silently dropped. Primitives stay unboxed because
+   * every handle keeps its real signature.
+   */
+  private static MethodHandle beanSetterFold(
+    final Class<?> srcCls,
+    final Class<?> beanCls,
+    final MethodHandle[] srcAccessors,
+    final int[] slotSrcPos,
+    final Iso<Object, Object>[] slotIso,
+    final MethodHandle isoDir,
+    final Iso<Object, Object> identity
+  ) {
+    final String[] props = Beans.propertyNames(beanCls);
+    MethodHandle mk = MethodHandles.dropArguments(Beans.beanNoArgCtorHandle(beanCls), 0, srcCls);
+    for (var i = 0; i < props.length; i++) {
+      final MethodHandle setter = Beans.beanSetterHandle(beanCls, props[i]);
+      final Class<?> slotType = setter.type().parameterType(1);
+      final MethodHandle readVal = buildFilter(
+        srcCls,
+        slotType,
+        srcAccessors,
+        slotSrcPos[i],
+        slotIso[i],
+        isoDir,
+        identity
+      );
+      final MethodHandle setFromS = MethodHandles.filterArguments(setter, 1, readVal);
+      final MethodHandle populate = MethodHandles.foldArguments(
+        MethodHandles.dropArguments(MethodHandles.identity(beanCls), 1, srcCls),
+        setFromS
+      );
+      mk = MethodHandles.foldArguments(populate, mk);
+    }
+    return mk.asType(MethodType.methodType(beanCls, srcCls));
   }
 
   private static RuntimeException rethrow(final Class<?> from, final Class<?> to, final Throwable e) {

--- a/internal/src/main/java/io/github/eschizoid/telescope/internal/MhIso.java
+++ b/internal/src/main/java/io/github/eschizoid/telescope/internal/MhIso.java
@@ -27,7 +27,9 @@ import java.util.function.Function;
  *       the raw canonical-constructor handle via {@link MethodHandles#filterArguments} + {@link
  *       MethodHandles#permuteArguments}. A bean target folds the raw no-arg constructor handle with
  *       one raw setter per slot via {@link MethodHandles#foldArguments} — the setter runs as a void
- *       side effect and the bean instance carries through, all unboxed.
+ *       side effect and the bean instance carries through. Identity and reference slots stay
+ *       unboxed; a primitive slot fed by a value-producing (non-identity) Iso is read boxed only so
+ *       it can be null-guarded before unboxing (see {@code setterFromSource}).
  * </ul>
  *
  * <p><b>Lattice.</b> The result is an ordinary {@link Iso#of(Function, Function)} — the composed
@@ -50,11 +52,11 @@ public final class MhIso {
   /**
    * Whether the {@code source} &harr; {@code target} conversion can be composed by this assembler:
    * each side must be a record within the arity ceiling, or a bean constructible via a no-arg
-   * constructor plus a public {@code setX} setter for every property this conversion writes. {@code
-   * DeepMap} consults this once, at build time, to choose the composed-handle leaf over the array
-   * leaf — a shape decision, not a runtime fallback. A bean that needs a builder or field injection
-   * (no no-arg constructor, or a mapped property with no setter) returns {@code false} and routes
-   * to the array leaf.
+   * constructor plus a public {@code setX} setter for every property of the bean (not only the
+   * mapped ones — the conservative per-class gate). {@code DeepMap} consults this once, at build
+   * time, to choose the composed-handle leaf over the array leaf — a shape decision, not a runtime
+   * fallback. A bean that needs a builder or field injection (no no-arg constructor, or any
+   * property with no setter) returns {@code false} and routes to the array leaf.
    */
   public static boolean supports(final Class<?> source, final Class<?> target) {
     return constructibleBy(source) && constructibleBy(target);
@@ -255,8 +257,10 @@ public final class MhIso {
    * </ol>
    *
    * <p>Properties in {@code names(...)} order are folded in turn; {@code MhIso.supports} guarantees
-   * a setter for every one of them, so no slot is silently dropped. Primitives stay unboxed because
-   * every handle keeps its real signature.
+   * a setter for every one of them, so no slot is silently dropped. Identity primitive slots stay
+   * unboxed (source primitive, never null); a primitive slot fed by a non-identity Iso is read
+   * boxed and null-guarded in {@code setterFromSource}, matching the array leaf's {@code
+   * SettersWriter}.
    */
   private static MethodHandle beanSetterFold(
     final Class<?> srcCls,
@@ -330,6 +334,10 @@ public final class MhIso {
   }
 
   private static RuntimeException rethrow(final Class<?> from, final Class<?> to, final Throwable e) {
+    // Let Errors (StackOverflowError, OutOfMemoryError, linkage faults) propagate unwrapped — the
+    // array leaf has no try/catch and lets them through raw; masking them as a RuntimeException
+    // would defeat monitoring/recovery that classifies VM-level errors separately.
+    if (e instanceof Error err) throw err;
     if (e instanceof RuntimeException re) return re;
     return new RuntimeException("Failed to convert " + from.getSimpleName() + " -> " + to.getSimpleName(), e);
   }

--- a/internal/src/main/java/io/github/eschizoid/telescope/internal/MhIso.java
+++ b/internal/src/main/java/io/github/eschizoid/telescope/internal/MhIso.java
@@ -4,6 +4,7 @@ import io.github.eschizoid.telescope.internal.optics.Iso;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
+import java.util.Objects;
 import java.util.function.Function;
 
 /**
@@ -73,12 +74,15 @@ public final class MhIso {
   // (Iso, Object) -> Object  ==  iso.to(v) / iso.from(v). Bound per non-identity field.
   private static final MethodHandle ISO_TO;
   private static final MethodHandle ISO_FROM;
+  // (Object) -> boolean  ==  value != null. Guards a primitive bean setter against a null value.
+  private static final MethodHandle NON_NULL;
 
   static {
     try {
       final MethodHandles.Lookup lk = MethodHandles.lookup();
       ISO_TO = lk.findVirtual(Iso.class, "to", MethodType.methodType(Object.class, Object.class));
       ISO_FROM = lk.findVirtual(Iso.class, "from", MethodType.methodType(Object.class, Object.class));
+      NON_NULL = lk.findStatic(Objects.class, "nonNull", MethodType.methodType(boolean.class, Object.class));
     } catch (final ReflectiveOperationException e) {
       throw new ExceptionInInitializerError(e);
     }
@@ -266,18 +270,23 @@ public final class MhIso {
     final String[] props = Beans.propertyNames(beanCls);
     MethodHandle mk = MethodHandles.dropArguments(Beans.beanNoArgCtorHandle(beanCls), 0, srcCls);
     for (var i = 0; i < props.length; i++) {
-      final MethodHandle setter = Beans.beanSetterHandle(beanCls, props[i]);
-      final Class<?> slotType = setter.type().parameterType(1);
-      final MethodHandle readVal = buildFilter(
+      final MethodHandle rawSetter = Beans.beanSetterHandle(beanCls, props[i]);
+      final Class<?> slotType = rawSetter.type().parameterType(1);
+      // Fluent / chained setters (Lombok @Accessors(chain=true), builder-style beans) return the
+      // bean rather than void. foldArguments needs a void combiner, so drop any returned value via
+      // asType(void) — a plain void setter is unchanged by this.
+      final MethodHandle setter = rawSetter.asType(rawSetter.type().changeReturnType(void.class));
+      final MethodHandle setFromS = setterFromSource(
         srcCls,
+        beanCls,
         slotType,
+        setter,
         srcAccessors,
         slotSrcPos[i],
         slotIso[i],
         isoDir,
         identity
       );
-      final MethodHandle setFromS = MethodHandles.filterArguments(setter, 1, readVal);
       final MethodHandle populate = MethodHandles.foldArguments(
         MethodHandles.dropArguments(MethodHandles.identity(beanCls), 1, srcCls),
         setFromS
@@ -285,6 +294,39 @@ public final class MhIso {
       mk = MethodHandles.foldArguments(populate, mk);
     }
     return mk.asType(MethodType.methodType(beanCls, srcCls));
+  }
+
+  /**
+   * Build {@code (beanCls, srcCls) -> void} — read the slot value from the source and apply {@code
+   * setter}. For a <b>primitive</b> setter fed by a <b>non-identity</b> Iso the value may be null
+   * (a user transform returning null), and unboxing null would NPE. The array leaf's {@code
+   * SettersWriter} instead <em>skips</em> the setter on null, leaving the JLS default; this mirrors
+   * that by reading the value boxed and guarding the setter with a null test. Identity primitive
+   * slots (source primitive, never null) keep the unboxed fast path; reference setters accept null
+   * as the array leaf does.
+   */
+  private static MethodHandle setterFromSource(
+    final Class<?> srcCls,
+    final Class<?> beanCls,
+    final Class<?> slotType,
+    final MethodHandle setter,
+    final MethodHandle[] srcAccessors,
+    final int sp,
+    final Iso<Object, Object> slotIso,
+    final MethodHandle isoDir,
+    final Iso<Object, Object> identity
+  ) {
+    if (slotType.isPrimitive() && slotIso != identity) {
+      final MethodHandle readBoxed = buildFilter(srcCls, Object.class, srcAccessors, sp, slotIso, isoDir, identity);
+      final MethodType guardType = MethodType.methodType(void.class, beanCls, Object.class);
+      final MethodHandle doSet = setter.asType(guardType); // unboxes the (non-null) Object into the primitive
+      final MethodHandle skip = MethodHandles.empty(guardType);
+      final MethodHandle test = MethodHandles.dropArguments(NON_NULL, 0, beanCls);
+      final MethodHandle guarded = MethodHandles.guardWithTest(test, doSet, skip);
+      return MethodHandles.filterArguments(guarded, 1, readBoxed);
+    }
+    final MethodHandle readVal = buildFilter(srcCls, slotType, srcAccessors, sp, slotIso, isoDir, identity);
+    return MethodHandles.filterArguments(setter, 1, readVal);
   }
 
   private static RuntimeException rethrow(final Class<?> from, final Class<?> to, final Throwable e) {

--- a/internal/src/main/java/io/github/eschizoid/telescope/internal/MhIso.java
+++ b/internal/src/main/java/io/github/eschizoid/telescope/internal/MhIso.java
@@ -67,7 +67,10 @@ public final class MhIso {
     return constructibleBy(source) && constructibleBy(target);
   }
 
-  /** System property (test-only) that forces every pair to the legacy array leaf. See {@link #supports}. */
+  /**
+   * System property (test-only) that forces every pair to the legacy array leaf. See {@link
+   * #supports}.
+   */
   public static final String DISABLE_PROPERTY = "io.github.eschizoid.telescope.mhiso.disabled";
 
   private static boolean constructibleBy(final Class<?> cls) {
@@ -284,7 +287,8 @@ public final class MhIso {
     for (var i = 0; i < props.length; i++) {
       final MethodHandle discovered = Beans.beanSetterHandle(beanCls, props[i]);
       final Class<?> slotType = discovered.type().parameterType(1);
-      // An inherited setter (declared on a superclass) is unreflected against its DECLARING class, so
+      // An inherited setter (declared on a superclass) is unreflected against its DECLARING class,
+      // so
       // its receiver type is that superclass, not beanCls. The fold produces a beanCls instance and
       // foldArguments requires the combiner's receiver to match — narrow the receiver to beanCls (a
       // safe upcast on invoke; no-op when the setter is declared on beanCls itself).

--- a/internal/src/main/java/io/github/eschizoid/telescope/internal/MhIso.java
+++ b/internal/src/main/java/io/github/eschizoid/telescope/internal/MhIso.java
@@ -59,8 +59,16 @@ public final class MhIso {
    * property with no setter) returns {@code false} and routes to the array leaf.
    */
   public static boolean supports(final Class<?> source, final Class<?> target) {
+    // Test seam for the differential parity oracle: with the system property below set,
+    // MhIsoDifferentialParityTest routes the identical conversion through the legacy array leaf and
+    // asserts byte-identical output against this leaf. Unset in production; read once at build time
+    // (never per conversion), so no steady-state cost.
+    if (Boolean.getBoolean(DISABLE_PROPERTY)) return false;
     return constructibleBy(source) && constructibleBy(target);
   }
+
+  /** System property (test-only) that forces every pair to the legacy array leaf. See {@link #supports}. */
+  public static final String DISABLE_PROPERTY = "io.github.eschizoid.telescope.mhiso.disabled";
 
   private static boolean constructibleBy(final Class<?> cls) {
     if (cls.isRecord()) return cls.getRecordComponents().length <= MAX_ARITY;
@@ -274,8 +282,13 @@ public final class MhIso {
     final String[] props = Beans.propertyNames(beanCls);
     MethodHandle mk = MethodHandles.dropArguments(Beans.beanNoArgCtorHandle(beanCls), 0, srcCls);
     for (var i = 0; i < props.length; i++) {
-      final MethodHandle rawSetter = Beans.beanSetterHandle(beanCls, props[i]);
-      final Class<?> slotType = rawSetter.type().parameterType(1);
+      final MethodHandle discovered = Beans.beanSetterHandle(beanCls, props[i]);
+      final Class<?> slotType = discovered.type().parameterType(1);
+      // An inherited setter (declared on a superclass) is unreflected against its DECLARING class, so
+      // its receiver type is that superclass, not beanCls. The fold produces a beanCls instance and
+      // foldArguments requires the combiner's receiver to match — narrow the receiver to beanCls (a
+      // safe upcast on invoke; no-op when the setter is declared on beanCls itself).
+      final MethodHandle rawSetter = discovered.asType(discovered.type().changeParameterType(0, beanCls));
       // Fluent / chained setters (Lombok @Accessors(chain=true), builder-style beans) return the
       // bean rather than void. foldArguments needs a void combiner, so drop any returned value via
       // asType(void) — a plain void setter is unchanged by this.

--- a/internal/src/test/java/io/github/eschizoid/telescope/internal/MhIsoTest.java
+++ b/internal/src/test/java/io/github/eschizoid/telescope/internal/MhIsoTest.java
@@ -59,6 +59,36 @@ class MhIsoTest {
     }
   }
 
+  /**
+   * Fluent / chained setters returning {@code this} (Lombok {@code @Accessors(chain=true)},
+   * builder-style beans) — the non-void setter shape the void-only fold breaks on.
+   */
+  static final class FluentBeanUser {
+
+    private String name;
+    private int age;
+
+    public FluentBeanUser() {}
+
+    public String getName() {
+      return name;
+    }
+
+    public int getAge() {
+      return age;
+    }
+
+    public FluentBeanUser setName(final String name) {
+      this.name = name;
+      return this;
+    }
+
+    public FluentBeanUser setAge(final int age) {
+      this.age = age;
+      return this;
+    }
+  }
+
   private static BeanUser bean(final String name, final int age) {
     final var b = new BeanUser();
     b.setName(name);
@@ -136,6 +166,17 @@ class MhIsoTest {
       assertEquals("cara", out.getName());
       assertEquals(25, out.getAge());
     }
+
+    @Test
+    @DisplayName("record to a fluent-setter bean folds through chained setters that return this")
+    void recordToFluentBean() {
+      assertTrue(MhIso.supports(RecUser.class, FluentBeanUser.class));
+      final Iso<RecUser, FluentBeanUser> iso = identityPair(RecUser.class, FluentBeanUser.class);
+      final var b = iso.to(new RecUser("eve", 51));
+      assertEquals("eve", b.getName());
+      assertEquals(51, b.getAge());
+      assertEquals(new RecUser("eve", 51), iso.from(b));
+    }
   }
 
   @Nested
@@ -187,6 +228,25 @@ class MhIsoTest {
       final var b = iso.to(new RecUser("ignored", 9));
       assertEquals("CONST", b.getName());
       assertEquals(9, b.getAge());
+    }
+
+    @Test
+    @DisplayName("a non-identity Iso yielding null into a primitive bean setter is skipped, leaving the default")
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    void nullTransformIntoPrimitiveBeanSkipped() {
+      final Iso<Object, Object> identity = Iso.identity();
+      // The age slot's forward always yields null. The array leaf's SettersWriter skips a null into
+      // a
+      // primitive setter, leaving the JLS default (0); unboxing null would NPE. MhIso must match.
+      final Iso<Object, Object> nullify = Iso.of(ignored -> null, ignored -> 0);
+      final int[] fwd = { 0, 1 };
+      final int[] bwd = { 0, 1 };
+      final Iso<Object, Object>[] fwdIso = new Iso[] { identity, nullify };
+      final Iso<Object, Object>[] bwdIso = new Iso[] { identity, identity };
+      final Iso<RecUser, BeanUser> iso = MhIso.pair(RecUser.class, BeanUser.class, fwd, fwdIso, bwd, bwdIso, identity);
+      final var b = iso.to(new RecUser("zoe", 99));
+      assertEquals("zoe", b.getName());
+      assertEquals(0, b.getAge()); // skipped → JLS default, not an NPE
     }
   }
 }

--- a/internal/src/test/java/io/github/eschizoid/telescope/internal/MhIsoTest.java
+++ b/internal/src/test/java/io/github/eschizoid/telescope/internal/MhIsoTest.java
@@ -1,0 +1,192 @@
+package io.github.eschizoid.telescope.internal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.github.eschizoid.telescope.internal.optics.Iso;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Direct contract tests for {@link MhIso} — the MethodHandle-combinator conversion leaf. Covers all
+ * four shape combinations of the read side (record vs bean getter) and the construct side (record
+ * canonical constructor vs bean setter fold), plus the build-time capability gate and the semantics
+ * the array leaf established: null-in/null-out, primitive slots flowing through the fold, identity
+ * passthrough, non-identity per-slot Iso, and the {@code sp < 0} constant/compute slot.
+ */
+class MhIsoTest {
+
+  record RecUser(String name, int age) {}
+
+  static final class BeanUser {
+
+    private String name;
+    private int age;
+
+    public BeanUser() {}
+
+    public String getName() {
+      return name;
+    }
+
+    public int getAge() {
+      return age;
+    }
+
+    public void setName(final String name) {
+      this.name = name;
+    }
+
+    public void setAge(final int age) {
+      this.age = age;
+    }
+  }
+
+  /**
+   * No-arg constructor but no setter for {@code name} — the field-injection shape MhIso declines.
+   */
+  static final class GetterOnlyBean {
+
+    private final String name = "fixed";
+
+    public GetterOnlyBean() {}
+
+    public String getName() {
+      return name;
+    }
+  }
+
+  private static BeanUser bean(final String name, final int age) {
+    final var b = new BeanUser();
+    b.setName(name);
+    b.setAge(age);
+    return b;
+  }
+
+  // Identity passthrough for the two same-name/same-type slots (name, age), positions aligned.
+  @SuppressWarnings({ "unchecked", "rawtypes" })
+  private static <S, T> Iso<S, T> identityPair(final Class<S> source, final Class<T> target) {
+    final Iso<Object, Object> identity = Iso.identity();
+    final int[] fwd = { 0, 1 };
+    final int[] bwd = { 0, 1 };
+    final Iso<Object, Object>[] fwdIso = new Iso[] { identity, identity };
+    final Iso<Object, Object>[] bwdIso = new Iso[] { identity, identity };
+    return MhIso.pair(source, target, fwd, fwdIso, bwd, bwdIso, identity);
+  }
+
+  @Nested
+  @DisplayName("supports — build-time capability gate")
+  class Supports {
+
+    @Test
+    @DisplayName("both records within arity are supported")
+    void recordRecord() {
+      assertTrue(MhIso.supports(RecUser.class, RecUser.class));
+    }
+
+    @Test
+    @DisplayName("bean with no-arg ctor and full setter coverage is supported both directions")
+    void beanEitherSide() {
+      assertTrue(MhIso.supports(BeanUser.class, RecUser.class));
+      assertTrue(MhIso.supports(RecUser.class, BeanUser.class));
+      assertTrue(MhIso.supports(BeanUser.class, BeanUser.class));
+    }
+
+    @Test
+    @DisplayName("a bean with a getter-only property is declined (routes to the array leaf)")
+    void getterOnlyDeclined() {
+      assertFalse(MhIso.supports(BeanUser.class, GetterOnlyBean.class));
+      assertFalse(MhIso.supports(GetterOnlyBean.class, BeanUser.class));
+    }
+  }
+
+  @Nested
+  @DisplayName("conversion — the four read/construct shape combinations")
+  class Conversion {
+
+    @Test
+    @DisplayName("bean to record and back, primitive age unboxed through the canonical constructor")
+    void beanToRecord() {
+      final Iso<BeanUser, RecUser> iso = identityPair(BeanUser.class, RecUser.class);
+      final var r = iso.to(bean("ann", 30));
+      assertEquals(new RecUser("ann", 30), r);
+      final var back = iso.from(r);
+      assertEquals("ann", back.getName());
+      assertEquals(30, back.getAge());
+    }
+
+    @Test
+    @DisplayName("record to bean via the setter fold, primitive age unboxed into setAge(int)")
+    void recordToBean() {
+      final Iso<RecUser, BeanUser> iso = identityPair(RecUser.class, BeanUser.class);
+      final var b = iso.to(new RecUser("bob", 42));
+      assertEquals("bob", b.getName());
+      assertEquals(42, b.getAge());
+      assertEquals(new RecUser("bob", 42), iso.from(b));
+    }
+
+    @Test
+    @DisplayName("bean to bean round-trips through getters and the setter fold")
+    void beanToBean() {
+      final Iso<BeanUser, BeanUser> iso = identityPair(BeanUser.class, BeanUser.class);
+      final var out = iso.to(bean("cara", 25));
+      assertEquals("cara", out.getName());
+      assertEquals(25, out.getAge());
+    }
+  }
+
+  @Nested
+  @DisplayName("preserved array-leaf semantics")
+  class Semantics {
+
+    @Test
+    @DisplayName("null in yields null out in both directions of a bean target")
+    void nullInNullOut() {
+      final Iso<RecUser, BeanUser> iso = identityPair(RecUser.class, BeanUser.class);
+      assertNull(iso.to(null));
+      assertNull(iso.from(null));
+    }
+
+    @Test
+    @DisplayName("a non-identity per-slot Iso is applied on the way into a bean setter")
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    void nonIdentitySlotIntoBean() {
+      final Iso<Object, Object> identity = Iso.identity();
+      // name slot upper-cases forward / lower-cases backward; age stays identity.
+      final Iso<Object, Object> upper = Iso.of(
+        v -> v == null ? null : ((String) v).toUpperCase(),
+        v -> v == null ? null : ((String) v).toLowerCase()
+      );
+      final int[] fwd = { 0, 1 };
+      final int[] bwd = { 0, 1 };
+      final Iso<Object, Object>[] fwdIso = new Iso[] { upper, identity };
+      final Iso<Object, Object>[] bwdIso = new Iso[] { upper, identity };
+      final Iso<RecUser, BeanUser> iso = MhIso.pair(RecUser.class, BeanUser.class, fwd, fwdIso, bwd, bwdIso, identity);
+      final var b = iso.to(new RecUser("dan", 7));
+      assertEquals("DAN", b.getName());
+      assertEquals(7, b.getAge());
+      assertEquals(new RecUser("dan", 7), iso.from(b));
+    }
+
+    @Test
+    @DisplayName("a source-less (sp < 0) slot still applies its Iso, producing a constant from null")
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    void sourcelessSlotStillAppliesIso() {
+      final Iso<Object, Object> identity = Iso.identity();
+      // The name slot has no source (sp = -1) and a constant Iso that ignores its input and yields
+      // a fixed value — the array leaf's iso.to(null) contract, which MhIso must not regress.
+      final Iso<Object, Object> constant = Iso.of(ignored -> "CONST", ignored -> null);
+      final int[] fwd = { -1, 1 };
+      final int[] bwd = { 0, 1 };
+      final Iso<Object, Object>[] fwdIso = new Iso[] { constant, identity };
+      final Iso<Object, Object>[] bwdIso = new Iso[] { identity, identity };
+      final Iso<RecUser, BeanUser> iso = MhIso.pair(RecUser.class, BeanUser.class, fwd, fwdIso, bwd, bwdIso, identity);
+      final var b = iso.to(new RecUser("ignored", 9));
+      assertEquals("CONST", b.getName());
+      assertEquals(9, b.getAge());
+    }
+  }
+}

--- a/internal/src/test/java/io/github/eschizoid/telescope/internal/MhIsoTest.java
+++ b/internal/src/test/java/io/github/eschizoid/telescope/internal/MhIsoTest.java
@@ -3,6 +3,7 @@ package io.github.eschizoid.telescope.internal;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.github.eschizoid.telescope.internal.optics.Iso;
@@ -247,6 +248,27 @@ class MhIsoTest {
       final var b = iso.to(new RecUser("zoe", 99));
       assertEquals("zoe", b.getName());
       assertEquals(0, b.getAge()); // skipped → JLS default, not an NPE
+    }
+
+    @Test
+    @DisplayName("an Error thrown during conversion propagates unwrapped, not masked as a RuntimeException")
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    void errorPropagatesUnwrapped() {
+      final Iso<Object, Object> identity = Iso.identity();
+      // A slot Iso that throws an Error mid-conversion. The array leaf has no try/catch and lets
+      // Errors through raw; MhIso must not mask it as a RuntimeException.
+      final Iso<Object, Object> boom = Iso.of(
+        ignored -> {
+          throw new StackOverflowError("boom");
+        },
+        ignored -> null
+      );
+      final int[] fwd = { 0, 1 };
+      final int[] bwd = { 0, 1 };
+      final Iso<Object, Object>[] fwdIso = new Iso[] { boom, identity };
+      final Iso<Object, Object>[] bwdIso = new Iso[] { identity, identity };
+      final Iso<RecUser, BeanUser> iso = MhIso.pair(RecUser.class, BeanUser.class, fwd, fwdIso, bwd, bwdIso, identity);
+      assertThrows(StackOverflowError.class, () -> iso.to(new RecUser("x", 1)));
     }
   }
 }

--- a/internal/src/test/java/io/github/eschizoid/telescope/internal/MhIsoTest.java
+++ b/internal/src/test/java/io/github/eschizoid/telescope/internal/MhIsoTest.java
@@ -232,7 +232,7 @@ class MhIsoTest {
     }
 
     @Test
-    @DisplayName("a non-identity Iso yielding null into a primitive bean setter is skipped, leaving the default")
+    @DisplayName("a non-identity Iso yielding null into a primitive bean setter is skipped, leaving the" + " default")
     @SuppressWarnings({ "unchecked", "rawtypes" })
     void nullTransformIntoPrimitiveBeanSkipped() {
       final Iso<Object, Object> identity = Iso.identity();


### PR DESCRIPTION
## What

Extends the MethodHandle-combinator runtime path (records, #236) to cover **bean-involving** pairs — **bean→record, record→bean, bean→bean** — where the bean is constructed via no-arg-ctor + setters (the common JavaBean / Lombok `@Data` shape). Same lattice-native `Iso.of` leaf; unboxed end to end.

## How

`MhIso.recordPair` → generalized `pair`, split into two independently record-or-bean halves:
- **Read half** — raw primitive-typed accessor handles: record component accessors (`RecordInfo.accessorHandles`) or **bean getters** (new `Beans.beanAccessorHandles`).
- **Construct half** — record canonical-ctor combinator (`filterArguments`+`permuteArguments`) **or a bean setter-fold**:
  ```
  mk = dropArguments(noArgCtor, 0, srcCls)                              // (S) -> Bean
  per property i:
    setFromS = filterArguments(setter_i, 1, readVal_i)                 // (Bean, S) -> void
    populate = foldArguments(dropArguments(identity(Bean),1,S), setFromS)  // (Bean, S) -> Bean
    mk       = foldArguments(populate, mk)                             // (S) -> Bean
  ```
  The void-returning fold combiner runs each setter as a side effect and threads the bean through — primitives stay **unboxed** because every handle keeps its real signature.

Both halves share one `buildFilter`, so the **identity fast path stays unboxed** and the **`sp<0 → iso.to(null)`** rule (constant / compute / `when`-gate rows) is byte-identical to the array leaf.

## Scope gate (build-time, not a runtime fallback)

`MhIso.supports` returns true when each side is a record (within the arity ceiling) or a bean with a no-arg ctor and a setter for **every** property. Builder-only / immutable / field-injection beans → the array leaf that owns them. No try/catch, no flag — a per-class shape question.

## Lattice

The result is an ordinary `Iso.of(forward, backward)`; composition above the leaf (nested pairs, `liftList`/`liftMapValues`, `.then`) is unchanged and still lattice-routed. The composed handles *are* the leaf's transforms.

## Tests

Full suite green — **1206 tests** across `:core` / `:internal` / `:codegen` / `:lombok` / starters / examples, **optic laws included**, plus 9 new direct `MhIsoTest` cases. Conversion results verified byte-identical to the array leaf, primitives flowing unboxed through getter→setter and getter→ctor. Independently re-run and confirmed (`./gradlew test spotlessCheck` → BUILD SUCCESSFUL).

## Benchmark (canonical CI, 3 forks + gc)

Runtime `MapStructComparison` rows — array (pre-work) → this MH path, and vs MapStruct on the same run:

| tier · direction | array (pre-work) | MH (this work) | improvement | MapStruct | now vs MapStruct |
|---|---:|---:|---:|---:|---:|
| flat forward | 55.6 | **11.8** | 4.7× | 3.11 | 3.8× |
| flat backward | 160.1 | **10.7** | **15.0×** | 3.21 | 3.3× |
| nested forward | 87.6 | **28.4** | 3.1× | 4.33 | 6.6× |
| nested backward | 249.1 | **28.2** | 8.8× | 5.28 | 5.3× |
| deep forward | 377.9 | **193.8** | 1.9× | 46.49 | 4.2× |
| deep backward | 868.7 | **196.7** | 4.4× | 46.06 | 4.3× |

The **backward (record→bean)** direction — previously the pathological case (allocate a bean, then N boxed setter calls: ~48× MapStruct on flat) — is the headline: the unboxed setter-fold takes it to **3.3× MapStruct**, matching the forward direction. Allocation (`gc.alloc.rate.norm`) collapses to result-objects only: flat 32 B/op, nested 48, deep 552 — the `Object[]` and every primitive box gone.

Honest note: the **deep forward** tier improves least (1.9×) because it's `List`-hop-heavy — container elements still route through their `liftList` Iso (boxed per element). Scalar/record leaves within it are unboxed; a container-element MH loop is the next frontier, out of scope here. Cross-hardware caveat: the "array" column is the pre-work baseline run; the vs-MapStruct column is same-run (clean).

No public API change.
