### PR TITLE
refactor(core): drop the redundant container-element reach-through

### DIFF
--- a/core/src/main/java/io/github/eschizoid/telescope/DeepMap.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/DeepMap.java
@@ -1146,26 +1146,28 @@ public final class DeepMap {
         cyclicPairs,
         inProgress
       );
-      // For the collection lifts, reach through the acyclic cache proxy to the concrete element Iso
-      // so the lift can loop over an MhIso leaf's raw handle (see resolveElementForLift). Optional
-      // is
-      // ≤1 element — no loop to sharpen — so it keeps the proxy.
-      final var forLift = resolveElementForLift(
-        d.src().elementType(),
-        d.tgt().elementType(),
-        cache,
-        cyclicPairs,
-        elementIso
-      );
+      // The lifts consult MhIso.liftCollection/liftMap, which sharpen to a MethodHandle loop when
+      // the
+      // element is a composed-handle leaf. For an acyclic nested pair `elementIso` already IS that
+      // leaf (lazyCacheIso hands the concrete leaf through); a cyclic or non-leaf nested pair is
+      // the
+      // null-guarding lazyCacheIso proxy, and a scalar element is an identity/primitive Iso. The
+      // lifts
+      // see the right shape directly — no extra reach-through — and treat every non-leaf shape the
+      // same (plain Java loop).
       return switch (d.src().kind()) {
         case LIST -> liftListIntoTargetRaw(
-          eraseIso(forLift),
+          eraseIso(elementIso),
           (Class<?>) d.src().rawType(),
           (Class<?>) d.tgt().rawType()
         );
-        case SET -> liftSetIntoTargetRaw(eraseIso(forLift), (Class<?>) d.src().rawType(), (Class<?>) d.tgt().rawType());
+        case SET -> liftSetIntoTargetRaw(
+          eraseIso(elementIso),
+          (Class<?>) d.src().rawType(),
+          (Class<?>) d.tgt().rawType()
+        );
         case MAP_VALUES -> liftMapIntoTargetRaw(
-          eraseIso(forLift),
+          eraseIso(elementIso),
           (Class<?>) d.src().rawType(),
           (Class<?>) d.tgt().rawType()
         );
@@ -1792,39 +1794,6 @@ public final class DeepMap {
   private static final ThreadLocal<IdentityHashMap<Object, Boolean>> BACKWARD_SEEN = ThreadLocal.withInitial(
     IdentityHashMap::new
   );
-
-  /**
-   * Reach through the {@link #lazyCacheIso} proxy that {@code autoIso} returns for a container's
-   * element to the concrete element {@link Iso} in the cache, so a collection/map lift can loop
-   * over an {@code MhIso} leaf's raw handle instead of dispatching through the proxy per element.
-   *
-   * <p>Safe only for an <b>acyclic</b> pair: the proxy's acyclic branch is {@code v == null ? null
-   * : cache.get(key).to(v)} — a null guard plus a delegate — and the container loops reproduce that
-   * null guard per element, so looping over the cached leaf is byte-identical to looping over the
-   * proxy. By the time this runs (during the outer pair's {@code populateIso}), the element pair's
-   * {@code populateIso} has already completed, so {@code cache.get(key)} is the finished leaf.
-   *
-   * <p>Returns the {@code proxy} unchanged when the pair is cyclic (the per-call cycle guard in the
-   * proxy must stay), when either element type is not a raw {@link Class} (nested containers,
-   * wildcard elements — no cache key), or when the element is a scalar with no cache entry. In
-   * every fall-back case the lift keeps its plain Java loop.
-   */
-  private static Iso<?, ?> resolveElementForLift(
-    final Type srcElem,
-    final Type tgtElem,
-    final Map<TypePair, Iso<?, ?>> cache,
-    final Set<TypePair> cyclicPairs,
-    final Iso<?, ?> proxy
-  ) {
-    if (srcElem instanceof Class<?> s && tgtElem instanceof Class<?> t) {
-      final var key = new TypePair(s, t);
-      if (!cyclicPairs.contains(key)) {
-        final var cached = cache.get(key);
-        if (cached != null) return cached;
-      }
-    }
-    return proxy;
-  }
 
   @SuppressWarnings("unchecked")
   private static Iso<?, ?> lazyCacheIso(

--- a/core/src/test/java/io/github/eschizoid/telescope/MhIsoDifferentialParityTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/MhIsoDifferentialParityTest.java
@@ -13,6 +13,9 @@ import io.github.eschizoid.telescope.conversion.Mapper;
 import io.github.eschizoid.telescope.internal.MhIso;
 import io.github.eschizoid.telescope.mapping.MapStep;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -1070,6 +1073,18 @@ final class MhIsoDifferentialParityTest {
       ),
       // empty containers + empty optional
       new ContRec(List.of(), Set.of(), Map.of(), Optional.empty()),
+      // null ELEMENTS inside non-null containers: the leaf path null-guards each element
+      // (guardElement); the array-leaf path routes each through the cache proxy. Both must
+      // map a
+      // null element to null identically — this pins the container element-null semantics
+      // that the
+      // (now removed) resolveElementForLift reach-through used to straddle.
+      new ContRec(
+        new ArrayList<>(Arrays.asList(new InnerRec("a", 1), null)),
+        new LinkedHashSet<>(Arrays.asList(new InnerRec("s", 9), null)),
+        nullValueMap(),
+        Optional.empty()
+      ),
       // null containers + null optional-holder
       new ContRec(null, null, null, null)
     );
@@ -1233,6 +1248,15 @@ final class MhIsoDifferentialParityTest {
   }
 
   // ---- helpers ----
+  // A map with a present value and a null value, to exercise null map-value conversion on both
+  // leaves.
+  private static Map<String, InnerRec> nullValueMap() {
+    final var m = new LinkedHashMap<String, InnerRec>();
+    m.put("k1", new InnerRec("m1", 11));
+    m.put("k2", null);
+    return m;
+  }
+
   private static PrimBean bean(
     final int i,
     final long l,


### PR DESCRIPTION
## What

Delete the now-redundant `DeepMap.resolveElementForLift` and let the container-lift branch pass `elementIso` straight through.

## Why it's redundant (and slightly unsafe)

`resolveElementForLift` was added in #240 to reach *through* the `lazyCacheIso` proxy to the concrete `MhIso.Leaf` so a container lift could loop over its raw handle. But #241 (full-tree fusion) changed `lazyCacheIso` to hand the concrete leaf through directly for an **acyclic** pair. So by the time the `LiftContainer` branch runs, `elementIso` is *already*:

- the composed-handle **leaf** for an acyclic pair (→ `MhIso.liftCollection`/`liftMap` sharpen to the MH loop), or
- the **null-guarding proxy** for a cyclic / non-leaf / scalar element (→ the plain Java loop).

`resolveElementForLift` then re-read the cache and, for an acyclic **non-leaf** element, returned the **raw** cached Iso — stripping the proxy's `v == null ? null` guard. That's a latent divergence from the pre-#240 behavior. Deleting it restores the correct proxy null-guard for non-leaf elements **and** keeps #241's leaf fusion.

## Correctness

Hardened `MhIsoDifferentialParityTest` with a **null-element container** sample (`List`/`Set`/`Map` element = `null`) — the previous fuzz used `List.of(...)`, which rejects nulls, so this exact case was untested. The leaf path's `guardElement` and the array-leaf path's proxy must map a null element to `null` identically. Byte-identical across both leaves; full `:core` + `:internal` suites green.

Net: −18 lines (one method + a call site), no behavior change on any tested path, one latent inconsistency removed, one coverage gap closed.
