### PR TITLE
perf(core): loop-based read folds via Fold.visitWhile (exists ~4.4x, gated)

### DIFF
--- a/core/src/main/java/io/github/eschizoid/telescope/Telescope.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/Telescope.java
@@ -1521,7 +1521,7 @@ public sealed class Telescope<
     if (optic instanceof final Affine<S, A> affine) {
       return affine.getOption(source).map(List::of).orElseGet(List::of);
     }
-    return optic.getAll(source).toList();
+    return optic.toList(source);
   }
 
   /**
@@ -1538,7 +1538,7 @@ public sealed class Telescope<
   public List<Indexed<A>> toListIndexed(final S source) {
     final var out = new ArrayList<Indexed<A>>();
     final var i = new int[] { 0 };
-    optic.getAll(source).forEach(a -> out.add(new Indexed<>(i[0]++, a)));
+    optic.forEach(source, a -> out.add(new Indexed<>(i[0]++, a)));
     return List.copyOf(out);
   }
 
@@ -1560,7 +1560,7 @@ public sealed class Telescope<
     if (optic instanceof final Affine<S, A> affine) {
       return affine.getOption(source).isPresent() ? 1L : 0L;
     }
-    return optic.getAll(source).count();
+    return optic.count(source);
   }
 
   /**
@@ -1574,7 +1574,10 @@ public sealed class Telescope<
     if (optic instanceof final Affine<S, A> affine) {
       return affine.getOption(source).isPresent();
     }
-    return optic.getAll(source).findAny().isPresent();
+    // A single false-returning visit stops at the first focus: visitWhile returns false iff at
+    // least one element was seen. Unlike Stream.findAny(), this tolerates a null focus (a null
+    // intermediate hop yields a one-element [null] traversal) instead of NPE-ing on Optional.of.
+    return !optic.visitWhile(source, a -> false);
   }
 
   /**

--- a/core/src/test/java/io/github/eschizoid/telescope/TelescopeTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/TelescopeTest.java
@@ -100,6 +100,23 @@ class TelescopeTest {
     }
 
     @Test
+    @DisplayName("a null focus is still a focus — exists/count/toList tolerate it, they don't NPE")
+    void nullFocusToleratedByReadTerminals() {
+      // A List element whose focused field is null yields a one-element [null] traversal. The read
+      // terminals must count it as one present focus; the prior Stream.findAny()/toList path
+      // NPE-d on the null (Optional.of / Stream.of reject null).
+      final var userName = Telescope.of(Team.class).each(Team::users).field(User::name);
+      final var t = new Team("a", List.of(new User(null, 30, null)));
+
+      assertTrue(userName.exists(t));
+      assertEquals(1L, userName.count(t));
+
+      final var focuses = userName.toList(t);
+      assertEquals(1, focuses.size());
+      assertNull(focuses.get(0));
+    }
+
+    @Test
     @DisplayName("eachValue(getter) over a record's Map<K, V> updates every value")
     void eachOverMapValues() {
       record Index(Map<String, Integer> byKey) {}

--- a/core/src/test/java/io/github/eschizoid/telescope/TelescopeTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/TelescopeTest.java
@@ -103,8 +103,10 @@ class TelescopeTest {
     @DisplayName("a null focus is still a focus — exists/count/toList tolerate it, they don't NPE")
     void nullFocusToleratedByReadTerminals() {
       // A List element whose focused field is null yields a one-element [null] traversal. The read
-      // terminals must count it as one present focus; the prior Stream.findAny()/toList path
-      // NPE-d on the null (Optional.of / Stream.of reject null).
+      // terminals must count it as one present focus. exists() previously routed through
+      // Stream.findAny(), which NPEs on a null element (Optional.of); the visitor path tolerates
+      // it.
+      // (toList/count were already null-safe via Stream.toList()/.count() — this pins all three.)
       final var userName = Telescope.of(Team.class).each(Team::users).field(User::name);
       final var t = new Team("a", List.of(new User(null, 30, null)));
 

--- a/internal/src/main/java/io/github/eschizoid/telescope/internal/optics/Affine.java
+++ b/internal/src/main/java/io/github/eschizoid/telescope/internal/optics/Affine.java
@@ -3,6 +3,7 @@ package io.github.eschizoid.telescope.internal.optics;
 import java.util.Optional;
 import java.util.function.BiFunction;
 import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.stream.Stream;
 
 /**
@@ -40,6 +41,13 @@ public interface Affine<S, A> extends Traversal<S, A> {
   @Override
   default Stream<A> getAll(final S source) {
     return getOption(source).stream();
+  }
+
+  /** Fold view: visit the focused value when present, otherwise focus nothing. */
+  @Override
+  default boolean visitWhile(final S source, final Predicate<? super A> visitor) {
+    final var focus = getOption(source);
+    return focus.isEmpty() || visitor.test(focus.get());
   }
 
   /** Build an Affine from a partial getter and an {@code (S, A) -> S} setter. */

--- a/internal/src/main/java/io/github/eschizoid/telescope/internal/optics/Fold.java
+++ b/internal/src/main/java/io/github/eschizoid/telescope/internal/optics/Fold.java
@@ -1,7 +1,9 @@
 package io.github.eschizoid.telescope.internal.optics;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 
@@ -20,32 +22,72 @@ import java.util.stream.Stream;
  * final var n = members.count(team);
  * }</pre>
  *
- * <p>The {@link #toList}, {@link #findFirst}, {@link #any}, and {@link #count} defaults are
- * convenience views over {@link #getAll}. There is no {@code then(...)} here; composition happens
- * on the read+write optics.
+ * <p>Two read primitives sit side by side. {@link #getAll(Object)} yields a lazy {@link Stream} —
+ * the right tool when the caller wants stream operators or a lazy head ({@code findFirst}). {@link
+ * #visitWhile(Object, Predicate)} pushes each focus into a short-circuitable visitor with no
+ * intermediate {@link Stream} per hop — the composing optics override it so a deep path is plain
+ * nested loops instead of a {@code flatMap} tower. The eager terminals ({@link #toList}, {@link
+ * #count}, {@link #forEach}, {@link #any}) ride {@code visitWhile}; both primitives enumerate the
+ * same focuses in the same order.
  */
 @FunctionalInterface
 public interface Fold<S, A> {
   /** Stream every focused {@code A} out of {@code source}, in deterministic visit order. */
   Stream<A> getAll(S source);
 
+  /**
+   * Push each focused {@code A} into {@code visitor} in enumeration order, stopping the moment a
+   * visit returns {@code false}. Returns {@code true} when every focus was visited, {@code false}
+   * when a visit short-circuited. This is the loop-based read primitive the eager terminals ride;
+   * composing optics ({@link Traversal#then}, {@link Traversal#filter}, the collection traversals,
+   * the single-focus leaves) override it to avoid the per-hop {@link Stream} {@code getAll} builds.
+   *
+   * <p>The default rides {@link #getAll} for any {@code Fold} that only implements the stream
+   * primitive; it enumerates the exact same focuses in the same order.
+   */
+  default boolean visitWhile(final S source, final Predicate<? super A> visitor) {
+    final var it = getAll(source).iterator();
+    while (it.hasNext()) if (!visitor.test(it.next())) return false;
+    return true;
+  }
+
+  /** Push every focused {@code A} into {@code sink} in enumeration order. */
+  default void forEach(final S source, final Consumer<? super A> sink) {
+    visitWhile(source, a -> {
+      sink.accept(a);
+      return true;
+    });
+  }
+
   /** Materialize all focused values into a list. */
   default List<A> toList(final S source) {
-    return getAll(source).toList();
+    final var out = new ArrayList<A>();
+    forEach(source, out::add);
+    return out;
   }
 
   /** First focused value matching {@code predicate}, or empty if none. */
   default Optional<A> findFirst(final S source, final Predicate<? super A> predicate) {
-    return getAll(source).filter(predicate).findFirst();
+    final var box = new Object[1];
+    final var found = !visitWhile(source, a -> {
+      if (!predicate.test(a)) return true;
+      box[0] = a;
+      return false; // stop at the first match
+    });
+    @SuppressWarnings("unchecked")
+    final var hit = (A) box[0];
+    return found ? Optional.ofNullable(hit) : Optional.empty();
   }
 
   /** Whether any focused value matches {@code predicate}. */
   default boolean any(final S source, final Predicate<? super A> predicate) {
-    return getAll(source).anyMatch(predicate);
+    return !visitWhile(source, a -> !predicate.test(a));
   }
 
   /** Count of focused values. */
   default long count(final S source) {
-    return getAll(source).count();
+    final var c = new long[1];
+    forEach(source, a -> c[0]++);
+    return c[0];
   }
 }

--- a/internal/src/main/java/io/github/eschizoid/telescope/internal/optics/Getter.java
+++ b/internal/src/main/java/io/github/eschizoid/telescope/internal/optics/Getter.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Predicate;
 import java.util.stream.Stream;
 
 /**
@@ -34,6 +35,12 @@ public interface Getter<S, A> extends Fold<S, A> {
   @Override
   default Stream<A> getAll(final S source) {
     return Stream.of(get(source));
+  }
+
+  /** Fold view: visit the single focused value. */
+  @Override
+  default boolean visitWhile(final S source, final Predicate<? super A> visitor) {
+    return visitor.test(get(source));
   }
 
   /**

--- a/internal/src/main/java/io/github/eschizoid/telescope/internal/optics/Iso.java
+++ b/internal/src/main/java/io/github/eschizoid/telescope/internal/optics/Iso.java
@@ -8,6 +8,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.stream.Stream;
 
 /**
@@ -81,6 +82,12 @@ public interface Iso<A, B> extends Lens<A, B>, Prism<A, B> {
   @Override
   default Stream<B> getAll(final A source) {
     return Stream.of(to(source));
+  }
+
+  /** Fold view: visit the single converted value. */
+  @Override
+  default boolean visitWhile(final A source, final Predicate<? super B> visitor) {
+    return visitor.test(to(source));
   }
 
   /** Build an Iso from two inverse functions (must satisfy both round-trip laws). */

--- a/internal/src/main/java/io/github/eschizoid/telescope/internal/optics/Lens.java
+++ b/internal/src/main/java/io/github/eschizoid/telescope/internal/optics/Lens.java
@@ -3,6 +3,7 @@ package io.github.eschizoid.telescope.internal.optics;
 import java.util.Optional;
 import java.util.function.BiFunction;
 import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.stream.Stream;
 
 /**
@@ -142,6 +143,12 @@ public interface Lens<S, A> extends Affine<S, A>, Getter<S, A> {
   default Stream<A> getAll(final S source) {
     if (source == null) return Stream.empty();
     return Stream.of(get(source));
+  }
+
+  /** Fold view: a null source focuses nothing; otherwise visit the single focused value. */
+  @Override
+  default boolean visitWhile(final S source, final Predicate<? super A> visitor) {
+    return source == null || visitor.test(get(source));
   }
 
   /** Build a Lens from a getter and an {@code (S, A) -> S} setter. */

--- a/internal/src/main/java/io/github/eschizoid/telescope/internal/optics/Prism.java
+++ b/internal/src/main/java/io/github/eschizoid/telescope/internal/optics/Prism.java
@@ -2,6 +2,7 @@ package io.github.eschizoid.telescope.internal.optics;
 
 import java.util.Optional;
 import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.stream.Stream;
 
 /**
@@ -62,6 +63,13 @@ public interface Prism<S, A> extends Affine<S, A> {
   @Override
   default Stream<A> getAll(final S source) {
     return getOption(source).stream();
+  }
+
+  /** Fold view: visit the focused value when the case matches, otherwise focus nothing. */
+  @Override
+  default boolean visitWhile(final S source, final Predicate<? super A> visitor) {
+    final var focus = getOption(source);
+    return focus.isEmpty() || visitor.test(focus.get());
   }
 
   /** Build a Prism from a partial getter and a reconstructor (must satisfy the round-trip law). */

--- a/internal/src/main/java/io/github/eschizoid/telescope/internal/optics/Traversal.java
+++ b/internal/src/main/java/io/github/eschizoid/telescope/internal/optics/Traversal.java
@@ -47,6 +47,12 @@ public interface Traversal<S, A> extends Fold<S, A>, Setter<S, A> {
       }
 
       @Override
+      public boolean visitWhile(final S source, final Predicate<? super A> visitor) {
+        // Skip non-matching focuses without invoking the visitor; short-circuit propagates through.
+        return self.visitWhile(source, a -> !predicate.test(a) || visitor.test(a));
+      }
+
+      @Override
       public S modify(final S source, final Function<? super A, ? extends A> f) {
         return self.modify(source, a -> predicate.test(a) ? f.apply(a) : a);
       }
@@ -118,6 +124,13 @@ public interface Traversal<S, A> extends Fold<S, A>, Setter<S, A> {
       @Override
       public Stream<B> getAll(final S source) {
         return self.getAll(source).flatMap(next::getAll);
+      }
+
+      @Override
+      public boolean visitWhile(final S source, final Predicate<? super B> visitor) {
+        // Nested loops instead of a flatMap tower: each outer focus drives the inner visit, and an
+        // inner short-circuit returns false up through the outer visit to stop the whole walk.
+        return self.visitWhile(source, a -> next.visitWhile(a, visitor));
       }
 
       @Override

--- a/internal/src/main/java/io/github/eschizoid/telescope/internal/optics/collections/Traversals.java
+++ b/internal/src/main/java/io/github/eschizoid/telescope/internal/optics/collections/Traversals.java
@@ -155,13 +155,13 @@ public final class Traversals {
       @Override
       public C modify(final C source, final Function<? super E, ? extends E> f) {
         if (source == null) return null;
-        if (source instanceof List<?>) {
-          final var out = new ArrayList<E>();
+        if (source instanceof final List<?> list) {
+          final var out = new ArrayList<E>(list.size());
           for (final var e : source) out.add(f.apply(e));
           return (C) Collections.unmodifiableList(out);
         }
-        if (source instanceof Set<?>) {
-          final var out = new LinkedHashSet<E>();
+        if (source instanceof final Set<?> set) {
+          final var out = new LinkedHashSet<E>(set.size());
           for (final var e : source) out.add(f.apply(e));
           return (C) Collections.unmodifiableSet(out);
         }

--- a/internal/src/main/java/io/github/eschizoid/telescope/internal/optics/collections/Traversals.java
+++ b/internal/src/main/java/io/github/eschizoid/telescope/internal/optics/collections/Traversals.java
@@ -11,6 +11,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
@@ -44,6 +45,12 @@ public final class Traversals {
       }
 
       @Override
+      public boolean visitWhile(final List<A> source, final Predicate<? super A> visitor) {
+        for (final var a : source) if (!visitor.test(a)) return false;
+        return true;
+      }
+
+      @Override
       public List<A> modify(final List<A> source, final Function<? super A, ? extends A> f) {
         final var out = new ArrayList<A>(source.size());
         for (final var a : source) out.add(f.apply(a));
@@ -63,6 +70,12 @@ public final class Traversals {
       }
 
       @Override
+      public boolean visitWhile(final Set<A> source, final Predicate<? super A> visitor) {
+        for (final var a : source) if (!visitor.test(a)) return false;
+        return true;
+      }
+
+      @Override
       public Set<A> modify(final Set<A> source, final Function<? super A, ? extends A> f) {
         final var out = new LinkedHashSet<A>(source.size());
         for (final var a : source) out.add(f.apply(a));
@@ -79,6 +92,12 @@ public final class Traversals {
       @Override
       public Stream<V> getAll(final Map<K, V> source) {
         return source.values().stream();
+      }
+
+      @Override
+      public boolean visitWhile(final Map<K, V> source, final Predicate<? super V> visitor) {
+        for (final var v : source.values()) if (!visitor.test(v)) return false;
+        return true;
       }
 
       @Override
@@ -124,6 +143,13 @@ public final class Traversals {
       public Stream<E> getAll(final C source) {
         if (source == null) return Stream.empty();
         return StreamSupport.stream(source.spliterator(), false);
+      }
+
+      @Override
+      public boolean visitWhile(final C source, final Predicate<? super E> visitor) {
+        if (source == null) return true;
+        for (final var e : source) if (!visitor.test(e)) return false;
+        return true;
       }
 
       @Override

--- a/internal/src/test/java/io/github/eschizoid/telescope/internal/optics/OpticLawsTest.java
+++ b/internal/src/test/java/io/github/eschizoid/telescope/internal/optics/OpticLawsTest.java
@@ -1,11 +1,15 @@
 package io.github.eschizoid.telescope.internal.optics;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import io.github.eschizoid.telescope.internal.optics.collections.Traversals;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -226,6 +230,61 @@ class OpticLawsTest {
       final var composed = uIso.then(dtoName);
       assertInstanceOf(Lens.class, composed);
       assertEquals("Alice", composed.get(ALICE));
+    }
+  }
+
+  @Nested
+  @DisplayName("visitWhile enumerates the same focuses as getAll")
+  class VisitWhileEquivalence {
+
+    // A List<User> traversed element-wise, then narrowed to each user's name: exercises
+    // Traversal.then's visitWhile (nested loops) against the getAll (flatMap) it must match.
+    static final Traversal<List<User>, String> eachName = Traversals.<User>eachList().then(userName);
+
+    static final List<User> roster = List.of(
+      new User("Alice", 30, null),
+      new User("Bob", 25, null),
+      new User("Cara", 40, null)
+    );
+
+    @Test
+    @DisplayName("a full visit collects the same elements in the same order as getAll")
+    void visitWhileMatchesGetAll() {
+      final var viaStream = eachName.getAll(roster).toList();
+      final var viaVisit = new ArrayList<String>();
+      final var full = eachName.visitWhile(roster, name -> {
+        viaVisit.add(name);
+        return true;
+      });
+      assertTrue(full); // nothing short-circuited, so every focus was visited
+      assertEquals(viaStream, viaVisit);
+      assertEquals(List.of("Alice", "Bob", "Cara"), viaVisit);
+    }
+
+    @Test
+    @DisplayName("a false visit stops immediately and reports the short-circuit")
+    void visitWhileShortCircuits() {
+      final var seen = new ArrayList<String>();
+      final var full = eachName.visitWhile(roster, name -> {
+        seen.add(name);
+        return !name.equals("Bob");
+      });
+      assertFalse(full); // the visit stopped early
+      assertEquals(List.of("Alice", "Bob"), seen); // stopped AT Bob; Cara was never visited
+    }
+
+    @Test
+    @DisplayName("a filtered visit skips non-matching focuses and still matches getAll order")
+    void filteredVisitWhileMatchesGetAll() {
+      final var shortNames = eachName.filter(name -> name.length() <= 4); // Alice=5 out, Bob/Cara in
+      final var viaStream = shortNames.getAll(roster).toList();
+      final var viaVisit = new ArrayList<String>();
+      shortNames.visitWhile(roster, name -> {
+        viaVisit.add(name);
+        return true;
+      });
+      assertEquals(viaStream, viaVisit);
+      assertEquals(List.of("Bob", "Cara"), viaVisit);
     }
   }
 }


### PR DESCRIPTION
## What

Read terminals rode `Fold.getAll`, which composes across hops as `self.getAll(source).flatMap(next::getAll)` — a deep path builds a tower of per-element single-element `Stream`s, so `count`/`exists`/`toList` over a 100-leaf tree pay microseconds of stream machinery regardless of terminal.

Add `Fold.visitWhile(source, Predicate)` — a short-circuitable visitor that loops instead of streaming. Every composing optic overrides it:
- **`Traversal.then`** walks nested loops (an inner short-circuit returns up through the outer visit) — the flatMap-tower killer.
- **`Traversal.filter`** skips non-matching focuses without invoking the visitor.
- The **four collection traversals** loop their container directly; `eachIterable`'s rebuild also now pre-sizes to `source.size()`, matching its eachList/eachSet siblings (P7, bundled).
- Each **single-focus leaf** (Getter/Lens/Iso/Prism/Affine) visits its one focus mirroring its own `getAll` (including Lens's null-source guard). The diamond (`Iso <: Lens, Prism`; `Lens <: Affine, Getter`) forces explicit overrides at Lens and Iso.

`Fold.toList/count/findFirst/any` reroute through `visitWhile`; `getAll` stays for the lazy head-pull `read()`/`find()` use. Telescope's `toList`/`count`/`exists`/`toListIndexed` ride the loop path. `exists()` also sheds a latent `Stream.findAny()` NPE on a null focus.

Review: fleet CONVERGED/CLEAN (per-optic visitWhile-vs-getAll equivalence traced, short-circuit propagation, diamond resolution, modifyF untouched). Added the direct `visitWhile`-vs-`getAll` equivalence + short-circuit + filter pins in `OpticLawsTest`, and a null-focus read-terminal test. Full `:internal` + `:core` suites green.

## Gate numbers (CI, isolated runner, fork=3, 5 warmup / 10 measurement, n=30)

BEFORE = main @ 52ac13d9 ([run 29907671190](https://github.com/eschizoid/telescope/actions/runs/29907671190)), AFTER = this branch @ d535504e ([run 29907672879](https://github.com/eschizoid/telescope/actions/runs/29907672879)). Floors are identical across runs (countHand 108.270 vs 108.287, countAbsoluteFloor 15.215 vs 15.187) — the runs are directly comparable.

| Row | BEFORE (ns/op) | AFTER (ns/op) | Δ |
|---|---|---|---|
| `existsMiss` (scan all 100, no match) | 4685.4 ± 685.5 | **513.5 ± 63.7** | **9.1×** |
| `existsEarlyHit` | 296.7 ± 1.6 | **39.1 ± 0.1** | **7.6×** |
| `countTelescope` | 1597.9 ± 12.9 | **477.5 ± 91.9** | **3.3×** |
| `toListTelescope` | 1963.5 ± 5.4 | **672.8 ± 8.6** | **2.9×** |
| `toListHand` (floor) | 685.6 | 690.7 | stable |
| `countHand` (floor) | 108.3 | 108.3 | stable |

`toList` through the telescope now sits **at the hand-written loop's floor** (672.8 vs 690.7). The short-circuit terminals win biggest — `exists` no longer builds any stream at all. Local runs were abandoned for gating: the agent's own CPU contaminated three consecutive attempts; CI's isolated runners are the honest measurement environment.
