### PR TITLE
test(internal): meaningful contract tests for the reflection substrate

### DIFF
--- a/internal/src/test/java/io/github/eschizoid/telescope/internal/BeansTest.java
+++ b/internal/src/test/java/io/github/eschizoid/telescope/internal/BeansTest.java
@@ -11,6 +11,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.github.eschizoid.telescope.internal.optics.Lens;
+import java.lang.invoke.MethodHandle;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Map;
@@ -581,7 +582,7 @@ class BeansTest {
   class GetterScan {
 
     @Test
-    @DisplayName("getX / isX / boolean and Boolean isX / URL two-caps rule all resolve to expected property names")
+    @DisplayName("getX / isX / boolean and Boolean isX / URL two-caps rule all resolve to expected property" + " names")
     void propertyNamesCoverConventions() {
       final var names = Arrays.asList(Beans.propertyNames(WithGetters.class));
       assertTrue(names.contains("id"));
@@ -658,7 +659,9 @@ class BeansTest {
     }
 
     @Test
-    @DisplayName("readProperty auto-boxes primitive getter returns (int → Integer, long → Long, boolean → Boolean)")
+    @DisplayName(
+      "readProperty auto-boxes primitive getter returns (int → Integer, long → Long, boolean →" + " Boolean)"
+    )
     void readPropertyAutoBoxesPrimitives() {
       // Pins the LambdaMetafactory instantiatedMethodType bridge: the (P -> int) MethodHandle
       // surfaces through Function<Object, Object>::apply as a boxed Integer without a per-call
@@ -692,7 +695,7 @@ class BeansTest {
     }
 
     @Test
-    @DisplayName("inherited getter resolves through the parent's declaring class (no cross-class lookup error)")
+    @DisplayName("inherited getter resolves through the parent's declaring class (no cross-class lookup" + " error)")
     void getterOnInheritedAccessor() {
       // ChildBean inherits getId() from ParentBean. The LMF cache must build the invoker via a
       // lookup pinned to ParentBean (the declaring class), not ChildBean — otherwise an
@@ -797,7 +800,7 @@ class BeansTest {
     }
 
     @Test
-    @DisplayName("settersWriter round-trips a value through an inherited setter (declared on a parent class)")
+    @DisplayName("settersWriter round-trips a value through an inherited setter (declared on a parent" + " class)")
     void settersOnInheritedSetter() {
       // ChildBean inherits setId(String) from ParentBean. The LMF builder must use the setter's
       // declaring class (ParentBean) for privateLookupIn and the instantiated receiver — using
@@ -811,7 +814,7 @@ class BeansTest {
     }
 
     @Test
-    @DisplayName("LambdaMetafactory invoker auto-unboxes a boxed Integer source value into a setX(int) setter")
+    @DisplayName("LambdaMetafactory invoker auto-unboxes a boxed Integer source value into a setX(int)" + " setter")
     void settersAutoUnboxesPrimitiveArg() {
       // NoArgSetters has setScore(int). The source map carries an Object value (boxed Integer);
       // the LambdaMetafactory-built BiConsumer<Object, Object> must auto-unbox to int. This pins
@@ -906,7 +909,8 @@ class BeansTest {
 
     @Test
     @DisplayName(
-      "construct propagates dispatch-time failures raw (matching the other writer strategies and pre-LMF BuilderWriter)"
+      "construct propagates dispatch-time failures raw (matching the other writer strategies and" +
+        " pre-LMF BuilderWriter)"
     )
     void builderConstructPropagatesDispatchFailures() {
       // A String value flows into a setter expecting an int — the LMF auto-unbox bridge throws
@@ -1006,14 +1010,15 @@ class BeansTest {
     }
 
     @Test
-    @DisplayName("autoWriter prefers SettersWriter over BuilderWriter when both apply (@Data @Builder shape)")
+    @DisplayName("autoWriter prefers SettersWriter over BuilderWriter when both apply (@Data @Builder" + " shape)")
     void autoPrefersSettersOverBuilder() {
       final var writer = Beans.autoWriter(DataAndBuilder.class);
       assertEquals(
         "SettersWriter",
         writer.getClass().getSimpleName(),
-        "for Lombok @Data @Builder POJOs, SETTERS is the user-expected default — the public setters " +
-          "and the builder both apply, and SETTERS wins so no explicit writeBean hint is required"
+        "for Lombok @Data @Builder POJOs, SETTERS is the user-expected default — the public" +
+          " setters and the builder both apply, and SETTERS wins so no explicit writeBean" +
+          " hint is required"
       );
       final var pojo = writer.construct(new String[] { "name", "score" }, n -> Objects.equals(n, "name") ? "y" : 42);
       assertEquals("y", pojo.getName());
@@ -1191,7 +1196,7 @@ class BeansTest {
     }
 
     @Test
-    @DisplayName("readProperty routes through persistentClassOf so a subclass shares the parent's cache entry")
+    @DisplayName("readProperty routes through persistentClassOf so a subclass shares the parent's cache" + " entry")
     void readPropertyUnwrapsToParentCache() {
       // Even without a real HibernateProxy, prove readProperty works on a subclass instance —
       // the cache lookup uses the runtime class (or the unwrapped persistent class). This is the
@@ -1227,7 +1232,7 @@ class BeansTest {
     }
 
     @Test
-    @DisplayName("getter-only / no-setter property silently no-ops (matches MapStruct's @MappingTarget contract)")
+    @DisplayName("getter-only / no-setter property silently no-ops (matches MapStruct's @MappingTarget" + " contract)")
     void getterOnlyPropertyIsSilentNoOp() {
       // Documented contract at Beans.buildSetterInvoker: a property with no setX(value) method
       // gets a no-op BiConsumer rather than throwing — Mapper.into(target, source) would
@@ -1241,7 +1246,9 @@ class BeansTest {
     }
 
     @Test
-    @DisplayName("inherited setter: writeBeanProperty routes through the parent's declaring class for privateLookupIn")
+    @DisplayName(
+      "inherited setter: writeBeanProperty routes through the parent's declaring class for" + " privateLookupIn"
+    )
     void inheritedSetterRoutesThroughDeclaringClass() {
       // ChildBean inherits setId(String) from ParentBean. The LMF invoker must resolve a Lookup
       // against ParentBean (where setId is declared) rather than ChildBean — using the child's
@@ -1268,7 +1275,7 @@ class BeansTest {
     }
 
     @Test
-    @DisplayName("set rebuilds the POJO with the focused property replaced; off-path values are carried through")
+    @DisplayName("set rebuilds the POJO with the focused property replaced; off-path values are carried" + " through")
     void setReplacesFocusedPropertyAndCarriesOffPath() {
       final Lens<NoArgSetters, String> nameLens = Beans.fieldLens("name");
       final var src = new NoArgSetters();
@@ -1298,7 +1305,7 @@ class BeansTest {
     }
 
     @Test
-    @DisplayName("modify(non-null, fn) applies fn to the current value and rebuilds the POJO with the result")
+    @DisplayName("modify(non-null, fn) applies fn to the current value and rebuilds the POJO with the" + " result")
     void modifyOnNonNullSourceAppliesFnAndRebuilds() {
       // The non-null branch of modify reads the current value through get, applies the function,
       // and delegates to set for the rebuild. Off-path properties round-trip through the writer's
@@ -1313,7 +1320,7 @@ class BeansTest {
     }
 
     @Test
-    @DisplayName("set on a subtype source rebuilds using the subtype's class (writer is resolved at call time)")
+    @DisplayName("set on a subtype source rebuilds using the subtype's class (writer is resolved at call" + " time)")
     void setOnSubtypeRebuildsAsSubtype() {
       // fieldLens is class-deferred: the writer is resolved against source.getClass() per call,
       // not captured at lens build time. A ChildBean carrying both inherited and own properties
@@ -1329,7 +1336,7 @@ class BeansTest {
     }
 
     @Test
-    @DisplayName("set(s, null) on a primitive property substitutes the JLS default via SettersWriter's null-guard")
+    @DisplayName("set(s, null) on a primitive property substitutes the JLS default via SettersWriter's" + " null-guard")
     void setNullOnPrimitiveSubstitutesJlsDefault() {
       // Documented contract on Beans.fieldLens: when the focused property is a Java primitive,
       // set(s, null) substitutes the JLS default (0 for int) rather than throwing on the
@@ -1360,7 +1367,9 @@ class BeansTest {
     }
 
     @Test
-    @DisplayName("class lacking a public no-arg ctor but exposing static builder().build() yields a built instance")
+    @DisplayName(
+      "class lacking a public no-arg ctor but exposing static builder().build() yields a built" + " instance"
+    )
     void staticBuilderChainYieldsBuiltInstance() {
       // WithBuilder's ctor is private — the no-arg attempt fails and falls through to the
       // builder() lookup. The chained LMF Supplier composes builder() with build() and produces
@@ -1389,7 +1398,7 @@ class BeansTest {
   class LensSubtypeSlowPath {
 
     @Test
-    @DisplayName("set on a subtype instance reads off-path values through readProperty and rebuilds as pojoClass")
+    @DisplayName("set on a subtype instance reads off-path values through readProperty and rebuilds as" + " pojoClass")
     void setOnSubtypeUsesSlowPathReadAndRebuildsAsCapturedClass() {
       // Lens<ParentBean, String> captures the writer + reader-map for ParentBean. When set is
       // called with a ChildBean instance, source.getClass() != pojoClass, so the fast-path
@@ -1411,7 +1420,7 @@ class BeansTest {
   class ScanGettersModuleSkip {
 
     @Test
-    @DisplayName("a POJO extending java.util.ArrayList does not surface the inherited isEmpty/size as properties")
+    @DisplayName("a POJO extending java.util.ArrayList does not surface the inherited isEmpty/size as" + " properties")
     void platformInheritedAccessorsDoNotLeakAsProperties() {
       // Defence-in-depth against any caller that touches a JDK-derived class directly. Without
       // the java.*/jdk.* skip, propertyNames would include `empty` (from isEmpty) and downstream
@@ -1426,12 +1435,14 @@ class BeansTest {
   }
 
   @Nested
-  @DisplayName("SettersWriter — primitive-variant unbox bridges for every long/double/float/byte/short/char setter")
+  @DisplayName(
+    "SettersWriter — primitive-variant unbox bridges for every long/double/float/byte/short/char" + " setter"
+  )
   class PrimitiveSetterDispatch {
 
     @Test
     @DisplayName(
-      "long/double/float/byte/short/char setters each bind an LMF unbox bridge end-to-end through SettersWriter"
+      "long/double/float/byte/short/char setters each bind an LMF unbox bridge end-to-end through" + " SettersWriter"
     )
     void sixPrimitiveVariantsRoundTripThroughSettersWriter() {
       // Each setter forces wrap() to map its primitive type to the matching wrapper class; the
@@ -1462,6 +1473,178 @@ class BeansTest {
       assertEquals((byte) 7, built.getByteVal());
       assertEquals((short) 1234, built.getShortVal());
       assertEquals('Z', built.getCharVal());
+    }
+  }
+
+  @Nested
+  @DisplayName(
+    "capturedReader — pre-bound LMF reader, invokevirtual-dispatched (holder positional-read" + " substrate)"
+  )
+  class CapturedReader {
+
+    @Test
+    @DisplayName(
+      "returns the raw cached Function directly — same instance across calls, no per-call capture" + " lambda"
+    )
+    void returnsSameCachedFunctionInstance() {
+      // capturedReader hands back the raw cached Function from GETTER_INVOKERS (unlike getter(),
+      // which wraps a fresh capturing lambda each call). Two calls for the same (class, name) must
+      // return the identical instance so a positional-read loop can bind it once at assembly time.
+      final var a = Beans.capturedReader(NoArgSetters.class, "name");
+      final var b = Beans.capturedReader(NoArgSetters.class, "name");
+      assertSame(a, b, "capturedReader must return the cached Function, not a fresh wrapper per call");
+    }
+
+    @Test
+    @DisplayName("a reader bound to the parent class reads a subtype instance correctly (invokevirtual" + " dispatch)")
+    void readerBoundToParentReadsSubtype() {
+      // The reader is bound to ParentBean's getId(), but dispatches invokevirtual — so applying it
+      // to a ChildBean instance still reads the right value even though the reader was resolved
+      // against the declared parent class. This is the documented reason capturedReader can be
+      // bound once for the declared class and sidestep the per-proxy-subclass cache bloat.
+      final var reader = Beans.capturedReader(ParentBean.class, "id");
+      final var child = new ChildBean();
+      child.setId("via-subtype");
+      assertEquals("via-subtype", reader.apply(child));
+    }
+
+    @Test
+    @DisplayName("auto-boxes a primitive getter return through the Function<Object, Object> boundary")
+    void autoBoxesPrimitiveReturn() {
+      final var reader = Beans.capturedReader(WithPrimitives.class, "age");
+      final var age = reader.apply(new WithPrimitives(21, 0L, false));
+      assertEquals(Integer.class, age.getClass());
+      assertEquals(21, age);
+    }
+
+    @Test
+    @DisplayName("unknown property throws IllegalArgumentException at bind time, naming the property and" + " class")
+    void unknownPropertyThrows() {
+      final var ex = assertThrows(IllegalArgumentException.class, () ->
+        Beans.capturedReader(NoArgSetters.class, "ghost")
+      );
+      assertTrue(ex.getMessage().contains("ghost"), ex::getMessage);
+      assertTrue(ex.getMessage().contains(NoArgSetters.class.getName()), ex::getMessage);
+    }
+  }
+
+  @Nested
+  @DisplayName(
+    "isSetterConstructible — MhIso build-time shape gate (no-arg ctor + a setter per required" + " property)"
+  )
+  class SetterConstructible {
+
+    @Test
+    @DisplayName("true when a no-arg ctor exists and every required property has a public setter")
+    void trueWhenNoArgCtorAndAllSetters() {
+      assertTrue(Beans.isSetterConstructible(NoArgSetters.class, new String[] { "name", "score" }));
+    }
+
+    @Test
+    @DisplayName("false when a required property has no public setter (getter-only field)")
+    void falseWhenRequiredPropertyHasNoSetter() {
+      // NoArgFields has a no-arg ctor and getters but no setters — a required property with no
+      // matching setX gates the whole bean out of the setter fold.
+      assertFalse(Beans.isSetterConstructible(NoArgFields.class, new String[] { "name" }));
+    }
+
+    @Test
+    @DisplayName("false when the bean has no no-arg constructor even if setters exist")
+    void falseWhenNoNoArgConstructor() {
+      // ImmutableCtor has getters but no no-arg ctor — the setter fold constructs via the no-arg
+      // ctor first, so a missing one rules the strategy out regardless of setter presence.
+      assertFalse(Beans.isSetterConstructible(ImmutableCtor.class, new String[] { "label" }));
+    }
+
+    @Test
+    @DisplayName("empty required-property set with a no-arg ctor is trivially constructible")
+    void trueForEmptyRequiredSetWithNoArgCtor() {
+      assertTrue(Beans.isSetterConstructible(NoArgSetters.class, new String[] {}));
+    }
+  }
+
+  @Nested
+  @DisplayName("BeanMhInfo raw handles — beanAccessorHandles / beanSetterHandle / beanNoArgCtorHandle" + " (unboxed)")
+  class RawBeanHandles {
+
+    @Test
+    @DisplayName("accessor handles keep the getter's unboxed primitive return type and read the right value")
+    void accessorHandlesAreUnboxed() throws Throwable {
+      final var names = Beans.propertyNames(WithPrimitives.class);
+      final var handles = Beans.beanAccessorHandles(WithPrimitives.class);
+      assertEquals(names.length, handles.length);
+      final var ageIdx = indexOf(names, "age");
+      assertEquals(int.class, handles[ageIdx].type().returnType(), "handle keeps the unboxed int return type");
+      final var pojo = new WithPrimitives(9, 5L, true);
+      assertEquals(9, (int) handles[ageIdx].invoke(pojo));
+    }
+
+    @Test
+    @DisplayName("setterHandle keeps the setter's unboxed parameter type and writes through it")
+    void setterHandleIsUnboxedAndWrites() throws Throwable {
+      final MethodHandle setter = Beans.beanSetterHandle(NoArgSetters.class, "score");
+      assertNotNull(setter, "a property with a public setX must expose a raw setter handle");
+      assertEquals(int.class, setter.type().parameterType(1), "handle keeps the unboxed int parameter type");
+      final var pojo = new NoArgSetters();
+      setter.invoke(pojo, 42);
+      assertEquals(42, pojo.getScore());
+    }
+
+    @Test
+    @DisplayName("setterHandle is null for a getter-only property (no public setX)")
+    void setterHandleNullForGetterOnly() {
+      // NoArgFields exposes getName/getScore but no setters — the raw setter handle map must not
+      // carry an entry, so MhIso's supports() probe (via isSetterConstructible) can gate the bean
+      // out.
+      assertNull(Beans.beanSetterHandle(NoArgFields.class, "name"));
+    }
+
+    @Test
+    @DisplayName("noArgCtorHandle builds a fresh instance; absent (null) when the bean has no no-arg ctor")
+    void noArgCtorHandlePresenceMatchesCtorAvailability() throws Throwable {
+      final MethodHandle ctor = Beans.beanNoArgCtorHandle(NoArgSetters.class);
+      assertNotNull(ctor);
+      assertInstanceOf(NoArgSetters.class, ctor.invoke());
+      assertNull(Beans.beanNoArgCtorHandle(ImmutableCtor.class), "no no-arg ctor → null handle");
+    }
+
+    private static int indexOf(final String[] arr, final String needle) {
+      for (var i = 0; i < arr.length; i++) if (arr[i].equals(needle)) return i;
+      throw new IllegalArgumentException("not found: " + needle);
+    }
+  }
+
+  @Nested
+  @DisplayName("ClassValue caches key by class — distinct classes never bleed getter/property state")
+  class ClassValueKeying {
+
+    @Test
+    @DisplayName("propertyNames of two distinct classes are independent (no cross-class cache bleed)")
+    void distinctClassesHaveIndependentPropertyNames() {
+      // Both classes flow through the same GETTERS ClassValue. A keying regression that returned
+      // one
+      // class's entry for the other would surface here: NoArgSetters exposes name/score,
+      // WithGetters
+      // exposes id/active/flag/URL — disjoint sets, so a bleed is unambiguous.
+      final var setters = Arrays.asList(Beans.propertyNames(NoArgSetters.class));
+      final var getters = Arrays.asList(Beans.propertyNames(WithGetters.class));
+      assertTrue(setters.contains("name") && setters.contains("score"));
+      assertFalse(setters.contains("URL"), "WithGetters' property must not leak into NoArgSetters' entry");
+      assertTrue(getters.contains("URL"));
+      assertFalse(getters.contains("score"), "NoArgSetters' property must not leak into WithGetters' entry");
+    }
+
+    @Test
+    @DisplayName("a getter and a same-named setter on different classes resolve to their own class's" + " members")
+    void capturedReaderIsPerClass() {
+      // capturedReader for the same property name on two classes must return distinct Functions
+      // reading each class's own field — a shared-key regression would return one for both.
+      final var child = new ChildBean();
+      child.setName("child-name");
+      final var parent = new ParentBean();
+      parent.setId("parent-id");
+      assertEquals("child-name", Beans.capturedReader(ChildBean.class, "name").apply(child));
+      assertEquals("parent-id", Beans.capturedReader(ParentBean.class, "id").apply(parent));
     }
   }
 }

--- a/internal/src/test/java/io/github/eschizoid/telescope/internal/RecordsTest.java
+++ b/internal/src/test/java/io/github/eschizoid/telescope/internal/RecordsTest.java
@@ -29,6 +29,22 @@ class RecordsTest {
 
   static class NotARecord {}
 
+  // Compact-constructor record: the canonical constructor normalises `name` (trims + lower-cases)
+  // and rejects a negative `age`. The rebuild path (Records.with / construct / fieldLens.set) goes
+  // through the canonical constructor, so the normalisation MUST run on every rebuild — a
+  // regression
+  // that bypassed the canonical ctor (e.g. field-poking) would silently skip it.
+  record NormalizingUser(String name, int age) {
+    NormalizingUser {
+      if (age < 0) throw new IllegalArgumentException("age must be non-negative");
+      name = name == null ? null : name.trim().toLowerCase();
+    }
+  }
+
+  // All-primitive record pinning the unboxed accessor/ctor MethodHandle path (accessorHandles /
+  // ctorHandle) that MhIso consumes — distinct from the boxing Function<Object, Object> readers.
+  record PrimitiveRecord(int i, long l, double d, boolean b) {}
+
   @Nested
   @DisplayName("Public read / write surface")
   class PublicSurface {
@@ -48,7 +64,7 @@ class RecordsTest {
     }
 
     @Test
-    @DisplayName("read with an unknown component name throws IllegalArgumentException naming the missing field")
+    @DisplayName("read with an unknown component name throws IllegalArgumentException naming the missing" + " field")
     void readUnknownComponentThrows() {
       final var user = new User("alice", 30);
       final var ex = assertThrows(IllegalArgumentException.class, () -> Records.read(user, "ghost"));
@@ -109,7 +125,8 @@ class RecordsTest {
 
     @Test
     @DisplayName(
-      "componentType returns the generic Type — preserving parameterised List<String> for downstream shape detection"
+      "componentType returns the generic Type — preserving parameterised List<String> for" +
+        " downstream shape detection"
     )
     void componentTypePreservesGenerics() {
       // DeepMap shape detection (List<X>, Map<K, V>, Optional<X>) needs the generic Type, not the
@@ -174,7 +191,7 @@ class RecordsTest {
   class FieldLensClassAware {
 
     @Test
-    @DisplayName("captures the per-class RecordInfo at construction; per-call dispatch reads without name lookup")
+    @DisplayName("captures the per-class RecordInfo at construction; per-call dispatch reads without name" + " lookup")
     void getReadsViaCapturedReader() {
       final Lens<User, Integer> ageLens = Records.fieldLens(User.class, "age");
       assertEquals(30, ageLens.get(new User("alice", 30)));
@@ -195,7 +212,7 @@ class RecordsTest {
     }
 
     @Test
-    @DisplayName("constructing a lens for an unknown component fails fast at lens build time, not at first read")
+    @DisplayName("constructing a lens for an unknown component fails fast at lens build time, not at first" + " read")
     void unknownComponentFailsFastAtBuildTime() {
       // The class-aware variant resolves info+idx at construction — the IAE must fire at the
       // fieldLens(Class, String) call site, not later when .get/.set is invoked. Pins the
@@ -218,7 +235,7 @@ class RecordsTest {
     }
 
     @Test
-    @DisplayName("info() returns the same RecordInfo instance across calls — per-class memoisation, no rebuild")
+    @DisplayName("info() returns the same RecordInfo instance across calls — per-class memoisation, no" + " rebuild")
     void infoCacheReturnsSameInstance() {
       // The package-private info() method is the single cache entry point — calling it twice for
       // the same class must return the very same RecordInfo (LMF-built readers + ctorFn) instead
@@ -229,5 +246,129 @@ class RecordsTest {
       // info(User) returned Account's entry would have the wrong reference, not the wrong value.
       assertNotSame(Records.info(User.class), Records.info(Account.class));
     }
+  }
+
+  @Nested
+  @DisplayName("Compact constructor — canonical-ctor rebuild runs the normalisation / validation")
+  class CompactConstructor {
+
+    @Test
+    @DisplayName(
+      "with(...) rebuilds through the canonical ctor so the compact-ctor normalisation applies to" +
+        " carried-over components"
+    )
+    void withRunsCompactCtorNormalisation() {
+      // The source is already normalised (built through the ctor). Replacing `age` carries `name`
+      // over into a fresh canonical-ctor call — and the compact ctor re-normalises it. Prove the
+      // normalisation is not skipped on the off-path (carried-over) component by feeding a value
+      // that would only be lower-cased if the ctor actually ran on rebuild.
+      final var src = Records.construct(NormalizingUser.class, name ->
+        switch (name) {
+          case "name" -> "  ALICE  ";
+          case "age" -> 30;
+          default -> throw new IllegalStateException();
+        }
+      );
+      assertEquals("alice", src.name(), "construct must run the compact ctor forward");
+      final NormalizingUser bumped = Records.with(src, "age", 31);
+      assertEquals(new NormalizingUser("alice", 31), bumped);
+      assertEquals("alice", bumped.name(), "carried-over name stays normalised through the rebuild ctor");
+    }
+
+    @Test
+    @DisplayName("construct with an invalid value surfaces the compact ctor's IllegalArgumentException" + " (wrapped)")
+    void constructPropagatesCompactCtorRejection() {
+      // A validating compact ctor that throws must not be swallowed — the canonical-ctor invoker
+      // wraps the failure, but the original IAE stays reachable as the cause so the caller can see
+      // exactly which invariant was violated.
+      final var ex = assertThrows(RuntimeException.class, () ->
+        Records.construct(NormalizingUser.class, name ->
+          switch (name) {
+            case "name" -> "x";
+            case "age" -> -1;
+            default -> throw new IllegalStateException();
+          }
+        )
+      );
+      assertInstanceOf(IllegalArgumentException.class, rootCause(ex), () -> "root cause: " + rootCause(ex));
+      assertTrue(rootCause(ex).getMessage().contains("non-negative"), () -> rootCause(ex).getMessage());
+    }
+
+    @Test
+    @DisplayName(
+      "fieldLens.set rebuilds through the canonical ctor, re-running normalisation on the written" + " value"
+    )
+    void fieldLensSetReNormalisesWrittenValue() {
+      final Lens<NormalizingUser, String> nameLens = Records.fieldLens(NormalizingUser.class, "name");
+      final var src = new NormalizingUser("alice", 30);
+      final var rebuilt = nameLens.set(src, "  BOB  ");
+      assertEquals("bob", rebuilt.name(), "the written value flows through the compact ctor and is normalised");
+      assertEquals(30, rebuilt.age(), "off-path age carries over unchanged");
+    }
+  }
+
+  @Nested
+  @DisplayName("construct — primitive component fed a null value throws (canonical-ctor unbox)")
+  class PrimitiveNullConstruct {
+
+    @Test
+    @DisplayName("passing null for a primitive component throws when the spread ctor handle unboxes it")
+    void nullForPrimitiveComponentThrows() {
+      // The spread-MethodHandle ctor path unboxes each Object[] slot into the primitive parameter.
+      // A null slot for the `age` int cannot unbox — the JVM raises NPE inside the ctor invoker,
+      // which Records wraps as a RuntimeException. Pins that a null-for-primitive is a loud
+      // failure,
+      // not a silent 0-default (records have no null-guard; that lives only in the bean
+      // SettersWriter
+      // primitive path).
+      final var ex = assertThrows(RuntimeException.class, () ->
+        Records.construct(User.class, name -> name.equals("name") ? "x" : null)
+      );
+      assertInstanceOf(NullPointerException.class, rootCause(ex), () -> "root cause: " + rootCause(ex));
+    }
+  }
+
+  @Nested
+  @DisplayName("RecordInfo raw handles — unboxed accessor / ctor MethodHandle path (MhIso substrate)")
+  class RawHandles {
+
+    @Test
+    @DisplayName("accessorHandles keep the component's primitive return type (unboxed) and read the right" + " value")
+    void accessorHandlesAreUnboxedAndCorrect() throws Throwable {
+      final var info = Records.info(PrimitiveRecord.class);
+      final var handles = info.accessorHandles();
+      assertEquals(4, handles.length);
+      // The int accessor handle's return type is the raw primitive int, not Integer — this is the
+      // whole point of the raw-handle path (readers[] box; accessorHandles don't).
+      assertEquals(int.class, handles[0].type().returnType(), "accessor handle keeps the unboxed int return");
+      assertEquals(long.class, handles[1].type().returnType());
+      assertEquals(double.class, handles[2].type().returnType());
+      assertEquals(boolean.class, handles[3].type().returnType());
+      final var rec = new PrimitiveRecord(7, 42L, 3.5, true);
+      assertEquals(7, (int) handles[0].invoke(rec));
+      assertEquals(42L, (long) handles[1].invoke(rec));
+    }
+
+    @Test
+    @DisplayName("ctorHandle keeps the unboxed canonical-constructor signature and builds the record")
+    void ctorHandleIsUnboxedAndBuilds() throws Throwable {
+      final var info = Records.info(PrimitiveRecord.class);
+      final var ctor = info.ctorHandle();
+      final var type = ctor.type();
+      assertEquals(PrimitiveRecord.class, type.returnType());
+      assertArrayEquals(
+        new Class<?>[] { int.class, long.class, double.class, boolean.class },
+        type.parameterArray(),
+        "ctor handle keeps the raw primitive parameter signature, no boxing"
+      );
+      final PrimitiveRecord built = (PrimitiveRecord) ctor.invoke(1, 2L, 3.0, false);
+      assertEquals(new PrimitiveRecord(1, 2L, 3.0, false), built);
+    }
+  }
+
+  private static Throwable rootCause(final Throwable t) {
+    var cur = t;
+    while (cur.getCause() != null && cur.getCause() != cur) cur = cur.getCause();
+    return cur;
   }
 }

--- a/internal/src/test/java/io/github/eschizoid/telescope/internal/ReflectiveSurfaceTest.java
+++ b/internal/src/test/java/io/github/eschizoid/telescope/internal/ReflectiveSurfaceTest.java
@@ -155,7 +155,7 @@ class ReflectiveSurfaceTest {
 
     @Test
     @DisplayName(
-      "hint map is consulted before falling through to autoWriter — wrapping HashMap records the get() probe"
+      "hint map is consulted before falling through to autoWriter — wrapping HashMap records the" + " get() probe"
     )
     void hintMapIsConsultedBeforeAutoWriter() {
       // The hint payload alone can't distinguish "hint fired" from "autoWriter happened to pick the
@@ -188,7 +188,8 @@ class ReflectiveSurfaceTest {
 
     @Test
     @DisplayName(
-      "default factory is consulted on every construct() call for unhinted classes (no per-class memoisation today)"
+      "default factory is consulted on every construct() call for unhinted classes (no per-class" +
+        " memoisation today)"
     )
     void defaultFactoryFiresOncePerConstructCall() {
       // Pins the actual (non-memoised) resolution behaviour at the constructBeanWithHints call
@@ -208,6 +209,31 @@ class ReflectiveSurfaceTest {
 
       assertEquals(2, factoryCalls[0], "default factory fires once per construct() call for unhinted classes");
     }
+
+    @Test
+    @DisplayName("a per-class hint takes precedence: the default factory is NOT consulted for a hinted" + " class")
+    void hintTakesPrecedenceOverDefaultFactory() {
+      // Resolution order is hint → default factory → autoWriter. When a hint exists for the target
+      // class, the default factory must be short-circuited entirely — not merely produce the same
+      // result. Pin the precedence with a factory that would throw if it were ever consulted for
+      // the hinted class, so a regression collapsing the two tiers fails loudly.
+      final var hints = new HashMap<Class<?>, Beans.BeanWriter<?>>();
+      hints.put(SimpleBean.class, Beans.settersWriter(SimpleBean.class));
+      final var refl = Reflective.beansWithHints(hints, cls -> {
+        throw new AssertionError("default factory must not be consulted when a hint exists for " + cls);
+      });
+
+      final var built = (SimpleBean) refl.construct(SimpleBean.class, name ->
+        switch (name) {
+          case "name" -> "ivy";
+          case "age" -> 44;
+          default -> null;
+        }
+      );
+
+      assertEquals("ivy", built.getName());
+      assertEquals(44, built.getAge());
+    }
   }
 
   @Nested
@@ -215,7 +241,7 @@ class ReflectiveSurfaceTest {
   class PositionalBuilder {
 
     @Test
-    @DisplayName("record fast-path: no holder data → cached canonical-ctor function applies the array directly")
+    @DisplayName("record fast-path: no holder data → cached canonical-ctor function applies the array" + " directly")
     void recordFastPathBindsCanonicalCtor() {
       final var builder = Reflective.RECORDS.positionalBuilder(SimpleUser.class, null, null);
       assertNotNull(builder);
@@ -254,7 +280,7 @@ class ReflectiveSurfaceTest {
     }
 
     @Test
-    @DisplayName("bean path captures the property name per slot and reads through Beans.readProperty's substrate")
+    @DisplayName("bean path captures the property name per slot and reads through Beans.readProperty's" + " substrate")
     void beanReadersReadByPropertyName() {
       final var refl = Reflective.BEANS;
       final var readers = refl.positionalReaders(SimpleBean.class, null);
@@ -282,7 +308,8 @@ class ReflectiveSurfaceTest {
 
     @Test
     @DisplayName(
-      "holderConstructor short-circuits the reflective construct path: returned function is applied with a name-indexed array view"
+      "holderConstructor short-circuits the reflective construct path: returned function is" +
+        " applied with a name-indexed array view"
     )
     void holderConstructorTakesPriorityOverReflectiveBuild() {
       // Stand-in for a codegen FieldOptics' bound construct(Function<String, Object>): if the


### PR DESCRIPTION
23 contract tests filling real gaps below the 60% line — **meaningful, not coverage-bait**. Pin behavior a regression would break: compact-ctor normalization on rebuild, the null-into-primitive asymmetry (records throw / beans JLS-default), `capturedReader` cache identity + parent-bound-reader-on-subtype dispatch, `isSetterConstructible` edges, the raw unboxed MethodHandle accessors MhIso consumes, ClassValue cross-class keying, hint-vs-default-writer-factory precedence. `:internal:test` green. No production change.