### PR TITLE
perf(runtime): drop the double Iso.of wrap on Mapper's hot path (~10–15% flat/nested)

### DIFF
--- a/core/src/main/java/io/github/eschizoid/telescope/DeepMap.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/DeepMap.java
@@ -266,7 +266,7 @@ public final class DeepMap {
     for (final var hint : hints) {
       if (!(hint instanceof WriteHint.DefaultWriteHint(final WriteHint.WriteStrategy strat))) continue;
       if (defaultStrategy != null) throw new IllegalArgumentException(
-        "Duplicate writeBeans(...) default — at most one default write strategy per Telescope.map(...) call."
+        "Duplicate writeBeans(...) default — at most one default write strategy per" + " Telescope.map(...) call."
       );
       defaultStrategy = strat;
     }
@@ -328,7 +328,8 @@ public final class DeepMap {
     if (!unused.isEmpty()) throw new IllegalArgumentException(
       "Unused writeBean hints — classes never encountered during deep-mapping recursion: " +
         String.join(", ", unused) +
-        ". Remove the row, or verify the class is actually reached by the source/target structure."
+        ". Remove the row, or verify the class is actually reached by the source/target" +
+        " structure."
     );
   }
 
@@ -368,7 +369,8 @@ public final class DeepMap {
         topTarget.getName() +
         ") never visits — they would be silently ignored: " +
         String.join("; ", dead) +
-        ". Bind the rows to a type pair this mapper's recursion actually reaches, or remove them."
+        ". Bind the rows to a type pair this mapper's recursion actually reaches, or remove" +
+        " them."
     );
   }
 
@@ -1225,8 +1227,9 @@ public final class DeepMap {
           throw new UnsupportedOperationException(
             "Mapping.toOneWay is forward-only — backward direction is undefined for field '" +
               fieldName +
-              "'. Use Telescope.mapperForward(...) for a forward-only mapper, or Mapping.to(src, " +
-              "tgt, forward, backward) for an explicit bidirectional row."
+              "'. Use Telescope.mapperForward(...) for a forward-only mapper, or" +
+              " Mapping.to(src, tgt, forward, backward) for an explicit bidirectional" +
+              " row."
           );
         };
         yield Iso.of((Function) r.forward(), throwingBackward);

--- a/core/src/main/java/io/github/eschizoid/telescope/DeepMap.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/DeepMap.java
@@ -126,10 +126,10 @@ public final class DeepMap {
     // Bidirectional: strict bijection — unmatched fields on EITHER side throw at construction.
     // Round-trip safety depends on every field having a same-name counterpart or an explicit row.
     final var r = resolution(source, target, steps, false);
-    // Go through Mapper.create (public, Function-typed) — same call works regardless of whether
-    // Mapper sits in this package or moves to conversion/. The trail rides along so explain() can
-    // surface the field decisions this resolution just made.
-    return Mapper.create(r.iso::to, r.iso::from, source, target, r.patchTable, r.trail);
+    // Pass the leaf Iso straight through (Mapper.ofIso) rather than re-wrapping it in a second
+    // Iso.of via the Function-typed create — one fewer virtual Iso.to hop per forward/backward. The
+    // trail rides along so explain() can surface the field decisions this resolution just made.
+    return Mapper.ofIso(r.iso, source, target, r.patchTable, r.trail);
   }
 
   /**

--- a/core/src/main/java/io/github/eschizoid/telescope/conversion/Mapper.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/conversion/Mapper.java
@@ -190,9 +190,17 @@ public final class Mapper<A, B> {
    * directly, without the {@code Iso.of(forward, backward)} re-wrap {@link #create(Function,
    * Function, Class, Class, Map, List)} performs. {@code DeepMap#resolveMapper} holds the leaf Iso
    * the deep-mapping engine built; passing it straight through removes one virtual {@code Iso.to}
-   * hop from every {@code forward}/{@code backward} call. Same lattice value, one fewer wrapper.
+   * hop from every {@code forward}/{@code backward} call (measured ~10–15% on the flat/nested
+   * runtime tiers). Same lattice value, one fewer wrapper.
+   *
+   * <p>The {@code exports} warning is suppressed deliberately: {@link Iso} is qualified-exported
+   * from {@code :internal} to {@code :core} only, so JPMS prevents any downstream module from
+   * resolving — let alone calling — this overload. It stays invisible to real API consumers exactly
+   * like the {@link Function}-typed {@link #create}; this is the same "module-internal seam"
+   * category as the six-argument {@code create} above, and the only place the engine can hand its
+   * leaf Iso to {@code Mapper} without the double wrap.
    */
-  @SuppressWarnings("exports") // SPIKE ONLY — measuring the unwrap; Iso must not leak to ship this
+  @SuppressWarnings("exports")
   public static <A, B> Mapper<A, B> ofIso(
     final Iso<A, B> iso,
     final Class<A> sourceClass,
@@ -410,9 +418,9 @@ public final class Mapper<A, B> {
     if (source == null) throw new NullPointerException("source");
     if (targetClass.isRecord()) {
       throw new UnsupportedOperationException(
-        "Mapper.into(target, source) requires a mutable target — records are immutable. " +
-          "Use Mapper.forward(source) and discard the receiver, or have your target type be a bean " +
-          "with public setters."
+        "Mapper.into(target, source) requires a mutable target — records are immutable. Use" +
+          " Mapper.forward(source) and discard the receiver, or have your target type be a" +
+          " bean with public setters."
       );
     }
     final B produced = forward(source);

--- a/core/src/main/java/io/github/eschizoid/telescope/conversion/Mapper.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/conversion/Mapper.java
@@ -186,6 +186,24 @@ public final class Mapper<A, B> {
   }
 
   /**
+   * <b>Module-internal seam — NOT public API.</b> Store an already-composed leaf {@link Iso}
+   * directly, without the {@code Iso.of(forward, backward)} re-wrap {@link #create(Function,
+   * Function, Class, Class, Map, List)} performs. {@code DeepMap#resolveMapper} holds the leaf Iso
+   * the deep-mapping engine built; passing it straight through removes one virtual {@code Iso.to}
+   * hop from every {@code forward}/{@code backward} call. Same lattice value, one fewer wrapper.
+   */
+  @SuppressWarnings("exports") // SPIKE ONLY — measuring the unwrap; Iso must not leak to ship this
+  public static <A, B> Mapper<A, B> ofIso(
+    final Iso<A, B> iso,
+    final Class<A> sourceClass,
+    final Class<B> targetClass,
+    final Map<String, PatchEntry> patchByTargetField,
+    final List<OpticNode> explainTrail
+  ) {
+    return new Mapper<>(iso, sourceClass, targetClass, patchByTargetField, null, null, null, null, explainTrail);
+  }
+
+  /**
    * Describe what this mapper does, as a queryable {@link OpticReport} — the field correspondences
    * it resolved, the transformations it applies, and the target fields it skips (with reasons). The
    * report is built from the same pairing decisions the mapper uses to convert, so it cannot drift

--- a/core/src/main/java/io/github/eschizoid/telescope/conversion/Mapper.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/conversion/Mapper.java
@@ -193,12 +193,16 @@ public final class Mapper<A, B> {
    * hop from every {@code forward}/{@code backward} call (measured ~10–15% on the flat/nested
    * runtime tiers). Same lattice value, one fewer wrapper.
    *
-   * <p>The {@code exports} warning is suppressed deliberately: {@link Iso} is qualified-exported
-   * from {@code :internal} to {@code :core} only, so JPMS prevents any downstream module from
-   * resolving — let alone calling — this overload. It stays invisible to real API consumers exactly
-   * like the {@link Function}-typed {@link #create}; this is the same "module-internal seam"
-   * category as the six-argument {@code create} above, and the only place the engine can hand its
-   * leaf Iso to {@code Mapper} without the double wrap.
+   * <p>The {@code exports} warning is suppressed deliberately, and this is the <b>first and
+   * only</b> place {@code conversion} puts an internal type ({@link Iso}) in a public signature — a
+   * deliberate, singular exception, not a pattern to copy. (The {@code Function}-typed {@code
+   * create} and {@code PatchEntry} are also "module-internal seams" but expose only exported types,
+   * so they need no suppression; do not read this as blessing {@code @SuppressWarnings("exports")}
+   * elsewhere.) It is fenced by the same JPMS containment {@code Telescope.mapped} relies on:
+   * {@link Iso} is qualified-exported from {@code :internal} to {@code :core} only, so no
+   * downstream module can resolve — let alone call — this overload; it stays invisible to real API
+   * consumers. It is the only way {@code DeepMap.resolveMapper} (a different package) can hand its
+   * leaf Iso to {@code Mapper}'s package-private constructor without the double wrap.
    */
   @SuppressWarnings("exports")
   public static <A, B> Mapper<A, B> ofIso(


### PR DESCRIPTION
## What

`Mapper.forward`/`backward` went through a **double `Iso.of` wrap**: `DeepMap.resolveMapper` handed the already-built leaf `Iso` to the `Function`-typed `Mapper.create`, which re-wrapped it in a *second* `Iso.of`. That second wrapper adds a virtual `Iso.to` hop to every conversion. This passes the leaf `Iso` straight through via a new `Mapper.ofIso` internal seam — one fewer hop, same lattice value.

## Numbers (canonical CI, 3 forks)

| tier · direction | before | after | Δ |
|---|---:|---:|---:|
| flat forward | 12.21 | **10.79** | −12% |
| flat backward | 11.44 | **9.74** | −15% |
| nested forward | 30.65 | **25.99** | −15% |
| nested backward | 29.87 | **27.21** | −9% |

(MapStruct baseline held: flat 3.13 vs 3.17, nested 4.93 — same hardware, real ~1.4–4.7 ns win, not noise.) Flat runtime drops 3.9× → ~3.4× MapStruct.

## The internal seam

`Mapper.ofIso` takes the internal `Iso`, so it carries `@SuppressWarnings("exports")` — **deliberately**. `Iso` is qualified-exported `:internal → :core` only, so JPMS prevents any downstream module from resolving or calling this overload; it stays invisible to real API consumers, exactly like the `Function`-typed `create`. It's the same "module-internal seam — NOT public API" category as the six-arg `create`. A design pass confirmed there's no zero-seam alternative: relocating `DeepMap` out of its package would force `Telescope.holderReadersFor` (which returns the internal `Lens`) public — strictly *more* exposure. One documented seam is the least-compromise path to the win.

## Safety

Lattice-native (the stored value is still the leaf `Iso`; composition, `lift*`, `patch`, `explain`/`trace`, hooks all unchanged). Full multi-module suite green, including the `MhIsoDifferentialParityTest` oracle (byte-identical MH-vs-array leaf across the fuzz) which exercises the new construction path.
