### PR TITLE
perf(core): merge positional bind — drop the per-call staging map (1.8x, gated)

### DIFF
--- a/core/src/main/java/io/github/eschizoid/telescope/Merge.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/Merge.java
@@ -113,11 +113,20 @@ final class Merge {
       slots[i] = planByTgt.get(names[i]);
     }
     return sources -> {
+      // Read every bound row up front, then serve the writer from the filled array. Eager reads
+      // preserve the prior contract that a missing source throws even when the target's writer
+      // would not query that property — a getter-only property with no backing field is skipped by
+      // the field writer, so a lazy per-property read would swallow the source-missing throw there.
+      // Unbound slots stay null (merge applies no JLS defaults). The per-call staging map is still
+      // gone: values land in a positional array, resolved by the prebuilt name→index map.
+      final var values = new Object[n];
+      for (var i = 0; i < n; i++) {
+        final var r = slots[i];
+        if (r != null) values[i] = r.srcAccessor().get(sourceOrThrow(sources, r));
+      }
       final Function<String, Object> valueByName = name -> {
         final var i = indexByName.get(name);
-        if (i == null) return null;
-        final var r = slots[i];
-        return r == null ? null : r.srcAccessor().get(sourceOrThrow(sources, r));
+        return i == null ? null : values[i];
       };
       return (T) targetRefl.construct(target, valueByName);
     };

--- a/core/src/main/java/io/github/eschizoid/telescope/Merge.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/Merge.java
@@ -2,6 +2,7 @@ package io.github.eschizoid.telescope;
 
 import io.github.eschizoid.telescope.conversion.Mapper;
 import io.github.eschizoid.telescope.internal.LambdaIntrospection;
+import io.github.eschizoid.telescope.internal.Records;
 import io.github.eschizoid.telescope.internal.Reflective;
 import io.github.eschizoid.telescope.internal.optics.Getter;
 import io.github.eschizoid.telescope.mapping.MergeStep;
@@ -48,25 +49,15 @@ final class Merge {
       resolveStep(step, i, target, targetRefl, claimedTgt, plan);
     }
 
-    final Function<Sources, T> forward = sources -> {
-      final Map<String, Object> byName = new HashMap<>(plan.size() * 2);
-      for (final var r : plan) {
-        final Object src = sources.byClass(r.sourceClass());
-        if (src == null) throw new IllegalStateException(
-          "Telescope.merge: forward called without a source for class " +
-            r.sourceClass().getName() +
-            " (required by the row writing target field '" +
-            r.tgtName() +
-            "'). Sources bag contains: " +
-            sources.classes().stream().map(Class::getSimpleName).toList() +
-            ". Pass a value of " +
-            r.sourceClass().getSimpleName() +
-            " via Sources.of(...) or Sources.builder().with(...)."
-        );
-        byName.put(r.tgtName(), r.srcAccessor().get(src));
-      }
-      return (T) targetRefl.construct(target, byName::get);
-    };
+    // Positional bind: align each row to its target slot once, so the forward path is a per-slot
+    // source read with no per-call staging map or name→row lookup. Unmatched target components stay
+    // null (merge applies no JLS defaults — unlike fromMap); a null-valued primitive component
+    // therefore fails at construct time exactly as the prior name-keyed path did.
+    final var planByTgt = new HashMap<String, ResolvedStep>(plan.size() * 2);
+    for (final var r : plan) planByTgt.put(r.tgtName(), r);
+    final Function<Sources, T> forward = target.isRecord()
+      ? recordForward(target, planByTgt)
+      : beanForward(target, targetRefl, planByTgt);
 
     final Function<T, Sources> backward = t -> {
       throw new UnsupportedOperationException(
@@ -76,6 +67,79 @@ final class Merge {
     };
 
     return Mapper.create(forward, backward, Sources.class, target, Map.of());
+  }
+
+  /**
+   * Record target — the full positional bind. Each canonical component resolves once to its row (or
+   * to a null-producing empty slot); the forward fills a positional args array by reading each
+   * bound row's source from the {@link Sources} bag and constructs via the cached canonical
+   * constructor. No staging map, no name→row lookup survives to the hot path.
+   */
+  private static <T> Function<Sources, T> recordForward(
+    final Class<T> target,
+    final Map<String, ResolvedStep> planByTgt
+  ) {
+    final var comps = target.getRecordComponents();
+    final var n = comps.length;
+    final var slots = new ResolvedStep[n];
+    for (var i = 0; i < n; i++) slots[i] = planByTgt.get(comps[i].getName());
+    return sources -> {
+      final var args = new Object[n];
+      for (var i = 0; i < n; i++) {
+        final var r = slots[i];
+        args[i] = r == null ? null : r.srcAccessor().get(sourceOrThrow(sources, r));
+      }
+      return Records.construct(target, args);
+    };
+  }
+
+  /**
+   * Bean target — the writer's {@code construct} contract stays name-driven, so one {@code
+   * name→index} lookup per property remains, but the per-call staging {@code HashMap} is gone: rows
+   * bind to positional arrays at build time and the forward closure reads them by resolved index.
+   */
+  @SuppressWarnings("unchecked")
+  private static <T> Function<Sources, T> beanForward(
+    final Class<T> target,
+    final Reflective targetRefl,
+    final Map<String, ResolvedStep> planByTgt
+  ) {
+    final var names = targetRefl.names(target);
+    final var n = names.length;
+    final var slots = new ResolvedStep[n];
+    final var indexByName = new HashMap<String, Integer>(n * 2);
+    for (var i = 0; i < n; i++) {
+      indexByName.put(names[i], i);
+      slots[i] = planByTgt.get(names[i]);
+    }
+    return sources -> {
+      final Function<String, Object> valueByName = name -> {
+        final var i = indexByName.get(name);
+        if (i == null) return null;
+        final var r = slots[i];
+        return r == null ? null : r.srcAccessor().get(sourceOrThrow(sources, r));
+      };
+      return (T) targetRefl.construct(target, valueByName);
+    };
+  }
+
+  // The forward-time source-presence guard, shared by both target shapes. Preserves the detailed
+  // "you forgot to bind a source" message so a missing Sources entry stays distinguishable from a
+  // build-time misconfiguration.
+  private static Object sourceOrThrow(final Sources sources, final ResolvedStep r) {
+    final Object src = sources.byClass(r.sourceClass());
+    if (src == null) throw new IllegalStateException(
+      "Telescope.merge: forward called without a source for class " +
+        r.sourceClass().getName() +
+        " (required by the row writing target field '" +
+        r.tgtName() +
+        "'). Sources bag contains: " +
+        sources.classes().stream().map(Class::getSimpleName).toList() +
+        ". Pass a value of " +
+        r.sourceClass().getSimpleName() +
+        " via Sources.of(...) or Sources.builder().with(...)."
+    );
+    return src;
   }
 
   private static void resolveStep(

--- a/core/src/test/java/io/github/eschizoid/telescope/MergeTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/MergeTest.java
@@ -340,4 +340,99 @@ class MergeTest {
       assertTrue(ex.getMessage().contains("Customer"));
     }
   }
+
+  // A mutable POJO target: no-arg ctor + setters => the setters write strategy. The common
+  // bean-target shape, and the one the merge engine's bean path assembles.
+  static final class SettersProfile {
+
+    private String id;
+    private String region;
+
+    public SettersProfile() {}
+
+    public String getId() {
+      return id;
+    }
+
+    public void setId(final String id) {
+      this.id = id;
+    }
+
+    public String getRegion() {
+      return region;
+    }
+
+    public void setRegion(final String region) {
+      this.region = region;
+    }
+  }
+
+  // A field-injection target: no-arg ctor, NO setters, no static builder => the field write
+  // strategy. `label` is a getter-only computed property with no backing field, so the field
+  // writer skips it entirely — the corner where a lazily-read bound row could swallow a
+  // source-missing throw.
+  static final class FieldsTarget {
+
+    private String id;
+
+    public FieldsTarget() {}
+
+    public String getId() {
+      return id;
+    }
+
+    public String getLabel() {
+      return "label-of-" + id;
+    }
+  }
+
+  @Nested
+  @DisplayName("bean targets — the merge engine's bean write path")
+  class BeanTargets {
+
+    @Test
+    @DisplayName("forward assembles a mutable POJO target through its setters")
+    void beanTargetForwardAssembles() {
+      final Mapper<Sources, SettersProfile> mapper = Telescope.merge(
+        SettersProfile.class,
+        from(Customer::id, SettersProfile::getId),
+        from(Audit::createdBy, SettersProfile::getRegion)
+      );
+
+      final var result = mapper.forward(Sources.of(new Customer("c-9", "z@z.com"), new Audit("auditor", "2026-07-21")));
+      assertEquals("c-9", result.getId());
+      assertEquals("auditor", result.getRegion());
+    }
+
+    @Test
+    @DisplayName("a bean target left partially unmapped leaves the untouched property null")
+    void beanTargetUnmappedPropertyNull() {
+      final Mapper<Sources, SettersProfile> mapper = Telescope.merge(
+        SettersProfile.class,
+        from(Customer::id, SettersProfile::getId)
+      );
+
+      final var result = mapper.forward(Sources.of(new Customer("c-9", "z@z.com")));
+      assertEquals("c-9", result.getId());
+      assertEquals(null, result.getRegion());
+    }
+
+    @Test
+    @DisplayName("a missing source still throws even when the field writer would skip that bound property")
+    void beanFieldWriterMissingSourceStillThrows() {
+      // The row binds Audit->getLabel, a getter-only property the field writer skips at construct
+      // time. A lazily-read bound row would never be queried, swallowing the source-missing throw;
+      // the eager read keeps the guarantee that an absent source is reported.
+      final Mapper<Sources, FieldsTarget> mapper = Telescope.merge(
+        FieldsTarget.class,
+        from(Customer::id, FieldsTarget::getId),
+        from(Audit::createdBy, FieldsTarget::getLabel)
+      );
+
+      final var bag = Sources.of(new Customer("c-1", "x@y.com")); // no Audit
+      final var ex = assertThrows(IllegalStateException.class, () -> mapper.forward(bag));
+      assertTrue(ex.getMessage().contains("Audit"));
+      assertTrue(ex.getMessage().contains("label"));
+    }
+  }
 }

--- a/docs/native-image.md
+++ b/docs/native-image.md
@@ -1,4 +1,4 @@
- # telescope on GraalVM native-image
+# telescope on GraalVM native-image
 
 Telescope's runtime hot path is reflection-free by design: field reads and record/bean rebuilds ride a per-class cache
 of `LambdaMetafactory`-built `Function` / `Supplier` / `BiConsumer` instances (see `internal/Records.java`,

--- a/docs/native-image.md
+++ b/docs/native-image.md
@@ -1,4 +1,4 @@
-# telescope on GraalVM native-image
+ # telescope on GraalVM native-image
 
 Telescope's runtime hot path is reflection-free by design: field reads and record/bean rebuilds ride a per-class cache
 of `LambdaMetafactory`-built `Function` / `Supplier` / `BiConsumer` instances (see `internal/Records.java`,


### PR DESCRIPTION
## What

`Telescope.merge` positional bind — the merge-engine sibling of the fromMap work (#265). The forward path staged every field through a per-call `HashMap` and then constructed the target by name; it now binds each row to its target slot once at build time.

- **Record target**: each canonical component resolves once to its row (or a null-producing empty slot); the forward fills a positional args array and constructs via the cached canonical constructor (`Records.construct(Class, Object[])`, the overload added in #265). No staging map, no name→row lookup survives to the hot path.
- **Bean target**: the writer's `construct` contract stays name-driven, so one `name→index` lookup per property remains — but the per-call `HashMap` allocation and its N puts are gone.

Behavior preserved exactly, including the corners that differ from fromMap:
- **Unmatched target components stay null** — merge applies no JLS defaults (fromMap does). A null-valued primitive component therefore fails at construct time exactly as the prior name-keyed path did.
- **The source-missing `IllegalStateException`** keeps its full "you forgot to bind a source" message, shared by both target shapes via `sourceOrThrow`.
- Backward stays unsupported (multi-source has no general inverse).

## Gate numbers (`MergeBenchmark`, fork=3, 15 samples each, same machine, quiescent)

| Row | BEFORE (ns/op) | AFTER (ns/op) | Δ |
|---|---|---|---|
| `explicitRows` | 182.4 ± 3.1 | **101.3 ± 2.3** | **−44% (1.80×)** |
| `autoRows` | 307.2 ± 31.5 | **205.7 ± 2.4** | **−33% (1.49×)** |
| `handMerge` (floor) | 8.80 ± 0.5 | 8.55 ± 0.06 | stable — confirms comparable runs |

The floor is identical hand-written code in both runs; its stability (8.80 → 8.55, within noise) is the check that BEFORE and AFTER were measured under comparable conditions. An earlier baseline ran under CPU contention (floor drifted to ~19.5ns with wide error bars) and was discarded — these numbers are the clean re-run.

**Why `autoRows` improves less than `explicitRows`:** the staging-map removal is the same for both, but `auto(...)` rows still read each source field through a per-call name-keyed getter (`sourceRefl.read(src, name)`) that `from(...)` rows avoid — a separate cost this change doesn't target. The remaining `explicitRows` gap over the floor (101 vs 8.5) is the reflective read + construct dispatch that codegen, not the runtime path, removes.
