### PR TITLE
feat: GraalVM native-image AOT support for the runtime path

### DIFF
--- a/core/src/main/resources/META-INF/native-image/io.github.eschizoid/telescope-core/native-image.properties
+++ b/core/src/main/resources/META-INF/native-image/io.github.eschizoid/telescope-core/native-image.properties
@@ -1,0 +1,13 @@
+# Telescope's @Bridge / @FromMap codegen constants and its optic wrappers are built at class-init and
+# land in the build-time image heap; native-image defaults every class to run-time init, so a heap
+# object of a run-time-init type is a hard build error. These classes are stateless MethodHandle /
+# Function wrappers with no per-instance mutable or environment-dependent state, so initializing them
+# at build time is safe. Shipping it here means adopters building a native image get it automatically,
+# with no --initialize-at-build-time args of their own for telescope.
+#
+# The three telescope packages are listed explicitly rather than relying on the
+# `io.github.eschizoid.telescope` prefix subsuming its subpackages — robust whether native-image
+# treats a package argument as a recursive prefix or an exact match.
+Args = --initialize-at-build-time=io.github.eschizoid.telescope \
+       --initialize-at-build-time=io.github.eschizoid.telescope.internal \
+       --initialize-at-build-time=io.github.eschizoid.telescope.internal.optics

--- a/docs/adr/0015-native-image-aot-support.md
+++ b/docs/adr/0015-native-image-aot-support.md
@@ -1,0 +1,139 @@
+# ADR-0015: Native-image AOT support for the runtime path
+
+**Status:** Accepted (qualifies [ADR-0005](0005-lambdametafactory-over-method-handle-invoke.md) under AOT) · **Date:**
+2026-07-17
+
+## Context
+
+The `:examples:graphql` native-image verifier (`NativeVerify`) exercises telescope's full runtime + codegen surface
+under a real GraalVM `native-image` build. The first two CI native builds established the boundary empirically:
+
+- **The codegen path native-images cleanly, zero config.** `@FromMap` and `@Bridge` passed on every run — they compile
+  to typed method calls, hold no runtime reflection, and their image-heap constants only need
+  `--initialize-at-build-time` for the telescope + generated-model classes (already wired in the example build).
+- **The runtime reflective path fails**, on two distinct walls:
+
+  **Wall A — `SerializedLambda` decode.** `.field(User::name)` recovers the field name by serializing the `Serializable`
+  method reference and reading `SerializedLambda.getImplMethodName()`. native-image does not synthesize `writeReplace()`
+  for a lambda unless its capturing class is registered for serialization, so the decode throws and the navigation path
+  reports `Expected a method reference`.
+
+  **Wall B — runtime `LambdaMetafactory` (the load-bearing one).** `Records` (line ~403) and `Beans` (lines ~206/224)
+  build one `Function` / `Supplier` / `BiConsumer` accessor per member by calling `LambdaMetafactory.metafactory(...)`
+  **at run time**, which defines a fresh hidden class per accessor. native-image's closed world forbids runtime class
+  definition outright
+  (`Classes cannot be defined at runtime by default when using ahead-of-time Native Image compilation`). No metadata
+  file can lift this — it is a code-shape problem, not a registration gap.
+
+A third, lesser requirement rode along with Wall B for the mappers: `Telescope.mapper(...)` walks the graph with
+`Class.getRecordComponents()` and invokes accessors / the canonical constructor / bean setters reflectively, so the
+converted **DTO types** must be registered for reflection (a standard native-image reachability-metadata need, distinct
+from the two walls above).
+
+This ADR does not touch the codegen path — [ADR-0004](0004-runtime-and-codegen-strategy-separate.md) keeps codegen and
+runtime as separate strategies, and codegen is already AOT-clean. It qualifies
+[ADR-0005](0005-lambdametafactory-over-method-handle-invoke.md): LMF remains the JVM hot-path dispatch primitive; under
+native-image the same accessors take a class-definition-free shape.
+
+## Decision
+
+Make the **runtime path AOT-capable out of the box** by fixing Wall B in the substrate, and ship a **`telescope-graalvm`
+module** as the ergonomic layer that supplies the metadata Walls A and the DTO-reflection requirement need. The module
+is optional — without it, the runtime path still works in native-image for everything that does not decode a method
+reference; with it, adopters get the metadata registered for them.
+
+### 1. Wall B → gated `MethodHandle` accessor branch in `:internal` (no new dependency)
+
+Telescope already builds one accessor shape without `LambdaMetafactory`: `Records.buildCtorFn` uses
+`MethodHandle.asSpreader(...).asType(...).invokeExact(...)` — a compile-time closure over a `MethodHandle`, no
+synthesized class — precisely because LMF rejects the non-direct spreader handle. That same shape is the AOT-safe path
+for the reader/writer accessors.
+
+Add a one-time flag and branch the accessor builders in `Records` / `Beans` / `MetadataHolderProbe`:
+
+```java
+// JDK-only detection — no org.graalvm.nativeimage dependency added to :internal.
+static final boolean IN_IMAGE = System.getProperty("org.graalvm.nativeimage.imagecode") != null;
+
+Function<Object, Object> reader = IN_IMAGE
+  ? mhInvokeClosure(handle) // obj -> handle.invoke(obj); compile-time lambda, no runtime class def
+  : lmfFunction(handle); // LambdaMetafactory — the JVM hot path (ADR-0005), unchanged
+```
+
+`mhInvokeClosure` is a source-level lambda closing over the resolved `MethodHandle`; native-image supports it because
+the lambda class is compile-time and the `MethodHandle` targets a member the `telescope-graalvm` Feature (or manual
+metadata) has registered for reflection. This keeps `:internal` dependency-free — the detection is a JDK system
+property, not `org.graalvm.nativeimage.ImageInfo`.
+
+Rejected alternative for Wall B — **GraalVM `@Substitute` in the module.** Keeping `:internal` pristine and substituting
+`Records`/`Beans` from `telescope-graalvm` was considered and rejected: substitutions are brittle (bound to internal
+method signatures, silently rot when the substrate refactors) and would make `telescope-graalvm` **mandatory** for any
+AOT use of the runtime path. The gated branch makes telescope AOT-capable with zero extra artifact — the stronger
+"drop-in under native-image" story. The branch cost on the JVM is one already-hoisted `static final boolean` read that
+the JIT folds; the JVM hot path is byte-for-byte the ADR-0005 LMF path.
+
+### 2. Wall A + DTO reflection → the `telescope-graalvm` module (a GraalVM `Feature`)
+
+New published module `telescope-graalvm` (group `io.github.eschizoid`, artifact `telescope-graalvm`), sibling to the
+`:quarkus` / `:spring-boot-starter` starters. It ships one `org.graalvm.nativeimage.hosted.Feature`
+(`TelescopeFeature`), registered via `META-INF/native-image/native-image.properties`, that at image-build time:
+
+- **Registers telescope's own substrate for reflection** — the `Records` / `Beans` accessor targets the gated
+  `MethodHandle` path resolves, so `mhInvokeClosure` can bind them.
+- **Registers `@Focus` / `@BeanFocus` / `@Bridge`-annotated types for reflection** — including their record components /
+  bean accessors / constructors, which is exactly what `Telescope.mapper(...)`'s `getRecordComponents()` walk needs. The
+  annotation is the opt-in signal (no fuzzy classpath heuristics — consistent with
+  [ADR-0002](0002-no-fuzzy-auto-mapping.md)). A type an adopter drives through the runtime mapper but never annotates is
+  registered by a hand-written `reachability-metadata.json`, documented as the fallback.
+- **Registers serialization for the lambda-capturing types it is told about** (Wall A) — so `.field(User::name)` can
+  `writeReplace()`. Adopter call-site classes that use `.field(methodref)` under AOT either carry an explicit
+  registration or switch to `.fieldByName(String)` / a codegen navigator, both of which are `SerializedLambda`-free. The
+  module documents this; the verifier registers its own capturing class.
+
+### 3. Adopter contract (documented in `docs/native-image.md`)
+
+- **Codegen path (`@Focus`/`@BeanFocus`/`@Bridge`/`@FromMap`): native-image with zero config.** Unchanged, already true.
+- **Runtime mapper (`Telescope.mapper(A, B)`): works under native-image** with the gated branch (Wall B) plus the DTO
+  types registered — automatic for `@Focus`/`@BeanFocus`/`@Bridge`-annotated DTOs when `telescope-graalvm` is on the
+  build path, manual `reachability-metadata.json` otherwise.
+- **Runtime navigation (`.field(methodref)`): works under native-image** once the call-site class's lambda serialization
+  is registered (Wall A); `.fieldByName(String)` is the registration-free alternative.
+
+## Consequences
+
+- **Telescope is AOT-capable without a mandatory extra artifact.** The core walls fall to a substrate branch; the module
+  only removes boilerplate. An adopter who hand-writes metadata does not need `telescope-graalvm` at all.
+- **JVM hot path is unchanged.** The gated branch adds a folded `static final boolean` read; steady-state dispatch is
+  the ADR-0005 LMF path unmodified. Benchmarks re-run to confirm no regression.
+- **A new published coordinate** (`telescope-graalvm`) to maintain — JReleaser + release list + module-info. Justified:
+  it is the natural home for the Feature and the adopter-facing native-image story, mirroring the starter modules.
+- **The verifier becomes the standing proof.** Once the gated branch + Feature land, `NativeVerify`'s seven capabilities
+  are expected to pass natively; the native-image workflow is the regression gate. The `docs/native-image.md` verdict
+  moves from "codegen only" to "runtime + codegen, with the documented adopter contract."
+- **Wall A stays a sharp edge for `.field(methodref)`.** It is inherent to method-reference field-name recovery under a
+  closed world; the honest answer is `.fieldByName` / codegen, not a claim that every call site is transparent.
+
+## Alternatives considered
+
+- **Metadata only (no substrate change).** Rejected — cannot clear Wall B. A `reflect-config.json` / tracing-agent run
+  registers reflection and serialization but does not stop `LambdaMetafactory.metafactory(...)` from defining a class at
+  runtime. Empirically confirmed: adding reflection metadata changed the failure set but left the runtime-LMF wall
+  standing (and perturbed the `.field` paths that had passed without it).
+- **Substitutions in `telescope-graalvm` for Wall B.** Rejected — brittle and makes the module mandatory for AOT. See
+  the gated-branch decision above.
+- **Scope the native tripwire to the codegen path; declare the runtime path JVM-only under AOT.** Rejected as the target
+  state (though it is the honest interim). It concedes a MapStruct-parity axis — MapStruct is codegen-only and
+  AOT-clean; matching it on codegen while abandoning the runtime path under AOT is weaker than making the runtime path
+  work too.
+- **Do nothing.** Rejected. The verifier already surfaced the gap; leaving it means "native support" can only ever mean
+  the codegen path.
+
+## Build increments (one PR each, gated on a green native-image CI run)
+
+1. **Wall B substrate branch** in `:internal` (`Records` / `Beans` / `MetadataHolderProbe`) + reflection metadata for
+   the verifier's DTO types, proving the runtime **mapper** capabilities pass natively.
+2. **`telescope-graalvm` module** — `TelescopeFeature` registering `@Focus`/`@BeanFocus`/`@Bridge` types + telescope
+   substrate reflection, wired into the example build; drop the hand-written DTO metadata from increment 1.
+3. **Wall A** — serialization registration for the verifier's method-reference call sites (or convert them to
+   `.fieldByName`), turning the remaining `.field(methodref)` capabilities green, and finalize the
+   `docs/native-image.md` adopter contract.

--- a/docs/adr/0015-native-image-aot-support.md
+++ b/docs/adr/0015-native-image-aot-support.md
@@ -37,10 +37,20 @@ native-image the same accessors take a class-definition-free shape.
 
 ## Decision
 
-Make the **runtime path AOT-capable out of the box** by fixing Wall B in the substrate, and ship a **`telescope-graalvm`
-module** as the ergonomic layer that supplies the metadata Walls A and the DTO-reflection requirement need. The module
-is optional — without it, the runtime path still works in native-image for everything that does not decode a method
-reference; with it, adopters get the metadata registered for them.
+Make the **runtime path AOT-capable out of the box** by fixing Wall B in the substrate, ship telescope's own build-time
+init as `native-image.properties` **inside `telescope-core`**, and leave adopter DTO / lambda metadata to standard
+app-level GraalVM reachability files. **No separate `telescope-graalvm` module** — increment 1 proved it unnecessary
+(see the amendment note below).
+
+> **Amendment (2026-07-17, after the build).** The original decision was to ship a `telescope-graalvm` Feature module
+> for Walls A and the DTO-reflection requirement. Building it out revealed the module earns nothing: the runtime-mapper
+> DTO types are typically **un-annotated** (annotate with `@Focus` and you get the reflection-free codegen path, which
+> needs none of this), so a Feature keyed on `@Focus`/`@BeanFocus`/`@Bridge` would not cover the common case, and
+> un-annotated types cannot be discovered at build time — the app must declare them regardless. The graphql verifier
+> reached **all seven capabilities green** under native-image with only: the Wall B substrate branch, telescope-core's
+> `native-image.properties`, and the example's own `reflect-config.json` + `serialization-config.json`. Apps shipping
+> reachability metadata for their own types is idiomatic GraalVM, not telescope's job. So the module is dropped; the
+> section below records the shape that actually shipped.
 
 ### 1. Wall B → gated `MethodHandle` accessor branch in `:internal` (no new dependency)
 
@@ -49,7 +59,7 @@ Telescope already builds one accessor shape without `LambdaMetafactory`: `Record
 synthesized class — precisely because LMF rejects the non-direct spreader handle. That same shape is the AOT-safe path
 for the reader/writer accessors.
 
-Add a one-time flag and branch the accessor builders in `Records` / `Beans` / `MetadataHolderProbe`:
+Add a one-time flag and branch the accessor builders in `Records` and `Beans`:
 
 ```java
 // JDK-only detection — no org.graalvm.nativeimage dependency added to :internal.
@@ -61,57 +71,59 @@ Function<Object, Object> reader = IN_IMAGE
 ```
 
 `mhInvokeClosure` is a source-level lambda closing over the resolved `MethodHandle`; native-image supports it because
-the lambda class is compile-time and the `MethodHandle` targets a member the `telescope-graalvm` Feature (or manual
-metadata) has registered for reflection. This keeps `:internal` dependency-free — the detection is a JDK system
-property, not `org.graalvm.nativeimage.ImageInfo`.
+the lambda class is compile-time and the `MethodHandle` targets a member the app's reflection metadata has registered.
+This keeps `:internal` dependency-free — the detection is a JDK system property, not
+`org.graalvm.nativeimage.ImageInfo`. The sites that shipped are `Records.buildReaders` and `Beans.buildCtorSupplier` /
+`buildSetterInvoker` / `buildGetterInvokers`; `Records.buildCtorFn` was already `MethodHandle`-based.
 
-Rejected alternative for Wall B — **GraalVM `@Substitute` in the module.** Keeping `:internal` pristine and substituting
-`Records`/`Beans` from `telescope-graalvm` was considered and rejected: substitutions are brittle (bound to internal
-method signatures, silently rot when the substrate refactors) and would make `telescope-graalvm` **mandatory** for any
-AOT use of the runtime path. The gated branch makes telescope AOT-capable with zero extra artifact — the stronger
-"drop-in under native-image" story. The branch cost on the JVM is one already-hoisted `static final boolean` read that
-the JIT folds; the JVM hot path is byte-for-byte the ADR-0005 LMF path.
+Rejected alternative for Wall B — **GraalVM `@Substitute` in a separate module.** Keeping `:internal` pristine and
+substituting `Records`/`Beans` was considered and rejected: substitutions are brittle (bound to internal method
+signatures, silently rot when the substrate refactors) and would make an extra module **mandatory** for any AOT use of
+the runtime path. The gated branch makes telescope AOT-capable with zero extra artifact — the stronger "drop-in under
+native-image" story. The branch cost on the JVM is one already-hoisted `static final boolean` read that the JIT folds;
+the JVM hot path is byte-for-byte the ADR-0005 LMF path.
 
-### 2. Wall A + DTO reflection → the `telescope-graalvm` module (a GraalVM `Feature`)
+### 2. Telescope's own build-time init → `native-image.properties` in `telescope-core`
 
-New published module `telescope-graalvm` (group `io.github.eschizoid`, artifact `telescope-graalvm`), sibling to the
-`:quarkus` / `:spring-boot-starter` starters. It ships one `org.graalvm.nativeimage.hosted.Feature`
-(`TelescopeFeature`), registered via `META-INF/native-image/native-image.properties`, that at image-build time:
+`telescope-core` ships `META-INF/native-image/io.github.eschizoid/telescope-core/native-image.properties` with the
+`--initialize-at-build-time` args for the telescope packages (`io.github.eschizoid.telescope`, `...internal`,
+`...internal.optics`). native-image auto-loads it from the jar, so an adopter needs **no build args for telescope
+itself** — the `@Bridge` / `@FromMap` heap constants and the optic wrappers (all stateless `MethodHandle` / `Function`
+holders) initialize at build time automatically. This is the idiomatic "a library ships its own image metadata" pattern.
 
-- **Registers telescope's own substrate for reflection** — the `Records` / `Beans` accessor targets the gated
-  `MethodHandle` path resolves, so `mhInvokeClosure` can bind them.
-- **Registers `@Focus` / `@BeanFocus` / `@Bridge`-annotated types for reflection** — including their record components /
-  bean accessors / constructors, which is exactly what `Telescope.mapper(...)`'s `getRecordComponents()` walk needs. The
-  annotation is the opt-in signal (no fuzzy classpath heuristics — consistent with
-  [ADR-0002](0002-no-fuzzy-auto-mapping.md)). A type an adopter drives through the runtime mapper but never annotates is
-  registered by a hand-written `reachability-metadata.json`, documented as the fallback.
-- **Registers serialization for the lambda-capturing types it is told about** (Wall A) — so `.field(User::name)` can
-  `writeReplace()`. Adopter call-site classes that use `.field(methodref)` under AOT either carry an explicit
-  registration or switch to `.fieldByName(String)` / a codegen navigator, both of which are `SerializedLambda`-free. The
-  module documents this; the verifier registers its own capturing class.
+### 3. Adopter DTO reflection + Wall A → app-level reachability metadata (standard GraalVM)
 
-### 3. Adopter contract (documented in `docs/native-image.md`)
+The runtime reflective mapper's source/target types need reflection registration (`getRecordComponents()` + accessors +
+constructor + setters), and `.field(methodref)` needs the call-site class registered as a lambda-capturing type for
+serialization (Wall A). Both are **the app's own types**, so they belong in the app's own reachability metadata —
+`reflect-config.json` + `serialization-config.json` under the app's `META-INF/native-image/...`, exactly as every
+GraalVM app ships for its own domain types. The graphql example does this for its DTOs; the verifier registers its own
+lambda-capturing class. Adopters can hand-write these or generate them with the GraalVM tracing agent.
+`.fieldByName(String)` and codegen navigators are the `SerializedLambda`-free alternatives that need no serialization
+registration at all.
 
-- **Codegen path (`@Focus`/`@BeanFocus`/`@Bridge`/`@FromMap`): native-image with zero config.** Unchanged, already true.
-- **Runtime mapper (`Telescope.mapper(A, B)`): works under native-image** with the gated branch (Wall B) plus the DTO
-  types registered — automatic for `@Focus`/`@BeanFocus`/`@Bridge`-annotated DTOs when `telescope-graalvm` is on the
-  build path, manual `reachability-metadata.json` otherwise.
-- **Runtime navigation (`.field(methodref)`): works under native-image** once the call-site class's lambda serialization
-  is registered (Wall A); `.fieldByName(String)` is the registration-free alternative.
+### 4. Adopter contract (documented in `docs/native-image.md`)
+
+- **Codegen path (`@Focus`/`@BeanFocus`/`@Bridge`/`@FromMap`): native-image with zero config.** Already true; unchanged.
+- **Runtime mapper (`Telescope.mapper(A, B)`): works under native-image** with the Wall B substrate branch (free, in
+  core) plus the DTO source/target types in the app's `reflect-config.json`.
+- **Runtime navigation (`.field(methodref)`): works under native-image** with the call-site class registered as a
+  lambda-capturing type in the app's `serialization-config.json`; `.fieldByName(String)` and codegen navigators are the
+  registration-free alternatives.
 
 ## Consequences
 
-- **Telescope is AOT-capable without a mandatory extra artifact.** The core walls fall to a substrate branch; the module
-  only removes boilerplate. An adopter who hand-writes metadata does not need `telescope-graalvm` at all.
+- **Telescope is AOT-capable with no extra artifact.** Wall B falls to a substrate branch in core; telescope's own
+  build-time init ships in core's `native-image.properties`. Adopters add only the reachability metadata for their own
+  types, exactly as any GraalVM app does.
 - **JVM hot path is unchanged.** The gated branch adds a folded `static final boolean` read; steady-state dispatch is
-  the ADR-0005 LMF path unmodified. Benchmarks re-run to confirm no regression.
-- **A new published coordinate** (`telescope-graalvm`) to maintain — JReleaser + release list + module-info. Justified:
-  it is the natural home for the Feature and the adopter-facing native-image story, mirroring the starter modules.
-- **The verifier becomes the standing proof.** Once the gated branch + Feature land, `NativeVerify`'s seven capabilities
-  are expected to pass natively; the native-image workflow is the regression gate. The `docs/native-image.md` verdict
-  moves from "codegen only" to "runtime + codegen, with the documented adopter contract."
+  the ADR-0005 LMF path unmodified. Full test suite green; benchmarks unaffected.
+- **The verifier is the standing proof.** `NativeVerify`'s seven capabilities pass natively (empirically confirmed), and
+  the native-image workflow is the regression gate. The `docs/native-image.md` verdict is "runtime + codegen both work
+  under native-image, with the documented adopter metadata."
 - **Wall A stays a sharp edge for `.field(methodref)`.** It is inherent to method-reference field-name recovery under a
-  closed world; the honest answer is `.fieldByName` / codegen, not a claim that every call site is transparent.
+  closed world; the honest answer is app-level lambda-serialization registration, or `.fieldByName` / codegen — not a
+  claim that every call site is transparent.
 
 ## Alternatives considered
 
@@ -119,21 +131,26 @@ New published module `telescope-graalvm` (group `io.github.eschizoid`, artifact 
   registers reflection and serialization but does not stop `LambdaMetafactory.metafactory(...)` from defining a class at
   runtime. Empirically confirmed: adding reflection metadata changed the failure set but left the runtime-LMF wall
   standing (and perturbed the `.field` paths that had passed without it).
-- **Substitutions in `telescope-graalvm` for Wall B.** Rejected — brittle and makes the module mandatory for AOT. See
-  the gated-branch decision above.
-- **Scope the native tripwire to the codegen path; declare the runtime path JVM-only under AOT.** Rejected as the target
-  state (though it is the honest interim). It concedes a MapStruct-parity axis — MapStruct is codegen-only and
-  AOT-clean; matching it on codegen while abandoning the runtime path under AOT is weaker than making the runtime path
-  work too.
-- **Do nothing.** Rejected. The verifier already surfaced the gap; leaving it means "native support" can only ever mean
-  the codegen path.
+- **A separate `telescope-graalvm` Feature module.** Considered and rejected after building it out — see the amendment
+  under Decision. It earns nothing for the common (un-annotated) runtime-mapper case, and app-level DTO metadata is
+  standard GraalVM practice regardless.
+- **GraalVM `@Substitute`s for Wall B.** Rejected — brittle (bound to internal method signatures, rot on refactor) and
+  would make an extra module mandatory for AOT; the gated branch is self-contained and dependency-free.
+- **Scope the native tripwire to the codegen path; declare the runtime path JVM-only under AOT.** Rejected. It concedes
+  a MapStruct-parity axis — matching MapStruct on codegen while abandoning the runtime path under AOT is weaker than
+  making the runtime path work too, which it now does.
+- **Do nothing.** Rejected. The verifier already surfaced the gap; leaving it means "native support" could only ever
+  mean the codegen path.
 
-## Build increments (one PR each, gated on a green native-image CI run)
+## Build increments (what shipped)
 
-1. **Wall B substrate branch** in `:internal` (`Records` / `Beans` / `MetadataHolderProbe`) + reflection metadata for
-   the verifier's DTO types, proving the runtime **mapper** capabilities pass natively.
-2. **`telescope-graalvm` module** — `TelescopeFeature` registering `@Focus`/`@BeanFocus`/`@Bridge` types + telescope
-   substrate reflection, wired into the example build; drop the hand-written DTO metadata from increment 1.
-3. **Wall A** — serialization registration for the verifier's method-reference call sites (or convert them to
-   `.fieldByName`), turning the remaining `.field(methodref)` capabilities green, and finalize the
-   `docs/native-image.md` adopter contract.
+1. **Wall B substrate branch** in `:internal` — `Records.buildReaders` + `Beans.buildCtorSupplier` /
+   `buildSetterInvoker` / `buildGetterInvokers` dispatch to a `MethodHandle` closure under `NativeImage.IN_IMAGE`
+   (`Records.buildCtorFn` was already MH-based). Cleared the runtime-LMF wall for readers, getters, setters, and the
+   no-arg constructor; the record canonical-constructor path was already AOT-safe.
+2. **Metadata** — telescope-core's `native-image.properties` (build-time init for the telescope packages), plus the
+   example's own `reflect-config.json` (DTO reflection) and `serialization-config.json` (lambda-capturing registration
+   for Wall A).
+
+All seven verifier capabilities pass under native-image; the `telescope-graalvm` module planned as a third increment was
+dropped as unnecessary (amendment above).

--- a/docs/adr/0015-native-image-aot-support.md
+++ b/docs/adr/0015-native-image-aot-support.md
@@ -47,10 +47,11 @@ app-level GraalVM reachability files. **No separate `telescope-graalvm` module**
 > DTO types are typically **un-annotated** (annotate with `@Focus` and you get the reflection-free codegen path, which
 > needs none of this), so a Feature keyed on `@Focus`/`@BeanFocus`/`@Bridge` would not cover the common case, and
 > un-annotated types cannot be discovered at build time — the app must declare them regardless. The graphql verifier
-> reached **all seven capabilities green** under native-image with only: the Wall B substrate branch, telescope-core's
-> `native-image.properties`, and the example's own `reflect-config.json` + `serialization-config.json`. Apps shipping
-> reachability metadata for their own types is idiomatic GraalVM, not telescope's job. So the module is dropped; the
-> section below records the shape that actually shipped.
+> reached all its capabilities green under native-image (seven at the time this decision was taken; an eighth,
+> builder-target, was added when Wall B was extended to the `BuilderWriter` path) with only: the Wall B substrate
+> branch, telescope-core's `native-image.properties`, and the example's own `reflect-config.json` +
+> `serialization-config.json`. Apps shipping reachability metadata for their own types is idiomatic GraalVM, not
+> telescope's job. So the module is dropped; the section below records the shape that actually shipped.
 
 ### 1. Wall B → gated `MethodHandle` accessor branch in `:internal` (no new dependency)
 
@@ -127,7 +128,7 @@ registration at all.
   types, exactly as any GraalVM app does.
 - **JVM hot path is unchanged.** The gated branch adds a folded `static final boolean` read; steady-state dispatch is
   the ADR-0005 LMF path unmodified. Full test suite green; benchmarks unaffected.
-- **The verifier is the standing proof.** `NativeVerify`'s seven capabilities pass natively (empirically confirmed), and
+- **The verifier is the standing proof.** `NativeVerify`'s eight capabilities pass natively (empirically confirmed), and
   the native-image workflow is the regression gate. The `docs/native-image.md` verdict is "runtime + codegen both work
   under native-image, with the documented adopter metadata."
 - **Wall A stays a sharp edge for `.field(methodref)`.** It is inherent to method-reference field-name recovery under a

--- a/docs/adr/0015-native-image-aot-support.md
+++ b/docs/adr/0015-native-image-aot-support.md
@@ -18,10 +18,10 @@ under a real GraalVM `native-image` build. The first two CI native builds establ
   for a lambda unless its capturing class is registered for serialization, so the decode throws and the navigation path
   reports `Expected a method reference`.
 
-  **Wall B — runtime `LambdaMetafactory` (the load-bearing one).** `Records` (line ~403) and `Beans` (lines ~206/224)
-  build one `Function` / `Supplier` / `BiConsumer` accessor per member by calling `LambdaMetafactory.metafactory(...)`
-  **at run time**, which defines a fresh hidden class per accessor. native-image's closed world forbids runtime class
-  definition outright
+  **Wall B — runtime `LambdaMetafactory` (the load-bearing one).** `Records.buildReaders` and the `Beans` no-arg-ctor /
+  setter / getter builders construct one `Function` / `Supplier` / `BiConsumer` accessor per member by calling
+  `LambdaMetafactory.metafactory(...)` **at run time**, which defines a fresh hidden class per accessor. native-image's
+  closed world forbids runtime class definition outright
   (`Classes cannot be defined at runtime by default when using ahead-of-time Native Image compilation`). No metadata
   file can lift this — it is a code-shape problem, not a registration gap.
 
@@ -70,11 +70,20 @@ Function<Object, Object> reader = IN_IMAGE
   : lmfFunction(handle); // LambdaMetafactory — the JVM hot path (ADR-0005), unchanged
 ```
 
-`mhInvokeClosure` is a source-level lambda closing over the resolved `MethodHandle`; native-image supports it because
-the lambda class is compile-time and the `MethodHandle` targets a member the app's reflection metadata has registered.
-This keeps `:internal` dependency-free — the detection is a JDK system property, not
-`org.graalvm.nativeimage.ImageInfo`. The sites that shipped are `Records.buildReaders` and `Beans.buildCtorSupplier` /
-`buildSetterInvoker` / `buildGetterInvokers`; `Records.buildCtorFn` was already `MethodHandle`-based.
+The MethodHandle closures are centralized in `internal/MhAccessors` — one `supplier` / `function` / `biConsumer` /
+`biFunction` builder, each closing over an `asType`-adapted handle, so every branched site shares one proven
+implementation per SAM shape. Each is a source-level lambda; native-image supports it because the lambda class is
+compile-time and the `MethodHandle` targets a member the app's reflection metadata has registered. This keeps
+`:internal` dependency-free — the detection is a JDK system property, not `org.graalvm.nativeimage.ImageInfo`.
+
+The branched sites cover every runtime rebuild strategy: `Records.buildReaders` (record reads); the `Beans` no-arg-ctor
+`Supplier`, the top-level and `SettersWriter` setters, and the getter invokers (the `SETTERS` / `FIELDS` strategies);
+and the `BuilderWriter` strategy end to end — `builder()` factory, fluent / void setters, `build()`, and the
+`builderDefaultSupplier` intermediate. `MetadataHolderProbe`'s `construct(Function)` binder is branched too, and
+`Records.buildCtorFn` was already `MethodHandle`-based. The one deliberate exception is the Hibernate-proxy accessor
+pair (`buildHibernateLazyInitializerFn` / `buildHibernatePersistentClassFn`): guarded by a Hibernate-on-classpath check,
+unreachable in the verifier, and not convertible-with-proof there — documented as JVM/codegen-only under AOT rather than
+shipped unverified.
 
 Rejected alternative for Wall B — **GraalVM `@Substitute` in a separate module.** Keeping `:internal` pristine and
 substituting `Records`/`Beans` was considered and rejected: substitutions are brittle (bound to internal method
@@ -144,13 +153,15 @@ registration at all.
 
 ## Build increments (what shipped)
 
-1. **Wall B substrate branch** in `:internal` — `Records.buildReaders` + `Beans.buildCtorSupplier` /
-   `buildSetterInvoker` / `buildGetterInvokers` dispatch to a `MethodHandle` closure under `NativeImage.IN_IMAGE`
-   (`Records.buildCtorFn` was already MH-based). Cleared the runtime-LMF wall for readers, getters, setters, and the
-   no-arg constructor; the record canonical-constructor path was already AOT-safe.
+1. **Wall B substrate branch** in `:internal` — every runtime rebuild strategy dispatches to an `MhAccessors` closure
+   under `NativeImage.IN_IMAGE`: `Records.buildReaders`; the `Beans` no-arg-ctor `Supplier`, top-level + `SettersWriter`
+   setters, and getter invokers; the whole `BuilderWriter` strategy (`builder()` / fluent + void setters / `build()` /
+   `builderDefaultSupplier`); and `MetadataHolderProbe.construct(Function)`. `Records.buildCtorFn` was already MH-based.
+   The Hibernate-proxy accessors are the one documented JVM/codegen-only exception.
 2. **Metadata** — telescope-core's `native-image.properties` (build-time init for the telescope packages), plus the
-   example's own `reflect-config.json` (DTO reflection) and `serialization-config.json` (lambda-capturing registration
-   for Wall A).
+   example's own `reflect-config.json` (DTO reflection, including the builder-only bean + its `Builder`) and
+   `serialization-config.json` (lambda-capturing registration for Wall A).
 
-All seven verifier capabilities pass under native-image; the `telescope-graalvm` module planned as a third increment was
-dropped as unnecessary (amendment above).
+All eight verifier capabilities — including the runtime record→builder-bean mapper, which exercises the `BuilderWriter`
+path no other capability reaches — pass under native-image. The `telescope-graalvm` module planned as a third increment
+was dropped as unnecessary (amendment above).

--- a/docs/native-image.md
+++ b/docs/native-image.md
@@ -19,15 +19,16 @@ GraphQL servers.
 survival under native-image is what we verify. Each capability prints `PASS` / `FAIL` and the process exits non-zero on
 any failure — so `native-image` compiling and running the binary **is** the test.
 
-| Capability                       | Substrate mechanic under test                                                                         |
-| -------------------------------- | ----------------------------------------------------------------------------------------------------- |
-| Record field update              | `SerializedLambda` method-reference decode + LMF record reader + cached canonical-ctor `MethodHandle` |
-| Record read (`.read()`)          | pure LMF-dispatched record component read (the `Records.read` path through the public surface)        |
-| Bean read (`.read()`)            | LMF-dispatched bean getter `Function` (`ofBean(...).field(getter).read()`, the `Beans` read path)     |
-| Runtime record → record `mapper` | LMF record readers on the source, canonical-constructor rebuild, carrying a nested record + enum      |
-| Runtime record → bean `mapper`   | LMF getter readers + no-arg-ctor `Supplier` + LMF setter `BiConsumer` writers (the `Beans` path)      |
-| Generated `@FromMap`             | reflection-free codegen `Map → record` converter — the control (no LMF, no `SerializedLambda`)        |
-| Generated `@Bridge` constant     | the emitted `AccountBridge.BRIDGE` (`Telescope<Account, AccountEntity>`) baked into the image heap    |
+| Capability                        | Substrate mechanic under test                                                                            |
+| --------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| Record field update               | `SerializedLambda` method-reference decode + LMF record reader + cached canonical-ctor `MethodHandle`    |
+| Record read (`.read()`)           | pure LMF-dispatched record component read (the `Records.read` path through the public surface)           |
+| Bean read (`.read()`)             | LMF-dispatched bean getter `Function` (`ofBean(...).field(getter).read()`, the `Beans` read path)        |
+| Runtime record → record `mapper`  | LMF record readers on the source, canonical-constructor rebuild, carrying a nested record + enum         |
+| Runtime record → bean `mapper`    | LMF getter readers + no-arg-ctor `Supplier` + LMF setter `BiConsumer` writers (the `Beans` path)         |
+| Runtime record → builder `mapper` | the `Beans` `BuilderWriter` — `builder()` `Supplier` + fluent-setter `BiFunction` + `build()` `Function` |
+| Generated `@FromMap`              | reflection-free codegen `Map → record` converter — the control (no LMF, no `SerializedLambda`)           |
+| Generated `@Bridge` constant      | the emitted `AccountBridge.BRIDGE` (`Telescope<Account, AccountEntity>`) baked into the image heap       |
 
 `Records` / `Beans` live in `:internal`, JPMS-sealed to `:core`, so the verifier cannot call them directly. It reaches
 the identical LMF call sites through the public `Telescope.of(...).field(...).read()` /
@@ -54,9 +55,13 @@ member by calling `LambdaMetafactory.metafactory(...)` **at run time**, which sy
 native-image's closed world forbids defining a class at run time (`Classes cannot be defined at runtime`). Fixed **in
 the substrate**: `internal/NativeImage.IN_IMAGE` (a JDK-only `org.graalvm.nativeimage.imagecode` system-property check,
 no GraalVM dependency) branches the accessor builders to a `MethodHandle.asType` closure inside an image — the same
-class-definition-free shape `Records.buildCtorFn` already used for the canonical constructor. The JVM keeps the
-`LambdaMetafactory` hot path unchanged; the branch is one folded `static final boolean`. This ships in `telescope-core`,
-so the runtime path is AOT-capable out of the box.
+class-definition-free shape `Records.buildCtorFn` already used for the canonical constructor, centralized in
+`internal/MhAccessors` (one closure per SAM shape). Every runtime rebuild strategy is covered: record reads, the
+no-arg-constructor + setter + getter paths, and the whole `BuilderWriter` path (`builder()` → fluent setters →
+`build()`), so mapping to an immutable `@Builder` target works too. The JVM keeps the `LambdaMetafactory` hot path
+unchanged; the branch is one folded `static final boolean`. This ships in `telescope-core`, so the runtime path is
+AOT-capable out of the box. (The one exception is the optional Hibernate-proxy accessor path, which stays
+JVM/codegen-only under AOT.)
 
 **Wall A — `SerializedLambda` decode.** `.field(User::name)` recovers the field name by invoking the method reference's
 `writeReplace()` to read a `SerializedLambda`. native-image only synthesizes `writeReplace()` for a lambda whose
@@ -77,21 +82,24 @@ navigators are the `SerializedLambda`-free alternatives that need no such regist
   with `Class.getRecordComponents()` and unreflects their accessors / constructor / setters, so those DTO types need a
   `reflect-config.json`; `.field(methodref)` needs the call-site class in a `serialization-config.json` (Wall A). Both
   live under the app's `META-INF/native-image/...`, exactly as every GraalVM app ships for its own domain types — the
-  example does this for its six model types. Hand-write them, or generate them with the GraalVM tracing agent.
+  example does this for its model types (including the builder-only bean and its `Builder`). Hand-write them, or
+  generate them with the GraalVM tracing agent.
 - **`privateLookupIn`.** All records/beans here are public on the classpath, so `MethodHandles.privateLookupIn` succeeds
   without an `opens` directive. A downstream consumer with JPMS-closed packages still needs
   `opens ... to io.github.eschizoid.telescope;` — a module-descriptor requirement, not a native-image one.
 
 ## Verdict
 
-**Runtime and codegen both work under GraalVM native-image.** All seven verifier capabilities — record field update,
-record read, bean read, the runtime record→record and record→bean mappers, `@FromMap`, and `@Bridge` — build and run in
-the native binary, confirmed by `.github/workflows/native-image.yaml`. Telescope's runtime reflective mapper is
-AOT-capable out of the box (Wall B is fixed in `telescope-core`); the adopter supplies only the standard reachability
-metadata for their own types (`reflect-config.json` for runtime-mapper DTOs, `serialization-config.json` for
-`.field(methodref)` call-site classes). The codegen path (`@Focus`/`@BeanFocus`/`@Bridge`/`@FromMap`) needs none of that
-— it is reflection-free and native-images with zero config. The workflow re-checks the whole surface on every push to
-`main` and weekly against GraalVM updates, so a regression in any capability turns the job red.
+**Runtime and codegen both work under GraalVM native-image.** All eight verifier capabilities — record field update,
+record read, bean read, the runtime record→record / record→bean / record→builder-bean mappers, `@FromMap`, and `@Bridge`
+— build and run in the native binary, confirmed by `.github/workflows/native-image.yaml`. Telescope's runtime reflective
+mapper is AOT-capable out of the box for every rebuild strategy (records, no-arg-ctor + setters, immutable `@Builder`
+targets); Wall B is fixed in `telescope-core`, and the adopter supplies only the standard reachability metadata for
+their own types (`reflect-config.json` for runtime-mapper DTOs, `serialization-config.json` for `.field(methodref)`
+call-site classes). The codegen path (`@Focus`/`@BeanFocus`/`@Bridge`/`@FromMap`) needs none of that — it is
+reflection-free and native-images with zero config. The one runtime path still JVM/codegen-only under AOT is the
+Hibernate-proxy accessor. The workflow re-checks the whole surface on every push to `main` and weekly against GraalVM
+updates, so a regression in any capability turns the job red.
 
 ## Appendix — feasibility of shading `:internal` into `:core` at publish
 

--- a/docs/native-image.md
+++ b/docs/native-image.md
@@ -44,53 +44,54 @@ CI wiring: `.github/workflows/native-image.yaml` installs GraalVM via `graalvm/s
 `main` that touch the example or the substrate modules, and weekly (to catch a GraalVM-version regression on its own
 cadence). Native builds are minutes-long, so it deliberately does **not** gate every PR.
 
-## GraalVM config the substrate needs
+## Two walls, and how each falls
 
-Two build args, both in `examples/graphql/build.gradle.kts`:
+The codegen path (`@Bridge` / `@FromMap`) native-images with zero reflection config — it compiles to typed method calls.
+The runtime reflective path hit two walls under native-image; both are now cleared.
 
-- **`--no-fallback`** — fail rather than silently emit a JVM-fallback image, so a reachability gap is a hard error, not
-  a slow "native" binary that is really the JVM.
-- **`--initialize-at-build-time=...`** for the telescope classes (`io.github.eschizoid.telescope`,
-  `...telescope.internal`, `...telescope.internal.optics`) and the generated model package
-  (`...examples.graphql.model`). **This is the load-bearing arg.** Without it a native-image build of the `@Bridge`
-  capability fails — the earlier native-image build of this exact mechanic surfaced:
+**Wall B — runtime `LambdaMetafactory` (the load-bearing one).** `Records` / `Beans` build one accessor `Function` per
+member by calling `LambdaMetafactory.metafactory(...)` **at run time**, which synthesizes a class per accessor —
+native-image's closed world forbids defining a class at run time (`Classes cannot be defined at runtime`). Fixed **in
+the substrate**: `internal/NativeImage.IN_IMAGE` (a JDK-only `org.graalvm.nativeimage.imagecode` system-property check,
+no GraalVM dependency) branches the accessor builders to a `MethodHandle.asType` closure inside an image — the same
+class-definition-free shape `Records.buildCtorFn` already used for the canonical constructor. The JVM keeps the
+`LambdaMetafactory` hot path unchanged; the branch is one folded `static final boolean`. This ships in `telescope-core`,
+so the runtime path is AOT-capable out of the box.
 
-  ```
-  UnsupportedFeatureException: An object of type 'io.github.eschizoid.telescope.Telescope$BridgeTelescope'
-  was found in the image heap. This type, however, is marked for initialization at image run time...
-  ```
+**Wall A — `SerializedLambda` decode.** `.field(User::name)` recovers the field name by invoking the method reference's
+`writeReplace()` to read a `SerializedLambda`. native-image only synthesizes `writeReplace()` for a lambda whose
+capturing class is registered as a lambda-capturing type for serialization. Fixed with an app-level
+`serialization-config.json` naming the call-site class (here, `NativeVerify`). `.fieldByName(String)` and codegen
+navigators are the `SerializedLambda`-free alternatives that need no such registration.
 
-  The `@Bridge`-generated `AccountBridge.BRIDGE` constant is a `Telescope` instance built at the generated class's
-  static init, so it lands in the build-time image heap; native-image defaults every class to run-time init, and a heap
-  object of a run-time-init type is a hard error. Initializing the telescope + generated-model classes at build time
-  bakes the constant safely. These classes are stateless optic wrappers over `MethodHandle`/`Function` fields — no
-  per-instance mutable or environment-dependent state — so build-time init is safe.
+## What ships where
 
-On the other mechanics, the expectation is that no `reflect-config.json` / `serialization-config.json` is needed — the
-first green CI run is what confirms it:
-
-- **LMF / `invokedynamic`.** Telescope builds its readers/writers by calling `LambdaMetafactory.metafactory(...)`
-  **explicitly at runtime** over `MethodHandle`s to accessors/constructors the verifier reaches through concrete,
-  statically-reachable types. native-image folds those synthetic `Function`/`Supplier`/`BiConsumer` classes when the
-  target member is reachable — no `Method.invoke`, so no reflection registration is implied.
-- **`SerializedLambda`.** `.field(User::name)` decodes a `Serializable` method reference. The record-field-update and
-  read capabilities exercise this; the decode targets concrete, statically-reachable accessors, so no
-  `serialization-config.json` entry is expected. If a native-image run regresses this, the failing capability line + the
-  uploaded build report will name the registration.
+- **Build-time init — `telescope-core`'s own `native-image.properties`.** The `@Bridge` / `@FromMap` codegen constants
+  (e.g. `AccountBridge.BRIDGE`, a `Telescope` built at the generated class's static init) land in the build-time image
+  heap; native-image defaults every class to run-time init, and a heap object of a run-time-init type is a hard error.
+  telescope-core ships `--initialize-at-build-time` for the telescope packages in its jar, so **adopters need no build
+  args for telescope itself**. The example still initializes its own generated-model package (app-specific).
+- **`--no-fallback`** — in the example build: fail rather than silently emit a JVM-fallback image, so a reachability gap
+  is a hard error, not a slow "native" binary that is really the JVM.
+- **App-level reachability metadata — the app's own types.** The runtime reflective mapper walks its source/target types
+  with `Class.getRecordComponents()` and unreflects their accessors / constructor / setters, so those DTO types need a
+  `reflect-config.json`; `.field(methodref)` needs the call-site class in a `serialization-config.json` (Wall A). Both
+  live under the app's `META-INF/native-image/...`, exactly as every GraalVM app ships for its own domain types — the
+  example does this for its six model types. Hand-write them, or generate them with the GraalVM tracing agent.
 - **`privateLookupIn`.** All records/beans here are public on the classpath, so `MethodHandles.privateLookupIn` succeeds
   without an `opens` directive. A downstream consumer with JPMS-closed packages still needs
   `opens ... to io.github.eschizoid.telescope;` — a module-descriptor requirement, not a native-image one.
 
 ## Verdict
 
-**Pending the first green CI run.** What is confirmed today: the JVM run of `NativeVerify` (`runNativeVerify`) passes
-all seven capabilities, so the harness and its assertions are sound. On the native-image side, the one requirement found
-so far is the `--initialize-at-build-time` config above — the codegen `@Bridge`/`@FromMap` constant classes need
-build-time init because the constants live in the image heap. The expectation is that the seven capabilities then build
-and run natively with no further config, but the standing verdict is the workflow's actual green native-image run, not
-this prediction. This section will be updated to a firm "works" (or to name whatever additional config the run demands)
-once `.github/workflows/native-image.yaml` has its first green run — it fires on the next push to `main` and weekly
-thereafter against GraalVM updates.
+**Runtime and codegen both work under GraalVM native-image.** All seven verifier capabilities — record field update,
+record read, bean read, the runtime record→record and record→bean mappers, `@FromMap`, and `@Bridge` — build and run in
+the native binary, confirmed by `.github/workflows/native-image.yaml`. Telescope's runtime reflective mapper is
+AOT-capable out of the box (Wall B is fixed in `telescope-core`); the adopter supplies only the standard reachability
+metadata for their own types (`reflect-config.json` for runtime-mapper DTOs, `serialization-config.json` for
+`.field(methodref)` call-site classes). The codegen path (`@Focus`/`@BeanFocus`/`@Bridge`/`@FromMap`) needs none of that
+— it is reflection-free and native-images with zero config. The workflow re-checks the whole surface on every push to
+`main` and weekly against GraalVM updates, so a regression in any capability turns the job red.
 
 ## Appendix — feasibility of shading `:internal` into `:core` at publish
 

--- a/examples/graphql/build.gradle.kts
+++ b/examples/graphql/build.gradle.kts
@@ -61,22 +61,12 @@ graalvmNative {
             imageName.set("telescope-native-verify")
             buildArgs.add("--no-fallback")
             buildArgs.add("-H:+ReportExceptionStackTraces")
-            // The codegen @Bridge / @FromMap constants (e.g. AccountBridge.BRIDGE — a
-            // Telescope<Account, AccountEntity>) are baked into the image heap at class-init.
-            // native-image defaults every class to run-time init, so the telescope classes that
-            // back those constants (Telescope + its inner Bridge/typed-container navigators, the
-            // optic lattice) and the generated model classes that hold them must be initialized at
-            // build time — otherwise a heap object of a run-time-init type is a hard build error.
-            //
-            // The four entries are listed explicitly rather than collapsed to the
-            // `io.github.eschizoid.telescope` prefix on purpose: the prefix subsumes the others only
-            // if native-image treats a package arg as a recursive prefix, and until the first green
-            // CI run pins that behaviour the belt-and-suspenders list is the safe form. Keep them
-            // explicit — do not "optimize" to one line before the workflow has run green.
+            // The telescope classes that back the codegen @Bridge / @FromMap image-heap constants are
+            // initialized at build time by telescope-core's own native-image.properties (shipped in
+            // the jar) — adopters need no --initialize-at-build-time args for telescope itself. Only
+            // this example's generated model package (which holds the AccountBridge / UserFromMap
+            // constants) is app-specific and stays here.
             buildArgs.add("--initialize-at-build-time=io.github.eschizoid.telescope.examples.graphql.model")
-            buildArgs.add("--initialize-at-build-time=io.github.eschizoid.telescope")
-            buildArgs.add("--initialize-at-build-time=io.github.eschizoid.telescope.internal")
-            buildArgs.add("--initialize-at-build-time=io.github.eschizoid.telescope.internal.optics")
         }
     }
 }

--- a/examples/graphql/src/main/java/io/github/eschizoid/telescope/examples/graphql/model/AccountBuilderBean.java
+++ b/examples/graphql/src/main/java/io/github/eschizoid/telescope/examples/graphql/model/AccountBuilderBean.java
@@ -1,0 +1,53 @@
+package io.github.eschizoid.telescope.examples.graphql.model;
+
+/**
+ * An immutable, builder-only mirror of {@link Account} — no no-arg constructor and no public
+ * setters, so a runtime {@code Telescope.mapper(Account.class, AccountBuilderBean.class)} must
+ * construct it through the {@code BuilderWriter} strategy (static {@code builder()} → fluent
+ * setters → {@code build()}). Used by {@link
+ * io.github.eschizoid.telescope.examples.graphql.server.NativeVerify} to exercise that write path
+ * under native-image, which the no-arg-ctor {@link AccountEntity} does not reach.
+ */
+public final class AccountBuilderBean {
+
+  private final String username;
+  private final String email;
+
+  private AccountBuilderBean(final String username, final String email) {
+    this.username = username;
+    this.email = email;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public String getUsername() {
+    return username;
+  }
+
+  public String getEmail() {
+    return email;
+  }
+
+  /** Fluent builder — each setter returns {@code this}, exercising the {@code BiFunction} bind. */
+  public static final class Builder {
+
+    private String username;
+    private String email;
+
+    public Builder username(final String username) {
+      this.username = username;
+      return this;
+    }
+
+    public Builder email(final String email) {
+      this.email = email;
+      return this;
+    }
+
+    public AccountBuilderBean build() {
+      return new AccountBuilderBean(username, email);
+    }
+  }
+}

--- a/examples/graphql/src/main/java/io/github/eschizoid/telescope/examples/graphql/server/NativeVerify.java
+++ b/examples/graphql/src/main/java/io/github/eschizoid/telescope/examples/graphql/server/NativeVerify.java
@@ -44,8 +44,9 @@ import java.util.Map;
  *       codegen control — no LMF, no {@code SerializedLambda}, just typed method calls.
  *   <li><b>generated {@code @Bridge}</b> — {@code AccountBridge.BRIDGE.read(a)}: the codegen bridge
  *       constant, a {@code Telescope<Account, AccountEntity>} that lands in the build-time image
- *       heap — which is why the telescope and generated-model classes take {@code
- *       --initialize-at-build-time} (see {@code build.gradle.kts}).
+ *       heap — which is why the telescope classes take {@code --initialize-at-build-time} from
+ *       telescope-core's {@code native-image.properties} and this example's generated-model package
+ *       takes it from {@code build.gradle.kts}.
  * </ul>
  *
  * <p>A JVM run only validates the harness; a green native-image run is the real verdict, and {@link

--- a/examples/graphql/src/main/java/io/github/eschizoid/telescope/examples/graphql/server/NativeVerify.java
+++ b/examples/graphql/src/main/java/io/github/eschizoid/telescope/examples/graphql/server/NativeVerify.java
@@ -4,6 +4,7 @@ import io.github.eschizoid.telescope.Telescope;
 import io.github.eschizoid.telescope.conversion.Mapper;
 import io.github.eschizoid.telescope.examples.graphql.model.Account;
 import io.github.eschizoid.telescope.examples.graphql.model.AccountBridge;
+import io.github.eschizoid.telescope.examples.graphql.model.AccountBuilderBean;
 import io.github.eschizoid.telescope.examples.graphql.model.AccountEntity;
 import io.github.eschizoid.telescope.examples.graphql.model.Address;
 import io.github.eschizoid.telescope.examples.graphql.model.Role;
@@ -35,6 +36,10 @@ import java.util.Map;
  *       {@link Address} record through unchanged and the {@link Role} enum through by identity.
  *   <li><b>runtime record→bean mapper</b> — {@code Telescope.mapper(Account, AccountEntity)}: the
  *       Beans LMF no-arg-constructor {@code Supplier} + LMF setter {@code BiConsumer} write path.
+ *   <li><b>runtime record→builder bean mapper</b> — {@code Telescope.mapper(Account,
+ *       AccountBuilderBean)}: the Beans {@code BuilderWriter} — {@code builder()} {@code Supplier}
+ *       + fluent-setter {@code BiFunction} + {@code build()} {@code Function}; the only capability
+ *       that reaches the builder write path (the target has no no-arg constructor or setters).
  *   <li><b>generated {@code @FromMap}</b> — {@code UserFromMap.fromMap(map)}: the reflection-free
  *       codegen control — no LMF, no {@code SerializedLambda}, just typed method calls.
  *   <li><b>generated {@code @Bridge}</b> — {@code AccountBridge.BRIDGE.read(a)}: the codegen bridge
@@ -44,7 +49,7 @@ import java.util.Map;
  * </ul>
  *
  * <p>A JVM run only validates the harness; a green native-image run is the real verdict, and {@link
- * #runtimeLabel()} says which one just passed. All seven capabilities are required on both
+ * #runtimeLabel()} says which one just passed. All eight capabilities are required on both
  * runtimes: the Wall B substrate branch plus telescope's build-time-init metadata and the example's
  * own reflection / serialization metadata carry the full runtime + codegen surface through
  * native-image, so any FAIL is a real regression.
@@ -69,6 +74,9 @@ public final class NativeVerify {
       guard("runtime record → record mapper (LMF readers + ctor rebuild, nested + enum)", NativeVerify::recordMapper)
     );
     results.add(guard("runtime record → bean mapper (Beans LMF no-arg ctor + setters)", NativeVerify::beanMapper));
+    results.add(
+      guard("runtime record → builder bean mapper (builder() + fluent setters + build())", NativeVerify::builderMapper)
+    );
     results.add(guard("generated @FromMap converter (reflection-free codegen control)", NativeVerify::fromMap));
     results.add(guard("generated @Bridge constant (AccountBridge.BRIDGE.read())", NativeVerify::bridgeConstant));
 
@@ -149,7 +157,19 @@ public final class NativeVerify {
     );
   }
 
-  // (f) generated @FromMap converter — reflection-free codegen control; also exercises enum +
+  // (f) runtime record → builder-only bean: Beans BuilderWriter — builder() Supplier + fluent
+  // setter BiFunction + build() Function. AccountBuilderBean has no no-arg ctor / setters, so this
+  // is the only capability that reaches the builder write path.
+  private static void builderMapper() {
+    final Mapper<Account, AccountBuilderBean> mapper = Telescope.mapper(Account.class, AccountBuilderBean.class);
+    final var bean = mapper.forward(new Account("ivy", "ivy@example.com"));
+    expect(
+      "ivy".equals(bean.getUsername()) && "ivy@example.com".equals(bean.getEmail()),
+      "builder mapper.forward mismatch: username=" + bean.getUsername() + " email=" + bean.getEmail()
+    );
+  }
+
+  // (g) generated @FromMap converter — reflection-free codegen control; also exercises enum +
   // nested.
   private static void fromMap() {
     final Map<String, Object> address = new HashMap<>();
@@ -171,7 +191,7 @@ public final class NativeVerify {
     );
   }
 
-  // (g) generated @Bridge constant — pure typed method calls, baked into the image heap.
+  // (h) generated @Bridge constant — pure typed method calls, baked into the image heap.
   private static void bridgeConstant() {
     final var entity = AccountBridge.BRIDGE.read(new Account("grace", "grace@example.com"));
     expect(

--- a/examples/graphql/src/main/java/io/github/eschizoid/telescope/examples/graphql/server/NativeVerify.java
+++ b/examples/graphql/src/main/java/io/github/eschizoid/telescope/examples/graphql/server/NativeVerify.java
@@ -44,47 +44,83 @@ import java.util.Map;
  * </ul>
  *
  * <p>A JVM run only validates the harness; a green native-image run is the real verdict, and {@link
- * #runtimeLabel()} says which one just passed.
+ * #runtimeLabel()} says which one just passed. On the JVM every capability is required. Under
+ * native-image the runtime mappers and the codegen path are required (SUPPORTED); the three {@code
+ * .field(methodref)} capabilities are reported but not yet required (PENDING) until lambda
+ * serialization is registered — so a green run proves the supported surface without a still-open
+ * increment masking a regression.
  */
 public final class NativeVerify {
 
   private NativeVerify() {}
 
   public static void main(final String[] args) {
+    // Wall A (SerializedLambda method-reference decode) is not yet cleared under native-image, so
+    // the
+    // three .field(methodref) capabilities are PENDING there — run and reported, but not required
+    // to
+    // pass until the increment that registers lambda serialization lands. The runtime mappers and
+    // the
+    // codegen path are SUPPORTED: they must pass on every runtime, native-image included. On the
+    // JVM
+    // everything is required (there are no walls), so this distinction only bites under
+    // native-image.
     final var results = new ArrayList<Result>();
     results.add(
-      guard("record field update (SerializedLambda + LMF reader + ctor MH)", NativeVerify::recordFieldUpdate)
+      guard(
+        "record field update (SerializedLambda + LMF reader + ctor MH)",
+        Aot.PENDING,
+        NativeVerify::recordFieldUpdate
+      )
     );
-    results.add(guard("record read path (.field(...).read())", NativeVerify::recordReadPath));
+    results.add(guard("record read path (.field(...).read())", Aot.PENDING, NativeVerify::recordReadPath));
     results.add(
-      guard("bean getter read (ofBean.field(getter).read(), LMF getter Function)", NativeVerify::beanReadPath)
+      guard(
+        "bean getter read (ofBean.field(getter).read(), LMF getter Function)",
+        Aot.PENDING,
+        NativeVerify::beanReadPath
+      )
     );
     results.add(
-      guard("runtime record → record mapper (LMF readers + ctor rebuild, nested + enum)", NativeVerify::recordMapper)
+      guard(
+        "runtime record → record mapper (LMF readers + ctor rebuild, nested + enum)",
+        Aot.SUPPORTED,
+        NativeVerify::recordMapper
+      )
     );
-    results.add(guard("runtime record → bean mapper (Beans LMF no-arg ctor + setters)", NativeVerify::beanMapper));
-    results.add(guard("generated @FromMap converter (reflection-free codegen control)", NativeVerify::fromMap));
-    results.add(guard("generated @Bridge constant (AccountBridge.BRIDGE.read())", NativeVerify::bridgeConstant));
+    results.add(
+      guard("runtime record → bean mapper (Beans LMF no-arg ctor + setters)", Aot.SUPPORTED, NativeVerify::beanMapper)
+    );
+    results.add(
+      guard("generated @FromMap converter (reflection-free codegen control)", Aot.SUPPORTED, NativeVerify::fromMap)
+    );
+    results.add(
+      guard("generated @Bridge constant (AccountBridge.BRIDGE.read())", Aot.SUPPORTED, NativeVerify::bridgeConstant)
+    );
 
+    final var nativeImage = System.getProperty("org.graalvm.nativeimage.imagecode") != null;
     System.out.println();
     System.out.println("=== telescope native-image verification (graphql example) ===");
     var failures = 0;
+    var required = 0;
     for (final var r : results) {
+      // A capability is required on the JVM always, and under native-image only when SUPPORTED. A
+      // PENDING capability that fails natively prints PEND, not FAIL, and does not fail the build —
+      // so
+      // a green run proves the SUPPORTED surface without the still-open Wall A masking a
+      // regression.
+      final var mustPass = !nativeImage || r.aot() == Aot.SUPPORTED;
+      if (mustPass) required++;
+      final var status = r.passed() ? "PASS" : (mustPass ? "FAIL" : "PEND");
       final var detail = r.detail() == null ? "" : "  — " + r.detail();
-      System.out.println((r.passed() ? "PASS  " : "FAIL  ") + r.name() + detail);
-      if (!r.passed()) failures++;
+      System.out.println(status + "  " + r.name() + detail);
+      if (mustPass && !r.passed()) failures++;
     }
     System.out.println();
     if (failures == 0) {
-      System.out.println("ALL " + results.size() + " CAPABILITIES PASSED on this runtime (" + runtimeLabel() + ").");
+      System.out.println("ALL " + required + " REQUIRED CAPABILITIES PASSED on this runtime (" + runtimeLabel() + ").");
     } else {
-      System.out.println(
-        failures +
-          " of " +
-          results.size() +
-          " CAPABILITIES FAILED — the substrate needs native-image config" +
-          " (see the failing lines)."
-      );
+      System.out.println(failures + " of " + required + " REQUIRED CAPABILITIES FAILED — see the FAIL lines.");
     }
     System.exit(failures == 0 ? 0 : 1);
   }
@@ -190,16 +226,24 @@ public final class NativeVerify {
     if (!condition) throw new AssertionError(message);
   }
 
-  private static Result guard(final String name, final Runnable capability) {
+  private static Result guard(final String name, final Aot aot, final Runnable capability) {
     try {
       capability.run();
-      return new Result(name, true, null);
+      return new Result(name, true, null, aot);
     } catch (final Throwable t) {
       System.err.println("[FAIL] " + name);
       t.printStackTrace();
-      return new Result(name, false, t.getClass().getSimpleName() + ": " + t.getMessage());
+      return new Result(name, false, t.getClass().getSimpleName() + ": " + t.getMessage(), aot);
     }
   }
 
-  private record Result(String name, boolean passed, String detail) {}
+  /** Whether a capability is required to pass under native-image, or a still-open increment. */
+  private enum Aot {
+    /** Must pass on every runtime, native-image included. */
+    SUPPORTED,
+    /** Reported under native-image but not yet required — Wall A (SerializedLambda decode). */
+    PENDING,
+  }
+
+  private record Result(String name, boolean passed, String detail, Aot aot) {}
 }

--- a/examples/graphql/src/main/java/io/github/eschizoid/telescope/examples/graphql/server/NativeVerify.java
+++ b/examples/graphql/src/main/java/io/github/eschizoid/telescope/examples/graphql/server/NativeVerify.java
@@ -44,83 +44,47 @@ import java.util.Map;
  * </ul>
  *
  * <p>A JVM run only validates the harness; a green native-image run is the real verdict, and {@link
- * #runtimeLabel()} says which one just passed. On the JVM every capability is required. Under
- * native-image the runtime mappers and the codegen path are required (SUPPORTED); the three {@code
- * .field(methodref)} capabilities are reported but not yet required (PENDING) until lambda
- * serialization is registered — so a green run proves the supported surface without a still-open
- * increment masking a regression.
+ * #runtimeLabel()} says which one just passed. All seven capabilities are required on both
+ * runtimes: the Wall B substrate branch plus telescope's build-time-init metadata and the example's
+ * own reflection / serialization metadata carry the full runtime + codegen surface through
+ * native-image, so any FAIL is a real regression.
  */
 public final class NativeVerify {
 
   private NativeVerify() {}
 
   public static void main(final String[] args) {
-    // Wall A (SerializedLambda method-reference decode) is not yet cleared under native-image, so
-    // the
-    // three .field(methodref) capabilities are PENDING there — run and reported, but not required
-    // to
-    // pass until the increment that registers lambda serialization lands. The runtime mappers and
-    // the
-    // codegen path are SUPPORTED: they must pass on every runtime, native-image included. On the
-    // JVM
-    // everything is required (there are no walls), so this distinction only bites under
-    // native-image.
+    // Every capability is required on both runtimes: with the Wall B substrate branch and the
+    // build-time-init + reflection/serialization metadata in place, the full runtime + codegen
+    // surface passes under native-image, so any FAIL here — JVM or native — is a real regression.
     final var results = new ArrayList<Result>();
     results.add(
-      guard(
-        "record field update (SerializedLambda + LMF reader + ctor MH)",
-        Aot.PENDING,
-        NativeVerify::recordFieldUpdate
-      )
+      guard("record field update (SerializedLambda + LMF reader + ctor MH)", NativeVerify::recordFieldUpdate)
     );
-    results.add(guard("record read path (.field(...).read())", Aot.PENDING, NativeVerify::recordReadPath));
+    results.add(guard("record read path (.field(...).read())", NativeVerify::recordReadPath));
     results.add(
-      guard(
-        "bean getter read (ofBean.field(getter).read(), LMF getter Function)",
-        Aot.PENDING,
-        NativeVerify::beanReadPath
-      )
+      guard("bean getter read (ofBean.field(getter).read(), LMF getter Function)", NativeVerify::beanReadPath)
     );
     results.add(
-      guard(
-        "runtime record → record mapper (LMF readers + ctor rebuild, nested + enum)",
-        Aot.SUPPORTED,
-        NativeVerify::recordMapper
-      )
+      guard("runtime record → record mapper (LMF readers + ctor rebuild, nested + enum)", NativeVerify::recordMapper)
     );
-    results.add(
-      guard("runtime record → bean mapper (Beans LMF no-arg ctor + setters)", Aot.SUPPORTED, NativeVerify::beanMapper)
-    );
-    results.add(
-      guard("generated @FromMap converter (reflection-free codegen control)", Aot.SUPPORTED, NativeVerify::fromMap)
-    );
-    results.add(
-      guard("generated @Bridge constant (AccountBridge.BRIDGE.read())", Aot.SUPPORTED, NativeVerify::bridgeConstant)
-    );
+    results.add(guard("runtime record → bean mapper (Beans LMF no-arg ctor + setters)", NativeVerify::beanMapper));
+    results.add(guard("generated @FromMap converter (reflection-free codegen control)", NativeVerify::fromMap));
+    results.add(guard("generated @Bridge constant (AccountBridge.BRIDGE.read())", NativeVerify::bridgeConstant));
 
-    final var nativeImage = System.getProperty("org.graalvm.nativeimage.imagecode") != null;
     System.out.println();
     System.out.println("=== telescope native-image verification (graphql example) ===");
     var failures = 0;
-    var required = 0;
     for (final var r : results) {
-      // A capability is required on the JVM always, and under native-image only when SUPPORTED. A
-      // PENDING capability that fails natively prints PEND, not FAIL, and does not fail the build —
-      // so
-      // a green run proves the SUPPORTED surface without the still-open Wall A masking a
-      // regression.
-      final var mustPass = !nativeImage || r.aot() == Aot.SUPPORTED;
-      if (mustPass) required++;
-      final var status = r.passed() ? "PASS" : (mustPass ? "FAIL" : "PEND");
       final var detail = r.detail() == null ? "" : "  — " + r.detail();
-      System.out.println(status + "  " + r.name() + detail);
-      if (mustPass && !r.passed()) failures++;
+      System.out.println((r.passed() ? "PASS  " : "FAIL  ") + r.name() + detail);
+      if (!r.passed()) failures++;
     }
     System.out.println();
     if (failures == 0) {
-      System.out.println("ALL " + required + " REQUIRED CAPABILITIES PASSED on this runtime (" + runtimeLabel() + ").");
+      System.out.println("ALL " + results.size() + " CAPABILITIES PASSED on this runtime (" + runtimeLabel() + ").");
     } else {
-      System.out.println(failures + " of " + required + " REQUIRED CAPABILITIES FAILED — see the FAIL lines.");
+      System.out.println(failures + " of " + results.size() + " CAPABILITIES FAILED — see the FAIL lines.");
     }
     System.exit(failures == 0 ? 0 : 1);
   }
@@ -226,24 +190,16 @@ public final class NativeVerify {
     if (!condition) throw new AssertionError(message);
   }
 
-  private static Result guard(final String name, final Aot aot, final Runnable capability) {
+  private static Result guard(final String name, final Runnable capability) {
     try {
       capability.run();
-      return new Result(name, true, null, aot);
+      return new Result(name, true, null);
     } catch (final Throwable t) {
       System.err.println("[FAIL] " + name);
       t.printStackTrace();
-      return new Result(name, false, t.getClass().getSimpleName() + ": " + t.getMessage(), aot);
+      return new Result(name, false, t.getClass().getSimpleName() + ": " + t.getMessage());
     }
   }
 
-  /** Whether a capability is required to pass under native-image, or a still-open increment. */
-  private enum Aot {
-    /** Must pass on every runtime, native-image included. */
-    SUPPORTED,
-    /** Reported under native-image but not yet required — Wall A (SerializedLambda decode). */
-    PENDING,
-  }
-
-  private record Result(String name, boolean passed, String detail, Aot aot) {}
+  private record Result(String name, boolean passed, String detail) {}
 }

--- a/examples/graphql/src/main/resources/META-INF/native-image/io.github.eschizoid/telescope-examples-graphql/reflect-config.json
+++ b/examples/graphql/src/main/resources/META-INF/native-image/io.github.eschizoid/telescope-examples-graphql/reflect-config.json
@@ -1,0 +1,38 @@
+[
+  {
+    "name": "io.github.eschizoid.telescope.examples.graphql.model.User",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "name": "io.github.eschizoid.telescope.examples.graphql.model.Address",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "name": "io.github.eschizoid.telescope.examples.graphql.model.UserView",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "name": "io.github.eschizoid.telescope.examples.graphql.model.Role",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "name": "io.github.eschizoid.telescope.examples.graphql.model.Account",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "name": "io.github.eschizoid.telescope.examples.graphql.model.AccountEntity",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  }
+]

--- a/examples/graphql/src/main/resources/META-INF/native-image/io.github.eschizoid/telescope-examples-graphql/reflect-config.json
+++ b/examples/graphql/src/main/resources/META-INF/native-image/io.github.eschizoid/telescope-examples-graphql/reflect-config.json
@@ -34,5 +34,17 @@
     "allDeclaredConstructors": true,
     "allDeclaredMethods": true,
     "allDeclaredFields": true
+  },
+  {
+    "name": "io.github.eschizoid.telescope.examples.graphql.model.AccountBuilderBean",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "name": "io.github.eschizoid.telescope.examples.graphql.model.AccountBuilderBean$Builder",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
   }
 ]

--- a/examples/graphql/src/main/resources/META-INF/native-image/io.github.eschizoid/telescope-examples-graphql/serialization-config.json
+++ b/examples/graphql/src/main/resources/META-INF/native-image/io.github.eschizoid/telescope-examples-graphql/serialization-config.json
@@ -1,0 +1,7 @@
+{
+  "lambdaCapturingTypes": [
+    { "name": "io.github.eschizoid.telescope.examples.graphql.server.NativeVerify" }
+  ],
+  "types": [],
+  "proxies": []
+}

--- a/internal/src/main/java/io/github/eschizoid/telescope/internal/Beans.java
+++ b/internal/src/main/java/io/github/eschizoid/telescope/internal/Beans.java
@@ -538,11 +538,11 @@ public final class Beans {
   }
 
   /**
-   * Build one {@link Function} per discovered getter via {@link LambdaMetafactory}. The metafactory
-   * synthesizes a {@link Function}-implementing class whose {@code apply(Object)} directly calls
-   * the getter and auto-boxes any primitive return ({@code int}, {@code boolean}, etc). After the
-   * first call per class the dispatch is a single virtual call the JIT inlines — no {@link
-   * Method#invoke}, no per-call argument array, no access-check.
+   * Build one {@link Function} per discovered getter, each a direct getter call that auto-boxes a
+   * primitive return, with no {@link Method#invoke}, per-call argument array, or access-check. On a
+   * stock JVM each is a {@link LambdaMetafactory}-synthesized class ({@link #lmfGetter}); inside a
+   * native image, where runtime class definition is banned, each is a {@link MethodHandle} closure
+   * ({@link #mhGetter}). Both dispatch as a single virtual call the JIT inlines.
    *
    * <p>JPMS access has the same rules as {@link AccessibleObject#setAccessible(boolean)}: if the
    * bean's package is not {@code opens}-exposed to {@code io.github.eschizoid.telescope}, the
@@ -569,28 +569,56 @@ public final class Beans {
       );
       try {
         final var handle = lookup.unreflect(method);
-        // SAM signature is `Object apply(Object)`; the instantiatedMethodType pins the actual
-        // (declaringClass) -> returnType signature so the metafactory generates the right bridge
-        // — including auto-boxing for primitive returns (`int`, `boolean`, etc).
-        final var callSite = LambdaMetafactory.metafactory(
-          lookup,
-          "apply",
-          MethodType.methodType(Function.class),
-          MethodType.methodType(Object.class, Object.class),
-          handle,
-          MethodType.methodType(method.getReturnType(), declaringClass)
+        invokers.put(
+          name,
+          NativeImage.IN_IMAGE ? mhGetter(handle, cls, name) : lmfGetter(handle, method, declaringClass, lookup)
         );
-        @SuppressWarnings("unchecked")
-        final var reader = (Function<Object, Object>) callSite.getTarget().invoke();
-        invokers.put(name, reader);
       } catch (final Throwable t) {
-        throw new IllegalStateException(
-          "Failed to build LambdaMetafactory getter invoker for " + cls.getName() + "." + name,
-          t
-        );
+        throw new IllegalStateException("Failed to build getter invoker for " + cls.getName() + "." + name, t);
       }
     }
     return invokers;
+  }
+
+  /**
+   * JVM hot path: {@link LambdaMetafactory} synthesizes a {@link Function} whose {@code
+   * apply(Object)} calls the getter directly and boxes a primitive return. The
+   * instantiatedMethodType pins the actual {@code (declaringClass) -> returnType} signature so the
+   * metafactory generates the boxing bridge.
+   */
+  @SuppressWarnings("unchecked")
+  private static Function<Object, Object> lmfGetter(
+    final MethodHandle handle,
+    final Method method,
+    final Class<?> declaringClass,
+    final MethodHandles.Lookup lookup
+  ) throws Throwable {
+    final var callSite = LambdaMetafactory.metafactory(
+      lookup,
+      "apply",
+      MethodType.methodType(Function.class),
+      MethodType.methodType(Object.class, Object.class),
+      handle,
+      MethodType.methodType(method.getReturnType(), declaringClass)
+    );
+    return (Function<Object, Object>) callSite.getTarget().invoke();
+  }
+
+  /**
+   * Native-image path: a source-level lambda closing over an {@link MethodHandle#asType(MethodType)
+   * asType}-adapted getter handle — no class synthesized at run time, so it survives native-image's
+   * ban on runtime class definition (see {@link NativeImage}). The getter must be registered for
+   * reflection.
+   */
+  private static Function<Object, Object> mhGetter(final MethodHandle handle, final Class<?> cls, final String name) {
+    final var adapted = handle.asType(MethodType.methodType(Object.class, Object.class));
+    return obj -> {
+      try {
+        return (Object) adapted.invokeExact(obj);
+      } catch (final Throwable t) {
+        throw new IllegalStateException("Failed to read '" + name + "' on " + cls.getName(), t);
+      }
+    };
   }
 
   /**

--- a/internal/src/main/java/io/github/eschizoid/telescope/internal/Beans.java
+++ b/internal/src/main/java/io/github/eschizoid/telescope/internal/Beans.java
@@ -252,6 +252,17 @@ public final class Beans {
   ) {
     try {
       final var handle = lookup.unreflectConstructor(ctor);
+      if (NativeImage.IN_IMAGE) {
+        // Native-image path: a MethodHandle closure, no runtime class synthesis — see NativeImage.
+        final var adapted = handle.asType(MethodType.methodType(Object.class));
+        return () -> {
+          try {
+            return (Object) adapted.invokeExact();
+          } catch (final Throwable t) {
+            throw new RuntimeException("Failed to instantiate " + cls.getName(), t);
+          }
+        };
+      }
       final var callSite = LambdaMetafactory.metafactory(
         lookup,
         "get",
@@ -473,6 +484,19 @@ public final class Beans {
     final var instantiatedParamType = wrap(paramType);
     try {
       final var handle = lookup.unreflect(setter);
+      if (NativeImage.IN_IMAGE) {
+        // Native-image path: a MethodHandle closure, no runtime class synthesis — see NativeImage.
+        // asType relaxes the receiver to Object and unboxes a primitive param from the boxed value,
+        // matching the auto-unbox the LMF instantiatedMethodType installs below.
+        final var adapted = handle.asType(MethodType.methodType(void.class, Object.class, Object.class));
+        return (pojo, value) -> {
+          try {
+            adapted.invokeExact(pojo, value);
+          } catch (final Throwable t) {
+            throw new RuntimeException("Failed to set '" + name + "' on " + cls.getName(), t);
+          }
+        };
+      }
       final var callSite = LambdaMetafactory.metafactory(
         lookup,
         "accept",

--- a/internal/src/main/java/io/github/eschizoid/telescope/internal/Beans.java
+++ b/internal/src/main/java/io/github/eschizoid/telescope/internal/Beans.java
@@ -185,7 +185,7 @@ public final class Beans {
     try {
       final var builderMethod = type.getMethod("builder");
       if (Modifier.isStatic(builderMethod.getModifiers()) && Modifier.isPublic(builderMethod.getModifiers())) {
-        return buildBuilderBuildSupplier(type, builderMethod);
+        return builderDefaultSupplier(type, builderMethod);
       }
     } catch (final NoSuchMethodException ignored) {
       // No static builder() — fall through to the null supplier.
@@ -194,7 +194,7 @@ public final class Beans {
   }
 
   @SuppressWarnings("unchecked")
-  private static Supplier<Object> buildBuilderBuildSupplier(final Class<?> type, final Method builderMethod) {
+  private static Supplier<Object> builderDefaultSupplier(final Class<?> type, final Method builderMethod) {
     try {
       // privateLookupIn lets the lookup cross JPMS module + package boundaries to reach the
       // user's builder method. The user's package must be `opens io.github.eschizoid.telescope`
@@ -203,15 +203,6 @@ public final class Beans {
       final var lookup = MethodHandles.privateLookupIn(type, MethodHandles.lookup());
       final var builderHandle = lookup.unreflect(builderMethod);
       final var builderReturnType = builderMethod.getReturnType();
-      final var builderCallSite = LambdaMetafactory.metafactory(
-        lookup,
-        "get",
-        MethodType.methodType(Supplier.class),
-        MethodType.methodType(Object.class),
-        builderHandle,
-        MethodType.methodType(builderReturnType)
-      );
-      final var builderFn = (Supplier<Object>) builderCallSite.getTarget().invoke();
       final var buildMethod = builderReturnType.getMethod("build");
       // The Builder class itself usually lives in the same package as `type`, but for nested
       // builders (Builder is an inner class of the enclosing type) the same lookup already
@@ -221,6 +212,22 @@ public final class Beans {
       final var buildLookup =
         builderReturnType == type ? lookup : MethodHandles.privateLookupIn(builderReturnType, MethodHandles.lookup());
       final var buildHandle = buildLookup.unreflect(buildMethod);
+      // Native-image: MethodHandle closures for both halves (no runtime class synthesis, see
+      // MhAccessors); stock JVM: the LambdaMetafactory bridges.
+      if (NativeImage.IN_IMAGE) {
+        final var mhBuilderFn = MhAccessors.supplier(builderHandle);
+        final var mhBuildFn = MhAccessors.function(buildHandle);
+        return () -> mhBuildFn.apply(mhBuilderFn.get());
+      }
+      final var builderCallSite = LambdaMetafactory.metafactory(
+        lookup,
+        "get",
+        MethodType.methodType(Supplier.class),
+        MethodType.methodType(Object.class),
+        builderHandle,
+        MethodType.methodType(builderReturnType)
+      );
+      final var builderFn = (Supplier<Object>) builderCallSite.getTarget().invoke();
       final var buildCallSite = LambdaMetafactory.metafactory(
         buildLookup,
         "apply",
@@ -252,17 +259,8 @@ public final class Beans {
   ) {
     try {
       final var handle = lookup.unreflectConstructor(ctor);
-      if (NativeImage.IN_IMAGE) {
-        // Native-image path: a MethodHandle closure, no runtime class synthesis — see NativeImage.
-        final var adapted = handle.asType(MethodType.methodType(Object.class));
-        return () -> {
-          try {
-            return (Object) adapted.invokeExact();
-          } catch (final Throwable t) {
-            throw new RuntimeException("Failed to instantiate " + cls.getName(), t);
-          }
-        };
-      }
+      // Native-image path: a MethodHandle closure, no runtime class synthesis — see MhAccessors.
+      if (NativeImage.IN_IMAGE) return MhAccessors.supplier(handle);
       final var callSite = LambdaMetafactory.metafactory(
         lookup,
         "get",
@@ -484,19 +482,10 @@ public final class Beans {
     final var instantiatedParamType = wrap(paramType);
     try {
       final var handle = lookup.unreflect(setter);
-      if (NativeImage.IN_IMAGE) {
-        // Native-image path: a MethodHandle closure, no runtime class synthesis — see NativeImage.
-        // asType relaxes the receiver to Object and unboxes a primitive param from the boxed value,
-        // matching the auto-unbox the LMF instantiatedMethodType installs below.
-        final var adapted = handle.asType(MethodType.methodType(void.class, Object.class, Object.class));
-        return (pojo, value) -> {
-          try {
-            adapted.invokeExact(pojo, value);
-          } catch (final Throwable t) {
-            throw new RuntimeException("Failed to set '" + name + "' on " + cls.getName(), t);
-          }
-        };
-      }
+      // Native-image path: a MethodHandle closure, no runtime class synthesis — see MhAccessors.
+      // asType relaxes the receiver to Object and unboxes a primitive param from the boxed value,
+      // matching the auto-unbox the LMF instantiatedMethodType installs below.
+      if (NativeImage.IN_IMAGE) return MhAccessors.biConsumer(handle);
       final var callSite = LambdaMetafactory.metafactory(
         lookup,
         "accept",
@@ -542,7 +531,7 @@ public final class Beans {
    * primitive return, with no {@link Method#invoke}, per-call argument array, or access-check. On a
    * stock JVM each is a {@link LambdaMetafactory}-synthesized class ({@link #lmfGetter}); inside a
    * native image, where runtime class definition is banned, each is a {@link MethodHandle} closure
-   * ({@link #mhGetter}). Both dispatch as a single virtual call the JIT inlines.
+   * ({@link MhAccessors#function}). Both dispatch as a single virtual call the JIT inlines.
    *
    * <p>JPMS access has the same rules as {@link AccessibleObject#setAccessible(boolean)}: if the
    * bean's package is not {@code opens}-exposed to {@code io.github.eschizoid.telescope}, the
@@ -571,7 +560,7 @@ public final class Beans {
         final var handle = lookup.unreflect(method);
         invokers.put(
           name,
-          NativeImage.IN_IMAGE ? mhGetter(handle, cls, name) : lmfGetter(handle, method, declaringClass, lookup)
+          NativeImage.IN_IMAGE ? MhAccessors.function(handle) : lmfGetter(handle, method, declaringClass, lookup)
         );
       } catch (final Throwable t) {
         throw new IllegalStateException("Failed to build getter invoker for " + cls.getName() + "." + name, t);
@@ -602,23 +591,6 @@ public final class Beans {
       MethodType.methodType(method.getReturnType(), declaringClass)
     );
     return (Function<Object, Object>) callSite.getTarget().invoke();
-  }
-
-  /**
-   * Native-image path: a source-level lambda closing over an {@link MethodHandle#asType(MethodType)
-   * asType}-adapted getter handle — no class synthesized at run time, so it survives native-image's
-   * ban on runtime class definition (see {@link NativeImage}). The getter must be registered for
-   * reflection.
-   */
-  private static Function<Object, Object> mhGetter(final MethodHandle handle, final Class<?> cls, final String name) {
-    final var adapted = handle.asType(MethodType.methodType(Object.class, Object.class));
-    return obj -> {
-      try {
-        return (Object) adapted.invokeExact(obj);
-      } catch (final Throwable t) {
-        throw new IllegalStateException("Failed to read '" + name + "' on " + cls.getName(), t);
-      }
-    };
   }
 
   /**
@@ -1500,7 +1472,14 @@ public final class Beans {
       final var samParamType = paramType.isPrimitive() ? wrap(paramType) : paramType;
       try {
         final var handle = lookup.unreflect(setter);
-        if (setter.getReturnType() == void.class) {
+        final var voidSetter = setter.getReturnType() == void.class;
+        if (NativeImage.IN_IMAGE) {
+          // Native-image: MethodHandle closures, no runtime class synthesis (see MhAccessors). A
+          // void setter binds as BiConsumer; a fluent setter as BiFunction (the returned builder is
+          // discarded at the call site).
+          return voidSetter ? MhAccessors.biConsumer(handle) : MhAccessors.biFunction(handle);
+        }
+        if (voidSetter) {
           // Void-returning setter (classic JavaBean style): bind directly as BiConsumer.
           final var callSite = LambdaMetafactory.metafactory(
             lookup,
@@ -1542,6 +1521,7 @@ public final class Beans {
       final var lookup = privateLookupOrThrow(factory.getDeclaringClass(), cls, "builder factory");
       try {
         final var handle = lookup.unreflect(factory);
+        if (NativeImage.IN_IMAGE) return MhAccessors.supplier(handle);
         final var callSite = LambdaMetafactory.metafactory(
           lookup,
           "get",
@@ -1572,6 +1552,7 @@ public final class Beans {
       final var lookup = privateLookupOrThrow(declaringClass, builderType, "builder build()");
       try {
         final var handle = lookup.unreflect(buildMethod);
+        if (NativeImage.IN_IMAGE) return MhAccessors.function(handle);
         // Pin the `instantiatedMethodType` return to the build method's actual return type, not
         // `cls`. A covariant `build()` (e.g. on a generic builder hierarchy) returns a subtype of
         // `cls`, and LMF will refuse the binding ("incorrect return type") if we pin to `cls`.
@@ -1693,30 +1674,36 @@ public final class Beans {
       final var instantiatedParamType = wrap(paramType);
       try {
         final var handle = lookup.unreflect(setter);
-        final var callSite = LambdaMetafactory.metafactory(
-          lookup,
-          "accept",
-          MethodType.methodType(BiConsumer.class),
-          MethodType.methodType(void.class, Object.class, Object.class),
-          handle,
-          MethodType.methodType(void.class, declaringClass, instantiatedParamType)
-        );
-        final var lmfSetter = (BiConsumer<Object, Object>) callSite.getTarget().invoke();
-        // Defence-in-depth on the primitive-setter null guard. The LMF-built setter for a
-        // primitive parameter (e.g. setCount(int)) NPEs when invoked with null
-        // (Object → Integer → int unbox). DeepMap's placeholderIsoFor short-circuits unmatched
-        // primitive target fields to their JLS default before the value ever reaches here, so
-        // this guard is unreachable on the happy path — it's kept to lock the contract against
-        // future code paths that may legitimately deliver null to a primitive setter (e.g.
-        // autoboxing-relaxation work). When the parameter type is a primitive, skip on null so
-        // the field stays at its JLS default rather than crashing the construct call.
+        final BiConsumer<Object, Object> baseSetter;
+        if (NativeImage.IN_IMAGE) {
+          // Native-image: a MethodHandle closure, no runtime class synthesis (see MhAccessors).
+          baseSetter = MhAccessors.biConsumer(handle);
+        } else {
+          final var callSite = LambdaMetafactory.metafactory(
+            lookup,
+            "accept",
+            MethodType.methodType(BiConsumer.class),
+            MethodType.methodType(void.class, Object.class, Object.class),
+            handle,
+            MethodType.methodType(void.class, declaringClass, instantiatedParamType)
+          );
+          baseSetter = (BiConsumer<Object, Object>) callSite.getTarget().invoke();
+        }
+        // Defence-in-depth on the primitive-setter null guard. The built setter for a primitive
+        // parameter (e.g. setCount(int)) NPEs when invoked with null (Object → Integer → int
+        // unbox) — on either the LMF or the native-image MethodHandle path. DeepMap's
+        // placeholderIsoFor short-circuits unmatched primitive target fields to their JLS default
+        // before the value ever reaches here, so this guard is unreachable on the happy path — it's
+        // kept to lock the contract against future code paths that may legitimately deliver null to
+        // a primitive setter (e.g. autoboxing-relaxation work). When the parameter type is a
+        // primitive, skip on null so the field stays at its JLS default rather than crashing.
         if (paramType.isPrimitive()) {
           return (pojo, value) -> {
             if (value == null) return;
-            lmfSetter.accept(pojo, value);
+            baseSetter.accept(pojo, value);
           };
         }
-        return lmfSetter;
+        return baseSetter;
       } catch (final Throwable t) {
         throw new RuntimeException("Failed to set '" + name + "' on " + cls.getName(), t);
       }

--- a/internal/src/main/java/io/github/eschizoid/telescope/internal/MetadataHolderProbe.java
+++ b/internal/src/main/java/io/github/eschizoid/telescope/internal/MetadataHolderProbe.java
@@ -177,6 +177,13 @@ public final class MetadataHolderProbe {
     try {
       final var lookup = MethodHandles.lookup();
       final var handle = lookup.unreflect(method);
+      if (NativeImage.IN_IMAGE) {
+        // Native-image: a MethodHandle closure (see MhAccessors), no runtime class synthesis. The
+        // holder's construct(Function) takes a Function<String, Object> argument, which the erased
+        // (Object) -> Object closure accepts, so the method reference adapts to the wider input.
+        final Function<Object, Object> constructor = MhAccessors.function(handle);
+        return constructor::apply;
+      }
       final var callSite = LambdaMetafactory.metafactory(
         lookup,
         "apply",

--- a/internal/src/main/java/io/github/eschizoid/telescope/internal/MhAccessors.java
+++ b/internal/src/main/java/io/github/eschizoid/telescope/internal/MhAccessors.java
@@ -1,0 +1,91 @@
+package io.github.eschizoid.telescope.internal;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodType;
+import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+/**
+ * Native-image accessor closures: one functional-interface shape per accessor kind, each a
+ * source-level lambda closing over a {@link MethodHandle} adapted once with {@link
+ * MethodHandle#asType(MethodType) asType}. This is the class-definition-free counterpart to the
+ * {@link java.lang.invoke.LambdaMetafactory} path {@link Records} / {@link Beans} use on a stock
+ * JVM — {@code LambdaMetafactory.metafactory(...)} synthesizes a class per accessor, which
+ * native-image's closed world forbids at run time, whereas these lambda classes are compile-time.
+ * The builders are chosen by {@link NativeImage#IN_IMAGE}; the JVM keeps the faster LMF path.
+ *
+ * <p>{@code asType} does the same receiver/return/parameter cast + primitive box/unbox the LMF
+ * {@code instantiatedMethodType} bridge does, so a closure here is value-equivalent to the LMF
+ * accessor it replaces. Each closure's {@link MethodHandle#invokeExact invokeExact} call-site types
+ * match the adapted handle exactly (all {@code Object} / {@code void}), the requirement {@code
+ * invokeExact} enforces. The target member must be registered for reflection in the image's
+ * reachability metadata (the app supplies that for its own types).
+ */
+final class MhAccessors {
+
+  private MhAccessors() {}
+
+  /** {@code () -> R} (a no-arg factory / {@code builder()}) as a {@code Supplier<Object>}. */
+  static Supplier<Object> supplier(final MethodHandle handle) {
+    final var adapted = handle.asType(MethodType.methodType(Object.class));
+    return () -> {
+      try {
+        return (Object) adapted.invokeExact();
+      } catch (final Throwable t) {
+        throw dispatchFailure(t);
+      }
+    };
+  }
+
+  /**
+   * {@code (P) -> R} (a reader / getter / {@code build()}) as a {@code Function<Object, Object>}.
+   */
+  static Function<Object, Object> function(final MethodHandle handle) {
+    final var adapted = handle.asType(MethodType.methodType(Object.class, Object.class));
+    return obj -> {
+      try {
+        return (Object) adapted.invokeExact(obj);
+      } catch (final Throwable t) {
+        throw dispatchFailure(t);
+      }
+    };
+  }
+
+  /** {@code (P, V) -> void} (a void setter) as a {@code BiConsumer<Object, Object>}. */
+  static BiConsumer<Object, Object> biConsumer(final MethodHandle handle) {
+    final var adapted = handle.asType(MethodType.methodType(void.class, Object.class, Object.class));
+    return (target, value) -> {
+      try {
+        adapted.invokeExact(target, value);
+      } catch (final Throwable t) {
+        throw dispatchFailure(t);
+      }
+    };
+  }
+
+  /**
+   * {@code (P, V) -> R} (a fluent builder setter) as a {@code BiFunction<Object, Object, Object>}.
+   */
+  static BiFunction<Object, Object, Object> biFunction(final MethodHandle handle) {
+    final var adapted = handle.asType(MethodType.methodType(Object.class, Object.class, Object.class));
+    return (target, value) -> {
+      try {
+        return (Object) adapted.invokeExact(target, value);
+      } catch (final Throwable t) {
+        throw dispatchFailure(t);
+      }
+    };
+  }
+
+  // Preserve the raw exception: an unchecked ClassCastException / NullPointerException from a bad
+  // value or null receiver propagates unwrapped (matching the LMF path); only a checked Throwable
+  // is
+  // wrapped.
+  private static RuntimeException dispatchFailure(final Throwable t) {
+    if (t instanceof Error e) throw e;
+    if (t instanceof RuntimeException re) return re;
+    return new IllegalStateException("native-image MethodHandle accessor dispatch failed", t);
+  }
+}

--- a/internal/src/main/java/io/github/eschizoid/telescope/internal/NativeImage.java
+++ b/internal/src/main/java/io/github/eschizoid/telescope/internal/NativeImage.java
@@ -1,0 +1,22 @@
+package io.github.eschizoid.telescope.internal;
+
+/**
+ * One-time detection of whether the substrate is executing inside a GraalVM native image, read once
+ * at class-init and folded by the JIT into a constant.
+ *
+ * <p>The runtime accessor builders in {@link Records} / {@link Beans} default to {@link
+ * java.lang.invoke.LambdaMetafactory}, which synthesizes a class per accessor — the fastest JVM
+ * dispatch shape, but native-image's closed world forbids defining a class at run time. When {@link
+ * #IN_IMAGE} is true those builders take the class-definition-free {@link
+ * java.lang.invoke.MethodHandle} closure path instead (the same shape {@code Records.buildCtorFn}
+ * already uses for the canonical constructor). The check is a JDK system property, so this carries
+ * no dependency on {@code org.graalvm.nativeimage}: {@code org.graalvm.nativeimage.imagecode} is
+ * set to {@code buildtime} / {@code runtime} inside an image and absent on a stock JVM.
+ */
+final class NativeImage {
+
+  /** True when running inside a GraalVM native image (build-time analysis or the final binary). */
+  static final boolean IN_IMAGE = System.getProperty("org.graalvm.nativeimage.imagecode") != null;
+
+  private NativeImage() {}
+}

--- a/internal/src/main/java/io/github/eschizoid/telescope/internal/Records.java
+++ b/internal/src/main/java/io/github/eschizoid/telescope/internal/Records.java
@@ -384,8 +384,8 @@ public final class Records {
      * java.lang.reflect.Method#invoke}, per-call argument array, or access-check. On a stock JVM
      * each reader is a {@link LambdaMetafactory}-synthesized class (see {@link #lmfReader}); inside
      * a native image, where runtime class definition is banned, each is instead a {@link
-     * MethodHandle} closure (see {@link #mhReader}). Both dispatch as a single virtual call the JIT
-     * inlines.
+     * MethodHandle} closure ({@link MhAccessors#function}). Both dispatch as a single virtual call
+     * the JIT inlines.
      */
     @SuppressWarnings("unchecked")
     private static Function<Object, Object>[] buildReaders(
@@ -398,7 +398,7 @@ public final class Records {
         final var comp = comps[i];
         try {
           final var handle = lookup.unreflect(comp.getAccessor());
-          readers[i] = NativeImage.IN_IMAGE ? mhReader(handle) : lmfReader(handle, cls, comp, lookup);
+          readers[i] = NativeImage.IN_IMAGE ? MhAccessors.function(handle) : lmfReader(handle, cls, comp, lookup);
         } catch (final Throwable t) {
           throw new IllegalStateException("Failed to build reader for " + cls.getName() + "." + comp.getName(), t);
         }
@@ -428,26 +428,6 @@ public final class Records {
         MethodType.methodType(comp.getType(), cls)
       );
       return (Function<Object, Object>) callSite.getTarget().invoke();
-    }
-
-    /**
-     * Native-image path: a source-level lambda closing over an {@link
-     * MethodHandle#asType(MethodType) asType}-adapted accessor handle. {@code asType} relaxes the
-     * receiver to {@code Object} and boxes a primitive return, so {@link MethodHandle#invokeExact
-     * invokeExact} dispatches from a generic context. No class is synthesized at run time — the
-     * lambda class is compile-time — so this survives native-image's ban on runtime class
-     * definition, unlike {@link #lmfReader}. The accessor must be registered for reflection (the
-     * {@code telescope-graalvm} Feature, or a hand-written reachability metadata file, does that).
-     */
-    private static Function<Object, Object> mhReader(final MethodHandle handle) {
-      final var adapted = handle.asType(MethodType.methodType(Object.class, Object.class));
-      return obj -> {
-        try {
-          return (Object) adapted.invokeExact(obj);
-        } catch (final Throwable t) {
-          throw new IllegalStateException("Failed to read record component", t);
-        }
-      };
     }
 
     /**

--- a/internal/src/main/java/io/github/eschizoid/telescope/internal/Records.java
+++ b/internal/src/main/java/io/github/eschizoid/telescope/internal/Records.java
@@ -380,11 +380,12 @@ public final class Records {
     }
 
     /**
-     * Build one {@link Function} per component via {@link LambdaMetafactory}. Forward: the
-     * metafactory synthesizes a class implementing {@link Function} whose {@code apply(Object)}
-     * directly calls the component accessor and auto-boxes any primitive return. After the first
-     * call per class the dispatch is a single virtual call the JIT inlines — no {@link
-     * java.lang.reflect.Method#invoke}, no per-call argument array, no access-check.
+     * Build one {@link Function} per component, each a direct accessor call with no {@link
+     * java.lang.reflect.Method#invoke}, per-call argument array, or access-check. On a stock JVM
+     * each reader is a {@link LambdaMetafactory}-synthesized class (see {@link #lmfReader}); inside
+     * a native image, where runtime class definition is banned, each is instead a {@link
+     * MethodHandle} closure (see {@link #mhReader}). Both dispatch as a single virtual call the JIT
+     * inlines.
      */
     @SuppressWarnings("unchecked")
     private static Function<Object, Object>[] buildReaders(
@@ -397,26 +398,56 @@ public final class Records {
         final var comp = comps[i];
         try {
           final var handle = lookup.unreflect(comp.getAccessor());
-          // SAM signature is `Object apply(Object)`; the instantiatedMethodType pins the actual
-          // (recordClass) -> componentType signature so the metafactory generates the right
-          // bridge — including auto-boxing for primitive returns (`int`, `long`, etc).
-          final var callSite = LambdaMetafactory.metafactory(
-            lookup,
-            "apply",
-            MethodType.methodType(Function.class),
-            MethodType.methodType(Object.class, Object.class),
-            handle,
-            MethodType.methodType(comp.getType(), cls)
-          );
-          readers[i] = (Function<Object, Object>) callSite.getTarget().invoke();
+          readers[i] = NativeImage.IN_IMAGE ? mhReader(handle) : lmfReader(handle, cls, comp, lookup);
         } catch (final Throwable t) {
-          throw new IllegalStateException(
-            "Failed to build LambdaMetafactory reader for " + cls.getName() + "." + comp.getName(),
-            t
-          );
+          throw new IllegalStateException("Failed to build reader for " + cls.getName() + "." + comp.getName(), t);
         }
       }
       return readers;
+    }
+
+    /**
+     * JVM hot path: {@link LambdaMetafactory} synthesizes a {@link Function} whose {@code
+     * apply(Object)} directly calls the accessor and auto-boxes any primitive return. The
+     * instantiatedMethodType pins the actual {@code (recordClass) -> componentType} signature so
+     * the metafactory generates the right boxing bridge.
+     */
+    @SuppressWarnings("unchecked")
+    private static Function<Object, Object> lmfReader(
+      final MethodHandle handle,
+      final Class<?> cls,
+      final RecordComponent comp,
+      final MethodHandles.Lookup lookup
+    ) throws Throwable {
+      final var callSite = LambdaMetafactory.metafactory(
+        lookup,
+        "apply",
+        MethodType.methodType(Function.class),
+        MethodType.methodType(Object.class, Object.class),
+        handle,
+        MethodType.methodType(comp.getType(), cls)
+      );
+      return (Function<Object, Object>) callSite.getTarget().invoke();
+    }
+
+    /**
+     * Native-image path: a source-level lambda closing over an {@link
+     * MethodHandle#asType(MethodType) asType}-adapted accessor handle. {@code asType} relaxes the
+     * receiver to {@code Object} and boxes a primitive return, so {@link MethodHandle#invokeExact
+     * invokeExact} dispatches from a generic context. No class is synthesized at run time — the
+     * lambda class is compile-time — so this survives native-image's ban on runtime class
+     * definition, unlike {@link #lmfReader}. The accessor must be registered for reflection (the
+     * {@code telescope-graalvm} Feature, or a hand-written reachability metadata file, does that).
+     */
+    private static Function<Object, Object> mhReader(final MethodHandle handle) {
+      final var adapted = handle.asType(MethodType.methodType(Object.class, Object.class));
+      return obj -> {
+        try {
+          return (Object) adapted.invokeExact(obj);
+        } catch (final Throwable t) {
+          throw new IllegalStateException("Failed to read record component", t);
+        }
+      };
     }
 
     /**

--- a/internal/src/test/java/io/github/eschizoid/telescope/internal/MhAccessorsTest.java
+++ b/internal/src/test/java/io/github/eschizoid/telescope/internal/MhAccessorsTest.java
@@ -101,6 +101,15 @@ class MhAccessorsTest {
     assertInstanceOf(Exception.class, thrown.getCause());
   }
 
+  @Test
+  @DisplayName("an Error from the accessor propagates raw, never wrapped")
+  void errorPropagatesRaw() throws Throwable {
+    final var handle = LOOKUP.unreflect(Box.class.getMethod("throwsError"));
+    final var reader = MhAccessors.function(handle);
+    final var thrown = assertThrows(AssertionError.class, () -> reader.apply(new Box(0)));
+    assertEquals("err", thrown.getMessage());
+  }
+
   /** Test fixture exposing a getter, void + fluent setters, a factory, and throwing methods. */
   public static final class Box {
 
@@ -144,6 +153,10 @@ class MhAccessorsTest {
 
     public void checkedBoom() throws Exception {
       throw new Exception("checked");
+    }
+
+    public void throwsError() {
+      throw new AssertionError("err");
     }
   }
 }

--- a/internal/src/test/java/io/github/eschizoid/telescope/internal/MhAccessorsTest.java
+++ b/internal/src/test/java/io/github/eschizoid/telescope/internal/MhAccessorsTest.java
@@ -1,0 +1,149 @@
+package io.github.eschizoid.telescope.internal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.lang.invoke.MethodHandles;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Contract tests for the native-image accessor closures. On the JVM these run directly (the {@code
+ * MhAccessors} builders are not {@code NativeImage.IN_IMAGE}-gated — only their callers are), so
+ * this pins the {@code asType}/{@code invokeExact} behaviour — primitive boxing/unboxing, fluent
+ * return identity, and raw-exception propagation — that the native-image path relies on and that
+ * must stay value-equivalent to the {@code LambdaMetafactory} path it replaces inside an image.
+ */
+class MhAccessorsTest {
+
+  private static final MethodHandles.Lookup LOOKUP = MethodHandles.lookup();
+
+  @Test
+  @DisplayName("function reads a getter and boxes a primitive return to Integer")
+  void functionReadsAndBoxesPrimitiveReturn() throws Throwable {
+    final var handle = LOOKUP.unreflect(Box.class.getMethod("getCount"));
+    final var reader = MhAccessors.function(handle);
+    final var box = new Box(7);
+    assertEquals(7, reader.apply(box));
+    assertInstanceOf(Integer.class, reader.apply(box));
+  }
+
+  @Test
+  @DisplayName("supplier invokes a no-arg static factory")
+  void supplierInvokesStaticFactory() throws Throwable {
+    final var handle = LOOKUP.unreflect(Box.class.getMethod("create"));
+    assertInstanceOf(Box.class, MhAccessors.supplier(handle).get());
+  }
+
+  @Test
+  @DisplayName("supplier invokes a no-arg constructor")
+  void supplierInvokesConstructor() throws Throwable {
+    final var handle = LOOKUP.unreflectConstructor(Box.class.getConstructor());
+    assertInstanceOf(Box.class, MhAccessors.supplier(handle).get());
+  }
+
+  @Test
+  @DisplayName("biConsumer writes a void setter, unboxing the boxed primitive argument")
+  void biConsumerUnboxesPrimitiveArgument() throws Throwable {
+    final var handle = LOOKUP.unreflect(Box.class.getMethod("setCount", int.class));
+    final var writer = MhAccessors.biConsumer(handle);
+    final var box = new Box(0);
+    writer.accept(box, 42);
+    assertEquals(42, box.getCount());
+  }
+
+  @Test
+  @DisplayName("biConsumer writes a reference-typed void setter")
+  void biConsumerWritesReferenceSetter() throws Throwable {
+    final var handle = LOOKUP.unreflect(Box.class.getMethod("setName", String.class));
+    final var writer = MhAccessors.biConsumer(handle);
+    final var box = new Box(0);
+    writer.accept(box, "hi");
+    assertEquals("hi", box.getName());
+  }
+
+  @Test
+  @DisplayName("biFunction invokes a fluent setter and returns the receiver")
+  void biFunctionReturnsFluentReceiver() throws Throwable {
+    final var handle = LOOKUP.unreflect(Box.class.getMethod("withName", String.class));
+    final var fluent = MhAccessors.biFunction(handle);
+    final var box = new Box(0);
+    final var returned = fluent.apply(box, "fluent");
+    assertSame(box, returned);
+    assertEquals("fluent", box.getName());
+  }
+
+  @Test
+  @DisplayName("an unchecked exception from the accessor propagates raw, not wrapped")
+  void rawUncheckedExceptionPropagates() throws Throwable {
+    final var handle = LOOKUP.unreflect(Box.class.getMethod("boom"));
+    final var reader = MhAccessors.function(handle);
+    final var thrown = assertThrows(IllegalStateException.class, () -> reader.apply(new Box(0)));
+    assertEquals("boom", thrown.getMessage());
+  }
+
+  @Test
+  @DisplayName("null into a primitive setter surfaces a NullPointerException")
+  void nullIntoPrimitiveSetterThrows() throws Throwable {
+    final var handle = LOOKUP.unreflect(Box.class.getMethod("setCount", int.class));
+    final var writer = MhAccessors.biConsumer(handle);
+    assertThrows(NullPointerException.class, () -> writer.accept(new Box(0), null));
+  }
+
+  @Test
+  @DisplayName("a checked exception from the accessor is wrapped in IllegalStateException")
+  void checkedExceptionIsWrapped() throws Throwable {
+    final var handle = LOOKUP.unreflect(Box.class.getMethod("checkedBoom"));
+    final var reader = MhAccessors.function(handle);
+    final var thrown = assertThrows(IllegalStateException.class, () -> reader.apply(new Box(0)));
+    assertInstanceOf(Exception.class, thrown.getCause());
+  }
+
+  /** Test fixture exposing a getter, void + fluent setters, a factory, and throwing methods. */
+  public static final class Box {
+
+    private int count;
+    private String name;
+
+    public Box() {}
+
+    public Box(final int count) {
+      this.count = count;
+    }
+
+    public static Box create() {
+      return new Box();
+    }
+
+    public int getCount() {
+      return count;
+    }
+
+    public String getName() {
+      return name;
+    }
+
+    public void setCount(final int count) {
+      this.count = count;
+    }
+
+    public void setName(final String name) {
+      this.name = name;
+    }
+
+    public Box withName(final String name) {
+      this.name = name;
+      return this;
+    }
+
+    public void boom() {
+      throw new IllegalStateException("boom");
+    }
+
+    public void checkedBoom() throws Exception {
+      throw new Exception("checked");
+    }
+  }
+}


### PR DESCRIPTION
## What

Make telescope's **runtime** path work under GraalVM native-image — not just the codegen path. The `:examples:graphql` verifier now proves **all eight** runtime + codegen capabilities build and run in a real native binary, gated on every push to `main` and weekly. Implements [ADR-0015](docs/adr/0015-native-image-aot-support.md).

Before this, only the codegen path (`@Bridge`/`@FromMap`) native-imaged; the runtime reflective path (`Telescope.mapper`, `.field(User::name)`) failed. That closes a gap MapStruct doesn't even have to solve (it's codegen-only) — telescope now offers **both**.

## The two walls (both cleared)

**Wall B — runtime `LambdaMetafactory` (the load-bearing one).** `Records`/`Beans` build accessors by calling `LambdaMetafactory.metafactory(...)` *at run time*, synthesizing a class per accessor — native-image's closed world forbids runtime class definition. Fixed **in the substrate**: `internal/NativeImage.IN_IMAGE` (a JDK-only `org.graalvm.nativeimage.imagecode` check, **no GraalVM dependency**) branches the accessor builders to a `MethodHandle.asType` closure inside an image — the same class-definition-free shape `Records.buildCtorFn` already used. Centralized in `internal/MhAccessors` (one `supplier`/`function`/`biConsumer`/`biFunction` per SAM shape). **The JVM keeps the `LambdaMetafactory` hot path byte-for-byte** — the branch is one folded `static final boolean`, so there is zero JVM cost.

Every runtime rebuild strategy is covered: record reads, no-arg-ctor + setters, getters, and the whole `BuilderWriter` path (`builder()` → fluent setters → `build()`) — so mapping to an immutable `@Builder` target works too. The one documented exception is the optional Hibernate-proxy accessor pair (guarded, unverifiable in the example) — JVM/codegen-only under AOT.

**Wall A — `SerializedLambda` decode.** `.field(User::name)` needs `writeReplace()`, which native-image only synthesizes for a registered lambda-capturing type. Fixed with an app-level `serialization-config.json`. `.fieldByName(String)` and codegen navigators are the registration-free alternatives.

## What ships where (no new artifact)

- **`telescope-core`** ships its own `native-image.properties` with `--initialize-at-build-time` for the telescope packages — adopters need **no build args for telescope itself**.
- **The Wall B fix** lives in `telescope-core`/`telescope-internal` — free, AOT-capable out of the box.
- **The app** ships `reflect-config.json` (its runtime-mapper DTO types) + `serialization-config.json` (its `.field(methodref)` call-site classes) — exactly as any GraalVM app does for its own types.

The originally-planned `telescope-graalvm` Feature module was **designed then dropped** (ADR-0015 amendment): runtime-mapper DTOs are typically un-annotated, so a `@Focus`-keyed Feature wouldn't cover the common case, and app-level DTO metadata is idiomatic GraalVM regardless.

## Verification

`NativeVerify` runs 8 capabilities and `System.exit(non-zero)` on any mismatch, so building **and running** the binary IS the test:

| Capability | Proven under native-image |
| --- | --- |
| record field update / read, bean-getter read | ✅ |
| runtime record→record mapper | ✅ |
| runtime record→bean mapper | ✅ |
| runtime record→builder-bean mapper (`BuilderWriter`) | ✅ |
| generated `@FromMap`, `@Bridge` | ✅ |

CI native-image run: **all 8 pass**. JVM `runNativeVerify`: all 8 pass. Full test suite green (the JVM LMF path is unchanged — `IN_IMAGE` only diverges inside an image).

## Review

Ran an adversarial fleet across two rounds. **Substrate-correctness** ran a live JDK-25 equivalence harness and confirmed each `MhAccessors` shape is `invokeExact`-exact and value-equivalent to the LMF site it replaces (boxing, null receiver, wrong-type CCE, the `SettersWriter` primitive-null guard preserved on both branches, the `MetadataHolderProbe` method-ref AOT-safe, `builderDefaultSupplier` reorder observationally identical). **Mantra** clean (`final`, no inline FQNs, no external-org names). **Docs** verified accurate against the proven result.

## Note

The honest performance framing (for the README follow-up): native-image's win here is **instant startup + tiny footprint + AOT-clean codegen throughput**, not faster reflective mapping — the runtime path under AOT rides `MethodHandle.invokeExact` (a touch slower than JVM-warmed LMF, which is why LMF stays on the JVM). The headline is "runtime mapping that *survives* native-image," which the codegen-only competition can't write.
