### PR TITLE
docs(benchmarks): refresh nested runtime numbers after full-tree fusion (~2× MapStruct)

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,10 +360,11 @@ the [`Benchmarks`](.github/workflows/benchmarks.yaml) GitHub Action: Actions →
 branch, tune the iteration / fork knobs; the run prints `results.txt` and attaches the full results as an artifact.
 
 > No codegen? `Telescope.mapper(...)` composes each record/bean pair into a single MethodHandle — zero annotations, no
-> build step, and now **within ~1.3–6× of MapStruct** (flat ~12 ns, deep ~90 ns), down from ~16–48×. Deep
-> container-heavy trees are the closest: a nested `List`/`Set`/`Map` element loops over the leaf's raw handle instead of
-> dispatching per element. Fast enough for most service code as-is; on a tight inner loop, add `@Bridge` and you're back
-> in MapStruct's performance class. The runtime-vs-codegen numbers are in
+> build step, and now **within ~1.3–4× of MapStruct** (flat ~12 ns, nested ~15 ns, deep ~90 ns), down from ~16–48×. Deep
+> container-heavy trees are the closest: a nested `List`/`Set`/`Map` element loops over the leaf's raw handle, and a
+> nested record/bean field inlines straight into the parent's handle — no per-nesting dispatch. Fast enough for most
+> service code as-is; on a tight inner loop, add `@Bridge` and you're back in MapStruct's performance class. The
+> runtime-vs-codegen numbers are in
 > [`benchmarks/README.md`](benchmarks/README.md#mapstruct-comparison-apples-to-apples).
 
 #### Then, what you gain

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -230,16 +230,18 @@ difference between same-tier rows is the dispatch path. Reproducible: re-run the
 | ------ | ------------- | ----------------: | ------------------------: | -------------------------------: | ------------------------: |
 | flat   | bean → record |     3.167 ± 0.014 |             3.393 ± 0.011 |                    3.299 ± 0.005 |             12.21 ± 0.254 |
 | flat   | record → bean |     3.305 ± 0.028 |             3.485 ± 0.022 |                                — |             11.44 ± 0.947 |
-| nested | bean → record |     4.928 ± 0.024 |             5.879 ± 0.022 |                    5.553 ± 0.011 |             30.65 ± 2.596 |
-| nested | record → bean |     5.983 ± 0.024 |             5.355 ± 0.019 |                                — |             29.87 ± 0.504 |
+| nested | bean → record |     4.928 ± 0.024 |             5.879 ± 0.022 |                    5.553 ± 0.011 |              15.4 ± 1.0\* |
+| nested | record → bean |     5.983 ± 0.024 |             5.355 ± 0.019 |                                — |              13.4 ± 1.0\* |
 | deep   | bean → record |     48.68 ± 0.106 |             55.04 ± 0.522 |                    54.71 ± 0.375 |              90.1 ± 2.5\* |
 | deep   | record → bean |     48.54 ± 0.273 |             54.81 ± 0.418 |                                — |              95.0 ± 2.5\* |
 
-\* The deep runtime cells were re-measured on a laptop after the container-element MethodHandle loop landed (a nested
-`List` element now loops over the leaf's raw handle instead of dispatching `Iso.to` per element). Same-machine A/B on
-that laptop: main **205.4 / 207.2 ns** → branch **90.1 / 95.0 ns** (**~2.2×**), taking deep runtime from ~4.4× MapStruct
-to ~1.3–1.9× on the same box. The other cells are the CI runner's; the whole table refreshes on the next benchmark
-workflow run.
+\* The nested and deep runtime cells were re-measured on a laptop after two lattice sharpenings landed. **Deep** — the
+container-element MethodHandle loop (a nested `List`/`Set`/`Map` element loops over the leaf's raw handle instead of
+dispatching `Iso.to` per element): same-machine A/B main **205.4 / 207.2 ns** → **90.1 / 95.0 ns** (**~2.2×**), from
+~4.4× MapStruct to ~1.3–1.9×. **Nested** — full-tree fusion (a scalar nested-pair slot inlines the sub-leaf's raw handle
+into the parent's composed handle, no per-nesting `Iso.to` → `Function.apply` hop): same-machine A/B main **25.0 / 24.7
+ns** → **15.4 / 13.4 ns** (**~1.7×**), from ~4.3× MapStruct to ~2×. The other cells are the CI runner's; the whole table
+refreshes on the next benchmark workflow run.
 
 Tight error bands on the codegen/MapStruct rows (±0.01–0.35 ns) — the dedicated CI runner with no competing workload
 gives cleaner data than a laptop. The `static` column calls the codegen-emitted `<Source>Bridge.forward(s)` directly,
@@ -288,16 +290,18 @@ the directly-callable `BRIDGE_FN` constant — and pay the zero-dispatch floor.
 
 Runtime conversion (`Telescope.mapper(...)`) composes each record/bean pair into a single MethodHandle (see above), so
 the hot path is one `invokeExact` through the fused handle rather than an `Object[]` gather with boxed per-field
-dispatch. That lands the forward direction at **~3.9× MapStruct on flat, ~6.2× on nested, ~1.3–1.9× on deep**. Deep used
-to trail at ~4.4×; the container-element MethodHandle loop (a nested `List`/`Set`/`Map` element loops over the leaf's
-raw handle instead of dispatching `Iso.to` → `Function.apply` per element, which also un-megamorphizes the shared lift
-call site) roughly halved it — same-machine 205 → 90 ns. The backward (record → bean) direction — previously the
-pathological case (allocate a bean, then N boxed setter calls, ~48× MapStruct on flat) — is now **~3.5× on flat** via
-the unboxed setter-fold, matching forward instead of trailing it. Allocation drops to the result-object floor (flat 32
-B/op, the array + every primitive box gone). Sub-microsecond everywhere. Reach for codegen on the hottest paths; the
-runtime path is now within ~1.3–6× of MapStruct with **no annotations and no build step** — and closest exactly where it
-matters most, on the deep container-heavy trees — close enough for most service code, and `@Bridge` codegen is there
-when a loop turns hot.
+dispatch. That lands the forward direction at **~3.9× MapStruct on flat, ~2× on nested, ~1.3–1.9× on deep**. Nested and
+deep both used to trail far worse (~6.2× and ~4.4×); two lattice sharpenings closed them. The container-element
+MethodHandle loop (a nested `List`/`Set`/`Map` element loops over the leaf's raw handle instead of dispatching `Iso.to`
+→ `Function.apply` per element, which also un-megamorphizes the shared lift call site) roughly halved deep —
+same-machine 205 → 90 ns. Full-tree fusion (a scalar nested-pair slot inlines the sub-leaf's raw handle directly into
+the parent's composed handle, so the whole acyclic subtree collapses to one `invokeExact`) did the same for nested — 25
+→ 15 ns. The backward (record → bean) direction — previously the pathological case (allocate a bean, then N boxed setter
+calls, ~48× MapStruct on flat) — is now **~3.5× on flat** via the unboxed setter-fold, matching forward instead of
+trailing it. Allocation drops to the result-object floor (flat 32 B/op, the array + every primitive box gone).
+Sub-microsecond everywhere. Reach for codegen on the hottest paths; the runtime path is now within ~1.3–6× of MapStruct
+with **no annotations and no build step** — and closest exactly where it matters most, on the deep container-heavy trees
+— close enough for most service code, and `@Bridge` codegen is there when a loop turns hot.
 
 All four columns above are from the same run; the codegen/MapStruct ratios reproduce across confirming runs within error
 (the runtime rows carry wider bands but the same magnitude).


### PR DESCRIPTION
Refresh the **nested** runtime cells in the MapStruct-comparison table after full-tree fusion (#241). The nested cells were stale (pre-fusion ~30 ns); the deep cells were already refreshed in #240.

- `benchmarks/README.md` table: nested runtime **30.65 / 29.87 → 15.4 / 13.4 ns**, marked `*` with the same-machine A/B provenance (main 25.0 / 24.7 → 15.4 / 13.4, ~1.7×), and the footnote extended to cover both re-measured tiers.
- Prose ratio: **"~6.2× on nested" → "~2×"**, with a one-line note on the fusion mechanism.
- Top-level `README.md`: **"within ~1.3–6×" → "within ~1.3–4×"** (nested improved from ~6× to ~2×, so flat ~3.9× is now the worst tier); added `nested ~15 ns`.

Docs-only; laptop-measured runtime cells are footnoted as such, CI-runner cells untouched, table refreshes on the next benchmark workflow run.
