### PR TITLE
fix(internal): native-image guard on the Hibernate-proxy LMF builders

### DIFF
--- a/core/src/main/java/io/github/eschizoid/telescope/Telescope.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/Telescope.java
@@ -139,9 +139,9 @@ public sealed class Telescope<
   // read/update hot path. Empty for a bare Telescope.of(...) or an iso-backed conversion.
   final List<OpticNode> trail;
 
-  // Package-private so that the conversion-builder classes (From, To, BeanTo, MapBuilder, Mapper,
-  // …) — extracted to sibling files in this same package to keep Telescope.java navigable — can
-  // construct Telescope instances without needing us to expose internals through the JPMS export.
+  // Package-private so that the conversion-builder classes (From, To, Mapper, …) — extracted to
+  // sibling files to keep Telescope.java navigable — can construct Telescope instances without
+  // needing us to expose internals through the JPMS export.
   Telescope(final Traversal<S, A> optic) {
     this(optic, RecordFieldOptics.INSTANCE, Function.identity(), null, List.of());
   }

--- a/internal/src/main/java/io/github/eschizoid/telescope/internal/Beans.java
+++ b/internal/src/main/java/io/github/eschizoid/telescope/internal/Beans.java
@@ -277,7 +277,11 @@ public final class Beans {
 
   @SuppressWarnings("unchecked")
   private static Function<Object, Object> buildHibernateLazyInitializerFn() {
-    if (HIBERNATE_PROXY == null) return null;
+    // In a native image, proxy unwrapping is off by contract (the one documented JVM/codegen-only
+    // accessor path). The guard also prevents a build-time-initialized LMF hidden class from being
+    // captured into the image heap when Hibernate is on the image classpath — these builders run at
+    // class init, which is build time under core's native-image.properties.
+    if (HIBERNATE_PROXY == null || NativeImage.IN_IMAGE) return null;
     try {
       final var method = HIBERNATE_PROXY.getMethod("getHibernateLazyInitializer");
       final var lookup = MethodHandles.lookup();
@@ -298,7 +302,8 @@ public final class Beans {
 
   @SuppressWarnings("unchecked")
   private static Function<Object, Class<?>> buildHibernatePersistentClassFn() {
-    if (HIBERNATE_PROXY == null) return null;
+    // Same native-image guard as buildHibernateLazyInitializerFn — see the comment there.
+    if (HIBERNATE_PROXY == null || NativeImage.IN_IMAGE) return null;
     try {
       final var lazyInitializer = Class.forName(
         "org.hibernate.proxy.LazyInitializer",


### PR DESCRIPTION
Found by a full-project architecture review: the two Hibernate-proxy accessor builders were the only runtime `LambdaMetafactory` sites without the `NativeImage.IN_IMAGE` branch (12 of 14 sites guarded). They run at class init — build time under core's `--initialize-at-build-time` metadata — so with Hibernate on a native-image classpath the LMF hidden-class instance gets baked into a static final and the image build fails on a heap-captured hidden class; the `catch(Throwable)` can't save it because `metafactory` succeeds on the builder JVM. Guarded both with `IN_IMAGE -> null`, which is the documented contract (Hibernate-proxy unwrapping = the one JVM/codegen-only accessor path under AOT). JVM behavior unchanged; internal+core tests green. Also sweeps two ghost `MapBuilder` references.