### PR TITLE
perf(runtime): full-tree fusion — inline nested-pair leaves (~1.7× on nested)

### DIFF
--- a/core/src/main/java/io/github/eschizoid/telescope/DeepMap.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/DeepMap.java
@@ -1839,9 +1839,16 @@ public final class DeepMap {
     // Object-typed component holding an instance-level cycle), the bypass would be unsafe — but the
     // structural typing already prevents DeepMap from descending into Object-typed fields.
     if (acyclic) {
+      // populateIso(key) has completed by now (the RecursePair branch calls it before this), so the
+      // cache entry is the finished sub-Iso, not the in-progress null reservation. When it is a
+      // composed-handle leaf, hand it to the parent directly: the leaf null-guards internally, so
+      // this is byte-identical to the null-guarding proxy below, and MhIso.pair can then inline the
+      // leaf's raw handle (full-tree fusion). Every other sub-Iso keeps the null-guarding proxy.
+      final var cached = cache.get(key);
+      if (MhIso.isComposedLeaf(cached)) return cached;
       return Iso.of(
-        v -> v == null ? null : ((Iso<Object, Object>) cache.get(key)).to(v),
-        v -> v == null ? null : ((Iso<Object, Object>) cache.get(key)).from(v)
+        v -> v == null ? null : ((Iso<Object, Object>) cached).to(v),
+        v -> v == null ? null : ((Iso<Object, Object>) cached).from(v)
       );
     }
     return Iso.of(

--- a/core/src/test/java/io/github/eschizoid/telescope/MhFusionParityTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/MhFusionParityTest.java
@@ -1,0 +1,257 @@
+package io.github.eschizoid.telescope;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.github.eschizoid.telescope.internal.MhIso;
+import java.util.List;
+import java.util.Objects;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Isolates full-tree fusion. {@link MhIsoDifferentialParityTest} pins the composed handle against
+ * the whole array leaf; this harness flips <em>only</em> whether a nested-pair slot is fused —
+ * {@link MhIso#FUSION_DISABLE_PROPERTY} routes the nested conversion through {@code Iso.to} over
+ * the same composed leaf instead of inlining its raw handle — and asserts the fused handle is
+ * byte-identical to the non-fused (proxy-dispatched) handle over that identical leaf, forward and
+ * backward, across single-level and multi-level nesting with null-nested and null-root samples,
+ * record and bean.
+ */
+@DisplayName("MhIso full-tree fusion ↔ proxy-dispatch parity (same leaf)")
+final class MhFusionParityTest {
+
+  @AfterEach
+  void restoreToggle() {
+    System.clearProperty(MhIso.FUSION_DISABLE_PROPERTY);
+  }
+
+  // Single-level nested record pair (distinct-but-equal element types).
+  record Inner(String city, int zip) {}
+
+  record Inner2(String city, int zip) {}
+
+  record Outer(String tag, Inner inner) {}
+
+  record Outer2(String tag, Inner2 inner) {}
+
+  // Three-level nesting to exercise bottom-up fusion of a fused sub-leaf.
+  record L3(int v) {}
+
+  record L2(String name, L3 leaf) {}
+
+  record L1(String top, L2 mid) {}
+
+  record L3b(int v) {}
+
+  record L2b(String name, L3b leaf) {}
+
+  record L1b(String top, L2b mid) {}
+
+  // Nested bean pair.
+  static final class InnerBean {
+
+    private String city;
+    private int zip;
+
+    public String getCity() {
+      return city;
+    }
+
+    public void setCity(final String v) {
+      this.city = v;
+    }
+
+    public int getZip() {
+      return zip;
+    }
+
+    public void setZip(final int v) {
+      this.zip = v;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+      return o instanceof InnerBean b && zip == b.zip && Objects.equals(city, b.city);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(city, zip);
+    }
+
+    @Override
+    public String toString() {
+      return "InnerBean{" + city + "," + zip + "}";
+    }
+  }
+
+  static final class OuterBean {
+
+    private String tag;
+    private InnerBean inner;
+
+    public String getTag() {
+      return tag;
+    }
+
+    public void setTag(final String v) {
+      this.tag = v;
+    }
+
+    public InnerBean getInner() {
+      return inner;
+    }
+
+    public void setInner(final InnerBean v) {
+      this.inner = v;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+      return o instanceof OuterBean b && Objects.equals(tag, b.tag) && Objects.equals(inner, b.inner);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(tag, inner);
+    }
+
+    @Override
+    public String toString() {
+      return "OuterBean{" + tag + "," + inner + "}";
+    }
+  }
+
+  @Test
+  @DisplayName("single-level nested record: fused == proxy-dispatched over the same leaf")
+  void nestedRecordFusion() {
+    for (final Outer sample : List.of(new Outer("t", new Inner("NYC", 10001)), new Outer(null, new Inner(null, 0)))) {
+      assertFusionParity(Outer.class, Outer2.class, sample);
+    }
+    assertFusionParity(Outer.class, Outer2.class, new Outer("solo", null)); // null nested
+    assertFusionParity(Outer.class, Outer2.class, null); // null root
+  }
+
+  @Test
+  @DisplayName("three-level nested record: bottom-up fusion == proxy-dispatched")
+  void deepNestedRecordFusion() {
+    for (final L1 sample : List.of(new L1("root", new L2("mid", new L3(7))), new L1(null, new L2(null, new L3(0))))) {
+      assertFusionParity(L1.class, L1b.class, sample);
+    }
+    assertFusionParity(L1.class, L1b.class, new L1("r", new L2("m", null))); // null at the deepest boundary
+  }
+
+  @Test
+  @DisplayName("nested bean: fused == proxy-dispatched over the same leaf")
+  void nestedBeanFusion() {
+    assertFusionParity(OuterBean.class, OuterBean.class, outerBean("t", "NYC", 10001));
+    assertFusionParity(OuterBean.class, OuterBean.class, outerBean("solo", null, 0)); // null nested bean
+    assertFusionParity(OuterBean.class, OuterBean.class, null);
+  }
+
+  /**
+   * Build the mapper with fusion enabled (cleared) and disabled (set) and assert forward — and, on
+   * a non-null match, backward — are byte-identical. Rebuilds per toggle so the flag is read at
+   * construction time.
+   */
+  private <A, B> void assertFusionParity(final Class<A> src, final Class<B> tgt, final A sample) {
+    System.clearProperty(MhIso.FUSION_DISABLE_PROPERTY);
+    final B fused = Telescope.mapper(src, tgt).forward(sample);
+    System.setProperty(MhIso.FUSION_DISABLE_PROPERTY, "true");
+    final B proxied = Telescope.mapper(src, tgt).forward(sample);
+    assertEquals(proxied, fused, "forward diverged for " + sample);
+
+    if (fused != null && Objects.equals(fused, proxied)) {
+      System.clearProperty(MhIso.FUSION_DISABLE_PROPERTY);
+      final A fusedBack = Telescope.mapper(src, tgt).backward(fused);
+      System.setProperty(MhIso.FUSION_DISABLE_PROPERTY, "true");
+      final A proxiedBack = Telescope.mapper(src, tgt).backward(fused);
+      assertEquals(proxiedBack, fusedBack, "backward diverged for " + fused);
+    }
+  }
+
+  // ---- exception-labelling: a nested conversion failure must name the nested pair, not the root
+  // ----
+
+  static final class Boom extends Exception {
+
+    private static final long serialVersionUID = 1L;
+
+    Boom(final String m) {
+      super(m);
+    }
+  }
+
+  // Plain source bean; the TARGET setter throws a CHECKED exception on a sentinel value. A checked
+  // throwable is the only shape whose wrapper label differs between fused (raw handle) and proxy
+  // (Leaf.forward wrap) dispatch, since rethrow passes RuntimeException/Error through unchanged.
+  static final class ThrowInner {
+
+    private int v;
+
+    public int getV() {
+      return v;
+    }
+
+    public void setV(final int v) {
+      this.v = v;
+    }
+  }
+
+  static final class ThrowInner2 {
+
+    private int v;
+
+    public int getV() {
+      return v;
+    }
+
+    public void setV(final int v) throws Boom {
+      if (v == 42) throw new Boom("boom@" + v);
+      this.v = v;
+    }
+  }
+
+  record ThrowOuter(ThrowInner inner) {}
+
+  record ThrowOuter2(ThrowInner2 inner) {}
+
+  @Test
+  @DisplayName("fused nested-conversion failure is labelled with the nested pair, not the root pair")
+  void nestedFailureLabelledWithNestedClasses() {
+    final var throwing = new ThrowInner();
+    throwing.setV(42); // source is fine; the target setter throws on 42 during conversion
+
+    System.clearProperty(MhIso.FUSION_DISABLE_PROPERTY); // fusion ON
+    final var fused = Telescope.mapper(ThrowOuter.class, ThrowOuter2.class);
+    final var ex = assertThrows(RuntimeException.class, () -> fused.forward(new ThrowOuter(throwing)));
+    assertTrue(
+      String.valueOf(ex.getMessage()).contains("ThrowInner"),
+      "fused failure should name the nested pair; got: " + ex.getMessage()
+    );
+
+    // Same label under the non-fused proxy path — the fix keeps them identical.
+    System.setProperty(MhIso.FUSION_DISABLE_PROPERTY, "true");
+    final var proxied = Telescope.mapper(ThrowOuter.class, ThrowOuter2.class);
+    final var ex2 = assertThrows(RuntimeException.class, () -> proxied.forward(new ThrowOuter(throwing)));
+    assertTrue(
+      String.valueOf(ex2.getMessage()).contains("ThrowInner"),
+      "proxy failure should name the nested pair too"
+    );
+  }
+
+  private static OuterBean outerBean(final String tag, final String city, final int zip) {
+    final var ob = new OuterBean();
+    ob.setTag(tag);
+    if (city != null) {
+      final var ib = new InnerBean();
+      ib.setCity(city);
+      ib.setZip(zip);
+      ob.setInner(ib);
+    }
+    return ob;
+  }
+}

--- a/internal/src/main/java/io/github/eschizoid/telescope/internal/MhIso.java
+++ b/internal/src/main/java/io/github/eschizoid/telescope/internal/MhIso.java
@@ -81,6 +81,28 @@ public final class MhIso {
    */
   public static final String DISABLE_PROPERTY = "io.github.eschizoid.telescope.mhiso.disabled";
 
+  /**
+   * Whether {@code iso} is a composed-handle {@code Leaf} this assembler produced (so it carries
+   * raw forward/backward handles). {@code DeepMap} consults this to hand a parent pair the concrete
+   * leaf for an acyclic nested slot — enabling full-tree fusion in {@link #pair}'s filters —
+   * instead of a proxy that would force an {@code Iso.to} &rarr; {@code Function.apply} hop per
+   * nested object.
+   */
+  public static boolean isComposedLeaf(final Iso<?, ?> iso) {
+    // Test seam: with FUSION_DISABLE_PROPERTY set, DeepMap hands the parent the null-guarding proxy
+    // rather than the leaf, so pair's filter routes the nested conversion through Iso.to over that
+    // same leaf (the non-fused path). MhFusionParityTest flips this to prove fusion is
+    // byte-identical.
+    if (Boolean.getBoolean(FUSION_DISABLE_PROPERTY)) return false;
+    return iso instanceof Leaf<?, ?>;
+  }
+
+  /**
+   * System property (test-only) that forces a nested-pair slot back to the proxy dispatch (no
+   * fusion) while keeping the same underlying leaf. See {@link #isComposedLeaf}.
+   */
+  public static final String FUSION_DISABLE_PROPERTY = "io.github.eschizoid.telescope.mhiso.fusion.disabled";
+
   private static boolean constructibleBy(final Class<?> cls) {
     if (cls.isRecord()) return cls.getRecordComponents().length <= MAX_ARITY;
     // A bean side is composable only when it has a no-arg constructor and every one of its
@@ -106,6 +128,8 @@ public final class MhIso {
   private static final MethodHandle ENTRY_KEY; //          (Object) -> Object        Map.Entry.getKey
   private static final MethodHandle ENTRY_VALUE; //        (Object) -> Object      Map.Entry.getValue
   private static final MethodHandle SUPPLIER_GET; //       (Supplier) -> Object      Supplier.get
+  // (Throwable, Object, Class, Class) -> Object : relabels a fused nested-conversion failure.
+  private static final MethodHandle THROW_CONVERSION;
 
   static {
     try {
@@ -134,6 +158,11 @@ public final class MhIso {
       SUPPLIER_GET = lk
         .findVirtual(Supplier.class, "get", MethodType.methodType(Object.class))
         .asType(MethodType.methodType(Object.class, Supplier.class));
+      THROW_CONVERSION = lk.findStatic(
+        MhIso.class,
+        "throwConversion",
+        MethodType.methodType(Object.class, Throwable.class, Object.class, Class.class, Class.class)
+      );
     } catch (final ReflectiveOperationException e) {
       throw new ExceptionInInitializerError(e);
     }
@@ -340,6 +369,29 @@ public final class MhIso {
       return MethodHandles.dropArguments(MethodHandles.constant(Object.class, null), 0, srcCls).asType(
         MethodType.methodType(slotType, srcCls)
       );
+    }
+    // Full-tree fusion: a nested-pair slot whose Iso is itself a composed-handle Leaf inlines that
+    // leaf's raw (Object)->Object handle directly into this handle — no per-nested-object
+    // slotIso.to -> Function.apply hop. A per-element null guard reproduces the leaf's own null
+    // short-circuit (a null nested source maps to null), and a catchException relabels a nested
+    // conversion failure with the leaf's own classes (matching the proxy path's Leaf.forward wrap,
+    // and the container lift's containerIso relabel) instead of letting it surface under the root
+    // pair's classes. Because sub-leaves are built the same way, their own nested slots are already
+    // fused into their raw handle, so this fuses the whole acyclic subtree bottom-up. Only
+    // reachable
+    // for sp >= 0 (a Leaf converts a real source value); DeepMap hands the Leaf through for acyclic
+    // pairs only (cyclic pairs keep the cycle-guarding proxy, never a Leaf).
+    if (sp >= 0 && slotIso instanceof Leaf<?, ?> leaf) {
+      final boolean forward = isoDir == ISO_TO;
+      final MethodHandle raw = forward ? leaf.rawForward() : leaf.rawBackward();
+      final Class<?> from = forward ? leaf.sourceClass() : leaf.targetClass();
+      final Class<?> to = forward ? leaf.targetClass() : leaf.sourceClass();
+      final MethodHandle rawStep = guardElement(labelFailures(raw, from, to));
+      final Class<?> leafReadType = srcAccessors[sp].type().returnType();
+      return MethodHandles.filterReturnValue(
+        srcAccessors[sp],
+        rawStep.asType(MethodType.methodType(Object.class, leafReadType))
+      ).asType(MethodType.methodType(slotType, srcCls));
     }
     // Non-identity Iso (rename-with-conversion, nested pair, container lift, constant, compute,
     // when-gate): mirror the array path's iso.to(v), where v is the read value or null when the
@@ -559,6 +611,30 @@ public final class MhIso {
       Object.class
     );
     return MethodHandles.guardWithTest(NON_NULL, rawElem.asType(t), nullConst);
+  }
+
+  /**
+   * Wrap {@code (Object)->Object} {@code raw} so a throwable it raises is relabelled with {@code
+   * from -> to} — the leaf's own classes — via {@link #rethrow}, matching the wrap the proxy path
+   * applies through {@code Leaf.forward}/{@code backward}. The catch is a MethodHandle combinator,
+   * so the fused handle stays one composed tree with no SAM boundary; the happy path pays nothing.
+   */
+  private static MethodHandle labelFailures(final MethodHandle raw, final Class<?> from, final Class<?> to) {
+    final MethodHandle handler = MethodHandles.insertArguments(THROW_CONVERSION, 2, from, to);
+    return MethodHandles.catchException(
+      raw.asType(MethodType.methodType(Object.class, Object.class)),
+      Throwable.class,
+      handler
+    );
+  }
+
+  /**
+   * {@code (Throwable, Object) -> Object} catch handler (bound to {@code from}/{@code to}): always
+   * throws, relabelling the failure via {@link #rethrow}. The {@code Object} argument is the leaf's
+   * input, ignored — it only aligns the handler arity with the guarded handle.
+   */
+  private static Object throwConversion(final Throwable t, final Object input, final Class<?> from, final Class<?> to) {
+    throw rethrow(from, to, t);
   }
 
   /**


### PR DESCRIPTION
## What

Full-tree fusion: a **scalar nested-pair slot** (a record/bean field that is itself a mapped record/bean) now inlines the sub-conversion's raw `(Object)->Object` handle directly into the parent's composed handle, instead of dispatching the cached pair's `Iso.to` → `Function.apply` per nested object.

Because sub-leaves are built the same way, their own nested slots are already fused into their raw handle — so this fuses the **whole acyclic subtree bottom-up** into one `invokeExact`, no per-nesting SAM hop.

## Numbers (same-machine A/B, `fork=3`)

| nested runtime | main | branch | speedup |
|---|--:|--:|--:|
| forward  | 25.0 ns | **15.4 ns** | **1.62×** |
| backward | 24.7 ns | **13.4 ns** | **1.84×** |

Nested went from **~4.3× MapStruct → ~2×** — this was the worst-ratio tier, now closed. Flat and deep are unchanged (flat has no nesting; deep is container-only, already loop-fused by #240). This composes with the MH-leaf and container-loop work: the runtime path is now roughly ~3× (flat) / ~2× (nested) / ~1.3× (deep) MapStruct.

## How

- **`MhIso.isComposedLeaf(Iso)`** lets `DeepMap` detect a composed leaf; **`buildFilter`** inlines a `Leaf` slot's `rawForward()`/`rawBackward()` (null-guarded) instead of binding `slotIso.to`.
- **`DeepMap.lazyCacheIso`** hands the parent the concrete leaf for **acyclic** pairs (the leaf null-guards internally, so byte-identical to the null-guarding proxy). Cyclic pairs keep the cycle-guarding proxy and are **never** fused — the load-bearing safety invariant.

## Correctness

- `MhIsoDifferentialParityTest` (fusion vs the whole array leaf) — byte-identical.
- New `MhFusionParityTest` (gated by `mhiso.fusion.disabled`) isolates **fused vs non-fused proxy-dispatch over the same leaf** — byte-identical across single/multi-level nesting, null-nested, null-root, record and bean.
- Full `:core` + `:internal` suites green.
