### PR TITLE
build(native): GraalVM native-image smoke-test harness + CI

### DIFF
--- a/.github/workflows/native-image.yaml
+++ b/.github/workflows/native-image.yaml
@@ -1,0 +1,72 @@
+name: Native Image Smoke Test
+
+# Proves telescope's reflection-free runtime substrate (the cached LambdaMetafactory-built
+# Function / Supplier / BiConsumer readers+writers, the SerializedLambda field-name decode, and a
+# codegen @Bridge constant) survives a GraalVM native-image build under the closed-world assumption.
+#
+# The :native-smoke module's main exits non-zero on any capability mismatch, so `nativeRun`
+# building AND running the binary IS the test — a red job means the substrate hit a real
+# native-image gap (missing reflection/serialization registration, an LMF call site the image
+# builder couldn't fold, or a SerializedLambda decode that closed-world analysis broke).
+
+on:
+  # Native-image builds are slow (several minutes) — don't gate every PR on them. Run on demand,
+  # on pushes to main, and on a weekly cadence so a GraalVM-version regression surfaces on its own.
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - "native-smoke/**"
+      - "core/**"
+      - "internal/**"
+      - "codegen/**"
+      - ".github/workflows/native-image.yaml"
+  schedule:
+    - cron: "0 6 * * 1" # Mondays 06:00 UTC
+
+permissions:
+  contents: read
+
+jobs:
+  native-smoke:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      # GraalVM ships native-image. The `java-version` here drives BOTH the compile toolchain and
+      # native-image; the smoke module targets release 21 bytecode, which GraalVM 21 consumes, but
+      # we install 25 to match the rest of the project's toolchain and keep the JDK surface uniform.
+      - name: Set up GraalVM (native-image)
+        uses: graalvm/setup-graalvm@v1
+        with:
+          java-version: "25"
+          distribution: graalvm
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          native-image-job-reports: "true"
+
+      - name: Show native-image version
+        run: native-image --version
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v6
+
+      # nativeCompile builds the binary; nativeRun builds (if needed) then executes it. Because the
+      # smoke main calls System.exit(non-zero) on any failed capability, a failing binary fails this
+      # step — no extra assertion needed. --no-daemon keeps the forked JVM settings honest.
+      - name: Build and run the native smoke test
+        run: ./gradlew :native-smoke:nativeRun --no-daemon --stacktrace
+
+      # Keep the produced binary + native-image build reports for post-mortem when the substrate
+      # needs config: the build report lists exactly which classes were registered for reflection /
+      # serialization and which were initialized at build vs run time — the real finding lives here.
+      - name: Upload native-image build reports
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: native-image-reports
+          path: |
+            native-smoke/build/native/nativeCompile/
+            native-smoke/build/reports/
+          retention-days: 14

--- a/docs/native-image.md
+++ b/docs/native-image.md
@@ -1,0 +1,105 @@
+# telescope on GraalVM native-image
+
+Telescope's runtime hot path is reflection-free by design: field reads and record/bean rebuilds ride a per-class cache
+of `LambdaMetafactory`-built `Function` / `Supplier` / `BiConsumer` instances (see `internal/Records.java`,
+`internal/Beans.java`), and `.field(Record::accessor)` recovers the field name from a `Serializable` method reference
+via `SerializedLambda` decode. GraalVM's closed-world assumption can break exactly these mechanics — synthetic LMF
+classes, `invokedynamic` bootstrap, `SerializedLambda` deserialization, and the `MethodHandles.privateLookupIn` path.
+
+The `:native-smoke` module is a self-contained harness that either lets the project claim native support or names the
+real gap.
+
+## What the smoke test covers
+
+`native-smoke/src/main/java/.../NativeSmokeMain.java` exercises, in one process, the substrate mechanics whose survival
+under native-image was unverified. Each capability prints `PASS` / `FAIL` and the process exits non-zero on any failure
+— so `native-image` compiling and running the binary **is** the test.
+
+| Capability                  | Substrate mechanic under test                                                                         |
+| --------------------------- | ----------------------------------------------------------------------------------------------------- |
+| Record field update         | `SerializedLambda` method-reference decode + LMF record reader + cached canonical-ctor `MethodHandle` |
+| Record → record `mapper`    | LMF record readers on the source, canonical-constructor rebuild on the target                         |
+| Bean → bean `mapper`        | LMF getter readers + no-arg-ctor `Supplier` + LMF setter `BiConsumer` writers                         |
+| LMF record read (`.read()`) | pure LMF-dispatched record component read (the `Records.read` path through the public surface)        |
+| LMF bean read (`.read()`)   | pure LMF-dispatched bean getter read (the `Beans.readProperty` path through the public surface)       |
+| Codegen `@Bridge` constant  | the generated `SmokeBeanABridge.BRIDGE` — typed method calls, **no** runtime reflection (control)     |
+
+The `@Bridge` row is the control: the codegen path uses no runtime reflection, so it should always survive. The other
+five rows are the ones that stress the reflective LMF / `SerializedLambda` substrate. (`:examples:graphql` already
+proves the codegen `@FromMap` path native-images with `--no-fallback`; this module is the missing coverage for the
+_reflective_ tier.)
+
+`Records` / `Beans` live in `:internal`, JPMS-sealed to `:core`, so the smoke module cannot call them directly. It
+reaches the identical LMF call sites through the public `Telescope.of(...).field(...).read()` /
+`Telescope.mapper(...).forward(...)` surface — same machinery, honest module boundary.
+
+## How to run it
+
+- **JVM sanity check** (validates the harness logic, not native-image): `./gradlew :native-smoke:run`
+- **Native build + run** (the real test, needs a GraalVM `native-image` on `PATH`): `./gradlew :native-smoke:nativeRun`
+
+CI wiring: `.github/workflows/native-image.yaml` installs GraalVM via `graalvm/setup-graalvm`, then runs
+`:native-smoke:nativeRun`. The job fails if the binary exits non-zero. It runs on `workflow_dispatch`, on pushes to
+`main` that touch the substrate modules, and weekly (to catch a GraalVM-version regression on its own cadence). Native
+builds are minutes-long, so it deliberately does **not** gate every PR.
+
+## GraalVM config the substrate required
+
+**None, as configured.** The build uses `--no-fallback` (fail rather than silently emit a JVM-fallback image) and
+`--initialize-at-build-time` scoped to the smoke module's own package. No `reflect-config.json`,
+`serialization-config.json`, or `resource-config.json` was wired, on the following reasoning (see the verdict caveat
+below):
+
+- **LMF / `invokedynamic`.** Telescope builds its readers/writers by calling `LambdaMetafactory.metafactory(...)`
+  **explicitly at runtime** (not via a compiler-emitted `invokedynamic` bootstrap). native-image supports runtime
+  `LambdaMetafactory` calls: the synthetic `Function`/`Supplier`/`BiConsumer` implementation classes are generated and
+  registered during image build as long as the target method (the record accessor, bean getter/setter, constructor) is
+  itself reachable — and it is, because the smoke `main` calls each accessor/constructor through concrete, statically
+  reachable types. No `reflect-config` entry is needed for the accessors because they are invoked through `MethodHandle`
+  call sites the analysis can see, not through `Method.invoke`.
+- **`SerializedLambda`.** `.field(User::name)` decodes a `Serializable` lambda. This is the one genuinely at-risk
+  mechanic: lambda deserialization historically needed a `serialization-config.json` entry (or the `$deserializeLambda$`
+  method to be reachable). Recent GraalVM registers the `altMetafactory`-generated lambda classes and their
+  `writeReplace`/`$deserializeLambda$` automatically when the lambda is created in reachable code, which the smoke
+  `main`'s method references are. **If any config turns out to be needed, this is the row that will demand it** — and
+  the smoke test is precisely what surfaces that.
+- **`privateLookupIn`.** All records/beans in the smoke module are public and in the same (open, unnamed-on-classpath)
+  module, so `MethodHandles.privateLookupIn` succeeds without an `opens` directive. A downstream consumer with
+  JPMS-closed packages still needs `opens ... to io.github.eschizoid.telescope;` — that is a module-descriptor
+  requirement, not a native-image one.
+
+## Verdict
+
+**Correct-by-construction, not yet CI-verified — local `native-image` was unavailable (OpenJDK 25 only on the build
+host), so the native binary has not actually been produced here.** The JVM run of the identical `main` passes all six
+capabilities, which proves the harness logic; the native verdict lands the first time the workflow runs on a
+GraalVM-equipped runner.
+
+Best current assessment from the LMF/`SerializedLambda` mechanics: the five reflective capabilities **should** survive
+on a modern GraalVM (24+) with **zero** reachability config, because telescope calls `LambdaMetafactory` at runtime over
+handles to statically-reachable accessors rather than going through `Method.invoke`, and the method references are
+created in reachable code. The single most likely place to need config is `SerializedLambda` deserialization for
+`.field(MethodRef)`; if the workflow's first run reds out, the failing capability line + the uploaded native-image build
+report will name the exact registration to add (expected shape: a `serialization-config.json` entry for the lambda's
+declaring class, or `-H:+ReportExceptionStackTraces` pointing at the `$deserializeLambda$` gap). Update this section
+with the real finding once the job has run.
+
+## Appendix — feasibility of shading `:internal` into `:core` at publish
+
+Today the internal optic lattice ships as a separate `telescope-internal` JPMS module whose packages are
+qualified-exported only to `io.github.eschizoid.telescope`; a downstream `import ...internal.optics.Lens` fails to
+compile with "package is not visible". The question is whether we could instead **shade** `:internal`'s bytecode into
+`telescope-core` at publish time so consumers physically cannot reference the lattice types.
+
+Short answer: a Gradle `com.gradleup.shadow` (shadow-jar) merge is mechanically possible but **fights the JPMS model and
+is not worth it** — the current qualified-export already delivers the exact "users cannot type `Lens`" guarantee, at
+compile time, for free. A shadow jar merges class files but does not merge module descriptors: `:core` and `:internal`
+each carry a `module-info.java`, and a fat jar can hold at most one module descriptor, so the merged artifact would have
+to either drop to the classpath (losing the JPMS boundary that is the whole encapsulation mechanism) or hand-author a
+single fused descriptor that re-exports nothing internal (doable, but now the lattice types live in `telescope-core`'s
+own unexported packages — encapsulated by _package non-export_ rather than _qualified export_, a lateral move, not a
+win). It also breaks the published `telescope-internal` coordinate that the release list and JReleaser staging already
+depend on, breaks the `--add-exports` seam the `:benchmarks` module uses to test internals, and complicates
+source/javadoc jars. A source-merge (physically relocating `internal/*` sources under `core/src`) is even worse: it
+erases the two-layer module boundary the architecture is built on and the qualified-export test guarantee with it. Net:
+keep the qualified-export boundary; shading buys no additional encapsulation and costs the published-module contract.

--- a/native-smoke/build.gradle.kts
+++ b/native-smoke/build.gradle.kts
@@ -1,0 +1,71 @@
+plugins {
+    java
+    id("org.graalvm.buildtools.native") version "1.1.4"
+}
+
+description =
+    "telescope-native-smoke — a GraalVM native-image smoke test proving the reflection-free " +
+    "LambdaMetafactory / SerializedLambda runtime substrate survives --initialize-at-build-time"
+
+repositories {
+    mavenCentral()
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
+tasks.withType<JavaCompile>().configureEach {
+    // Target release 21 bytecode (as every other module does) so a GraalVM 21+ native-image
+    // toolchain consumes it. -parameters lets the bean-mapper's name-based rebuild match cleanly.
+    options.release = 21
+    options.encoding = "UTF-8"
+    options.compilerArgs.addAll(listOf("-Xlint:all,-processing", "-parameters"))
+    // Classpath mode on purpose (no module-info.java): the smoke module runs on the plain
+    // classpath, which is the simplest, most representative shape a downstream native-image
+    // consumer of telescope-core will use. The JPMS module boundary is still exercised at the
+    // :core / :internal level upstream.
+}
+
+// Plain JVM run of the same main — a fast local sanity check that the harness itself is correct
+// (`./gradlew :native-smoke:run`). native-image is what actually proves the substrate; this JVM
+// run only proves the smoke logic is green before we hand it to native-image.
+tasks.register<JavaExec>("run") {
+    group = "verification"
+    description = "Run the native smoke main on the JVM (sanity check before the native build)"
+    mainClass.set("io.github.eschizoid.telescope.nativesmoke.NativeSmokeMain")
+    classpath = sourceSets["main"].runtimeClasspath
+}
+
+// GraalVM native build. Running the produced binary IS the test — it exits non-zero on any
+// capability failure, so `nativeRun` failing fails the CI job.
+graalvmNative {
+    // Use the GraalVM pointed to by GRAALVM_HOME / JAVA_HOME for native-image rather than letting
+    // toolchain detection pick the plain compile JDK (which has no native-image). Mirrors the
+    // :examples:graphql setup.
+    toolchainDetection.set(false)
+    binaries {
+        named("main") {
+            imageName.set("telescope-native-smoke")
+            mainClass.set("io.github.eschizoid.telescope.nativesmoke.NativeSmokeMain")
+            // --no-fallback: fail the build instead of silently emitting a JVM-fallback image if
+            //   any reachability gap is hit. This is what makes the smoke test honest — a fallback
+            //   image would "pass" while hiding the exact native-image incompatibility we're testing.
+            buildArgs.add("--no-fallback")
+            // Report the reason for any build-time initialization decision if the build fails, so a
+            // failing run tells us WHICH class the substrate couldn't initialize at build time.
+            buildArgs.add("--initialize-at-build-time=io.github.eschizoid.telescope.nativesmoke")
+            // Surface an actionable trace if native-image cannot fold something the substrate needs.
+            buildArgs.add("-H:+ReportExceptionStackTraces")
+        }
+    }
+}
+
+dependencies {
+    implementation(project(":core"))
+    // @Bridge(SmokeBeanB.class) on SmokeBeanA drives the :codegen processor to emit
+    // SmokeBeanABridge — the codegen control path in the smoke test.
+    annotationProcessor(project(":codegen"))
+}

--- a/native-smoke/src/main/java/io/github/eschizoid/telescope/nativesmoke/NativeSmokeMain.java
+++ b/native-smoke/src/main/java/io/github/eschizoid/telescope/nativesmoke/NativeSmokeMain.java
@@ -1,0 +1,194 @@
+package io.github.eschizoid.telescope.nativesmoke;
+
+import io.github.eschizoid.telescope.Telescope;
+import io.github.eschizoid.telescope.conversion.Mapper;
+import java.util.ArrayList;
+
+/**
+ * A self-contained GraalVM native-image smoke test for telescope's reflection-free runtime
+ * substrate. Every capability below rides the cached {@code LambdaMetafactory}-built {@code
+ * Function} / {@code Supplier} / {@code BiConsumer} readers and writers plus the {@code
+ * SerializedLambda} field-name decode that {@code .field(Record::accessor)} relies on — the exact
+ * machinery whose survival under {@code --initialize-at-build-time} + the native-image closed-world
+ * assumption is unverified.
+ *
+ * <p>Running this class <em>is</em> the test: each capability prints {@code PASS} / {@code FAIL}
+ * and a mismatch (or thrown exception) sets a non-zero exit code. When {@code native-image} bakes
+ * and runs this binary, a green run proves the substrate; a red run (or a build-time failure) is
+ * the real finding.
+ *
+ * <p>The capabilities exercised, mapped to the substrate mechanic each stresses:
+ *
+ * <ul>
+ *   <li><b>record field update</b> — {@code Telescope.of(Record).field(Record::x).update(...)}:
+ *       {@code SerializedLambda} decode of the method reference + LMF record reader + the cached
+ *       canonical-constructor {@code MethodHandle} rebuild.
+ *   <li><b>record → record mapper</b> — {@code Telescope.mapper(A, B).forward(a)}: LMF readers on
+ *       the source, canonical-constructor rebuild on the target.
+ *   <li><b>bean → bean mapper</b> — {@code Telescope.mapper(A, B).forward(a)} over POJOs: LMF
+ *       getter readers + the no-arg-ctor + LMF setter writer path in {@code Beans}.
+ *   <li><b>LMF read path (record + bean)</b> — {@code .field(...).read(source)}: the pure
+ *       LMF-dispatched read (the {@code Records.read} / {@code Beans.readProperty} equivalent
+ *       reached through the public surface, since {@code :internal} is JPMS-sealed to {@code
+ *       :core}).
+ *   <li><b>codegen {@code @Bridge}</b> — the generated {@code SmokeBeanABridge.BRIDGE} constant, a
+ *       {@code Telescope<SmokeBeanA, SmokeBeanB>} emitted at compile time. This path uses NO
+ *       runtime reflection (typed method calls only) and so is the control: it should always
+ *       survive native image. It doubles as a check that the codegen navigator classes are
+ *       reachable.
+ * </ul>
+ */
+public final class NativeSmokeMain {
+
+  private NativeSmokeMain() {}
+
+  /** A small record graph for the record-side capabilities. */
+  public record Address(String city, String zip) {}
+
+  /** Top-level record with a nested record and a primitive, to stress boxing on the LMF path. */
+  public record User(String name, int age, Address address) {}
+
+  /** Record mapper target — same field names / types as {@link User} for same-name deep mapping. */
+  public record UserDto(String name, int age, Address address) {}
+
+  public static void main(final String[] args) {
+    final var results = new ArrayList<Result>();
+
+    results.add(
+      guard("record field update (SerializedLambda + LMF reader + ctor MH)", NativeSmokeMain::recordFieldUpdate)
+    );
+    results.add(
+      guard("record → record mapper.forward (LMF readers + canonical-ctor rebuild)", NativeSmokeMain::recordMapper)
+    );
+    results.add(
+      guard("bean → bean mapper.forward (LMF getters + no-arg ctor + LMF setters)", NativeSmokeMain::beanMapper)
+    );
+    results.add(guard("LMF record read path (.field(...).read())", NativeSmokeMain::recordReadPath));
+    results.add(guard("LMF bean read path (.field(...).read())", NativeSmokeMain::beanReadPath));
+    results.add(guard("codegen @Bridge constant (SmokeBeanABridge.BRIDGE.read())", NativeSmokeMain::bridgeConstant));
+
+    System.out.println();
+    System.out.println("=== telescope native-image smoke test ===");
+    var failures = 0;
+    for (final var r : results) {
+      final var detail = r.detail() == null ? "" : "  — " + r.detail();
+      System.out.println((r.passed() ? "PASS  " : "FAIL  ") + r.name() + detail);
+      if (!r.passed()) failures++;
+    }
+    System.out.println();
+    if (failures == 0) {
+      System.out.println("ALL " + results.size() + " CAPABILITIES PASSED on this runtime (" + runtimeLabel() + ").");
+    } else {
+      System.out.println(
+        failures +
+          " of " +
+          results.size() +
+          " CAPABILITIES FAILED — the substrate needs native-image config (see the failing" +
+          " lines)."
+      );
+    }
+    System.exit(failures == 0 ? 0 : 1);
+  }
+
+  // (a) record field update through the full method-reference decode + rebuild path.
+  private static void recordFieldUpdate() {
+    final var before = new User("ada", 36, new Address("london", "NW1"));
+    final var after = Telescope.of(User.class).field(User::name).update(before, String::toUpperCase);
+    expect("ADA".equals(after.name()), "expected name=ADA, got " + after.name());
+    // Nested navigation + a primitive-carrying rebuild: the age (int) must survive the copy
+    // unboxed.
+    final var deeper = Telescope.of(User.class)
+      .field(User::address)
+      .field(Address::city)
+      .update(before, String::toUpperCase);
+    expect(
+      "LONDON".equals(deeper.address().city()) && deeper.age() == 36,
+      "nested update or primitive carry-over failed: " + deeper
+    );
+  }
+
+  // (b) record → record deep mapper (same-name auto mapping over the whole graph).
+  private static void recordMapper() {
+    final Mapper<User, UserDto> mapper = Telescope.mapper(User.class, UserDto.class);
+    final var dto = mapper.forward(new User("grace", 45, new Address("nyc", "10001")));
+    expect(
+      "grace".equals(dto.name()) && dto.age() == 45 && "nyc".equals(dto.address().city()),
+      "record mapper.forward mismatch: " + dto
+    );
+  }
+
+  // (c) bean → bean deep mapper: exercises Beans' LMF getter readers + no-arg-ctor Supplier +
+  // setters.
+  private static void beanMapper() {
+    final var src = new SmokeBeanA();
+    src.setId("id-1");
+    src.setEmail("Alan@Example.com");
+    src.setName("Alan");
+    final Mapper<SmokeBeanA, SmokeBeanB> mapper = Telescope.mapper(SmokeBeanA.class, SmokeBeanB.class);
+    final var out = mapper.forward(src);
+    expect(
+      "id-1".equals(out.getId()) && "Alan@Example.com".equals(out.getEmail()) && "Alan".equals(out.getName()),
+      "bean mapper.forward mismatch: id=" + out.getId() + " email=" + out.getEmail() + " name=" + out.getName()
+    );
+  }
+
+  // (d) LMF record read path — .read() dispatches the cached LMF record reader (Records.read
+  // equivalent).
+  private static void recordReadPath() {
+    final var user = new User("linus", 54, new Address("helsinki", "00100"));
+    final String city = Telescope.of(User.class).field(User::address).field(Address::city).read(user);
+    final int age = Telescope.of(User.class).field(User::age).read(user);
+    expect("helsinki".equals(city) && age == 54, "record read path mismatch: city=" + city + " age=" + age);
+  }
+
+  // LMF bean read path — .read() dispatches the cached LMF getter (Beans.readProperty equivalent).
+  private static void beanReadPath() {
+    final var bean = new SmokeBeanA();
+    bean.setId("id-2");
+    bean.setEmail("Barbara@Example.com");
+    bean.setName("Barbara");
+    final String email = Telescope.ofBean(SmokeBeanA.class).field(SmokeBeanA::getEmail).read(bean);
+    expect("Barbara@Example.com".equals(email), "bean read path mismatch: " + email);
+  }
+
+  // (e) codegen @Bridge constant — pure typed method calls, no runtime reflection. Control path.
+  private static void bridgeConstant() {
+    final var a = new SmokeBeanA();
+    a.setId("id-3");
+    a.setEmail("Katherine@Example.com");
+    a.setName("Katherine");
+    // SmokeBeanABridge is emitted by :codegen from @Bridge(SmokeBeanB.class) on SmokeBeanA.
+    // BRIDGE is a Telescope<SmokeBeanA, SmokeBeanB>; .read(a) runs the forward conversion.
+    final var b = SmokeBeanABridge.BRIDGE.read(a);
+    expect(
+      "id-3".equals(b.getId()) && "Katherine@Example.com".equals(b.getEmail()) && "Katherine".equals(b.getName()),
+      "bridge constant mismatch: id=" + b.getId() + " email=" + b.getEmail() + " name=" + b.getName()
+    );
+  }
+
+  // "native-image" when running as a compiled binary (org.graalvm.nativeimage.imagecode is set),
+  // otherwise "JVM". Lets the same main honestly say which runtime just proved the substrate — a
+  // green JVM run only validates the harness; a green native-image run is the real verdict.
+  private static String runtimeLabel() {
+    return System.getProperty("org.graalvm.nativeimage.imagecode") != null ? "native-image" : "JVM";
+  }
+
+  private static void expect(final boolean condition, final String message) {
+    if (!condition) throw new AssertionError(message);
+  }
+
+  private static Result guard(final String name, final Runnable capability) {
+    try {
+      capability.run();
+      return new Result(name, true, null);
+    } catch (final Throwable t) {
+      // Print the full stack immediately so a native-image run surfaces the failing mechanic (an
+      // LMF build failure, a missing reflection registration, a SerializedLambda decode gap).
+      System.err.println("[FAIL] " + name);
+      t.printStackTrace();
+      return new Result(name, false, t.getClass().getSimpleName() + ": " + t.getMessage());
+    }
+  }
+
+  private record Result(String name, boolean passed, String detail) {}
+}

--- a/native-smoke/src/main/java/io/github/eschizoid/telescope/nativesmoke/SmokeBeanA.java
+++ b/native-smoke/src/main/java/io/github/eschizoid/telescope/nativesmoke/SmokeBeanA.java
@@ -1,0 +1,41 @@
+package io.github.eschizoid.telescope.nativesmoke;
+
+import io.github.eschizoid.telescope.annotations.Bridge;
+
+/**
+ * A classic mutable JavaBean source for the bean-mapper and {@code @Bridge} smoke capabilities.
+ * {@code @Bridge(SmokeBeanB.class)} drives the {@code :codegen} processor to emit {@code
+ * SmokeBeanABridge.BRIDGE : Telescope<SmokeBeanA, SmokeBeanB>}. The no-arg constructor + public
+ * setters are exactly the shape {@code Beans}' LMF getter/setter substrate rebuilds through.
+ */
+@Bridge(SmokeBeanB.class)
+public final class SmokeBeanA {
+
+  private String id;
+  private String email;
+  private String name;
+
+  public String getId() {
+    return id;
+  }
+
+  public String getEmail() {
+    return email;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setId(final String id) {
+    this.id = id;
+  }
+
+  public void setEmail(final String email) {
+    this.email = email;
+  }
+
+  public void setName(final String name) {
+    this.name = name;
+  }
+}

--- a/native-smoke/src/main/java/io/github/eschizoid/telescope/nativesmoke/SmokeBeanB.java
+++ b/native-smoke/src/main/java/io/github/eschizoid/telescope/nativesmoke/SmokeBeanB.java
@@ -1,0 +1,37 @@
+package io.github.eschizoid.telescope.nativesmoke;
+
+/**
+ * The {@code @Bridge} target and bean-mapper target for {@link SmokeBeanA} — same property names /
+ * types (a bijection), so both the runtime {@code Telescope.mapper(...)} deep-map and the codegen
+ * {@code @Bridge} bijection resolve without extra mapping rows.
+ */
+public final class SmokeBeanB {
+
+  private String id;
+  private String email;
+  private String name;
+
+  public String getId() {
+    return id;
+  }
+
+  public String getEmail() {
+    return email;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setId(final String id) {
+    this.id = id;
+  }
+
+  public void setEmail(final String email) {
+    this.email = email;
+  }
+
+  public void setName(final String name) {
+    this.name = name;
+  }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -7,6 +7,7 @@ include("lombok")
 include("spring-boot-starter")
 include("quarkus")
 include("benchmarks")
+include("native-smoke")
 
 include("examples:library")
 include("examples:mapstruct-vs-telescope")


### PR DESCRIPTION
New `:native-smoke` module — one main exercising 6 capabilities (record field update, record/bean `mapper.forward`, LMF record/bean read, codegen `@Bridge` constant), printing PASS/FAIL per line and exiting non-zero on failure, so native-image running it **is** the test. `native-image.yaml` (setup-graalvm, nativeRun, weekly + on-substrate-push) makes **CI the arbiter** of whether the LMF `Function`/`Supplier` + `SerializedLambda` substrate survives `--initialize-at-build-time`. `docs/native-image.md`: coverage + honest verdict (likely survives with zero config; `SerializedLambda` decode is the one at-risk row) + a **shading-`:internal`-declined** note (a fat jar loses the JPMS boundary). JVM run: 6/6 pass; local native-image not possible (no GraalVM on host) so CI is first real verification.