### PR TITLE
refactor(internal): one property-name derivation rule in pairing.PropertyNames

### DIFF
--- a/benchmarks/src/jmh/java/io/github/eschizoid/telescope/benchmarks/ContainerLoopSpikeBenchmark.java
+++ b/benchmarks/src/jmh/java/io/github/eschizoid/telescope/benchmarks/ContainerLoopSpikeBenchmark.java
@@ -9,14 +9,11 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
-import org.openjdk.jmh.annotations.Fork;
-import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
-import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.infra.Blackhole;
 
 /**
@@ -43,9 +40,6 @@ import org.openjdk.jmh.infra.Blackhole;
 @State(Scope.Thread)
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@Warmup(iterations = 5, time = 1)
-@Measurement(iterations = 5, time = 1)
-@Fork(2)
 public class ContainerLoopSpikeBenchmark {
 
   public record Src(String name, int headcount) {}

--- a/benchmarks/src/jmh/java/io/github/eschizoid/telescope/benchmarks/ContainerLoopSpikeBenchmark.java
+++ b/benchmarks/src/jmh/java/io/github/eschizoid/telescope/benchmarks/ContainerLoopSpikeBenchmark.java
@@ -20,27 +20,25 @@ import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.infra.Blackhole;
 
 /**
- * Decision-gate spike for the container-element lever: does mapping {@code List<Src> -> List<Dst>}
- * as a single {@link MethodHandles#iteratedLoop} over the raw {@code (Object)->Object} element
- * handle beat the current {@code liftList} path (a Java for-loop whose body dispatches {@code
- * Iso.to} -> {@code Function.apply} -> invokeExact per element)?
- *
- * <p>Fixture is the deep benchmark's inner hop: {@code List<Team>} of 3 elements, Team = {@code
- * (String name, int headcount)}, a record-to-record leaf. Four rows:
+ * REGRESSION GUARD (originally the decision spike for the container-element MethodHandle loop —
+ * that decision shipped: the runtime container path now loops the raw element handle, the shape the
+ * {@code mhIteratedLoop} / {@code fnLoop} rows model). The row names keep their original spike
+ * labels for continuity; read them for what they are today:
  *
  * <ul>
  *   <li>{@code handWritten} — Java for-loop, direct {@code new Dst(...)}. The MapStruct ceiling.
- *   <li>{@code liftListIso} — current path: a Java for-loop calling {@code elementIso.to(x)} where
- *       {@code elementIso} wraps the raw handle in {@code Iso.of}-shaped {@code (Object)->Object}
- *       Function (two virtual hops per element).
- *   <li>{@code mhIteratedLoop} — one {@code iteratedLoop} handle whose body invokes the raw element
- *       handle directly (invokeExact, no SAM hop), invoked once via invokeExact.
- *   <li>{@code fnLoop} — Java for-loop calling the raw element handle wrapped in a single {@code
- *       Function} (one virtual hop), to isolate the Iso.to layer from the Function.apply layer.
+ *   <li>{@code liftListIso} — the PRE-campaign shape (Iso.to -> Function.apply -> invokeExact, two
+ *       virtual hops per element), kept as the reference point the shipped path must stay below.
+ *   <li>{@code mhIteratedLoop} — one {@code iteratedLoop} handle invoking the raw element handle
+ *       directly; the shipped path's ceiling variant.
+ *   <li>{@code fnLoop} — the raw handle behind a single {@code Function} hop; closest model of the
+ *       shipped loop body.
  * </ul>
  *
- * <p>If {@code mhIteratedLoop} does not clear {@code liftListIso} by a real margin, the honest call
- * is that the runtime container path is at the dispatch floor and codegen owns the hot loop.
+ * <p>Fixture is the deep benchmark's inner hop: {@code List<Team>} of 3 elements, Team = {@code
+ * (String name, int headcount)}, a record-to-record leaf. The regression signal: {@code fnLoop} /
+ * {@code mhIteratedLoop} drifting up toward {@code liftListIso} means the shipped container loop
+ * regained a dispatch layer.
  */
 @State(Scope.Thread)
 @BenchmarkMode(Mode.AverageTime)

--- a/benchmarks/src/jmh/java/io/github/eschizoid/telescope/benchmarks/FromMapBenchmark.java
+++ b/benchmarks/src/jmh/java/io/github/eschizoid/telescope/benchmarks/FromMapBenchmark.java
@@ -27,7 +27,7 @@ import org.openjdk.jmh.annotations.State;
  * irreducible source-lookup cost that no binding strategy removes.
  *
  * <pre>{@code
- * ./gradlew :benchmarks:jmh -Pjmh.includes=FromMapBenchmark
+ * ./gradlew :benchmarks:jmh -Pjmh.includes=FromMapBenchmark -Pjmh.fork=3   # fork >= 3 for gating reads
  * }</pre>
  */
 @State(Scope.Benchmark)
@@ -131,5 +131,17 @@ public class FromMapBenchmark {
       0L,
       0
     );
+  }
+
+  /** The bean-side floor: same four source lookups, direct no-arg ctor + setters. */
+  @Benchmark
+  public PaymentBean handPositionalBean() {
+    final var amount = source.get("amountCents");
+    final var bean = new PaymentBean();
+    bean.setId(String.valueOf(source.get("id")));
+    bean.setCurrency(String.valueOf(source.get("currency")));
+    bean.setAmountCents(amount == null ? 0 : ((Number) amount).intValue());
+    bean.setReference(String.valueOf(source.get("reference")));
+    return bean;
   }
 }

--- a/benchmarks/src/jmh/java/io/github/eschizoid/telescope/benchmarks/FromMapBenchmark.java
+++ b/benchmarks/src/jmh/java/io/github/eschizoid/telescope/benchmarks/FromMapBenchmark.java
@@ -1,0 +1,135 @@
+package io.github.eschizoid.telescope.benchmarks;
+
+import static io.github.eschizoid.telescope.mapping.MapExtractStep.extract;
+
+import io.github.eschizoid.telescope.Telescope;
+import io.github.eschizoid.telescope.conversion.ForwardMapper;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+
+/**
+ * The gate benchmark for a positional {@code fromMap} bind: today's forward closure resolves each
+ * target component by name per call ({@code byField.get(name)}, the defaults probe, and the
+ * name-keyed {@code Records.construct} / bean-writer fill). A construction-time positional bind
+ * would remove the name-keyed hops and leave only the irreducible source {@code map.get(key)}s.
+ *
+ * <p>How to read it: {@code handPositionalRecord} is the floor (pre-resolved converters + direct
+ * constructor call — the shape a positional bind would compile down to). The gap between {@code
+ * fromMapRecord} and that floor is the available win; the gap between the floor and zero is the
+ * irreducible source-lookup cost that no binding strategy removes.
+ *
+ * <pre>{@code
+ * ./gradlew :benchmarks:jmh -Pjmh.includes=FromMapBenchmark
+ * }</pre>
+ */
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+public class FromMapBenchmark {
+
+  /** Six-component record: four extracted rows, two backfilled by JLS defaults. */
+  public record Payment(String id, String currency, int amountCents, String reference, long timestamp, int retries) {}
+
+  /** Bean sibling for the setter-writer fill path. */
+  public static final class PaymentBean {
+
+    private String id;
+    private String currency;
+    private int amountCents;
+    private String reference;
+
+    public PaymentBean() {}
+
+    public String getId() {
+      return id;
+    }
+
+    public void setId(final String id) {
+      this.id = id;
+    }
+
+    public String getCurrency() {
+      return currency;
+    }
+
+    public void setCurrency(final String currency) {
+      this.currency = currency;
+    }
+
+    public int getAmountCents() {
+      return amountCents;
+    }
+
+    public void setAmountCents(final int amountCents) {
+      this.amountCents = amountCents;
+    }
+
+    public String getReference() {
+      return reference;
+    }
+
+    public void setReference(final String reference) {
+      this.reference = reference;
+    }
+  }
+
+  private Map<String, Object> source;
+  private ForwardMapper<Map<String, Object>, Payment> recordMapper;
+  private ForwardMapper<Map<String, Object>, PaymentBean> beanMapper;
+
+  @Setup
+  public void setup() {
+    source = new HashMap<>();
+    source.put("id", "pay-42");
+    source.put("currency", "USD");
+    source.put("amountCents", 1999);
+    source.put("reference", "inv-7");
+
+    recordMapper = Telescope.fromMap(
+      Payment.class,
+      extract("id", Payment::id, Object::toString),
+      extract("currency", Payment::currency, Object::toString),
+      extract("amountCents", Payment::amountCents, v -> v == null ? 0 : ((Number) v).intValue()),
+      extract("reference", Payment::reference, Object::toString)
+    );
+    beanMapper = Telescope.fromMap(
+      PaymentBean.class,
+      extract("id", PaymentBean::getId, Object::toString),
+      extract("currency", PaymentBean::getCurrency, Object::toString),
+      extract("amountCents", PaymentBean::getAmountCents, v -> v == null ? 0 : ((Number) v).intValue()),
+      extract("reference", PaymentBean::getReference, Object::toString)
+    );
+  }
+
+  @Benchmark
+  public Payment fromMapRecord() {
+    return recordMapper.forward(source);
+  }
+
+  @Benchmark
+  public PaymentBean fromMapBean() {
+    return beanMapper.forward(source);
+  }
+
+  /** The positional floor: the same four source lookups, converters inlined, direct ctor. */
+  @Benchmark
+  public Payment handPositionalRecord() {
+    final var amount = source.get("amountCents");
+    return new Payment(
+      String.valueOf(source.get("id")),
+      String.valueOf(source.get("currency")),
+      amount == null ? 0 : ((Number) amount).intValue(),
+      String.valueOf(source.get("reference")),
+      0L,
+      0
+    );
+  }
+}

--- a/benchmarks/src/jmh/java/io/github/eschizoid/telescope/benchmarks/MapperConstructionBenchmark.java
+++ b/benchmarks/src/jmh/java/io/github/eschizoid/telescope/benchmarks/MapperConstructionBenchmark.java
@@ -1,0 +1,45 @@
+package io.github.eschizoid.telescope.benchmarks;
+
+import io.github.eschizoid.telescope.Telescope;
+import io.github.eschizoid.telescope.conversion.Mapper;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+
+/**
+ * Measures what every other conversion benchmark hides in {@code @Setup}: the cost of BUILDING a
+ * mapper. {@code Telescope.mapper(A, B)} walks the pair tree, runs pairing decisions, and composes
+ * the MethodHandle conversion leaf per type pair — and the per-call {@code TypePair → Iso} cache is
+ * local to one factory invocation, so a caller constructing in a request path pays all of it every
+ * time.
+ *
+ * <p>Two shapes: the flat 5-field pair and the deep 3-level container tree (the same domains the
+ * MapStruct comparison uses). Read the number against the forward call it amortizes — a
+ * construction cost of N µs versus a ~tens-of-ns forward means the break-even is N×30-ish calls,
+ * which is the "build once, hold it in a static" guidance quantified. This benchmark is a
+ * measurement, not a target: whether to memoize sub-Isos globally is a separate decision that
+ * starts from these numbers.
+ *
+ * <pre>{@code
+ * ./gradlew :benchmarks:jmh -Pjmh.includes=MapperConstructionBenchmark
+ * }</pre>
+ */
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+public class MapperConstructionBenchmark {
+
+  @Benchmark
+  public Mapper<McFlatRec, McFlatBean> constructFlat() {
+    return Telescope.mapper(McFlatRec.class, McFlatBean.class);
+  }
+
+  @Benchmark
+  public Mapper<McCompanyRec, McCompanyBean> constructDeep() {
+    return Telescope.mapper(McCompanyRec.class, McCompanyBean.class);
+  }
+}

--- a/benchmarks/src/jmh/java/io/github/eschizoid/telescope/benchmarks/MapperConstructionBenchmark.java
+++ b/benchmarks/src/jmh/java/io/github/eschizoid/telescope/benchmarks/MapperConstructionBenchmark.java
@@ -18,19 +18,19 @@ import org.openjdk.jmh.annotations.State;
  * time.
  *
  * <p>Two shapes: the flat 5-field pair and the deep 3-level container tree (the same domains the
- * MapStruct comparison uses). Read the number against the forward call it amortizes — a
- * construction cost of N µs versus a ~tens-of-ns forward means the break-even is N×30-ish calls,
- * which is the "build once, hold it in a static" guidance quantified. This benchmark is a
- * measurement, not a target: whether to memoize sub-Isos globally is a separate decision that
- * starts from these numbers.
+ * MapStruct comparison uses). The harness reports ns/op; expect microsecond-to-millisecond scale.
+ * Read the number against the forward call it amortizes — a construction cost of N µs versus a
+ * ~tens-of-ns forward means the break-even is N×30-ish calls, which is the "build once, hold it in
+ * a static" guidance quantified. This benchmark is a measurement, not a target: whether to memoize
+ * sub-Isos globally is a separate decision that starts from these numbers.
  *
  * <pre>{@code
- * ./gradlew :benchmarks:jmh -Pjmh.includes=MapperConstructionBenchmark
+ * ./gradlew :benchmarks:jmh -Pjmh.includes=MapperConstructionBenchmark -Pjmh.fork=3   # fork >= 3 for gating reads
  * }</pre>
  */
 @State(Scope.Benchmark)
 @BenchmarkMode(Mode.AverageTime)
-@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
 public class MapperConstructionBenchmark {
 
   @Benchmark

--- a/benchmarks/src/jmh/java/io/github/eschizoid/telescope/benchmarks/MatchDispatchBenchmark.java
+++ b/benchmarks/src/jmh/java/io/github/eschizoid/telescope/benchmarks/MatchDispatchBenchmark.java
@@ -22,7 +22,7 @@ import org.openjdk.jmh.infra.Blackhole;
  * sides. Read the ratio, not the absolutes.
  *
  * <pre>{@code
- * ./gradlew :benchmarks:jmh -Pjmh.includes=MatchDispatchBenchmark
+ * ./gradlew :benchmarks:jmh -Pjmh.includes=MatchDispatchBenchmark -Pjmh.fork=3   # fork >= 3 for gating reads
  * }</pre>
  */
 @State(Scope.Benchmark)

--- a/benchmarks/src/jmh/java/io/github/eschizoid/telescope/benchmarks/MatchDispatchBenchmark.java
+++ b/benchmarks/src/jmh/java/io/github/eschizoid/telescope/benchmarks/MatchDispatchBenchmark.java
@@ -1,0 +1,78 @@
+package io.github.eschizoid.telescope.benchmarks;
+
+import io.github.eschizoid.telescope.conversion.Match;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.infra.Blackhole;
+
+/**
+ * Positioning benchmark for {@code Match} sealed dispatch: the natural baseline is free — a Java
+ * pattern-matching {@code switch} over the same sealed hierarchy. {@code Match} buys build-time
+ * exhaustiveness verification and a first-class dispatch value; this measures what that costs per
+ * call so the docs can say honestly where it belongs (a wiring/ergonomics API, or fine in a loop).
+ *
+ * <p>The mixed-instance array forces a megamorphic call site — the realistic worst case for both
+ * sides. Read the ratio, not the absolutes.
+ *
+ * <pre>{@code
+ * ./gradlew :benchmarks:jmh -Pjmh.includes=MatchDispatchBenchmark
+ * }</pre>
+ */
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+public class MatchDispatchBenchmark {
+
+  public sealed interface Shape permits Circle, Square, Triangle {}
+
+  public record Circle(double radius) implements Shape {}
+
+  public record Square(double side) implements Shape {}
+
+  public record Triangle(double base, double height) implements Shape {}
+
+  private Shape[] shapes;
+  private Function<Shape, Double> match;
+
+  @Setup
+  public void setup() {
+    shapes = new Shape[96];
+    for (var i = 0; i < shapes.length; i += 3) {
+      shapes[i] = new Circle(i + 1.0);
+      shapes[i + 1] = new Square(i + 2.0);
+      shapes[i + 2] = new Triangle(i + 3.0, 2.0);
+    }
+    match = Match.<Shape, Double>of(Shape.class)
+      .when(Circle.class, c -> c.radius() * c.radius() * Math.PI)
+      .when(Square.class, s -> s.side() * s.side())
+      .when(Triangle.class, t -> (t.base() * t.height()) / 2.0)
+      .exhaustive();
+  }
+
+  @Benchmark
+  public void matchDispatch(final Blackhole bh) {
+    for (final var s : shapes) {
+      bh.consume(match.apply(s));
+    }
+  }
+
+  /** The free baseline: a pattern-matching switch over the same permits. */
+  @Benchmark
+  public void switchDispatch(final Blackhole bh) {
+    for (final var s : shapes) {
+      final double area = switch (s) {
+        case Circle c -> c.radius() * c.radius() * Math.PI;
+        case Square sq -> sq.side() * sq.side();
+        case Triangle t -> (t.base() * t.height()) / 2.0;
+      };
+      bh.consume(area);
+    }
+  }
+}

--- a/benchmarks/src/jmh/java/io/github/eschizoid/telescope/benchmarks/MergeBenchmark.java
+++ b/benchmarks/src/jmh/java/io/github/eschizoid/telescope/benchmarks/MergeBenchmark.java
@@ -26,7 +26,7 @@ import org.openjdk.jmh.annotations.State;
  * construct cost a positional bind would target.
  *
  * <pre>{@code
- * ./gradlew :benchmarks:jmh -Pjmh.includes=MergeBenchmark
+ * ./gradlew :benchmarks:jmh -Pjmh.includes=MergeBenchmark -Pjmh.fork=3   # fork >= 3 for gating reads
  * }</pre>
  */
 @State(Scope.Benchmark)

--- a/benchmarks/src/jmh/java/io/github/eschizoid/telescope/benchmarks/MergeBenchmark.java
+++ b/benchmarks/src/jmh/java/io/github/eschizoid/telescope/benchmarks/MergeBenchmark.java
@@ -1,0 +1,89 @@
+package io.github.eschizoid.telescope.benchmarks;
+
+import static io.github.eschizoid.telescope.mapping.MergeStep.auto;
+import static io.github.eschizoid.telescope.mapping.MergeStep.from;
+
+import io.github.eschizoid.telescope.Sources;
+import io.github.eschizoid.telescope.Telescope;
+import io.github.eschizoid.telescope.conversion.Mapper;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+
+/**
+ * The gate benchmark for build-time binding in {@code Telescope.merge}: today's forward path stages
+ * every field through a per-call {@code HashMap}, and {@code auto()}-matched fields additionally
+ * pay a per-call name→reader resolution that explicit {@code from(...)} rows already avoid.
+ *
+ * <p>How to read it: the {@code explicitRows} vs {@code autoRows} split isolates the auto-row
+ * resolution tax; {@code handMerge} is the floor (two direct reads per source, one constructor
+ * call). The gap between {@code explicitRows} and the floor is the staging-map + name-keyed
+ * construct cost a positional bind would target.
+ *
+ * <pre>{@code
+ * ./gradlew :benchmarks:jmh -Pjmh.includes=MergeBenchmark
+ * }</pre>
+ */
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+public class MergeBenchmark {
+
+  public record Customer(String id, String email, String name) {}
+
+  public record Audit(String createdBy, long createdAt, String region) {}
+
+  public record Profile(String id, String email, String name, String createdBy, long createdAt, String region) {}
+
+  private Sources sources;
+  private Mapper<Sources, Profile> explicitMerge;
+  private Mapper<Sources, Profile> autoMerge;
+  private Customer customer;
+  private Audit audit;
+
+  @Setup
+  public void setup() {
+    customer = new Customer("c-1", "a@acme.com", "Ada");
+    audit = new Audit("system", 1_700_000_000L, "emea");
+    sources = Sources.of(customer, audit);
+
+    explicitMerge = Telescope.merge(
+      Profile.class,
+      from(Customer::id, Profile::id),
+      from(Customer::email, Profile::email),
+      from(Customer::name, Profile::name),
+      from(Audit::createdBy, Profile::createdBy),
+      from(Audit::createdAt, Profile::createdAt),
+      from(Audit::region, Profile::region)
+    );
+    autoMerge = Telescope.merge(Profile.class, auto(Customer.class), auto(Audit.class));
+  }
+
+  @Benchmark
+  public Profile explicitRows() {
+    return explicitMerge.forward(sources);
+  }
+
+  @Benchmark
+  public Profile autoRows() {
+    return autoMerge.forward(sources);
+  }
+
+  /** The floor: direct reads, one constructor call, no staging map. */
+  @Benchmark
+  public Profile handMerge() {
+    return new Profile(
+      customer.id(),
+      customer.email(),
+      customer.name(),
+      audit.createdBy(),
+      audit.createdAt(),
+      audit.region()
+    );
+  }
+}

--- a/benchmarks/src/jmh/java/io/github/eschizoid/telescope/benchmarks/MethodHandleChainSpikeBenchmark.java
+++ b/benchmarks/src/jmh/java/io/github/eschizoid/telescope/benchmarks/MethodHandleChainSpikeBenchmark.java
@@ -17,27 +17,22 @@ import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.infra.Blackhole;
 
 /**
- * SPIKE (not a permanent benchmark): does a MethodHandle-combinator-composed {@code (Src) -> Dst}
- * forward — no {@code Object[]} intermediate, no boxing for primitive fields — beat the current
- * array-based reflective {@code Telescope.mapper(...).forward(...)} path, and how close does it get
- * to a hand-written constructor call (the MapStruct-equivalent unboxed ceiling)?
- *
- * <p>The fixture is a flat 5-field record pair with mixed primitives + a reference type, so boxing
- * is actually exercised. Three paths convert the SAME {@code Src} to a {@code Dst}:
+ * REGRESSION GUARD (originally the decision spike for the MethodHandle-combinator conversion leaf —
+ * that decision shipped, and {@code Telescope.mapper(...)} now IS the MH-chain path). The three
+ * rows keep their original names for continuity, but read them for what they are today:
  *
  * <ul>
  *   <li>{@code handWritten} — direct {@code new Dst(src.a(), ...)}; the unboxed ceiling.
- *   <li>{@code mhChain} — {@code filterArguments}(raw primitive accessors into raw ctor) {@code ->
- *       permuteArguments -> } one {@code (Src) -> Dst} handle, {@code invokeExact} through a {@code
- *       final} field. No array, no boxing.
- *   <li>{@code currentMapper} — {@code Telescope.mapper(...).forward(...)}; the {@code Object[]} +
- *       boxing baseline.
+ *   <li>{@code mhChain} — a hand-composed {@code filterArguments -> permuteArguments} handle
+ *       invoked through a {@code final} field; the shape the shipped leaf compiles down to.
+ *   <li>{@code currentMapper} — {@code Telescope.mapper(...).forward(...)}; since the leaf shipped
+ *       this rides the same MH chain plus the mapper's wrapper dispatch, so it should track {@code
+ *       mhChain} closely. A widening gap between the two rows is the regression signal — it means
+ *       the shipped mapper stopped compiling down to the composed handle.
  * </ul>
  *
- * <p>If {@code mhChain} lands near {@code handWritten} and well below {@code currentMapper}, the
- * lattice-legal structural win (a MH-combinator leaf {@code Iso}) is real. If {@code mhChain}
- * tracks {@code currentMapper}, the runtime floor is confirmed and hot loops belong on
- * {@code @Bridge}.
+ * <p>The fixture is a flat 5-field record pair with mixed primitives + a reference type, so boxing
+ * would show if it ever crept back in.
  */
 @State(Scope.Benchmark)
 @BenchmarkMode(Mode.AverageTime)

--- a/benchmarks/src/jmh/java/io/github/eschizoid/telescope/benchmarks/MultiEditBenchmark.java
+++ b/benchmarks/src/jmh/java/io/github/eschizoid/telescope/benchmarks/MultiEditBenchmark.java
@@ -1,0 +1,134 @@
+package io.github.eschizoid.telescope.benchmarks;
+
+import static io.github.eschizoid.telescope.Edit.over;
+
+import io.github.eschizoid.telescope.Telescope;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+
+/**
+ * The decision benchmark for multi-edit spine fusion: {@code Telescope.all(over(...), ...)} runs
+ * one full structural pass per edit today, so k edits pay k rebuilds of the same spine. This
+ * measures what that N-pass tax actually is, against a hand-fused single rebuild as the floor.
+ *
+ * <p>How to read it: if {@code allFlat4Edits} sits near 4× {@code allFlat1Edit} while {@code
+ * handFusedFlat4} sits near 1×, the redundancy is real and a lattice-level fusion (the {@code
+ * Traversal#structure()} extension) has that headroom. If the per-edit increment is small next to
+ * fixed dispatch overhead, fusion is not worth building — that verdict is the point.
+ *
+ * <p>The tree rows repeat the question where it costs most: k edits under a shared {@code
+ * .each(...)} prefix over a 100-element list rebuild the whole container k times.
+ *
+ * <pre>{@code
+ * ./gradlew :benchmarks:jmh -Pjmh.includes=MultiEditBenchmark
+ * }</pre>
+ */
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+public class MultiEditBenchmark {
+
+  /** Flat six-field record — the disjoint-lens fusion case. */
+  public record Flat(String a, String b, String c, String d, int e, int f) {}
+
+  /** One user leaf for the tree case. */
+  public record User(String name, String email, int age) {}
+
+  /** The shared-prefix container the tree edits fan over. */
+  public record Org(String title, List<User> users) {}
+
+  private Flat flat;
+  private Org org;
+
+  private Telescope<Flat, Flat> flat1;
+  private Telescope<Flat, Flat> flat2;
+  private Telescope<Flat, Flat> flat4;
+  private Telescope<Org, Org> tree1;
+  private Telescope<Org, Org> tree3;
+
+  @Setup
+  public void setup() {
+    flat = new Flat("Alpha", "Beta", "Gamma", "Delta", 41, 7);
+    final var users = new ArrayList<User>(100);
+    for (var i = 0; i < 100; i++) {
+      users.add(new User(" Name" + i + " ", "USER" + i + "@ACME.COM", i));
+    }
+    org = new Org("org", List.copyOf(users));
+
+    final var fa = Telescope.of(Flat.class).field(Flat::a);
+    final var fb = Telescope.of(Flat.class).field(Flat::b);
+    final var fc = Telescope.of(Flat.class).field(Flat::c);
+    final var fd = Telescope.of(Flat.class).field(Flat::d);
+    flat1 = Telescope.all(over(fa, String::toLowerCase));
+    flat2 = Telescope.all(over(fa, String::toLowerCase), over(fb, String::trim));
+    flat4 = Telescope.all(
+      over(fa, String::toLowerCase),
+      over(fb, String::trim),
+      over(fc, String::toUpperCase),
+      over(fd, String::strip)
+    );
+
+    final var emails = Telescope.of(Org.class).each(Org::users).field(User::email);
+    final var names = Telescope.of(Org.class).each(Org::users).field(User::name);
+    final var ages = Telescope.of(Org.class).each(Org::users).field(User::age);
+    tree1 = Telescope.all(over(emails, String::toLowerCase));
+    tree3 = Telescope.all(over(emails, String::toLowerCase), over(names, String::trim), over(ages, a -> a + 1));
+  }
+
+  @Benchmark
+  public Flat allFlat1Edit() {
+    return flat1.apply(flat);
+  }
+
+  @Benchmark
+  public Flat allFlat2Edits() {
+    return flat2.apply(flat);
+  }
+
+  @Benchmark
+  public Flat allFlat4Edits() {
+    return flat4.apply(flat);
+  }
+
+  /** The fusion floor: all four flat edits in one constructor call. */
+  @Benchmark
+  public Flat handFusedFlat4() {
+    return new Flat(
+      flat.a().toLowerCase(),
+      flat.b().trim(),
+      flat.c().toUpperCase(),
+      flat.d().strip(),
+      flat.e(),
+      flat.f()
+    );
+  }
+
+  @Benchmark
+  public Org allTree1Edit() {
+    return tree1.apply(org);
+  }
+
+  @Benchmark
+  public Org allTree3Edits() {
+    return tree3.apply(org);
+  }
+
+  /** The tree fusion floor: one pass over the container, all three leaf edits per element. */
+  @Benchmark
+  public Org handFusedTree3() {
+    final var users = org.users();
+    final var out = new ArrayList<User>(users.size());
+    for (final var u : users) {
+      out.add(new User(u.name().trim(), u.email().toLowerCase(), u.age() + 1));
+    }
+    return new Org(org.title(), List.copyOf(out));
+  }
+}

--- a/benchmarks/src/jmh/java/io/github/eschizoid/telescope/benchmarks/MultiEditBenchmark.java
+++ b/benchmarks/src/jmh/java/io/github/eschizoid/telescope/benchmarks/MultiEditBenchmark.java
@@ -4,6 +4,7 @@ import static io.github.eschizoid.telescope.Edit.over;
 
 import io.github.eschizoid.telescope.Telescope;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -28,7 +29,7 @@ import org.openjdk.jmh.annotations.State;
  * .each(...)} prefix over a 100-element list rebuild the whole container k times.
  *
  * <pre>{@code
- * ./gradlew :benchmarks:jmh -Pjmh.includes=MultiEditBenchmark
+ * ./gradlew :benchmarks:jmh -Pjmh.includes=MultiEditBenchmark -Pjmh.fork=3   # fork >= 3 for gating reads
  * }</pre>
  */
 @State(Scope.Benchmark)
@@ -121,7 +122,10 @@ public class MultiEditBenchmark {
     return tree3.apply(org);
   }
 
-  /** The tree fusion floor: one pass over the container, all three leaf edits per element. */
+  /**
+   * The tree fusion floor: one pass over the container, all three leaf edits per element. The
+   * rebuilt list is wrapped, not copied — matching the traversal's own rebuild shape.
+   */
   @Benchmark
   public Org handFusedTree3() {
     final var users = org.users();
@@ -129,6 +133,6 @@ public class MultiEditBenchmark {
     for (final var u : users) {
       out.add(new User(u.name().trim(), u.email().toLowerCase(), u.age() + 1));
     }
-    return new Org(org.title(), List.copyOf(out));
+    return new Org(org.title(), Collections.unmodifiableList(out));
   }
 }

--- a/benchmarks/src/jmh/java/io/github/eschizoid/telescope/benchmarks/ReadFoldBenchmark.java
+++ b/benchmarks/src/jmh/java/io/github/eschizoid/telescope/benchmarks/ReadFoldBenchmark.java
@@ -24,7 +24,7 @@ import org.openjdk.jmh.annotations.State;
  * existsMiss}, the fold materializes everything before answering, which is its own finding.
  *
  * <pre>{@code
- * ./gradlew :benchmarks:jmh -Pjmh.includes=ReadFoldBenchmark
+ * ./gradlew :benchmarks:jmh -Pjmh.includes=ReadFoldBenchmark -Pjmh.fork=3   # fork >= 3 for gating reads
  * }</pre>
  */
 @State(Scope.Benchmark)
@@ -81,21 +81,43 @@ public class ReadFoldBenchmark {
     return missEmails.exists(org);
   }
 
-  /** The loop floor for toList. */
+  /**
+   * The loop floor for toList: default capacity (a generic fold can't pre-size a flatMapped path)
+   * and a terminal copy to match the unmodifiable contract {@code Stream.toList()} pays.
+   */
   @Benchmark
   public List<String> toListHand() {
-    final var out = new ArrayList<String>(100);
+    final var out = new ArrayList<String>();
     for (final var team : org.teams()) {
       for (final var user : team.users()) {
         out.add(user.email());
       }
     }
-    return out;
+    return List.copyOf(out);
   }
 
-  /** The loop floor for count. */
+  /**
+   * The achievable loop floor for count: visits every leaf and applies the leaf read, which is what
+   * a generic push-based fold must also do — it cannot know the final hop is a total lens.
+   */
   @Benchmark
   public long countHand() {
+    var n = 0L;
+    for (final var team : org.teams()) {
+      for (final var user : team.users()) {
+        if (user.email() != null) n++;
+      }
+    }
+    return n;
+  }
+
+  /**
+   * The cardinality-exploiting ceiling: sums container sizes without visiting elements. No generic
+   * fold reaches this — it is a separate candidate (a count that short-circuits total-lens tails),
+   * kept as its own row so the gate never reads phantom headroom.
+   */
+  @Benchmark
+  public long countAbsoluteFloor() {
     var n = 0L;
     for (final var team : org.teams()) {
       n += team.users().size();

--- a/benchmarks/src/jmh/java/io/github/eschizoid/telescope/benchmarks/ReadFoldBenchmark.java
+++ b/benchmarks/src/jmh/java/io/github/eschizoid/telescope/benchmarks/ReadFoldBenchmark.java
@@ -1,0 +1,116 @@
+package io.github.eschizoid.telescope.benchmarks;
+
+import io.github.eschizoid.telescope.Telescope;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+
+/**
+ * The gate benchmark for a push-based read fold: multi-focus read terminals ({@code toList}, {@code
+ * count}, {@code exists}) currently ride the {@code Traversal.then} {@code
+ * getAll(...).flatMap(...)} Stream pipeline — one single-element Stream per element per lens hop —
+ * while the write side was converted to plain loops. The hand rows are the loop floor the proposed
+ * {@code Fold#forEach} rewrite would target.
+ *
+ * <p>How to read it: the telescope-vs-hand ratio per terminal is the available win. {@code
+ * existsEarlyHit} additionally probes short-circuiting — if it costs the same as {@code
+ * existsMiss}, the fold materializes everything before answering, which is its own finding.
+ *
+ * <pre>{@code
+ * ./gradlew :benchmarks:jmh -Pjmh.includes=ReadFoldBenchmark
+ * }</pre>
+ */
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+public class ReadFoldBenchmark {
+
+  public record User(String name, String email) {}
+
+  public record Team(String name, List<User> users) {}
+
+  public record Org(String name, List<Team> teams) {}
+
+  private Org org;
+  private Telescope<Org, String> emails;
+  private Telescope<Org, String> hitEmails;
+  private Telescope<Org, String> missEmails;
+
+  @Setup
+  public void setup() {
+    final var teams = new ArrayList<Team>(10);
+    for (var t = 0; t < 10; t++) {
+      final var users = new ArrayList<User>(10);
+      for (var u = 0; u < 10; u++) {
+        // The very first email carries the early-hit marker; nothing else matches "@first".
+        final var marker = (t == 0 && u == 0) ? "hit@first" : "u" + t + "x" + u + "@acme.com";
+        users.add(new User("user" + t + "-" + u, marker));
+      }
+      teams.add(new Team("team" + t, List.copyOf(users)));
+    }
+    org = new Org("org", List.copyOf(teams));
+    emails = Telescope.of(Org.class).each(Org::teams).each(Team::users).field(User::email);
+    hitEmails = emails.filter(e -> e.startsWith("hit@"));
+    missEmails = emails.filter(e -> e.startsWith("zz@"));
+  }
+
+  @Benchmark
+  public List<String> toListTelescope() {
+    return emails.toList(org);
+  }
+
+  @Benchmark
+  public long countTelescope() {
+    return emails.count(org);
+  }
+
+  @Benchmark
+  public boolean existsEarlyHit() {
+    return hitEmails.exists(org);
+  }
+
+  @Benchmark
+  public boolean existsMiss() {
+    return missEmails.exists(org);
+  }
+
+  /** The loop floor for toList. */
+  @Benchmark
+  public List<String> toListHand() {
+    final var out = new ArrayList<String>(100);
+    for (final var team : org.teams()) {
+      for (final var user : team.users()) {
+        out.add(user.email());
+      }
+    }
+    return out;
+  }
+
+  /** The loop floor for count. */
+  @Benchmark
+  public long countHand() {
+    var n = 0L;
+    for (final var team : org.teams()) {
+      n += team.users().size();
+    }
+    return n;
+  }
+
+  /** The loop floor for the early-hit exists. */
+  @Benchmark
+  public boolean existsHandEarlyHit() {
+    for (final var team : org.teams()) {
+      for (final var user : team.users()) {
+        if (user.email().startsWith("hit@")) return true;
+      }
+    }
+    return false;
+  }
+}

--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/AbstractTelescopeProcessor.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/AbstractTelescopeProcessor.java
@@ -1,5 +1,6 @@
 package io.github.eschizoid.telescope.codegen;
 
+import io.github.eschizoid.telescope.internal.pairing.PropertyNames;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.ArrayList;
@@ -148,12 +149,6 @@ public abstract class AbstractTelescopeProcessor extends AbstractProcessor {
 
   protected static String capitalize(final String s) {
     return s.isEmpty() ? s : Character.toUpperCase(s.charAt(0)) + s.substring(1);
-  }
-
-  protected static String decapitalize(final String s) {
-    if (s.isEmpty()) return s;
-    if (s.length() > 1 && Character.isUpperCase(s.charAt(0)) && Character.isUpperCase(s.charAt(1))) return s;
-    return Character.toLowerCase(s.charAt(0)) + s.substring(1);
   }
 
   /**
@@ -1287,15 +1282,16 @@ public abstract class AbstractTelescopeProcessor extends AbstractProcessor {
         continue;
       }
       final var name = m.getSimpleName().toString();
+      final var afterGet = PropertyNames.afterGet(name);
+      final var afterIs = PropertyNames.afterIs(name);
       final String prop;
-      if (name.length() > 3 && name.startsWith("get")) {
-        prop = decapitalize(name.substring(3));
+      if (afterGet != null) {
+        prop = afterGet;
       } else if (
-        name.length() > 2 &&
-        name.startsWith("is") &&
+        afterIs != null &&
         (m.getReturnType().getKind() == TypeKind.BOOLEAN || "java.lang.Boolean".equals(m.getReturnType().toString()))
       ) {
-        prop = decapitalize(name.substring(2));
+        prop = afterIs;
       } else {
         continue;
       }

--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/MapperVerifierProcessor.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/MapperVerifierProcessor.java
@@ -15,6 +15,7 @@ import io.github.eschizoid.telescope.annotations.UncheckedMapping;
 import io.github.eschizoid.telescope.internal.pairing.PairDecision;
 import io.github.eschizoid.telescope.internal.pairing.PairingMessages;
 import io.github.eschizoid.telescope.internal.pairing.PairingRules;
+import io.github.eschizoid.telescope.internal.pairing.PropertyNames;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.HashSet;
@@ -598,11 +599,13 @@ public final class MapperVerifierProcessor extends AbstractProcessor {
         if (moduleName.startsWith("java.") || moduleName.startsWith("jdk.")) continue;
       }
       final var rawName = method.getSimpleName().toString();
+      final var afterGet = PropertyNames.afterGet(rawName);
+      final var afterIs = PropertyNames.afterIs(rawName);
       final String prop;
-      if (rawName.length() > 3 && rawName.startsWith("get") && method.getReturnType().getKind() != TypeKind.VOID) {
-        prop = decapitalize(rawName.substring(3));
-      } else if (rawName.length() > 2 && rawName.startsWith("is") && booleanReturn(method)) {
-        prop = decapitalize(rawName.substring(2));
+      if (afterGet != null && method.getReturnType().getKind() != TypeKind.VOID) {
+        prop = afterGet;
+      } else if (afterIs != null && booleanReturn(method)) {
+        prop = afterIs;
       } else {
         continue;
       }
@@ -627,14 +630,6 @@ public final class MapperVerifierProcessor extends AbstractProcessor {
    * through unchanged.
    */
   private static String normalize(final String raw) {
-    if (raw.length() > 3 && raw.startsWith("get")) return decapitalize(raw.substring(3));
-    if (raw.length() > 2 && raw.startsWith("is")) return decapitalize(raw.substring(2));
-    return raw;
-  }
-
-  private static String decapitalize(final String s) {
-    if (s.isEmpty()) return s;
-    if (s.length() > 1 && Character.isUpperCase(s.charAt(0)) && Character.isUpperCase(s.charAt(1))) return s;
-    return Character.toLowerCase(s.charAt(0)) + s.substring(1);
+    return PropertyNames.property(raw);
   }
 }

--- a/core/src/main/java/io/github/eschizoid/telescope/Telescope.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/Telescope.java
@@ -22,6 +22,7 @@ import io.github.eschizoid.telescope.internal.optics.Lens;
 import io.github.eschizoid.telescope.internal.optics.Prism;
 import io.github.eschizoid.telescope.internal.optics.Traversal;
 import io.github.eschizoid.telescope.internal.optics.collections.Traversals;
+import io.github.eschizoid.telescope.internal.pairing.PropertyNames;
 import io.github.eschizoid.telescope.introspection.OpticNode;
 import io.github.eschizoid.telescope.introspection.OpticReport;
 import io.github.eschizoid.telescope.introspection.Trace;
@@ -2011,21 +2012,7 @@ public sealed class Telescope<
   private static String fieldNameOf(final Accessor<?, ?> getter) {
     final var raw = LambdaIntrospection.methodNameOf(getter);
     if (LambdaIntrospection.implClassOf(getter).isRecord()) return raw;
-    if (raw.length() > 3 && raw.startsWith("get") && Character.isUpperCase(raw.charAt(3))) return beanDecapitalize(
-      raw.substring(3)
-    );
-    if (raw.length() > 2 && raw.startsWith("is") && Character.isUpperCase(raw.charAt(2))) return beanDecapitalize(
-      raw.substring(2)
-    );
-    return raw;
-  }
-
-  // JavaBeans Introspector.decapitalize: an acronym whose first two chars are both uppercase (e.g.
-  // "URL") is left as-is; otherwise the first char is lowercased. Mirrors the codegen processor's
-  // property-name derivation so a runtime bean node's name agrees with the generated one.
-  private static String beanDecapitalize(final String s) {
-    if (s.length() > 1 && Character.isUpperCase(s.charAt(0)) && Character.isUpperCase(s.charAt(1))) return s;
-    return Character.toLowerCase(s.charAt(0)) + s.substring(1);
+    return PropertyNames.property(raw);
   }
 
   static <A> Class<A> implClassOf(final Serializable lambda) {

--- a/internal/src/main/java/io/github/eschizoid/telescope/internal/Beans.java
+++ b/internal/src/main/java/io/github/eschizoid/telescope/internal/Beans.java
@@ -32,19 +32,19 @@ import java.util.function.Supplier;
  *
  * <p><b>Read direction (POJO &rarr; record/Map).</b> Getters are discovered by convention — a
  * no-arg {@code getX()} with a non-void return, or {@code isX()} returning {@code boolean}/ {@code
- * Boolean} — and {@code X} is {@link #decapitalize(String) decapitalized} to a property name. This
- * deliberately avoids {@code java.beans.Introspector} so the library keeps zero dependencies
- * ({@code Introspector} lives in the {@code java.desktop} module). The discovered getter map is
- * cached per class via {@link ClassValue}. Alongside the {@link Method} cache, a sibling {@link
- * ClassValue} caches one {@link Function Function&lt;Object, Object&gt;} per property, built once
- * via {@link LambdaMetafactory} from the resolved accessor — the metafactory synthesizes a {@link
- * Function}-implementing class whose {@code apply(Object)} directly calls the getter and auto-boxes
- * any primitive return, so the hot path never touches {@link Method#invoke}. The lattice-primitive
- * read for one property is {@link #getter(Class, String)} — a {@link Getter Getter&lt;P,
- * Object&gt;} whose body delegates to the cached {@link Function} and allocates a fresh capturing
- * lambda per call (the lattice-shape entry for composing the read with other optics). {@link
- * #readProperty} is the hot-path shortcut that calls the cached {@link Function} directly, skipping
- * the per-call lambda allocation — preferred from inner loops (e.g. {@code
+ * Boolean} — and {@code X} is decapitalized to a property name by the shared {@code PropertyNames}
+ * rule. This deliberately avoids {@code java.beans.Introspector} so the library keeps zero
+ * dependencies ({@code Introspector} lives in the {@code java.desktop} module). The discovered
+ * getter map is cached per class via {@link ClassValue}. Alongside the {@link Method} cache, a
+ * sibling {@link ClassValue} caches one {@link Function Function&lt;Object, Object&gt;} per
+ * property, built once via {@link LambdaMetafactory} from the resolved accessor — the metafactory
+ * synthesizes a {@link Function}-implementing class whose {@code apply(Object)} directly calls the
+ * getter and auto-boxes any primitive return, so the hot path never touches {@link Method#invoke}.
+ * The lattice-primitive read for one property is {@link #getter(Class, String)} — a {@link Getter
+ * Getter&lt;P, Object&gt;} whose body delegates to the cached {@link Function} and allocates a
+ * fresh capturing lambda per call (the lattice-shape entry for composing the read with other
+ * optics). {@link #readProperty} is the hot-path shortcut that calls the cached {@link Function}
+ * directly, skipping the per-call lambda allocation — preferred from inner loops (e.g. {@code
  * Reflective.structuralIso(...).from(...)} reads every property of a target).
  *
  * <p><b>Write direction (Map/record &rarr; POJO).</b> Four strategies behind the sealed {@link

--- a/internal/src/main/java/io/github/eschizoid/telescope/internal/Beans.java
+++ b/internal/src/main/java/io/github/eschizoid/telescope/internal/Beans.java
@@ -2,6 +2,7 @@ package io.github.eschizoid.telescope.internal;
 
 import io.github.eschizoid.telescope.internal.optics.Getter;
 import io.github.eschizoid.telescope.internal.optics.Lens;
+import io.github.eschizoid.telescope.internal.pairing.PropertyNames;
 import java.lang.invoke.LambdaMetafactory;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
@@ -671,15 +672,13 @@ public final class Beans {
         if (moduleName.startsWith("java.") || moduleName.startsWith("jdk.")) continue;
       }
       final var n = m.getName();
+      final var afterGet = PropertyNames.afterGet(n);
+      final var afterIs = PropertyNames.afterIs(n);
       final String prop;
-      if (n.length() > 3 && n.startsWith("get") && m.getReturnType() != void.class) {
-        prop = decapitalize(n.substring(3));
-      } else if (
-        n.length() > 2 &&
-        n.startsWith("is") &&
-        (m.getReturnType() == boolean.class || m.getReturnType() == Boolean.class)
-      ) {
-        prop = decapitalize(n.substring(2));
+      if (afterGet != null && m.getReturnType() != void.class) {
+        prop = afterGet;
+      } else if (afterIs != null && (m.getReturnType() == boolean.class || m.getReturnType() == Boolean.class)) {
+        prop = afterIs;
       } else {
         continue;
       }
@@ -694,14 +693,6 @@ public final class Beans {
       }
     }
     return map;
-  }
-
-  // JavaBeans rule: a name whose first two characters are both uppercase is left unchanged (e.g.
-  // "URL").
-  private static String decapitalize(final String s) {
-    if (s.isEmpty()) return s;
-    if (s.length() > 1 && Character.isUpperCase(s.charAt(0)) && Character.isUpperCase(s.charAt(1))) return s;
-    return Character.toLowerCase(s.charAt(0)) + s.substring(1);
   }
 
   private static String capitalize(final String s) {
@@ -720,10 +711,7 @@ public final class Beans {
    * Beans.normalize}/{@code propertyOf} surface from NPE-ing if any future caller forgets to peel.
    */
   public static String propertyOf(final String getterName) {
-    if (getterName == null) return null;
-    if (getterName.length() > 3 && getterName.startsWith("get")) return decapitalize(getterName.substring(3));
-    if (getterName.length() > 2 && getterName.startsWith("is")) return decapitalize(getterName.substring(2));
-    return getterName;
+    return PropertyNames.property(getterName);
   }
 
   /**

--- a/internal/src/main/java/io/github/eschizoid/telescope/internal/pairing/PropertyNames.java
+++ b/internal/src/main/java/io/github/eschizoid/telescope/internal/pairing/PropertyNames.java
@@ -1,0 +1,67 @@
+package io.github.eschizoid.telescope.internal.pairing;
+
+/**
+ * The single home of the JavaBeans property-name derivation used everywhere a getter-shaped name
+ * becomes a property name: runtime bean discovery ({@code Beans}), accessor-reference normalization
+ * (the public DSL), and both annotation processors. One rule, five call sites — this class exists
+ * because the sites had drifted (only one of them required an uppercase character after the prefix,
+ * so {@code getaway()} derived property {@code "away"} in one world and stayed {@code "getaway"} in
+ * another).
+ *
+ * <p>The rule is the JavaBeans one: {@code getX} / {@code isX} strip only when the character after
+ * the prefix is uppercase ({@code getaway} is not a getter), and decapitalization preserves a
+ * leading acronym ({@code getURL} → {@code URL}, not {@code uRL}). Return-type conditions ({@code
+ * get} must not return {@code void}, {@code is} must return a boolean) stay at the call sites —
+ * they live in different worlds (reflection vs {@code javax.lang.model} mirrors); this class is
+ * name logic only.
+ */
+public final class PropertyNames {
+
+  private PropertyNames() {}
+
+  /**
+   * The property behind a {@code get}-prefixed name, or {@code null} when the name is not
+   * getter-shaped: {@code getCity} → {@code city}, {@code getURL} → {@code URL}, {@code getaway} →
+   * {@code null}.
+   */
+  public static String afterGet(final String name) {
+    if (name == null || name.length() <= 3 || !name.startsWith("get")) return null;
+    if (!Character.isUpperCase(name.charAt(3))) return null;
+    return decapitalize(name.substring(3));
+  }
+
+  /**
+   * The property behind an {@code is}-prefixed name, or {@code null} when the name is not
+   * getter-shaped: {@code isActive} → {@code active}, {@code isbn} → {@code null}.
+   */
+  public static String afterIs(final String name) {
+    if (name == null || name.length() <= 2 || !name.startsWith("is")) return null;
+    if (!Character.isUpperCase(name.charAt(2))) return null;
+    return decapitalize(name.substring(2));
+  }
+
+  /**
+   * Normalize an accessor name to its property name: the {@code getX} / {@code isX} strip when the
+   * name is getter-shaped, otherwise the name unchanged (record component accessors pass through).
+   * {@code null} passes through — callers that read a field name off a row shape whose
+   * nested-telescope variants return {@code null} by design rely on that.
+   */
+  public static String property(final String name) {
+    if (name == null) return name;
+    final var get = afterGet(name);
+    if (get != null) return get;
+    final var is = afterIs(name);
+    return is != null ? is : name;
+  }
+
+  /**
+   * JavaBeans {@code Introspector.decapitalize}: a name whose first two characters are both
+   * uppercase is left unchanged ({@code URL} stays {@code URL}); otherwise the first character is
+   * lowercased.
+   */
+  public static String decapitalize(final String s) {
+    if (s == null || s.isEmpty()) return s;
+    if (s.length() > 1 && Character.isUpperCase(s.charAt(0)) && Character.isUpperCase(s.charAt(1))) return s;
+    return Character.toLowerCase(s.charAt(0)) + s.substring(1);
+  }
+}

--- a/internal/src/test/java/io/github/eschizoid/telescope/internal/pairing/PropertyNamesTest.java
+++ b/internal/src/test/java/io/github/eschizoid/telescope/internal/pairing/PropertyNamesTest.java
@@ -1,0 +1,85 @@
+package io.github.eschizoid.telescope.internal.pairing;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Contract tests for the one property-name derivation rule. These pin exactly the cases the five
+ * pre-consolidation copies disagreed on — a name like {@code getaway} must NOT be a getter (the
+ * JavaBeans uppercase-after-prefix requirement), and a leading acronym must survive
+ * decapitalization.
+ */
+class PropertyNamesTest {
+
+  @Test
+  @DisplayName("getCity strips and decapitalizes to city")
+  void getStripsAndDecapitalizes() {
+    assertEquals("city", PropertyNames.afterGet("getCity"));
+    assertEquals("city", PropertyNames.property("getCity"));
+  }
+
+  @Test
+  @DisplayName("isActive strips and decapitalizes to active")
+  void isStripsAndDecapitalizes() {
+    assertEquals("active", PropertyNames.afterIs("isActive"));
+    assertEquals("active", PropertyNames.property("isActive"));
+  }
+
+  @Test
+  @DisplayName("a leading acronym survives: getURL derives URL, not uRL")
+  void acronymSurvivesDecapitalization() {
+    assertEquals("URL", PropertyNames.afterGet("getURL"));
+    assertEquals("URL", PropertyNames.decapitalize("URL"));
+  }
+
+  @Test
+  @DisplayName("getaway is not a getter — lowercase after the prefix fails the JavaBeans rule")
+  void lowercaseAfterGetPrefixIsNotAGetter() {
+    assertNull(PropertyNames.afterGet("getaway"));
+    assertEquals("getaway", PropertyNames.property("getaway"));
+  }
+
+  @Test
+  @DisplayName("isbn is not a boolean getter — lowercase after the prefix fails the rule")
+  void lowercaseAfterIsPrefixIsNotAGetter() {
+    assertNull(PropertyNames.afterIs("isbn"));
+    assertEquals("isbn", PropertyNames.property("isbn"));
+  }
+
+  @Test
+  @DisplayName("bare prefixes and short names pass through unchanged")
+  void barePrefixesPassThrough() {
+    assertNull(PropertyNames.afterGet("get"));
+    assertNull(PropertyNames.afterIs("is"));
+    assertEquals("get", PropertyNames.property("get"));
+    assertEquals("is", PropertyNames.property("is"));
+    assertEquals("x", PropertyNames.property("x"));
+  }
+
+  @Test
+  @DisplayName("record component accessors pass through unchanged")
+  void recordAccessorsPassThrough() {
+    assertEquals("email", PropertyNames.property("email"));
+    assertEquals("createdAt", PropertyNames.property("createdAt"));
+  }
+
+  @Test
+  @DisplayName("null passes through — nested-telescope row shapes return null field names by design")
+  void nullPassesThrough() {
+    assertNull(PropertyNames.property(null));
+    assertNull(PropertyNames.afterGet(null));
+    assertNull(PropertyNames.afterIs(null));
+    assertNull(PropertyNames.decapitalize(null));
+  }
+
+  @Test
+  @DisplayName("single-char and empty decapitalize edge cases")
+  void decapitalizeEdges() {
+    assertEquals("", PropertyNames.decapitalize(""));
+    assertEquals("x", PropertyNames.decapitalize("X"));
+    assertEquals("ab", PropertyNames.decapitalize("Ab"));
+  }
+}


### PR DESCRIPTION
The getX/isX strip + JavaBeans decapitalize rule was implemented five times
(Beans discovery scan + propertyOf, Telescope.fieldNameOf, the
AbstractTelescopeProcessor bean scan, and MapperVerifierProcessor's scan +
normalize) and had drifted: only Telescope.fieldNameOf required an uppercase
character after the prefix, so Pojo::getaway derived property "away" in the
Beans world but stayed "getaway" in the DSL — a lookup that could never
match its own discovery.

Concentrate the rule in pairing/PropertyNames (the shared property-spec
package both the runtime and :codegen already receive via qualified export):
afterGet / afterIs return the property or null under the spec rule
(uppercase required after the prefix, URL-style acronyms preserved);
property() is the normalize form with null passthrough. All five sites
routed; the three private decapitalize copies deleted. Return-type
conditions stay at the call sites — they live in different worlds
(reflection vs mirrors); the utility is name logic only.

Nine contract tests pin the cases the copies disagreed on (getaway, isbn,
getURL, bare prefixes, record accessors, null passthrough).

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>