### PR TITLE
perf(runtime): loop container elements over the raw handle (~2.2× on deep)

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,9 +360,10 @@ the [`Benchmarks`](.github/workflows/benchmarks.yaml) GitHub Action: Actions →
 branch, tune the iteration / fork knobs; the run prints `results.txt` and attaches the full results as an artifact.
 
 > No codegen? `Telescope.mapper(...)` composes each record/bean pair into a single MethodHandle — zero annotations, no
-> build step, and now **within ~4–6× of MapStruct** (flat ~12 ns, deep ~210 ns), down from ~16–48×. Fast enough for most
-> service code as-is; on a tight inner loop, add `@Bridge` and you're back in MapStruct's performance class. The
-> runtime-vs-codegen numbers are in
+> build step, and now **within ~1.3–6× of MapStruct** (flat ~12 ns, deep ~90 ns), down from ~16–48×. Deep
+> container-heavy trees are the closest: a nested `List`/`Set`/`Map` element loops over the leaf's raw handle instead of
+> dispatching per element. Fast enough for most service code as-is; on a tight inner loop, add `@Bridge` and you're back
+> in MapStruct's performance class. The runtime-vs-codegen numbers are in
 > [`benchmarks/README.md`](benchmarks/README.md#mapstruct-comparison-apples-to-apples).
 
 #### Then, what you gain

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -232,8 +232,14 @@ difference between same-tier rows is the dispatch path. Reproducible: re-run the
 | flat   | record → bean |     3.305 ± 0.028 |             3.485 ± 0.022 |                                — |             11.44 ± 0.947 |
 | nested | bean → record |     4.928 ± 0.024 |             5.879 ± 0.022 |                    5.553 ± 0.011 |             30.65 ± 2.596 |
 | nested | record → bean |     5.983 ± 0.024 |             5.355 ± 0.019 |                                — |             29.87 ± 0.504 |
-| deep   | bean → record |     48.68 ± 0.106 |             55.04 ± 0.522 |                    54.71 ± 0.375 |            212.26 ± 8.427 |
-| deep   | record → bean |     48.54 ± 0.273 |             54.81 ± 0.418 |                                — |            215.27 ± 2.921 |
+| deep   | bean → record |     48.68 ± 0.106 |             55.04 ± 0.522 |                    54.71 ± 0.375 |              90.1 ± 2.5\* |
+| deep   | record → bean |     48.54 ± 0.273 |             54.81 ± 0.418 |                                — |              95.0 ± 2.5\* |
+
+\* The deep runtime cells were re-measured on a laptop after the container-element MethodHandle loop landed (a nested
+`List` element now loops over the leaf's raw handle instead of dispatching `Iso.to` per element). Same-machine A/B on
+that laptop: main **205.4 / 207.2 ns** → branch **90.1 / 95.0 ns** (**~2.2×**), taking deep runtime from ~4.4× MapStruct
+to ~1.3–1.9× on the same box. The other cells are the CI runner's; the whole table refreshes on the next benchmark
+workflow run.
 
 Tight error bands on the codegen/MapStruct rows (±0.01–0.35 ns) — the dedicated CI runner with no competing workload
 gives cleaner data than a laptop. The `static` column calls the codegen-emitted `<Source>Bridge.forward(s)` directly,
@@ -282,12 +288,16 @@ the directly-callable `BRIDGE_FN` constant — and pay the zero-dispatch floor.
 
 Runtime conversion (`Telescope.mapper(...)`) composes each record/bean pair into a single MethodHandle (see above), so
 the hot path is one `invokeExact` through the fused handle rather than an `Object[]` gather with boxed per-field
-dispatch. That lands the forward direction at **~3.9× MapStruct on flat, ~6.2× on nested, ~4.4× on deep**. The backward
-(record → bean) direction — previously the pathological case (allocate a bean, then N boxed setter calls, ~48× MapStruct
-on flat) — is now **~3.5× on flat** via the unboxed setter-fold, matching forward instead of trailing it. Allocation
-drops to the result-object floor (flat 32 B/op, the array + every primitive box gone). Sub-microsecond everywhere. Reach
-for codegen on the hottest paths; the runtime path is now within ~4–6× of MapStruct with **no annotations and no build
-step** — close enough for most service code, and `@Bridge` codegen is there when a loop turns hot.
+dispatch. That lands the forward direction at **~3.9× MapStruct on flat, ~6.2× on nested, ~1.3–1.9× on deep**. Deep used
+to trail at ~4.4×; the container-element MethodHandle loop (a nested `List`/`Set`/`Map` element loops over the leaf's
+raw handle instead of dispatching `Iso.to` → `Function.apply` per element, which also un-megamorphizes the shared lift
+call site) roughly halved it — same-machine 205 → 90 ns. The backward (record → bean) direction — previously the
+pathological case (allocate a bean, then N boxed setter calls, ~48× MapStruct on flat) — is now **~3.5× on flat** via
+the unboxed setter-fold, matching forward instead of trailing it. Allocation drops to the result-object floor (flat 32
+B/op, the array + every primitive box gone). Sub-microsecond everywhere. Reach for codegen on the hottest paths; the
+runtime path is now within ~1.3–6× of MapStruct with **no annotations and no build step** — and closest exactly where it
+matters most, on the deep container-heavy trees — close enough for most service code, and `@Bridge` codegen is there
+when a loop turns hot.
 
 All four columns above are from the same run; the codegen/MapStruct ratios reproduce across confirming runs within error
 (the runtime rows carry wider bands but the same magnitude).

--- a/benchmarks/src/jmh/java/io/github/eschizoid/telescope/benchmarks/ContainerLoopSpikeBenchmark.java
+++ b/benchmarks/src/jmh/java/io/github/eschizoid/telescope/benchmarks/ContainerLoopSpikeBenchmark.java
@@ -1,0 +1,167 @@
+package io.github.eschizoid.telescope.benchmarks;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+/**
+ * Decision-gate spike for the container-element lever: does mapping {@code List<Src> -> List<Dst>}
+ * as a single {@link MethodHandles#iteratedLoop} over the raw {@code (Object)->Object} element
+ * handle beat the current {@code liftList} path (a Java for-loop whose body dispatches {@code
+ * Iso.to} -> {@code Function.apply} -> invokeExact per element)?
+ *
+ * <p>Fixture is the deep benchmark's inner hop: {@code List<Team>} of 3 elements, Team = {@code
+ * (String name, int headcount)}, a record-to-record leaf. Four rows:
+ *
+ * <ul>
+ *   <li>{@code handWritten} — Java for-loop, direct {@code new Dst(...)}. The MapStruct ceiling.
+ *   <li>{@code liftListIso} — current path: a Java for-loop calling {@code elementIso.to(x)} where
+ *       {@code elementIso} wraps the raw handle in {@code Iso.of}-shaped {@code (Object)->Object}
+ *       Function (two virtual hops per element).
+ *   <li>{@code mhIteratedLoop} — one {@code iteratedLoop} handle whose body invokes the raw element
+ *       handle directly (invokeExact, no SAM hop), invoked once via invokeExact.
+ *   <li>{@code fnLoop} — Java for-loop calling the raw element handle wrapped in a single {@code
+ *       Function} (one virtual hop), to isolate the Iso.to layer from the Function.apply layer.
+ * </ul>
+ *
+ * <p>If {@code mhIteratedLoop} does not clear {@code liftListIso} by a real margin, the honest call
+ * is that the runtime container path is at the dispatch floor and codegen owns the hot loop.
+ */
+@State(Scope.Thread)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(2)
+public class ContainerLoopSpikeBenchmark {
+
+  public record Src(String name, int headcount) {}
+
+  public record Dst(String name, int headcount) {}
+
+  private List<Src> input;
+
+  // Raw element handle: (Object)->Object == (Src)->Dst, erased. Same shape MhIso.compose emits.
+  private MethodHandle rawElem;
+  // The current path's element Iso, modeled as a (Object)->Object Function behind an Iso.to shim.
+  private ElementIso elementIso;
+  // Raw element as a single Function (isolates the Function.apply layer).
+  private Function<Object, Object> elemFn;
+  // The whole List->List conversion as one iteratedLoop handle.
+  private MethodHandle listLoop;
+
+  /** Minimal stand-in for Iso: to() dispatches through a stored Function (two virtual hops). */
+  interface ElementIso {
+    Object to(Object x);
+  }
+
+  @Setup
+  public void setup() throws Throwable {
+    input = new ArrayList<>(3);
+    input.add(new Src("alpha", 4));
+    input.add(new Src("beta", 7));
+    input.add(new Src("gamma", 2));
+
+    final MethodHandles.Lookup lk = MethodHandles.lookup();
+
+    final MethodHandle ctor = lk.findConstructor(Dst.class, MethodType.methodType(void.class, String.class, int.class));
+    final MethodHandle nameAcc = lk.findVirtual(Src.class, "name", MethodType.methodType(String.class));
+    final MethodHandle hcAcc = lk.findVirtual(Src.class, "headcount", MethodType.methodType(int.class));
+    // (Src, Src) -> Dst  then permute to a single Src input: (Src) -> Dst.
+    final MethodHandle filtered = MethodHandles.filterArguments(ctor, 0, nameAcc, hcAcc);
+    final MethodHandle elem = MethodHandles.permuteArguments(
+      filtered,
+      MethodType.methodType(Dst.class, Src.class),
+      0,
+      0
+    );
+    rawElem = elem.asType(MethodType.methodType(Object.class, Object.class));
+
+    final MethodHandle raw = rawElem;
+    elemFn = x -> {
+      try {
+        return raw.invokeExact(x);
+      } catch (final Throwable t) {
+        throw new RuntimeException(t);
+      }
+    };
+    final Function<Object, Object> fn = elemFn;
+    elementIso = fn::apply;
+
+    listLoop = buildListLoop(rawElem);
+  }
+
+  /**
+   * Build {@code (List)->List} as one {@code iteratedLoop}: init = new ArrayList, body = {@code
+   * acc.add(elem(x)); return acc}, default iteration over the sole external List argument.
+   */
+  private static MethodHandle buildListLoop(final MethodHandle elem) throws Throwable {
+    final MethodHandles.Lookup lk = MethodHandles.lookup();
+
+    // init: (List) -> ArrayList  == new ArrayList()
+    final MethodHandle newList = lk
+      .findConstructor(ArrayList.class, MethodType.methodType(void.class))
+      .asType(MethodType.methodType(ArrayList.class));
+    final MethodHandle init = MethodHandles.dropArguments(newList, 0, List.class);
+
+    // add: (ArrayList, Object) -> boolean  (List.add via ArrayList)
+    final MethodHandle add = lk
+      .findVirtual(ArrayList.class, "add", MethodType.methodType(boolean.class, Object.class))
+      .asType(MethodType.methodType(boolean.class, ArrayList.class, Object.class));
+    // filter the element through the raw handle: (ArrayList, Object) -> boolean
+    final MethodHandle mapped = MethodHandles.filterArguments(add, 1, elem);
+    // drop the boolean result -> void: (ArrayList, Object) -> void
+    final MethodHandle addVoid = mapped.asType(mapped.type().changeReturnType(void.class));
+    // return the accumulator: fold the void add before an identity that yields arg0.
+    final MethodHandle retAcc = MethodHandles.dropArguments(MethodHandles.identity(ArrayList.class), 1, Object.class);
+    final MethodHandle body2 = MethodHandles.foldArguments(retAcc, addVoid); // (ArrayList, Object) -> ArrayList
+    // iteratedLoop body wants (V, T, A...) -> V ; append the external List arg.
+    final MethodHandle body = MethodHandles.dropArguments(body2, 2, List.class); // (ArrayList, Object, List) -> ArrayList
+
+    // iterator = null -> default iterates the sole external argument (the List).
+    final MethodHandle loop = MethodHandles.iteratedLoop(null, init, body); // (List) -> ArrayList
+    return loop.asType(MethodType.methodType(List.class, List.class));
+  }
+
+  @Benchmark
+  public void handWritten(final Blackhole bh) {
+    final List<Dst> out = new ArrayList<>(input.size());
+    for (final Src s : input) out.add(new Dst(s.name(), s.headcount()));
+    bh.consume(out);
+  }
+
+  @Benchmark
+  public void liftListIso(final Blackhole bh) {
+    final List<Object> out = new ArrayList<>(input.size());
+    for (final Src s : input) out.add(elementIso.to(s));
+    bh.consume(out);
+  }
+
+  @Benchmark
+  public void fnLoop(final Blackhole bh) {
+    final List<Object> out = new ArrayList<>(input.size());
+    for (final Src s : input) out.add(elemFn.apply(s));
+    bh.consume(out);
+  }
+
+  @Benchmark
+  public void mhIteratedLoop(final Blackhole bh) throws Throwable {
+    final List<?> out = (List<?>) listLoop.invokeExact((List<Src>) input);
+    bh.consume(out);
+  }
+}

--- a/core/src/main/java/io/github/eschizoid/telescope/DeepMap.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/DeepMap.java
@@ -1146,19 +1146,26 @@ public final class DeepMap {
         cyclicPairs,
         inProgress
       );
+      // For the collection lifts, reach through the acyclic cache proxy to the concrete element Iso
+      // so the lift can loop over an MhIso leaf's raw handle (see resolveElementForLift). Optional
+      // is
+      // ≤1 element — no loop to sharpen — so it keeps the proxy.
+      final var forLift = resolveElementForLift(
+        d.src().elementType(),
+        d.tgt().elementType(),
+        cache,
+        cyclicPairs,
+        elementIso
+      );
       return switch (d.src().kind()) {
         case LIST -> liftListIntoTargetRaw(
-          eraseIso(elementIso),
+          eraseIso(forLift),
           (Class<?>) d.src().rawType(),
           (Class<?>) d.tgt().rawType()
         );
-        case SET -> liftSetIntoTargetRaw(
-          eraseIso(elementIso),
-          (Class<?>) d.src().rawType(),
-          (Class<?>) d.tgt().rawType()
-        );
+        case SET -> liftSetIntoTargetRaw(eraseIso(forLift), (Class<?>) d.src().rawType(), (Class<?>) d.tgt().rawType());
         case MAP_VALUES -> liftMapIntoTargetRaw(
-          eraseIso(elementIso),
+          eraseIso(forLift),
           (Class<?>) d.src().rawType(),
           (Class<?>) d.tgt().rawType()
         );
@@ -1405,6 +1412,16 @@ public final class DeepMap {
   ) {
     final var srcAlloc = listAllocatorFor(srcRaw);
     final var tgtAlloc = listAllocatorFor(tgtRaw);
+    // When the element is a composed-handle leaf, iterate with a MethodHandle loop over its raw
+    // element handle instead of dispatching elementIso.to(x) -> Function.apply per element. In a
+    // deep
+    // tree the shared Java-loop lambda's call site goes megamorphic across nesting levels and the
+    // JIT
+    // stops inlining the element conversion; a dedicated per-level loop handle stays monomorphic
+    // and
+    // inlines. Null for a scalar/array-leaf element; keep the plain Java loop for those.
+    final var mh = MhIso.liftCollection(elementIso, srcAlloc, tgtAlloc);
+    if (mh != null) return mh;
     return Iso.of(
       src -> {
         if (src == null) return null;
@@ -1434,6 +1451,10 @@ public final class DeepMap {
   ) {
     final var srcAlloc = setAllocatorFor(srcRaw);
     final var tgtAlloc = setAllocatorFor(tgtRaw);
+    // Same MethodHandle-loop sharpening as the List lift (Set is also Collection.add). Null element
+    // Iso => keep the Java loop.
+    final var mh = MhIso.liftCollection(elementIso, srcAlloc, tgtAlloc);
+    if (mh != null) return mh;
     return Iso.of(
       src -> {
         if (src == null) return null;
@@ -1465,6 +1486,11 @@ public final class DeepMap {
   ) {
     final var srcAlloc = mapAllocatorFor(srcRaw);
     final var tgtAlloc = mapAllocatorFor(tgtRaw);
+    // MethodHandle entry-loop over the value element's raw handle when it is a composed-handle
+    // leaf;
+    // keys pass through verbatim. Null value Iso => keep the Java loop.
+    final var mh = MhIso.liftMap(elementIso, srcAlloc, tgtAlloc);
+    if (mh != null) return mh;
     return Iso.of(
       src -> {
         if (src == null) return null;
@@ -1766,6 +1792,39 @@ public final class DeepMap {
   private static final ThreadLocal<IdentityHashMap<Object, Boolean>> BACKWARD_SEEN = ThreadLocal.withInitial(
     IdentityHashMap::new
   );
+
+  /**
+   * Reach through the {@link #lazyCacheIso} proxy that {@code autoIso} returns for a container's
+   * element to the concrete element {@link Iso} in the cache, so a collection/map lift can loop
+   * over an {@code MhIso} leaf's raw handle instead of dispatching through the proxy per element.
+   *
+   * <p>Safe only for an <b>acyclic</b> pair: the proxy's acyclic branch is {@code v == null ? null
+   * : cache.get(key).to(v)} — a null guard plus a delegate — and the container loops reproduce that
+   * null guard per element, so looping over the cached leaf is byte-identical to looping over the
+   * proxy. By the time this runs (during the outer pair's {@code populateIso}), the element pair's
+   * {@code populateIso} has already completed, so {@code cache.get(key)} is the finished leaf.
+   *
+   * <p>Returns the {@code proxy} unchanged when the pair is cyclic (the per-call cycle guard in the
+   * proxy must stay), when either element type is not a raw {@link Class} (nested containers,
+   * wildcard elements — no cache key), or when the element is a scalar with no cache entry. In
+   * every fall-back case the lift keeps its plain Java loop.
+   */
+  private static Iso<?, ?> resolveElementForLift(
+    final Type srcElem,
+    final Type tgtElem,
+    final Map<TypePair, Iso<?, ?>> cache,
+    final Set<TypePair> cyclicPairs,
+    final Iso<?, ?> proxy
+  ) {
+    if (srcElem instanceof Class<?> s && tgtElem instanceof Class<?> t) {
+      final var key = new TypePair(s, t);
+      if (!cyclicPairs.contains(key)) {
+        final var cached = cache.get(key);
+        if (cached != null) return cached;
+      }
+    }
+    return proxy;
+  }
 
   @SuppressWarnings("unchecked")
   private static Iso<?, ?> lazyCacheIso(

--- a/core/src/test/java/io/github/eschizoid/telescope/MhContainerLoopParityTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/MhContainerLoopParityTest.java
@@ -1,0 +1,127 @@
+package io.github.eschizoid.telescope;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.github.eschizoid.telescope.internal.MhIso;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Isolates the two container-lift loop strategies against each other. {@link
+ * MhIsoDifferentialParityTest} pins the MethodHandle loop against the whole array leaf; this
+ * harness flips <em>only</em> the loop strategy — {@link MhIso#CONTAINER_DISABLE_PROPERTY} routes a
+ * Leaf element back through the Java loop while keeping the same composed-handle Leaf on both sides
+ * — and asserts the MethodHandle {@code iteratedLoop} lift is byte-identical to the Java for-loop
+ * lift over that identical Leaf, forward and backward, across List / Set / Map with multi-element,
+ * null element, empty, and null-container samples.
+ */
+@DisplayName("MhIso container MethodHandle loop ↔ Java loop parity (same Leaf)")
+final class MhContainerLoopParityTest {
+
+  @AfterEach
+  void restoreToggle() {
+    System.clearProperty(MhIso.CONTAINER_DISABLE_PROPERTY);
+  }
+
+  // Distinct-but-structurally-equal element records so the element conversion is a real Leaf, not
+  // an identity.
+  record Elem(String name, int n) {}
+
+  record Elem2(String name, int n) {}
+
+  record ListHolder(List<Elem> items) {}
+
+  record ListHolder2(List<Elem2> items) {}
+
+  record SetHolder(Set<Elem> items) {}
+
+  record SetHolder2(Set<Elem2> items) {}
+
+  record MapHolder(Map<String, Elem> byKey) {}
+
+  record MapHolder2(Map<String, Elem2> byKey) {}
+
+  @Test
+  @DisplayName("List lift: MH loop == Java loop over the same Leaf element")
+  void listLoopParity() {
+    for (final ListHolder sample : List.of(
+      new ListHolder(List.of(new Elem("a", 1), new Elem("b", 2), new Elem("c", 3))),
+      new ListHolder(List.of()),
+      new ListHolder(nullableList(new Elem("x", 7), null, new Elem("z", 9)))
+    )) {
+      assertLoopParity(ListHolder.class, ListHolder2.class, sample);
+    }
+    assertLoopParity(ListHolder.class, ListHolder2.class, new ListHolder(null));
+    assertLoopParity(ListHolder.class, ListHolder2.class, null);
+  }
+
+  @Test
+  @DisplayName("Set lift: MH loop == Java loop over the same Leaf element")
+  void setLoopParity() {
+    for (final SetHolder sample : List.of(
+      new SetHolder(new LinkedHashSet<>(List.of(new Elem("a", 1), new Elem("b", 2)))),
+      new SetHolder(Set.of()),
+      new SetHolder(nullableSet(new Elem("x", 7), null))
+    )) {
+      assertLoopParity(SetHolder.class, SetHolder2.class, sample);
+    }
+    assertLoopParity(SetHolder.class, SetHolder2.class, new SetHolder(null));
+  }
+
+  @Test
+  @DisplayName("Map-values lift: MH loop == Java loop over the same Leaf element")
+  void mapLoopParity() {
+    final Map<String, Elem> multi = new LinkedHashMap<>();
+    multi.put("k1", new Elem("m1", 11));
+    multi.put("k2", new Elem("m2", 12));
+    final Map<String, Elem> withNullValue = new LinkedHashMap<>();
+    withNullValue.put("present", new Elem("p", 1));
+    withNullValue.put("absent", null);
+    for (final MapHolder sample : List.of(
+      new MapHolder(multi),
+      new MapHolder(Map.of()),
+      new MapHolder(withNullValue)
+    )) {
+      assertLoopParity(MapHolder.class, MapHolder2.class, sample);
+    }
+    assertLoopParity(MapHolder.class, MapHolder2.class, new MapHolder(null));
+  }
+
+  /**
+   * Build the mapper under each toggle (MH loop cleared, Java loop set) and assert forward — and,
+   * when the forward result is a non-null match, backward — are byte-identical. Rebuilds the mapper
+   * per toggle so the flag is read at construction time.
+   */
+  private <A, B> void assertLoopParity(final Class<A> src, final Class<B> tgt, final A sample) {
+    System.clearProperty(MhIso.CONTAINER_DISABLE_PROPERTY);
+    final B mh = Telescope.mapper(src, tgt).forward(sample);
+    System.setProperty(MhIso.CONTAINER_DISABLE_PROPERTY, "true");
+    final B java = Telescope.mapper(src, tgt).forward(sample);
+    assertEquals(java, mh, "forward diverged for " + sample);
+
+    if (mh != null && Objects.equals(mh, java)) {
+      System.clearProperty(MhIso.CONTAINER_DISABLE_PROPERTY);
+      final A mhBack = Telescope.mapper(src, tgt).backward(mh);
+      System.setProperty(MhIso.CONTAINER_DISABLE_PROPERTY, "true");
+      final A javaBack = Telescope.mapper(src, tgt).backward(mh);
+      assertEquals(javaBack, mhBack, "backward diverged for " + mh);
+    }
+  }
+
+  private static List<Elem> nullableList(final Elem... es) {
+    return new ArrayList<>(Arrays.asList(es));
+  }
+
+  private static Set<Elem> nullableSet(final Elem... es) {
+    return new LinkedHashSet<>(Arrays.asList(es));
+  }
+}

--- a/internal/src/main/java/io/github/eschizoid/telescope/internal/MhIso.java
+++ b/internal/src/main/java/io/github/eschizoid/telescope/internal/MhIso.java
@@ -4,8 +4,13 @@ import io.github.eschizoid.telescope.internal.optics.Iso;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 /**
  * MethodHandle-combinator assembly of a structural conversion {@link Iso} where each side is a
@@ -32,10 +37,13 @@ import java.util.function.Function;
  *       it can be null-guarded before unboxing (see {@code setterFromSource}).
  * </ul>
  *
- * <p><b>Lattice.</b> The result is an ordinary {@link Iso#of(Function, Function)} — the composed
- * handles <em>are</em> the leaf Iso's forward/backward transforms. Composition above this leaf
- * (nested pairs, {@code liftList}/{@code liftMapValues}, {@code .then(...)}) is unchanged and still
- * routes through the optic lattice. This sharpens the leaf; it does not bypass the lattice.
+ * <p><b>Lattice.</b> The result is a {@code Leaf} — an {@link Iso} whose forward/backward
+ * <em>are</em> the composed handles (wrapped as null-guarded {@code Function}s, exactly as {@link
+ * Iso#of(Function, Function)} would), and which additionally exposes those raw {@code
+ * (Object)->Object} handles so a parent container lift can loop over them directly (see {@link
+ * #liftCollection}/{@link #liftMap}). Composition above this leaf (nested pairs, {@code
+ * liftList}/{@code liftMapValues}, {@code .then(...)}) is unchanged and still routes through the
+ * optic lattice. This sharpens the leaf; it does not bypass the lattice.
  */
 public final class MhIso {
 
@@ -89,6 +97,15 @@ public final class MhIso {
   private static final MethodHandle ISO_FROM;
   // (Object) -> boolean  ==  value != null. Guards a primitive bean setter against a null value.
   private static final MethodHandle NON_NULL;
+  // Combinator primitives for the container-element loops (liftCollection / liftMap), all erased to
+  // Object receivers so the loop bodies read/write through the raw element handle with no box.
+  private static final MethodHandle ITERABLE_ITERATOR; // (Object) -> Iterator      Iterable.iterator
+  private static final MethodHandle COLLECTION_ADD; //     (Object, Object) -> boolean Collection.add
+  private static final MethodHandle MAP_ENTRYSET; //       (Object) -> Object        Map.entrySet
+  private static final MethodHandle MAP_PUT; //            (Object, Object, Object) -> Object Map.put
+  private static final MethodHandle ENTRY_KEY; //          (Object) -> Object        Map.Entry.getKey
+  private static final MethodHandle ENTRY_VALUE; //        (Object) -> Object      Map.Entry.getValue
+  private static final MethodHandle SUPPLIER_GET; //       (Supplier) -> Object      Supplier.get
 
   static {
     try {
@@ -96,6 +113,27 @@ public final class MhIso {
       ISO_TO = lk.findVirtual(Iso.class, "to", MethodType.methodType(Object.class, Object.class));
       ISO_FROM = lk.findVirtual(Iso.class, "from", MethodType.methodType(Object.class, Object.class));
       NON_NULL = lk.findStatic(Objects.class, "nonNull", MethodType.methodType(boolean.class, Object.class));
+      ITERABLE_ITERATOR = lk
+        .findVirtual(Iterable.class, "iterator", MethodType.methodType(Iterator.class))
+        .asType(MethodType.methodType(Iterator.class, Object.class));
+      COLLECTION_ADD = lk
+        .findVirtual(Collection.class, "add", MethodType.methodType(boolean.class, Object.class))
+        .asType(MethodType.methodType(boolean.class, Object.class, Object.class));
+      MAP_ENTRYSET = lk
+        .findVirtual(Map.class, "entrySet", MethodType.methodType(Set.class))
+        .asType(MethodType.methodType(Object.class, Object.class));
+      MAP_PUT = lk
+        .findVirtual(Map.class, "put", MethodType.methodType(Object.class, Object.class, Object.class))
+        .asType(MethodType.methodType(Object.class, Object.class, Object.class, Object.class));
+      ENTRY_KEY = lk
+        .findVirtual(Map.Entry.class, "getKey", MethodType.methodType(Object.class))
+        .asType(MethodType.methodType(Object.class, Object.class));
+      ENTRY_VALUE = lk
+        .findVirtual(Map.Entry.class, "getValue", MethodType.methodType(Object.class))
+        .asType(MethodType.methodType(Object.class, Object.class));
+      SUPPLIER_GET = lk
+        .findVirtual(Supplier.class, "get", MethodType.methodType(Object.class))
+        .asType(MethodType.methodType(Object.class, Supplier.class));
     } catch (final ReflectiveOperationException e) {
       throw new ExceptionInInitializerError(e);
     }
@@ -148,7 +186,76 @@ public final class MhIso {
         throw rethrow(target, source, e);
       }
     };
-    return Iso.of(forward, backward);
+    // Return a Leaf carrier rather than a bare Iso.of: it behaves identically as an Iso (to/from
+    // delegate to the null-guarded Functions above) but also carries the raw (Object)->Object
+    // composed handles and the element source/target classes, so a parent's container slot can loop
+    // over the handles directly (liftCollection / liftMap) and label a per-element conversion
+    // failure
+    // with the real classes. The raw handles carry NO null guard (that lives in forward/backward);
+    // the container loops add a per-element null guard so a null element maps to null, matching the
+    // Java path's iso.to(null) == null.
+    return new Leaf<>(source, target, forward, backward, fwd, bwd);
+  }
+
+  /**
+   * The Iso returned by {@link #pair}: an ordinary structural-conversion {@link Iso} that also
+   * exposes its raw {@code (Object)->Object} forward/backward handles and its element source/target
+   * classes. A parent leaf that holds this as a container element's Iso ({@code List<Leaf>}, {@code
+   * Set<Leaf>}, {@code Map<K, Leaf>}) can loop over {@link #rawForward()} / {@link #rawBackward()}
+   * with a MethodHandle loop instead of dispatching {@code Iso.to} &rarr; {@code Function.apply}
+   * per element, and label a per-element failure with {@link #sourceClass()} / {@link
+   * #targetClass()}.
+   */
+  private static final class Leaf<S, T> implements Iso<S, T> {
+
+    private final Class<S> sourceClass;
+    private final Class<T> targetClass;
+    private final Function<S, T> forward;
+    private final Function<T, S> backward;
+    private final MethodHandle rawFwd;
+    private final MethodHandle rawBwd;
+
+    Leaf(
+      final Class<S> sourceClass,
+      final Class<T> targetClass,
+      final Function<S, T> forward,
+      final Function<T, S> backward,
+      final MethodHandle rawFwd,
+      final MethodHandle rawBwd
+    ) {
+      this.sourceClass = sourceClass;
+      this.targetClass = targetClass;
+      this.forward = forward;
+      this.backward = backward;
+      this.rawFwd = rawFwd;
+      this.rawBwd = rawBwd;
+    }
+
+    @Override
+    public T to(final S source) {
+      return forward.apply(source);
+    }
+
+    @Override
+    public S from(final T value) {
+      return backward.apply(value);
+    }
+
+    MethodHandle rawForward() {
+      return rawFwd;
+    }
+
+    MethodHandle rawBackward() {
+      return rawBwd;
+    }
+
+    Class<S> sourceClass() {
+      return sourceClass;
+    }
+
+    Class<T> targetClass() {
+      return targetClass;
+    }
   }
 
   /**
@@ -348,6 +455,167 @@ public final class MhIso {
     }
     final MethodHandle readVal = buildFilter(srcCls, slotType, srcAccessors, sp, slotIso, isoDir, identity);
     return MethodHandles.filterArguments(setter, 1, readVal);
+  }
+
+  /**
+   * Sharpen a {@code Collection}-of-element container lift: when {@code elementIso} is a {@link
+   * Leaf} (a record/bean pair this assembler composed), build the {@code List}/{@code Set}
+   * conversion as a MethodHandle {@link MethodHandles#iteratedLoop} that invokes the leaf's raw
+   * {@code (Object)->Object} handle per element — no {@code Iso.to} &rarr; {@code Function.apply}
+   * SAM hop in the loop body. {@code srcAlloc}/{@code tgtAlloc} produce the concrete source/target
+   * collection (the same allocators {@code DeepMap} uses), so iteration order and collection type
+   * are preserved.
+   *
+   * <p>Returns {@code null} when {@code elementIso} is not a Leaf (a scalar element, or an element
+   * on the array leaf) — the caller keeps its plain Java-loop lift for those. Mirrors the {@link
+   * #supports} / {@link #pair} probe-then-build split: this is a build-time sharpening, never a
+   * runtime fallback. Also returns {@code null} when {@link #CONTAINER_DISABLE_PROPERTY} is set
+   * (the test seam that routes a Leaf element back through the Java loop for differential parity).
+   */
+  public static Iso<Object, Object> liftCollection(
+    final Iso<Object, Object> elementIso,
+    final Supplier<Object> srcAlloc,
+    final Supplier<Object> tgtAlloc
+  ) {
+    if (Boolean.getBoolean(CONTAINER_DISABLE_PROPERTY)) return null;
+    if (!(elementIso instanceof Leaf<?, ?> leaf)) return null;
+    final MethodHandle fwd = collectionLoop(guardElement(leaf.rawForward()), tgtAlloc);
+    final MethodHandle bwd = collectionLoop(guardElement(leaf.rawBackward()), srcAlloc);
+    return containerIso(fwd, bwd, leaf.sourceClass(), leaf.targetClass());
+  }
+
+  /**
+   * System property (test-only) that forces every container lift back to its caller's Java loop
+   * even for a Leaf element, so {@code MhContainerLoopParityTest} can compare the MethodHandle loop
+   * against the Java loop over the identical Leaf. Unset in production; read once at build time.
+   */
+  public static final String CONTAINER_DISABLE_PROPERTY = "io.github.eschizoid.telescope.mhiso.container.disabled";
+
+  /**
+   * Sharpen a {@code Map}-values container lift the same way {@link #liftCollection} sharpens
+   * List/Set: a MethodHandle loop over the source map's entry set that puts {@code key ->
+   * rawElement(value)} into a fresh target map. Keys pass through verbatim (matching {@code
+   * Iso.liftMapValues}); only values route through the Leaf's raw handle. Returns {@code null} when
+   * the value element is not a Leaf (or the container test seam is set).
+   */
+  public static Iso<Object, Object> liftMap(
+    final Iso<Object, Object> valueIso,
+    final Supplier<Object> srcAlloc,
+    final Supplier<Object> tgtAlloc
+  ) {
+    if (Boolean.getBoolean(CONTAINER_DISABLE_PROPERTY)) return null;
+    if (!(valueIso instanceof Leaf<?, ?> leaf)) return null;
+    final MethodHandle fwd = mapLoop(guardElement(leaf.rawForward()), tgtAlloc);
+    final MethodHandle bwd = mapLoop(guardElement(leaf.rawBackward()), srcAlloc);
+    return containerIso(fwd, bwd, leaf.sourceClass(), leaf.targetClass());
+  }
+
+  /**
+   * Wrap two {@code (Object)->Object} whole-container loop handles as an {@link Iso}. The null
+   * guard for a null container reference stays here (outside the loop), mirroring the Java lifts'
+   * {@code xs == null ? null} head; a null container round-trips to null. {@code elemSrc}/{@code
+   * elemTgt} are the container element's source/target classes, so a per-element conversion failure
+   * is labelled with the real types (and the right direction) exactly as the Java lift's {@code
+   * elementIso.to} / {@code from} would — the forward direction converts {@code elemSrc ->
+   * elemTgt}, the backward {@code elemTgt -> elemSrc}.
+   */
+  private static Iso<Object, Object> containerIso(
+    final MethodHandle fwd,
+    final MethodHandle bwd,
+    final Class<?> elemSrc,
+    final Class<?> elemTgt
+  ) {
+    return Iso.of(
+      xs -> {
+        if (xs == null) return null;
+        try {
+          return (Object) fwd.invokeExact(xs);
+        } catch (final Throwable e) {
+          throw rethrow(elemSrc, elemTgt, e);
+        }
+      },
+      ys -> {
+        if (ys == null) return null;
+        try {
+          return (Object) bwd.invokeExact(ys);
+        } catch (final Throwable e) {
+          throw rethrow(elemTgt, elemSrc, e);
+        }
+      }
+    );
+  }
+
+  /**
+   * Per-element null guard: {@code element == null ? null : raw(element)}. A container may hold
+   * null elements; the Java lift calls {@code elementIso.to(null)} which returns null (the Leaf's
+   * forward Function short-circuits on null). The raw handle has no such guard — apply one here so
+   * the loop body matches byte-for-byte.
+   */
+  private static MethodHandle guardElement(final MethodHandle rawElem) {
+    final MethodType t = MethodType.methodType(Object.class, Object.class);
+    final MethodHandle nullConst = MethodHandles.dropArguments(
+      MethodHandles.constant(Object.class, null),
+      0,
+      Object.class
+    );
+    return MethodHandles.guardWithTest(NON_NULL, rawElem.asType(t), nullConst);
+  }
+
+  /**
+   * Build {@code (Object srcColl) -> Object tgtColl}: allocate a fresh target collection, iterate
+   * the source, and {@code add(element(x))} for each. {@code element} is the null-guarded raw
+   * handle.
+   */
+  private static MethodHandle collectionLoop(final MethodHandle element, final Supplier<Object> tgtAlloc) {
+    // init : (Object srcColl) -> Object tgtColl  == fresh target collection, ignoring the source
+    // arg.
+    final MethodHandle init = MethodHandles.dropArguments(supplierGet(tgtAlloc), 0, Object.class);
+    // add(acc, element(x)) as a void side effect: (Object acc, Object x) -> void.
+    final MethodHandle mapped = MethodHandles.filterArguments(COLLECTION_ADD, 1, element);
+    final MethodHandle addVoid = mapped.asType(mapped.type().changeReturnType(void.class));
+    // body : (Object acc, Object x, Object srcColl) -> Object acc  (run add, return the
+    // accumulator).
+    final MethodHandle retAcc = MethodHandles.dropArguments(MethodHandles.identity(Object.class), 1, Object.class);
+    final MethodHandle body2 = MethodHandles.foldArguments(retAcc, addVoid);
+    final MethodHandle body = MethodHandles.dropArguments(body2, 2, Object.class);
+    return MethodHandles.iteratedLoop(ITERABLE_ITERATOR, init, body).asType(
+      MethodType.methodType(Object.class, Object.class)
+    );
+  }
+
+  /**
+   * Build {@code (Object srcMap) -> Object tgtMap}: allocate a fresh target map, iterate the
+   * source's entry set, and {@code put(entry.key, element(entry.value))} for each. Keys pass
+   * through unchanged.
+   */
+  private static MethodHandle mapLoop(final MethodHandle element, final Supplier<Object> tgtAlloc) {
+    // iterator : (Object srcMap) -> Iterator over the entry set.
+    final MethodHandle iterator = MethodHandles.filterReturnValue(MAP_ENTRYSET, ITERABLE_ITERATOR);
+    // init : (Object srcMap) -> Object tgtMap.
+    final MethodHandle init = MethodHandles.dropArguments(supplierGet(tgtAlloc), 0, Object.class);
+    // put(acc, entry.key, element(entry.value)) as a void side effect.
+    final MethodHandle valFromEntry = MethodHandles.filterReturnValue(ENTRY_VALUE, element);
+    final MethodHandle putFromEntries = MethodHandles.filterArguments(MAP_PUT, 1, ENTRY_KEY, valFromEntry);
+    // putFromEntries : (Object acc, Object entryForKey, Object entryForVal) -> Object; feed the
+    // same
+    // entry to both slots, drop the returned previous-value.
+    final MethodHandle putEntry = MethodHandles.permuteArguments(
+      putFromEntries.asType(putFromEntries.type().changeReturnType(void.class)),
+      MethodType.methodType(void.class, Object.class, Object.class),
+      0,
+      1,
+      1
+    );
+    // body : (Object acc, Object entry, Object srcMap) -> Object acc.
+    final MethodHandle retAcc = MethodHandles.dropArguments(MethodHandles.identity(Object.class), 1, Object.class);
+    final MethodHandle body2 = MethodHandles.foldArguments(retAcc, putEntry);
+    final MethodHandle body = MethodHandles.dropArguments(body2, 2, Object.class);
+    return MethodHandles.iteratedLoop(iterator, init, body).asType(MethodType.methodType(Object.class, Object.class));
+  }
+
+  /** {@code () -> Object} bound to {@code alloc.get()}, as a MethodHandle for loop {@code init}. */
+  private static MethodHandle supplierGet(final Supplier<Object> alloc) {
+    return SUPPLIER_GET.bindTo(alloc);
   }
 
   private static RuntimeException rethrow(final Class<?> from, final Class<?> to, final Throwable e) {


### PR DESCRIPTION
## What

Sharpen the **runtime** deep-tree conversion path. When a container's element is a record/bean pair the assembler already composed into an `MhIso` leaf, the `List` / `Set` / `Map`-values lift is now a `MethodHandle` `iteratedLoop` over the leaf's raw `(Object)->Object` handle — instead of a Java for-loop that dispatched `elementIso.to(x)` -> `Function.apply` -> `invokeExact` per element.

## Why it's a big win (not just the per-element hop)

The deep tree is `Company -> List<Department> -> List<Team>`. The old lift ran both nested list levels through the **same** `liftListIntoTargetRaw` lambda, so its `elementIso.to(x)` call site saw two receiver types (dept + team element Isos) — **megamorphic** — and the JIT could not inline the element conversion. The MH loop gives each level its own dedicated, monomorphic body, so the element handle inlines.

## Numbers (same-machine A/B, `fork=3`)

| deep runtime | main | branch | speedup |
|---|--:|--:|--:|
| forward  | 205.4 ns | **90.1 ns** | **2.28x** |
| backward | 207.2 ns | **95.0 ns** | **2.18x** |

Normalized to MapStruct within each run, deep runtime goes from **~3.9x MapStruct -> ~1.3x**. The `nested` tier (no containers) is unchanged — confirming the win is specifically the container path.

## How

- **`MhIso`** gains a `Leaf` carrier that exposes its raw forward/backward handles, plus `liftCollection` / `liftMap` factories. Each builds the whole-container conversion as an `iteratedLoop`; a per-element null guard reproduces the Java path's `iso.to(null) == null`. They return `null` for a non-leaf element (scalar, or array-leaf pair) so the caller keeps its plain Java loop — a build-time sharpening, mirroring the existing `supports` / `pair` split.
- **`DeepMap`** reaches through the acyclic cache proxy to the concrete leaf (`resolveElementForLift`) before building the List/Set/Map lift. Cyclic pairs, nested-container elements, and scalars fall back to the Java loop unchanged. `Optional` stays on `Iso.liftOptional` — <=1 element, no loop to sharpen.

## Correctness

`MhIsoDifferentialParityTest` toggles the MH leaf off and asserts the MH-loop output is **byte-identical** to the array/Java-loop path across the container fuzz (List / Set / Map / scalar element / empty / null container / null element / multi-element / via-nested-mapper). Full `:core` + `:internal` suites green.

## Also

`ContainerLoopSpikeBenchmark` — the decision-gate spike that isolated the mechanism (hand-written vs `liftList`-Iso vs raw-Function loop vs MH `iteratedLoop`), mirroring `MethodHandleChainSpikeBenchmark`'s role for the leaf work.
