### PR TITLE
perf(core): fromMap positional bind + engine extraction (~2x, gated)

### DIFF
--- a/core/src/main/java/io/github/eschizoid/telescope/FromMap.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/FromMap.java
@@ -19,11 +19,12 @@ import java.util.function.Function;
  * Map<String, Object> → T} boundary factory. Sibling of {@link Merge}: the {@code Telescope} facade
  * validates nothing and delegates here, keeping the factories-delegate-to-engines shape.
  *
- * <p>Everything name-keyed resolves at build time. Rows are matched to target components /
- * properties once, into positional arrays; the per-call forward path is then a source {@code
- * Map.get} plus converter call per extracted slot, a JLS default per unmatched slot, and one cached
- * canonical-constructor invocation (records) or writer fill (beans) — no per-call name→row or
- * name→default lookups.
+ * <p>Rows are matched to target components / properties once at build time, into positional arrays.
+ * On the record path the per-call forward is fully positional: a source {@code Map.get} plus
+ * converter per extracted slot, a JLS default per unmatched slot, and one cached
+ * canonical-constructor invocation — no name lookup survives. On the bean path the writer's {@code
+ * construct} contract stays name-driven, so one {@code name→index} lookup per property remains
+ * (down from the two the old engine paid — the row map and the defaults map).
  */
 final class FromMap {
 

--- a/core/src/main/java/io/github/eschizoid/telescope/FromMap.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/FromMap.java
@@ -1,0 +1,128 @@
+package io.github.eschizoid.telescope;
+
+import io.github.eschizoid.telescope.conversion.ForwardMapper;
+import io.github.eschizoid.telescope.internal.Beans;
+import io.github.eschizoid.telescope.internal.LambdaIntrospection;
+import io.github.eschizoid.telescope.internal.NullDefaults;
+import io.github.eschizoid.telescope.internal.Records;
+import io.github.eschizoid.telescope.internal.pairing.PropertyNames;
+import io.github.eschizoid.telescope.mapping.Extract;
+import io.github.eschizoid.telescope.mapping.MapExtractStep;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
+
+/**
+ * The engine behind {@link Telescope#fromMap(Class, MapExtractStep...)} — the untyped {@code
+ * Map<String, Object> → T} boundary factory. Sibling of {@link Merge}: the {@code Telescope} facade
+ * validates nothing and delegates here, keeping the factories-delegate-to-engines shape.
+ *
+ * <p>Everything name-keyed resolves at build time. Rows are matched to target components /
+ * properties once, into positional arrays; the per-call forward path is then a source {@code
+ * Map.get} plus converter call per extracted slot, a JLS default per unmatched slot, and one cached
+ * canonical-constructor invocation (records) or writer fill (beans) — no per-call name→row or
+ * name→default lookups.
+ */
+final class FromMap {
+
+  private FromMap() {}
+
+  @SuppressWarnings("unchecked")
+  static <T> ForwardMapper<Map<String, Object>, T> build(final Class<T> target, final MapExtractStep... rows) {
+    Objects.requireNonNull(target, "target");
+    Objects.requireNonNull(rows, "rows");
+    final var byField = new LinkedHashMap<String, Extract<?, ?>>();
+    for (final var row : rows) {
+      if (!(row instanceof Extract<?, ?> e)) throw new IllegalArgumentException(
+        "Telescope.fromMap rows must be built via MapExtractStep.extract(...)"
+      );
+      final var fieldName = PropertyNames.property(LambdaIntrospection.methodNameOf(e.targetAccessor()));
+      if (byField.put(fieldName, e) != null) throw new IllegalArgumentException(
+        "Telescope.fromMap: duplicate extract row for target field '" + fieldName + "'"
+      );
+    }
+    final Function<Map<String, Object>, T> forward = target.isRecord()
+      ? recordForward(target, byField)
+      : beanForward(target, byField);
+    return ForwardMapper.create(forward, (Class<Map<String, Object>>) (Class<?>) Map.class, target);
+  }
+
+  /**
+   * Record path — the full positional bind. Each canonical component resolves at build time to
+   * either its extract row (source key + converter) or its JLS default; the forward call fills a
+   * positional args array and invokes the cached canonical-constructor handle via {@link
+   * Records#construct(Class, Object[])}. No name-keyed dispatch survives to the hot path.
+   */
+  @SuppressWarnings("unchecked")
+  private static <T> Function<Map<String, Object>, T> recordForward(
+    final Class<T> target,
+    final Map<String, Extract<?, ?>> byField
+  ) {
+    final var comps = target.getRecordComponents();
+    final var n = comps.length;
+    final var keys = new String[n];
+    final var converters = (Function<Object, Object>[]) new Function<?, ?>[n];
+    final var defaults = new Object[n];
+    for (var i = 0; i < n; i++) {
+      final var e = byField.get(comps[i].getName());
+      if (e != null) {
+        keys[i] = e.key();
+        converters[i] = (Function<Object, Object>) e.converter();
+      } else {
+        defaults[i] = NullDefaults.defaultFor(comps[i].getGenericType());
+      }
+    }
+    return mapSrc -> {
+      if (mapSrc == null) return null;
+      final var args = new Object[n];
+      for (var i = 0; i < n; i++) {
+        args[i] = keys[i] != null ? converters[i].apply(mapSrc.get(keys[i])) : defaults[i];
+      }
+      return Records.construct(target, args);
+    };
+  }
+
+  /**
+   * Bean path — build-time alignment to the writer's property order. The writer's {@code construct}
+   * contract is name-driven, so the per-call closure keeps a name entry point but resolves it
+   * through one prebuilt name→index map into the positional arrays (replacing the previous two
+   * lookups: row map then defaults map). The writer's own internals (setter resolution) are
+   * unchanged here.
+   */
+  private static <T> Function<Map<String, Object>, T> beanForward(
+    final Class<T> target,
+    final Map<String, Extract<?, ?>> byField
+  ) {
+    final var writer = Beans.autoWriter(target);
+    final var propertyNames = Beans.propertyNames(target);
+    final var n = propertyNames.length;
+    final var keys = new String[n];
+    @SuppressWarnings("unchecked")
+    final var converters = (Function<Object, Object>[]) new Function<?, ?>[n];
+    final var defaults = new Object[n];
+    final var indexByName = new HashMap<String, Integer>(n * 2);
+    for (var i = 0; i < n; i++) {
+      indexByName.put(propertyNames[i], i);
+      final var e = byField.get(propertyNames[i]);
+      if (e != null) {
+        keys[i] = e.key();
+        @SuppressWarnings("unchecked")
+        final var conv = (Function<Object, Object>) e.converter();
+        converters[i] = conv;
+      } else {
+        defaults[i] = NullDefaults.defaultFor(Beans.propertyType(target, propertyNames[i]));
+      }
+    }
+    return mapSrc -> {
+      if (mapSrc == null) return null;
+      final Function<String, Object> valueByName = name -> {
+        final var i = indexByName.get(name);
+        if (i == null) return null;
+        return keys[i] != null ? converters[i].apply(mapSrc.get(keys[i])) : defaults[i];
+      };
+      return writer.construct(propertyNames, valueByName);
+    };
+  }
+}

--- a/core/src/main/java/io/github/eschizoid/telescope/Telescope.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/Telescope.java
@@ -13,7 +13,6 @@ import io.github.eschizoid.telescope.internal.Beans;
 import io.github.eschizoid.telescope.internal.BridgeHolderProbe;
 import io.github.eschizoid.telescope.internal.LambdaIntrospection;
 import io.github.eschizoid.telescope.internal.MetadataHolderProbe;
-import io.github.eschizoid.telescope.internal.NullDefaults;
 import io.github.eschizoid.telescope.internal.Records;
 import io.github.eschizoid.telescope.internal.Reflective;
 import io.github.eschizoid.telescope.internal.optics.Affine;
@@ -27,7 +26,6 @@ import io.github.eschizoid.telescope.introspection.OpticNode;
 import io.github.eschizoid.telescope.introspection.OpticReport;
 import io.github.eschizoid.telescope.introspection.Trace;
 import io.github.eschizoid.telescope.introspection.TraceLimits;
-import io.github.eschizoid.telescope.mapping.Extract;
 import io.github.eschizoid.telescope.mapping.ForwardOnlyTransformTo;
 import io.github.eschizoid.telescope.mapping.MapExtractStep;
 import io.github.eschizoid.telescope.mapping.MapStep;
@@ -40,12 +38,10 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -753,52 +749,8 @@ public sealed class Telescope<
    * @return a {@link ForwardMapper} from {@code Map<String, Object>} to {@code T}, ready to inject
    *     as a CDI/Spring bean.
    */
-  @SuppressWarnings("unchecked")
   public static <T> ForwardMapper<Map<String, Object>, T> fromMap(final Class<T> target, final MapExtractStep... rows) {
-    Objects.requireNonNull(target, "target");
-    Objects.requireNonNull(rows, "rows");
-    final var byField = new LinkedHashMap<String, Extract<?, ?>>();
-    for (final var row : rows) {
-      if (!(row instanceof Extract<?, ?> e)) throw new IllegalArgumentException(
-        "Telescope.fromMap rows must be built via MapExtractStep.extract(...)"
-      );
-      final var rawName = LambdaIntrospection.methodNameOf(e.targetAccessor());
-      final var prop = Beans.propertyOf(rawName);
-      final var fieldName = prop == null ? rawName : prop;
-      if (byField.put(fieldName, e) != null) throw new IllegalArgumentException(
-        "Telescope.fromMap: duplicate extract row for target field '" + fieldName + "'"
-      );
-    }
-    // Per-component JLS-default lookup table — built once at factory time, queried on every
-    // forward pass for unmatched target components. Records expose typed generic-type info on each
-    // RecordComponent; POJOs query Beans.propertyType per property.
-    final var defaultsByName = new HashMap<String, Object>();
-    final var isRecord = target.isRecord();
-    if (isRecord) {
-      for (final var c : target.getRecordComponents()) {
-        defaultsByName.put(c.getName(), NullDefaults.defaultFor(c.getGenericType()));
-      }
-    } else {
-      for (final var name : Beans.propertyNames(target)) {
-        defaultsByName.put(name, NullDefaults.defaultFor(Beans.propertyType(target, name)));
-      }
-    }
-    // Hoist the reflective writer + property-name array out of the hot path. Recomputing them per
-    // forward() would re-walk the bean's accessor methods every call — invariants in the closure.
-    final Beans.BeanWriter<T> writer = isRecord ? null : Beans.autoWriter(target);
-    final String[] propertyNames = isRecord ? null : Beans.propertyNames(target);
-    final Function<Map<String, Object>, T> forward = mapSrc -> {
-      if (mapSrc == null) return null;
-      final Function<String, Object> valueByName = name -> {
-        final var row = byField.get(name);
-        if (row == null) return defaultsByName.get(name); // unmatched target → JLS default
-        final var raw = mapSrc.get(row.key());
-        return ((Extract<?, Object>) row).converter().apply(raw);
-      };
-      if (isRecord) return Records.construct(target, valueByName);
-      return writer.construct(propertyNames, valueByName);
-    };
-    return ForwardMapper.create(forward, (Class<Map<String, Object>>) (Class<?>) Map.class, target);
+    return FromMap.build(target, rows);
   }
 
   /**

--- a/internal/src/main/java/io/github/eschizoid/telescope/internal/Records.java
+++ b/internal/src/main/java/io/github/eschizoid/telescope/internal/Records.java
@@ -203,6 +203,25 @@ public final class Records {
     return (R) info.ctorFn().apply(args);
   }
 
+  /**
+   * Positional sibling of {@link #construct(Class, Function)}: invoke the canonical constructor
+   * with {@code args} already in component order, skipping the per-component name dispatch
+   * entirely. For callers that resolved their per-component work at construction time (a
+   * factory-time positional bind), this is the whole hot path: one cached {@code MethodHandle}
+   * invocation.
+   *
+   * @throws IllegalArgumentException when {@code args.length} doesn't match the component count
+   */
+  @SuppressWarnings("unchecked")
+  public static <R> R construct(final Class<R> recordClass, final Object[] args) {
+    final var info = info(recordClass);
+    final var arity = info.components().length;
+    if (args.length != arity) throw new IllegalArgumentException(
+      recordClass.getName() + " has " + arity + " components; got " + args.length + " positional args"
+    );
+    return (R) info.ctorFn().apply(args);
+  }
+
   private static Object readField(final Object source, final String fieldName) {
     if (source == null) return null;
     final var info = info(source.getClass());


### PR DESCRIPTION
## What

`fromMap` positional bind + engine extraction — the first metrics-gated layer of the perf program. The forward closure used to resolve every target component **by name per call** (row map, defaults map, then the name-keyed construct dispatch); everything now binds positionally at build time.

- **`FromMap` engine class** (sibling of `Merge`) — `Telescope.fromMap` is a two-line delegate again, restoring the factories-delegate-to-engines invariant.
- **Record path**: each canonical component resolves once to its extract row (source key + converter) or JLS default, into positional arrays; per call it's a `Map.get` + converter per slot, an args-array fill, and one cached canonical-constructor invocation via the new `Records.construct(Class, Object[])` overload. Zero name lookups survive to the hot path.
- **Bean path**: build-time alignment to the writer's property order; one prebuilt name→index map replaces the two per-call lookups. The writer's internal setter resolution is unchanged (follow-up candidate; see numbers).

Behavior identical by construction — including the pre-existing quirk that a row matching no target component is silently ignored (fail-fast on that is a semantics change and gets its own change).

## Gate numbers (`FromMapBenchmark`, fork=3, 15 samples each, same machine)

| Row | BEFORE (ns/op) | AFTER (ns/op) | Δ |
|---|---|---|---|
| `fromMapRecord` | 123.1 ± 13.1 | **63.4 ± 3.8** | **−48% (1.94×)** |
| `fromMapBean` | 249.4 ± 105.2 | **126.7 ± 5.6** | **−49% (1.97×)** |
| `handPositionalRecord` (floor) | 16.3 ± 1.5 | 14.1 ± 0.1 | session drift ~14% |
| `handPositionalBean` (floor) | 45.0 ± 48.4 | 14.9 ± 0.2 | (before-floor noisy) |

Both paths halved; the improvement is ~2× against ~14% inter-session drift, far outside noise. The record path's remaining 63→14 gap is converter/ctor-handle dispatch; the bean path's remaining gap includes the writer's per-property CHM setter lookup — documented follow-up, not attempted here.

BEFORE was measured from an isolated git worktree pinned at the pre-change commit so no rebuilt artifacts could leak into the baseline forks.
