### PR TITLE
perf(core): multi-edit fusion — one structural pass for Telescope.all (2.2x flat / 1.8x tree, gated)

### DIFF
--- a/core/src/main/java/io/github/eschizoid/telescope/Edit.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/Edit.java
@@ -104,8 +104,11 @@ public interface Edit<S> {
    * factories when the carried value is {@code null}, so a sparse-PATCH composition can keep its
    * slot count visible without each null check distorting the surrounding shape.
    */
+  @SuppressWarnings("unchecked")
   static <S> Edit<S> identity() {
-    return s -> s;
+    // A shared singleton (safe: stateless) so Telescope.all's fusion pass can recognize and skip
+    // identity slots instead of treating each fresh lambda as an opaque, unfusible edit.
+    return (Edit<S>) EditIdentity.INSTANCE;
   }
 
   /**
@@ -113,15 +116,4 @@ public interface Edit<S> {
    * edits into a single {@code Function<S, S>}.
    */
   S apply(S s);
-}
-
-/**
- * The single {@link Edit} implementation. Package-private so users construct edits only through
- * {@link Edit#over(Telescope, Function)} and never see this type at the call site.
- */
-record EditImpl<S, X>(Telescope<S, X> path, Function<X, X> fn) implements Edit<S> {
-  @Override
-  public S apply(final S s) {
-    return path.update(s, fn);
-  }
 }

--- a/core/src/main/java/io/github/eschizoid/telescope/EditIdentity.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/EditIdentity.java
@@ -1,0 +1,9 @@
+package io.github.eschizoid.telescope;
+
+/** Holder for the {@link Edit#identity()} singleton — identifiable, stateless, shared. */
+final class EditIdentity {
+
+  static final Edit<Object> INSTANCE = s -> s;
+
+  private EditIdentity() {}
+}

--- a/core/src/main/java/io/github/eschizoid/telescope/EditImpl.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/EditImpl.java
@@ -1,0 +1,14 @@
+package io.github.eschizoid.telescope;
+
+import java.util.function.Function;
+
+/**
+ * The single {@link Edit} implementation. Package-private so users construct edits only through
+ * {@link Edit#over(Telescope, Function)} and never see this type at the call site.
+ */
+record EditImpl<S, X>(Telescope<S, X> path, Function<X, X> fn) implements Edit<S> {
+  @Override
+  public S apply(final S s) {
+    return path.update(s, fn);
+  }
+}

--- a/core/src/main/java/io/github/eschizoid/telescope/Fusion.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/Fusion.java
@@ -22,8 +22,9 @@ import java.util.function.Function;
  * <ul>
  *   <li><b>Prefix sharing</b> — a hop shared by several edits ({@code each(Team::users)}) runs its
  *       {@code modify} once, with the fused sub-edits applied per focused value. Hop identity is
- *       the {@link Hop#key()}: {@code (owner class, component name)} for field/traverse hops (so
- *       separately-built paths still share), reference identity for filter predicates.
+ *       the kind-tagged {@link Hop#key()}: {@code (kind, owner class, component name[, container
+ *       kind])} for field/traverse hops (so separately-built paths still share), the predicate
+ *       object itself for filter hops — equality-based, which for lambdas means the same instance.
  *   <li><b>Sibling slot fusion</b> — when a trie node branches into field/traverse edits of
  *       pairwise-distinct components of one record, the node compiles to a single positional
  *       rebuild: read every component once (build-time-captured readers), apply each branch's edit
@@ -126,8 +127,8 @@ final class Fusion {
     }
 
     static Hop filter(final Object predicate, final Traversal<Object, Object> filtered) {
-      // Reference identity: two filter hops share a trie node only when they are literally the
-      // same predicate instance on a shared prefix — lambda equality cannot be decided.
+      // The predicate object is the key: sharing is equals-based, which for lambdas (no equals
+      // override) means the same instance on a shared prefix — lambda equality cannot be decided.
       return new Hop(Kind.FILTER, predicate, filtered, null, null, null);
     }
   }

--- a/core/src/main/java/io/github/eschizoid/telescope/Fusion.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/Fusion.java
@@ -1,0 +1,243 @@
+package io.github.eschizoid.telescope;
+
+import io.github.eschizoid.telescope.internal.Records;
+import io.github.eschizoid.telescope.internal.optics.Lens;
+import io.github.eschizoid.telescope.internal.optics.Traversal;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.function.Function;
+
+/**
+ * The multi-edit fusion engine behind {@link Telescope#all(Edit[])}. Sibling of {@link DeepMap} /
+ * {@link Merge}: a package-private {@code :core} engine that composes existing lattice operations —
+ * it never hand-rolls structural plumbing the optics already provide.
+ *
+ * <p>{@code Telescope.all(over(...), over(...))} used to fold N edits into N sequential structural
+ * passes: k edits under a shared {@code .each(...)} prefix rebuilt the same container k times, and
+ * k disjoint field edits on one record rebuilt that record k times. Fusion unions the edits' hop
+ * lists into a prefix trie and compiles ONE walk:
+ *
+ * <ul>
+ *   <li><b>Prefix sharing</b> — a hop shared by several edits ({@code each(Team::users)}) runs its
+ *       {@code modify} once, with the fused sub-edits applied per focused value. Hop identity is
+ *       the {@link Hop#key()}: {@code (owner class, component name)} for field/traverse hops (so
+ *       separately-built paths still share), reference identity for filter predicates.
+ *   <li><b>Sibling slot fusion</b> — when a trie node branches into field/traverse edits of
+ *       pairwise-distinct components of one record, the node compiles to a single positional
+ *       rebuild: read every component once (build-time-captured readers), apply each branch's edit
+ *       to its slot, one cached canonical-constructor call. Traverse branches fold in as their
+ *       component's slot function ({@code inner.modify}), so a record level is rebuilt once no
+ *       matter how many of its components are edited.
+ * </ul>
+ *
+ * <p><b>Semantics bar: observationally identical to the sequential fold.</b> Fusion applies only
+ * where order-independence is provable, and {@link #fuse} returns {@code null} — caller falls back
+ * to the sequential fold — everywhere else:
+ *
+ * <ul>
+ *   <li>any edit that is not an {@link EditImpl} (a user-implemented {@code Edit}), or whose path
+ *       carries no hop record (runtime-checked navigation like {@code fieldByName}, bridge hops,
+ *       {@code from/to/using} entry points, custom lenses);
+ *   <li>one edit's path a strict prefix of another's (the deeper edit runs inside the shallower
+ *       one's leaf — sequential order is observable);
+ *   <li>a trie node branching on anything but same-owner, pairwise-distinct components — a filter
+ *       or narrow hop may sit in a shared prefix, but branching across one is not provably
+ *       order-free (a filtered branch and a direct branch can edit the same component).
+ * </ul>
+ *
+ * <p>Edits with EQUAL full paths do fuse: their leaf functions compose in edit order, which is
+ * exactly the sequential semantics. {@code Edit.identity()} slots (a sparse-PATCH {@code
+ * overIfPresent(null)}) are skipped — they contribute nothing.
+ *
+ * <p>A record-level slot plan routes a {@code null} focused value through the same per-segment
+ * sequential ops the fallback uses, so null handling is identical to composed-lens behavior by
+ * construction rather than by re-implementation.
+ *
+ * <p>Erasure note: the engine works in {@code Object}-typed segments. The types were proven at
+ * path-build time (each segment IS the lattice optic the DSL composed); this is the same erased
+ * assembly floor {@link DeepMap} sits on.
+ */
+final class Fusion {
+
+  private Fusion() {}
+
+  /**
+   * One navigation hop retained for fusion, parallel to the introspection trail: the identity key
+   * that drives trie sharing, the hop's un-composed optic segment, and — for component-anchored
+   * hops — the owning class and component name, plus the inner container traversal for traverse
+   * hops (used when the hop folds into a record slot plan).
+   */
+  record Hop(
+    Object key,
+    Traversal<Object, Object> segment,
+    Class<?> owner,
+    String component,
+    Traversal<Object, Object> inner
+  ) {
+    static Hop field(final Class<?> owner, final String component, final Traversal<Object, Object> lens) {
+      return new Hop(List.of(owner, component), lens, owner, component, null);
+    }
+
+    static Hop traverse(
+      final Class<?> owner,
+      final String component,
+      final String containerKind,
+      final Traversal<Object, Object> segment,
+      final Traversal<Object, Object> inner
+    ) {
+      return new Hop(List.of(owner, component, containerKind), segment, owner, component, inner);
+    }
+
+    static Hop narrow(final Class<?> subType, final Traversal<Object, Object> prism) {
+      return new Hop(List.of(subType, "as"), prism, null, null, null);
+    }
+
+    static Hop filter(final Object predicate, final Traversal<Object, Object> filtered) {
+      // Reference identity: two filter hops share a trie node only when they are literally the
+      // same predicate instance on a shared prefix — lambda equality cannot be decided.
+      return new Hop(predicate, filtered, null, null, null);
+    }
+  }
+
+  /**
+   * Fuse the edits into a single structural pass, or return {@code null} when fusion cannot be
+   * proven observationally identical to the sequential fold (the caller falls back).
+   */
+  @SuppressWarnings("unchecked")
+  static <S> Function<S, S> fuse(final Edit<S>[] edits) {
+    final var live = new ArrayList<EditImpl<S, ?>>(edits.length);
+    for (final var e : edits) {
+      if (e == EditIdentity.INSTANCE) continue; // sparse-PATCH null slot — contributes nothing
+      if (!(e instanceof EditImpl)) return null;
+      final var impl = (EditImpl<S, ?>) e;
+      if (impl.path().hops == null) return null;
+      live.add(impl);
+    }
+    if (live.size() < 2) return null; // nothing to fuse; the sequential fold is already minimal
+
+    // Overlap: a strict-prefix pair means the deeper edit rewrites part of the shallower edit's
+    // leaf — sequential order is observable there, so fusion declines.
+    final var keyLists = new ArrayList<List<Object>>(live.size());
+    for (final var e : live) {
+      final var keys = new ArrayList<Object>(e.path().hops.size());
+      for (final var h : e.path().hops) keys.add(h.key());
+      keyLists.add(keys);
+    }
+    for (var i = 0; i < keyLists.size(); i++) {
+      for (var j = 0; j < keyLists.size(); j++) {
+        if (i != j && isStrictPrefix(keyLists.get(i), keyLists.get(j))) return null;
+      }
+    }
+
+    final var root = new Node(null);
+    for (final var e : live) {
+      var node = root;
+      for (final var hop : e.path().hops) {
+        node = node.children.computeIfAbsent(hop.key(), __ -> new Node(hop));
+      }
+      node.leafFns.add((Function<Object, Object>) e.fn());
+    }
+
+    final var compiled = compile(root);
+    if (compiled == null) return null;
+    return s -> (S) compiled.apply(s);
+  }
+
+  private static boolean isStrictPrefix(final List<Object> shorter, final List<Object> longer) {
+    if (shorter.size() >= longer.size()) return false;
+    for (var i = 0; i < shorter.size(); i++) if (!shorter.get(i).equals(longer.get(i))) return false;
+    return true;
+  }
+
+  private static final class Node {
+
+    final Hop hop; // null at the root
+    final LinkedHashMap<Object, Node> children = new LinkedHashMap<>();
+    final List<Function<Object, Object>> leafFns = new ArrayList<>();
+
+    Node(final Hop hop) {
+      this.hop = hop;
+    }
+  }
+
+  /** Compile a trie node into the edit applied at its focus, or {@code null} when unfusible. */
+  @SuppressWarnings("unchecked")
+  private static Function<Object, Object> compile(final Node node) {
+    if (!node.leafFns.isEmpty()) {
+      // The strict-prefix check excluded leaf-and-children nodes; equal-path edits compose here in
+      // edit order — exactly the sequential semantics.
+      var fn = node.leafFns.get(0);
+      for (var i = 1; i < node.leafFns.size(); i++) fn = fn.andThen(node.leafFns.get(i));
+      return fn;
+    }
+
+    final var kids = List.copyOf(node.children.values());
+    final var childFns = new ArrayList<Function<Object, Object>>(kids.size());
+    for (final var child : kids) {
+      final var fn = compile(child);
+      if (fn == null) return null;
+      childFns.add(fn);
+    }
+
+    if (kids.size() == 1) {
+      final var seg = kids.get(0).hop.segment();
+      final var inner = childFns.get(0);
+      return x -> seg.modify(x, inner);
+    }
+
+    // Branching is fusible only across same-owner, pairwise-distinct components: that is the shape
+    // where cross-branch order is provably irrelevant. Filter / narrow hops carry no component and
+    // therefore never participate in a branch.
+    Class<?> owner = null;
+    final var seenComponents = new HashSet<String>();
+    for (final var child : kids) {
+      final var h = child.hop;
+      if (h.owner() == null || h.component() == null) return null;
+      if (owner == null) owner = h.owner();
+      else if (owner != h.owner()) return null;
+      if (!seenComponents.add(h.component())) return null; // field vs each on one component — bail
+    }
+
+    // The per-segment sequential shape: the bean-owner compile target, and the null-source route
+    // of the record slot plan (so null behavior matches composed lenses by construction).
+    Function<Object, Object> sequential = Function.identity();
+    for (var i = 0; i < kids.size(); i++) {
+      final var seg = kids.get(i).hop.segment();
+      final var fn = childFns.get(i);
+      sequential = sequential.andThen(x -> seg.modify(x, fn));
+    }
+    if (!owner.isRecord()) return sequential;
+
+    // Record slot plan: one positional rebuild for the whole branch level. Readers are captured at
+    // compile time (no per-call name lookup); traverse branches fold in as their component's slot
+    // function; untouched components copy through.
+    final var comps = Records.componentNames(owner);
+    final var readers = new ArrayList<Lens<Object, Object>>(comps.length);
+    final var recordClass = (Class<Object>) owner;
+    for (final var comp : comps) readers.add(Records.fieldLens(recordClass, comp));
+    final var slotFns = new ArrayList<Function<Object, Object>>(comps.length);
+    for (var i = 0; i < comps.length; i++) slotFns.add(null);
+    for (var i = 0; i < kids.size(); i++) {
+      final var h = kids.get(i).hop;
+      final var fn = childFns.get(i);
+      final var slot = List.of(comps).indexOf(h.component());
+      if (slot < 0) return null; // component not on the canonical ctor — defensive; bail to sequential fold
+      slotFns.set(slot, h.inner() == null ? fn : v -> h.inner().modify(v, fn));
+    }
+    final var cls = owner;
+    final var onNull = sequential;
+    final var n = comps.length;
+    return x -> {
+      if (x == null) return onNull.apply(x);
+      final var args = new Object[n];
+      for (var i = 0; i < n; i++) {
+        final var v = readers.get(i).get(x);
+        final var fn = slotFns.get(i);
+        args[i] = fn == null ? v : fn.apply(v);
+      }
+      return Records.construct(cls, args);
+    };
+  }
+}

--- a/core/src/main/java/io/github/eschizoid/telescope/Fusion.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/Fusion.java
@@ -42,18 +42,33 @@ import java.util.function.Function;
  *       {@code from/to/using} entry points, custom lenses);
  *   <li>one edit's path a strict prefix of another's (the deeper edit runs inside the shallower
  *       one's leaf — sequential order is observable);
- *   <li>a trie node branching on anything but same-owner, pairwise-distinct components — a filter
- *       or narrow hop may sit in a shared prefix, but branching across one is not provably
- *       order-free (a filtered branch and a direct branch can edit the same component).
+ *   <li>a trie node branching on anything but same-owner, pairwise-distinct components — filter and
+ *       narrow hops never participate in a branch (a filtered branch and a direct branch can edit
+ *       the same component).
  * </ul>
  *
- * <p>Edits with EQUAL full paths do fuse: their leaf functions compose in edit order, which is
- * exactly the sequential semantics. {@code Edit.identity()} slots (a sparse-PATCH {@code
+ * <p><b>Filters are value-dependent and get per-edit replay.</b> The sequential fold re-tests a
+ * filter's predicate between passes — an edit can change the very data the predicate reads, so a
+ * later edit must see the re-tested verdict on the already-edited value. A filter node carrying two
+ * or more edits therefore does NOT hoist the test: it compiles to a per-edit replay (each edit's
+ * remaining path applied through its own filter test, in edit order — per element, exactly the
+ * sequential work), while the container walk above the filter stays fused. Narrow hops need no
+ * replay: an edit's {@code Function<B, B>} cannot change whether the prism matches. Container
+ * traverses need none either: {@code modify} preserves element count and position.
+ *
+ * <p>Edits with EQUAL full paths fuse by composing leaf functions in edit order — sequential
+ * semantics, given the filter rule above. {@code Edit.identity()} slots (a sparse-PATCH {@code
  * overIfPresent(null)}) are skipped — they contribute nothing.
  *
  * <p>A record-level slot plan routes a {@code null} focused value through the same per-segment
  * sequential ops the fallback uses, so null handling is identical to composed-lens behavior by
  * construction rather than by re-implementation.
+ *
+ * <p><b>Purity scope.</b> "Observationally identical" assumes pure leaf functions, predicates, and
+ * record accessors — the standing optics assumption. Result values always match; what a fused pass
+ * changes is internal evaluation shape (element-major instead of edit-major, slot functions in
+ * component-declaration order, fewer structural rebuilds and accessor reads), which only a
+ * side-effecting function could observe.
  *
  * <p>Erasure note: the engine works in {@code Object}-typed segments. The types were proven at
  * path-build time (each segment IS the lattice optic the DSL composed); this is the same erased
@@ -64,20 +79,29 @@ final class Fusion {
   private Fusion() {}
 
   /**
-   * One navigation hop retained for fusion, parallel to the introspection trail: the identity key
-   * that drives trie sharing, the hop's un-composed optic segment, and — for component-anchored
-   * hops — the owning class and component name, plus the inner container traversal for traverse
-   * hops (used when the hop folds into a record slot plan).
+   * One navigation hop retained for fusion, parallel to the introspection trail: the hop kind, the
+   * identity key that drives trie sharing (kind-tagged so key domains cannot collide), the hop's
+   * un-composed optic segment, and — for component-anchored hops — the owning class and component
+   * name, plus the inner container traversal for traverse hops (used when the hop folds into a
+   * record slot plan).
    */
   record Hop(
+    Kind kind,
     Object key,
     Traversal<Object, Object> segment,
     Class<?> owner,
     String component,
     Traversal<Object, Object> inner
   ) {
+    enum Kind {
+      FIELD,
+      TRAVERSE,
+      NARROW,
+      FILTER,
+    }
+
     static Hop field(final Class<?> owner, final String component, final Traversal<Object, Object> lens) {
-      return new Hop(List.of(owner, component), lens, owner, component, null);
+      return new Hop(Kind.FIELD, List.of(Kind.FIELD, owner, component), lens, owner, component, null);
     }
 
     static Hop traverse(
@@ -87,17 +111,24 @@ final class Fusion {
       final Traversal<Object, Object> segment,
       final Traversal<Object, Object> inner
     ) {
-      return new Hop(List.of(owner, component, containerKind), segment, owner, component, inner);
+      return new Hop(
+        Kind.TRAVERSE,
+        List.of(Kind.TRAVERSE, owner, component, containerKind),
+        segment,
+        owner,
+        component,
+        inner
+      );
     }
 
     static Hop narrow(final Class<?> subType, final Traversal<Object, Object> prism) {
-      return new Hop(List.of(subType, "as"), prism, null, null, null);
+      return new Hop(Kind.NARROW, List.of(Kind.NARROW, subType), prism, null, null, null);
     }
 
     static Hop filter(final Object predicate, final Traversal<Object, Object> filtered) {
       // Reference identity: two filter hops share a trie node only when they are literally the
       // same predicate instance on a shared prefix — lambda equality cannot be decided.
-      return new Hop(predicate, filtered, null, null, null);
+      return new Hop(Kind.FILTER, predicate, filtered, null, null, null);
     }
   }
 
@@ -133,9 +164,17 @@ final class Fusion {
 
     final var root = new Node(null);
     for (final var e : live) {
+      final var hops = e.path().hops;
       var node = root;
-      for (final var hop : e.path().hops) {
+      for (var i = 0; i < hops.size(); i++) {
+        final var hop = hops.get(i);
         node = node.children.computeIfAbsent(hop.key(), __ -> new Node(hop));
+        // A filter's verdict is value-dependent: the sequential fold re-tests it between passes,
+        // so a filter node fusing >= 2 edits must replay them per edit. Record each edit's tail
+        // (remaining hops + leaf fn) at every filter node it crosses, in edit order.
+        if (node.hop.kind() == Hop.Kind.FILTER) {
+          node.tails.add(new Tail(hops.subList(i + 1, hops.size()), (Function<Object, Object>) e.fn()));
+        }
       }
       node.leafFns.add((Function<Object, Object>) e.fn());
     }
@@ -156,11 +195,17 @@ final class Fusion {
     final Hop hop; // null at the root
     final LinkedHashMap<Object, Node> children = new LinkedHashMap<>();
     final List<Function<Object, Object>> leafFns = new ArrayList<>();
+    // Populated at FILTER nodes only: one entry per edit crossing (or ending at) this node, in
+    // edit order — the replay data for the per-edit compile shape.
+    final List<Tail> tails = new ArrayList<>();
 
     Node(final Hop hop) {
       this.hop = hop;
     }
   }
+
+  /** An edit's remaining path below a filter node plus its leaf function. */
+  private record Tail(List<Hop> remaining, Function<Object, Object> fn) {}
 
   /** Compile a trie node into the edit applied at its focus, or {@code null} when unfusible. */
   @SuppressWarnings("unchecked")
@@ -174,30 +219,27 @@ final class Fusion {
     }
 
     final var kids = List.copyOf(node.children.values());
+
+    if (kids.size() == 1) return wrapChild(kids.get(0));
+
+    // Branching is fusible only across same-owner, pairwise-distinct components: that is the shape
+    // where cross-branch order is provably irrelevant. Filter / narrow hops never participate in a
+    // branch — a filtered branch and a direct branch can edit the same component.
+    Class<?> owner = null;
+    final var seenComponents = new HashSet<String>();
+    for (final var child : kids) {
+      final var h = child.hop;
+      if (h.kind() != Hop.Kind.FIELD && h.kind() != Hop.Kind.TRAVERSE) return null;
+      if (owner == null) owner = h.owner();
+      else if (owner != h.owner()) return null;
+      if (!seenComponents.add(h.component())) return null; // field vs each on one component — bail
+    }
+
     final var childFns = new ArrayList<Function<Object, Object>>(kids.size());
     for (final var child : kids) {
       final var fn = compile(child);
       if (fn == null) return null;
       childFns.add(fn);
-    }
-
-    if (kids.size() == 1) {
-      final var seg = kids.get(0).hop.segment();
-      final var inner = childFns.get(0);
-      return x -> seg.modify(x, inner);
-    }
-
-    // Branching is fusible only across same-owner, pairwise-distinct components: that is the shape
-    // where cross-branch order is provably irrelevant. Filter / narrow hops carry no component and
-    // therefore never participate in a branch.
-    Class<?> owner = null;
-    final var seenComponents = new HashSet<String>();
-    for (final var child : kids) {
-      final var h = child.hop;
-      if (h.owner() == null || h.component() == null) return null;
-      if (owner == null) owner = h.owner();
-      else if (owner != h.owner()) return null;
-      if (!seenComponents.add(h.component())) return null; // field vs each on one component — bail
     }
 
     // The per-segment sequential shape: the bean-owner compile target, and the null-source route
@@ -239,5 +281,38 @@ final class Fusion {
       }
       return Records.construct(cls, args);
     };
+  }
+
+  /**
+   * Compile a child node into the edit applied at its PARENT's focus (the child's segment wrap).
+   *
+   * <p>The filter-soundness seam lives here: a filter's verdict is value-dependent, and the
+   * sequential fold re-tests it between passes — an edit can change data the predicate reads, so a
+   * later edit must see the re-tested verdict on the already-edited value. A filter node fusing two
+   * or more edits therefore compiles to a per-edit replay: each edit's remaining path is applied
+   * through its own filter test, in edit order — per focused element, exactly the work the
+   * sequential fold does — while everything ABOVE the filter (the container walk) stays fused. A
+   * single-edit filter node has only one pass either way and takes the normal wrap.
+   */
+  private static Function<Object, Object> wrapChild(final Node child) {
+    final var seg = child.hop.segment();
+    if (child.hop.kind() == Hop.Kind.FILTER && child.tails.size() >= 2) {
+      Function<Object, Object> chain = Function.identity();
+      for (final var tail : child.tails) {
+        // edit order
+        var fn = tail.fn();
+        for (var i = tail.remaining().size() - 1; i >= 0; i--) {
+          final var hopSeg = tail.remaining().get(i).segment();
+          final var inner = fn;
+          fn = x -> hopSeg.modify(x, inner);
+        }
+        final var perEdit = fn;
+        chain = chain.andThen(x -> seg.modify(x, perEdit));
+      }
+      return chain;
+    }
+    final var inner = compile(child);
+    if (inner == null) return null;
+    return x -> seg.modify(x, inner);
   }
 }

--- a/core/src/main/java/io/github/eschizoid/telescope/Telescope.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/Telescope.java
@@ -390,8 +390,12 @@ public sealed class Telescope<
    * result, not the original source. An empty argument list returns an identity telescope (apply
    * returns the source unchanged).
    *
-   * <p><b>Cost.</b> One structural pass per edit — no fusion across shared prefixes in this
-   * version. Costs the same as the equivalent chain accumulator.
+   * <p><b>Cost.</b> Edits with provably order-free paths fuse into one structural pass: a shared
+   * prefix (the same {@code .each(...)} hop, by field identity — separately-built paths count) is
+   * walked once, and disjoint field edits at one record level rebuild that record once. Everything
+   * else — overlapping paths, runtime-checked navigation, custom edits — runs as the sequential
+   * edit-by-edit fold. Results are identical either way (assuming pure functions); fusion only
+   * removes redundant structural rebuilds.
    *
    * @param edits the edits to apply, in order
    * @param <S> the shared root type — all edits must target the same {@code S}

--- a/core/src/main/java/io/github/eschizoid/telescope/Telescope.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/Telescope.java
@@ -135,20 +135,25 @@ public sealed class Telescope<
   // whole path — accumulated immutably (copy-append) at build time, never touched on the
   // read/update hot path. Empty for a bare Telescope.of(...) or an iso-backed conversion.
   final List<OpticNode> trail;
+  // The fusion-facing twin of `trail`: one Fusion.Hop per combinator hop — the un-composed optic
+  // segment plus the identity key Telescope.all's fusion trie shares prefixes by. `null` marks the
+  // path unfusible (runtime-checked navigation, bridge hops, custom lenses, chain-carrying paths):
+  // Fusion declines and Telescope.all falls back to the sequential fold.
+  final List<Fusion.Hop> hops;
 
   // Package-private so that the conversion-builder classes (From, To, Mapper, …) — extracted to
   // sibling files to keep Telescope.java navigable — can construct Telescope instances without
   // needing us to expose internals through the JPMS export.
   Telescope(final Traversal<S, A> optic) {
-    this(optic, RecordFieldOptics.INSTANCE, Function.identity(), null, List.of());
+    this(optic, RecordFieldOptics.INSTANCE, Function.identity(), null, List.of(), null);
   }
 
   private Telescope(final Traversal<S, A> optic, final FieldOptics fieldOptics) {
-    this(optic, fieldOptics, Function.identity(), null, List.of());
+    this(optic, fieldOptics, Function.identity(), null, List.of(), null);
   }
 
   Telescope(final Traversal<S, A> optic, final FieldOptics fieldOptics, final Function<S, S> chain) {
-    this(optic, fieldOptics, chain, null, List.of());
+    this(optic, fieldOptics, chain, null, List.of(), null);
   }
 
   Telescope(
@@ -157,7 +162,7 @@ public sealed class Telescope<
     final Function<S, S> chain,
     final String firstHopName
   ) {
-    this(optic, fieldOptics, chain, firstHopName, List.of());
+    this(optic, fieldOptics, chain, firstHopName, List.of(), null);
   }
 
   Telescope(
@@ -167,10 +172,22 @@ public sealed class Telescope<
     final String firstHopName,
     final List<OpticNode> trail
   ) {
+    this(optic, fieldOptics, chain, firstHopName, trail, null);
+  }
+
+  Telescope(
+    final Traversal<S, A> optic,
+    final FieldOptics fieldOptics,
+    final Function<S, S> chain,
+    final String firstHopName,
+    final List<OpticNode> trail,
+    final List<Fusion.Hop> hops
+  ) {
     this.optic = optic;
     this.fieldOptics = fieldOptics;
     this.chain = chain;
     this.firstHopName = firstHopName;
+    this.hops = hops;
     // Stored as-is. The invariant callers must uphold is immutability, not non-sharing: every
     // internal caller passes an already-immutable list (an empty List.of(), a fresh unmodifiable
     // list from plus(), or a defensively-copied one from mapped()). then() may alias an existing
@@ -182,6 +199,17 @@ public sealed class Telescope<
   // Append one hop node to this Telescope's trail as a fresh immutable list — one copy of the
   // existing trail, wrapped as an unmodifiable view the constructor stores directly (no second
   // copy). The fresh ArrayList is never shared, so the view cannot be mutated behind our back.
+  // Null-propagating hop append: an unfusible prefix (hops == null) stays unfusible, and a hop
+  // that cannot carry an identity (null) poisons the path — Fusion then declines and the
+  // sequential fold runs. Mirrors plus() for the introspection trail.
+  private List<Fusion.Hop> plusHops(final Fusion.Hop hop) {
+    if (hops == null || hop == null) return null;
+    final var extended = new ArrayList<Fusion.Hop>(hops.size() + 1);
+    extended.addAll(hops);
+    extended.add(hop);
+    return Collections.unmodifiableList(extended);
+  }
+
   private List<OpticNode> plus(final OpticNode node) {
     final var extended = new ArrayList<OpticNode>(trail.size() + 1);
     extended.addAll(trail);
@@ -220,7 +248,7 @@ public sealed class Telescope<
    * @see #ofBean(Class)
    */
   public static <S> Telescope<S, S> of(final Class<S> rootType) {
-    return new Telescope<>(Iso.identity());
+    return new Telescope<>(Iso.identity(), RecordFieldOptics.INSTANCE, Function.identity(), null, List.of(), List.of());
   }
 
   /**
@@ -371,10 +399,13 @@ public sealed class Telescope<
    * @see #apply(Object)
    */
   @SafeVarargs
+  @SuppressWarnings("varargs")
   public static <S> Telescope<S, S> all(final Edit<S>... edits) {
-    Function<S, S> fused = Function.identity();
-    for (final var e : edits) fused = fused.andThen(e::apply);
-    return new Telescope<>(Iso.identity(), RecordFieldOptics.INSTANCE, fused);
+    final var fused = Fusion.fuse(edits);
+    if (fused != null) return new Telescope<>(Iso.identity(), RecordFieldOptics.INSTANCE, fused);
+    Function<S, S> fold = Function.identity();
+    for (final var e : edits) fold = fold.andThen(e::apply);
+    return new Telescope<>(Iso.identity(), RecordFieldOptics.INSTANCE, fold);
   }
 
   /**
@@ -406,7 +437,7 @@ public sealed class Telescope<
    * both kinds and any cross-paradigm mix.
    */
   public static <P> Telescope<P, P> ofBean(final Class<P> pojoClass) {
-    return new Telescope<>(Iso.identity(), BeanFieldOptics.INSTANCE);
+    return new Telescope<>(Iso.identity(), BeanFieldOptics.INSTANCE, Function.identity(), null, List.of(), List.of());
   }
 
   /**
@@ -825,14 +856,19 @@ public sealed class Telescope<
    * runtime escape hatch — no compile-time check on the name or the resulting type). For POJOs, use
    * {@link #ofBean(Class)} as the root — same {@code .field(...)} navigation, bean semantics.
    */
+  @SuppressWarnings("unchecked")
   public <B> Telescope<S, B> field(final Accessor<A, B> getter) {
     final Lens<A, B> lens = lensForAccessor(getter);
+    final var owner = LambdaIntrospection.implClassOf(getter);
+    final var name = fieldNameOf(getter);
+    final var hop = owner == null ? null : Fusion.Hop.field(owner, name, (Traversal<Object, Object>) lens);
     return new Telescope<>(
       optic.then(lens),
       fieldOptics,
       chain,
       hopName(getter),
-      plus(new OpticNode.Focus(fieldNameOf(getter)))
+      plus(new OpticNode.Focus(name)),
+      plusHops(hop)
     );
   }
 
@@ -966,15 +1002,30 @@ public sealed class Telescope<
    *     .field(User::email);
    * }</pre>
    */
+  @SuppressWarnings("unchecked")
   public <E> Telescope<S, E> each(final Accessor<A, ? extends Iterable<E>> getter) {
     final Traversal<Iterable<E>, E> elements = Traversals.eachIterable();
     final Lens<A, Iterable<E>> lens = lensForAccessor(getter);
+    final var owner = LambdaIntrospection.implClassOf(getter);
+    final var name = fieldNameOf(getter);
+    final var segment = lens.then(elements);
+    final var hop =
+      owner == null
+        ? null
+        : Fusion.Hop.traverse(
+            owner,
+            name,
+            "each",
+            (Traversal<Object, Object>) segment,
+            (Traversal<Object, Object>) (Traversal<?, ?>) elements
+          );
     return new Telescope<>(
-      optic.then(lens).then(elements),
+      optic.then(segment),
       fieldOptics,
       chain,
       hopName(getter),
-      plus(new OpticNode.Traverse(fieldNameOf(getter), "collection"))
+      plus(new OpticNode.Traverse(name, "collection")),
+      plusHops(hop)
     );
   }
 
@@ -991,15 +1042,30 @@ public sealed class Telescope<
    *     .update(ledger, b -> b.add(BigDecimal.TEN));
    * }</pre>
    */
+  @SuppressWarnings("unchecked")
   public <K, V> Telescope<S, V> eachValue(final Accessor<A, ? extends Map<K, V>> getter) {
     final Traversal<Map<K, V>, V> values = Traversals.eachMapValue();
     final Lens<A, Map<K, V>> lens = lensForAccessor(getter);
+    final var owner = LambdaIntrospection.implClassOf(getter);
+    final var name = fieldNameOf(getter);
+    final var segment = lens.then(values);
+    final var hop =
+      owner == null
+        ? null
+        : Fusion.Hop.traverse(
+            owner,
+            name,
+            "eachValue",
+            (Traversal<Object, Object>) segment,
+            (Traversal<Object, Object>) (Traversal<?, ?>) values
+          );
     return new Telescope<>(
-      optic.then(lens).then(values),
+      optic.then(segment),
       fieldOptics,
       chain,
       hopName(getter),
-      plus(new OpticNode.Traverse(fieldNameOf(getter), "map values"))
+      plus(new OpticNode.Traverse(name, "map values")),
+      plusHops(hop)
     );
   }
 
@@ -1015,15 +1081,30 @@ public sealed class Telescope<
    *     .update(person, String::trim);
    * }</pre>
    */
+  @SuppressWarnings("unchecked")
   public <E> Telescope<S, E> whenPresent(final Accessor<A, ? extends Optional<E>> getter) {
     final Traversal<Optional<E>, E> present = Traversals.eachOptional();
     final Lens<A, Optional<E>> lens = lensForAccessor(getter);
+    final var owner = LambdaIntrospection.implClassOf(getter);
+    final var name = fieldNameOf(getter);
+    final var segment = lens.then(present);
+    final var hop =
+      owner == null
+        ? null
+        : Fusion.Hop.traverse(
+            owner,
+            name,
+            "whenPresent",
+            (Traversal<Object, Object>) segment,
+            (Traversal<Object, Object>) (Traversal<?, ?>) present
+          );
     return new Telescope<>(
-      optic.then(lens).then(present),
+      optic.then(segment),
       fieldOptics,
       chain,
       hopName(getter),
-      plus(new OpticNode.Traverse(fieldNameOf(getter), "optional"))
+      plus(new OpticNode.Traverse(name, "optional")),
+      plusHops(hop)
     );
   }
 
@@ -1041,6 +1122,7 @@ public sealed class Telescope<
    *     .update(canvas, r -> r * 2);
    * }</pre>
    */
+  @SuppressWarnings("unchecked")
   public <B extends A> Telescope<S, B> as(final Class<B> subType) {
     final Prism<A, B> prism = Prism.downcast(subType);
     return new Telescope<>(
@@ -1048,7 +1130,8 @@ public sealed class Telescope<
       fieldOptics,
       chain,
       null,
-      plus(new OpticNode.Narrow(subType.getSimpleName()))
+      plus(new OpticNode.Narrow(subType.getSimpleName())),
+      plusHops(Fusion.Hop.narrow(subType, (Traversal<Object, Object>) prism))
     );
   }
 
@@ -1065,8 +1148,20 @@ public sealed class Telescope<
    *     .update(team, String::toLowerCase);
    * }</pre>
    */
+  @SuppressWarnings("unchecked")
   public Telescope<S, A> filter(final Predicate<? super A> predicate) {
-    return new Telescope<>(optic.filter(predicate), fieldOptics, chain, null, plus(new OpticNode.Filter("predicate")));
+    // The hop segment is the filter applied to an identity traversal: prefix.then(segment) is
+    // equivalent to prefix.filter(predicate) for both reads and writes, which lets fusion treat
+    // the filter as one more composable hop keyed by predicate reference identity.
+    final var segment = Iso.<A>identity().filter(predicate);
+    return new Telescope<>(
+      optic.filter(predicate),
+      fieldOptics,
+      chain,
+      null,
+      plus(new OpticNode.Filter("predicate")),
+      plusHops(Fusion.Hop.filter(predicate, (Traversal<Object, Object>) segment))
+    );
   }
 
   /**

--- a/core/src/test/java/io/github/eschizoid/telescope/AllOverFusionTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/AllOverFusionTest.java
@@ -5,6 +5,8 @@ import static io.github.eschizoid.telescope.Edit.overIfPresent;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -215,12 +217,12 @@ class AllOverFusionTest {
   @DisplayName("container and paradigm coverage")
   class ContainerCoverage {
 
-    record Prefs(java.util.Map<String, String> flags, java.util.Optional<String> nickname, String plan) {}
+    record Prefs(Map<String, String> flags, Optional<String> nickname, String plan) {}
 
     @Test
     @DisplayName("eachValue + whenPresent + field fuse at one record level and match sequential")
     void mapOptionalAndFieldAtOneLevel() {
-      final var prefs = new Prefs(java.util.Map.of("a", "1", "b", "2"), java.util.Optional.of("nick"), "pro");
+      final var prefs = new Prefs(Map.of("a", "1", "b", "2"), Optional.of("nick"), "pro");
       final var flags = over(Telescope.of(Prefs.class).eachValue(Prefs::flags), (final String v) -> v + "!");
       final var nick = over(Telescope.of(Prefs.class).whenPresent(Prefs::nickname), String::toUpperCase);
       final var plan = over(Telescope.of(Prefs.class).field(Prefs::plan), String::toUpperCase);
@@ -231,7 +233,7 @@ class AllOverFusionTest {
     @Test
     @DisplayName("empty containers and empty Optionals pass through the fused walk unchanged")
     void emptyContainers() {
-      final var empty = new Prefs(java.util.Map.of(), java.util.Optional.empty(), "free");
+      final var empty = new Prefs(Map.of(), Optional.empty(), "free");
       final var flags = over(Telescope.of(Prefs.class).eachValue(Prefs::flags), (final String v) -> v + "!");
       final var nick = over(Telescope.of(Prefs.class).whenPresent(Prefs::nickname), String::toUpperCase);
 

--- a/core/src/test/java/io/github/eschizoid/telescope/AllOverFusionTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/AllOverFusionTest.java
@@ -1,0 +1,184 @@
+package io.github.eschizoid.telescope;
+
+import static io.github.eschizoid.telescope.Edit.over;
+import static io.github.eschizoid.telescope.Edit.overIfPresent;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pins {@code Telescope.all}'s fusion pass against the sequential fold it replaces: every fused
+ * composition must produce the exact result the edit-by-edit application produces, the documented
+ * fallbacks must stay correct, and the one observable difference — how many structural passes a
+ * shared prefix runs — is pinned via a counting filter predicate.
+ */
+class AllOverFusionTest {
+
+  record Flat(String a, String b, String c, int d) {}
+
+  record User(String name, String email, int age) {}
+
+  record Team(String label, List<User> users) {}
+
+  record Wrap(String tag, Team team) {}
+
+  static final Flat FLAT = new Flat("a", "b", "c", 4);
+  static final Team TEAM = new Team(
+    "core",
+    List.of(new User("Ann", "ANN@x.io", 30), new User("Bo", "BO@x.io", 25), new User("Cy", "CY@x.io", 41))
+  );
+
+  /** The spec: what the sequential fold produces, edit by edit. */
+  @SafeVarargs
+  private static <S> S sequential(final S source, final Edit<S>... edits) {
+    var s = source;
+    for (final var e : edits) s = e.apply(s);
+    return s;
+  }
+
+  @Nested
+  @DisplayName("fused result == sequential result")
+  class Equivalence {
+
+    @Test
+    @DisplayName("flat disjoint fields — the record-level slot plan")
+    void flatDisjointFields() {
+      final var ea = over(Telescope.of(Flat.class).field(Flat::a), String::toUpperCase);
+      final var eb = over(Telescope.of(Flat.class).field(Flat::b), (final String v) -> v + "!");
+      final var ed = over(Telescope.of(Flat.class).field(Flat::d), (final Integer v) -> v * 10);
+
+      assertEquals(sequential(FLAT, ea, eb, ed), Telescope.all(ea, eb, ed).apply(FLAT));
+      assertEquals(new Flat("A", "b!", "c", 40), Telescope.all(ea, eb, ed).apply(FLAT));
+    }
+
+    @Test
+    @DisplayName("shared each(...) prefix with distinct leaf fields — trie sharing + per-element slot plan")
+    void sharedEachPrefix() {
+      final var names = over(Telescope.of(Team.class).each(Team::users).field(User::name), String::toLowerCase);
+      final var emails = over(Telescope.of(Team.class).each(Team::users).field(User::email), String::toLowerCase);
+      final var ages = over(Telescope.of(Team.class).each(Team::users).field(User::age), (final Integer a) -> a + 1);
+
+      assertEquals(sequential(TEAM, names, emails, ages), Telescope.all(names, emails, ages).apply(TEAM));
+    }
+
+    @Test
+    @DisplayName("deep nesting — a field hop above the shared each prefix")
+    void deepSharedPrefix() {
+      final var wrap = new Wrap("t", TEAM);
+      final var names = over(
+        Telescope.of(Wrap.class).field(Wrap::team).each(Team::users).field(User::name),
+        String::toUpperCase
+      );
+      final var label = over(Telescope.of(Wrap.class).field(Wrap::team).field(Team::label), String::toUpperCase);
+      final var tag = over(Telescope.of(Wrap.class).field(Wrap::tag), (final String t) -> t + t);
+
+      assertEquals(sequential(wrap, names, label, tag), Telescope.all(names, label, tag).apply(wrap));
+    }
+
+    @Test
+    @DisplayName("equal full paths compose in edit order — sequential semantics preserved")
+    void equalPathsComposeInOrder() {
+      final var first = over(Telescope.of(Flat.class).field(Flat::a), (final String v) -> v + "1");
+      final var second = over(Telescope.of(Flat.class).field(Flat::a), (final String v) -> v + "2");
+
+      // Order-sensitive on purpose: "a" -> "a1" -> "a12" only if fn1 runs before fn2.
+      assertEquals("a12", Telescope.all(first, second).apply(FLAT).a());
+      assertEquals(sequential(FLAT, first, second), Telescope.all(first, second).apply(FLAT));
+    }
+
+    @Test
+    @DisplayName("separately-built paths share by (owner, component) identity, not by instance")
+    void separatelyBuiltPathsShare() {
+      // Both edits rebuild each(users) — built as fully independent Telescope instances. Semantic
+      // keys must unify them; the result must still match sequential application.
+      final var e1 = over(Telescope.of(Team.class).each(Team::users).field(User::name), (final String n) -> n + "-x");
+      final var e2 = over(Telescope.of(Team.class).each(Team::users).field(User::email), String::toLowerCase);
+
+      assertEquals(sequential(TEAM, e1, e2), Telescope.all(e1, e2).apply(TEAM));
+    }
+
+    @Test
+    @DisplayName("sparse-PATCH identity slots are skipped and contribute nothing")
+    void identitySlotsSkipped() {
+      final var real = over(Telescope.of(Flat.class).field(Flat::a), String::toUpperCase);
+      final var nullSlot = overIfPresent(Telescope.of(Flat.class).field(Flat::b), (String) null);
+      final var nullSlot2 = overIfPresent(Telescope.of(Flat.class).field(Flat::c), null, (final String v) -> v);
+
+      final var out = Telescope.all(nullSlot, real, nullSlot2).apply(FLAT);
+      assertEquals(new Flat("A", "b", "c", 4), out);
+    }
+  }
+
+  @Nested
+  @DisplayName("documented fallbacks stay correct")
+  class Fallbacks {
+
+    @Test
+    @DisplayName("strict-prefix overlap (record edit above a field edit) falls back and matches sequential")
+    void strictPrefixOverlap() {
+      final var wrap = new Wrap("t", TEAM);
+      // Edit 1 rewrites the whole team; edit 2 then edits a field inside it. Order is observable —
+      // fusion must decline, and the sequential result is the spec.
+      final var wholeTeam = over(Telescope.of(Wrap.class).field(Wrap::team), (final Team t) ->
+        new Team(t.label() + "-r", t.users())
+      );
+      final var innerLabel = over(Telescope.of(Wrap.class).field(Wrap::team).field(Team::label), String::toUpperCase);
+
+      assertEquals(sequential(wrap, wholeTeam, innerLabel), Telescope.all(wholeTeam, innerLabel).apply(wrap));
+      assertEquals("CORE-R", Telescope.all(wholeTeam, innerLabel).apply(wrap).team().label());
+    }
+
+    @Test
+    @DisplayName("an unfusible hop (fieldByName) falls back and matches sequential")
+    void unfusibleHopFallsBack() {
+      final var byName = over(Telescope.of(Flat.class).<String>fieldByName("a"), String::toUpperCase);
+      final var typed = over(Telescope.of(Flat.class).field(Flat::b), (final String v) -> v + "!");
+
+      assertEquals(sequential(FLAT, byName, typed), Telescope.all(byName, typed).apply(FLAT));
+    }
+
+    @Test
+    @DisplayName("field vs each on the same component falls back (not provably order-free) and matches sequential")
+    void sameComponentDifferentKinds() {
+      final var whole = over(Telescope.of(Team.class).field(Team::users), (final List<User> us) -> us.subList(0, 2));
+      final var each = over(Telescope.of(Team.class).each(Team::users).field(User::name), String::toUpperCase);
+
+      assertEquals(sequential(TEAM, whole, each), Telescope.all(whole, each).apply(TEAM));
+    }
+  }
+
+  @Nested
+  @DisplayName("fusion is observable where it should be")
+  class PassCounting {
+
+    @Test
+    @DisplayName("a shared filter prefix evaluates its predicate once per element, not once per edit")
+    void sharedFilterPrefixRunsOnce() {
+      final var evaluations = new AtomicInteger();
+      // The shared prefix must be ONE instance: filter identity is the predicate reference.
+      final var adults = Telescope.of(Team.class)
+        .each(Team::users)
+        .filter(u -> {
+          evaluations.incrementAndGet();
+          return u.age() >= 30;
+        });
+      final var names = over(adults.field(User::name), String::toUpperCase);
+      final var emails = over(adults.field(User::email), String::toLowerCase);
+
+      final var fused = Telescope.all(names, emails);
+      evaluations.set(0);
+      final var out = fused.apply(TEAM);
+
+      // 3 elements, one structural pass: 3 evaluations. The sequential fold would run the filter
+      // once per edit — 6. This is the one observable trace of fusion, pinned on purpose.
+      assertEquals(3, evaluations.get());
+      assertEquals("ANN", out.users().get(0).name());
+      assertEquals("BO@x.io", out.users().get(1).email()); // under-30: filtered out of both edits
+      assertEquals(sequential(TEAM, names, emails), out);
+    }
+  }
+}

--- a/core/src/test/java/io/github/eschizoid/telescope/AllOverFusionTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/AllOverFusionTest.java
@@ -13,8 +13,9 @@ import org.junit.jupiter.api.Test;
 /**
  * Pins {@code Telescope.all}'s fusion pass against the sequential fold it replaces: every fused
  * composition must produce the exact result the edit-by-edit application produces, the documented
- * fallbacks must stay correct, and the one observable difference — how many structural passes a
- * shared prefix runs — is pinned via a counting filter predicate.
+ * fallbacks must stay correct, and filters — whose verdicts are value-dependent — must re-test
+ * between edits exactly as the sequential fold does (the two review counterexamples are pinned as
+ * regressions).
  */
 class AllOverFusionTest {
 
@@ -152,14 +153,48 @@ class AllOverFusionTest {
   }
 
   @Nested
-  @DisplayName("fusion is observable where it should be")
-  class PassCounting {
+  @DisplayName("filter semantics — the value-dependent re-test is preserved")
+  class FilterSemantics {
 
     @Test
-    @DisplayName("a shared filter prefix evaluates its predicate once per element, not once per edit")
-    void sharedFilterPrefixRunsOnce() {
+    @DisplayName("an edit that changes what the predicate reads hides the element from later edits")
+    void editedValueFailsLaterFilterPass() {
+      // Sequential: pass 1 demotes Ann to 20; pass 2 re-tests the filter on the EDITED user, so
+      // Ann no longer matches and her name stays "Ann". A fused pass that tested the predicate
+      // once on the original element would wrongly uppercase her — the review counterexample.
+      final var adults = Telescope.of(Team.class)
+        .each(Team::users)
+        .filter(u -> u.age() >= 30);
+      final var ages = over(adults.field(User::age), (final Integer a) -> a - 10);
+      final var names = over(adults.field(User::name), String::toUpperCase);
+
+      final var out = Telescope.all(ages, names).apply(TEAM);
+      assertEquals(sequential(TEAM, ages, names), out);
+      assertEquals("Ann", out.users().get(0).name()); // demoted to 20 before the name pass
+      assertEquals(20, out.users().get(0).age());
+      assertEquals("CY", out.users().get(2).name()); // 41 stays >= 30 through both passes
+    }
+
+    @Test
+    @DisplayName("equal paths below a filter re-test between the composed functions")
+    void equalPathsBelowFilterReTest() {
+      // Ann: 30 - 10 = 20, then the second edit's filter pass rejects her — 20, not (30-10)*2.
+      final var adults = Telescope.of(Team.class)
+        .each(Team::users)
+        .filter(u -> u.age() >= 30);
+      final var demote = over(adults.field(User::age), (final Integer a) -> a - 10);
+      final var doubleAge = over(adults.field(User::age), (final Integer a) -> a * 2);
+
+      final var out = Telescope.all(demote, doubleAge).apply(TEAM);
+      assertEquals(sequential(TEAM, demote, doubleAge), out);
+      assertEquals(20, out.users().get(0).age());
+      assertEquals(62, out.users().get(2).age()); // Cy: (41 - 10) = 31, still matching, * 2
+    }
+
+    @Test
+    @DisplayName("a single edit under a filter takes the fused path and matches sequential")
+    void singleEditUnderFilter() {
       final var evaluations = new AtomicInteger();
-      // The shared prefix must be ONE instance: filter identity is the predicate reference.
       final var adults = Telescope.of(Team.class)
         .each(Team::users)
         .filter(u -> {
@@ -167,18 +202,107 @@ class AllOverFusionTest {
           return u.age() >= 30;
         });
       final var names = over(adults.field(User::name), String::toUpperCase);
-      final var emails = over(adults.field(User::email), String::toLowerCase);
+      final var label = over(Telescope.of(Team.class).field(Team::label), String::toUpperCase);
 
-      final var fused = Telescope.all(names, emails);
       evaluations.set(0);
-      final var out = fused.apply(TEAM);
+      final var out = Telescope.all(names, label).apply(TEAM);
+      assertEquals(3, evaluations.get()); // one edit under the filter: one test per element
+      assertEquals(sequential(TEAM, names, label), out);
+    }
+  }
 
-      // 3 elements, one structural pass: 3 evaluations. The sequential fold would run the filter
-      // once per edit — 6. This is the one observable trace of fusion, pinned on purpose.
-      assertEquals(3, evaluations.get());
-      assertEquals("ANN", out.users().get(0).name());
-      assertEquals("BO@x.io", out.users().get(1).email()); // under-30: filtered out of both edits
-      assertEquals(sequential(TEAM, names, emails), out);
+  @Nested
+  @DisplayName("container and paradigm coverage")
+  class ContainerCoverage {
+
+    record Prefs(java.util.Map<String, String> flags, java.util.Optional<String> nickname, String plan) {}
+
+    @Test
+    @DisplayName("eachValue + whenPresent + field fuse at one record level and match sequential")
+    void mapOptionalAndFieldAtOneLevel() {
+      final var prefs = new Prefs(java.util.Map.of("a", "1", "b", "2"), java.util.Optional.of("nick"), "pro");
+      final var flags = over(Telescope.of(Prefs.class).eachValue(Prefs::flags), (final String v) -> v + "!");
+      final var nick = over(Telescope.of(Prefs.class).whenPresent(Prefs::nickname), String::toUpperCase);
+      final var plan = over(Telescope.of(Prefs.class).field(Prefs::plan), String::toUpperCase);
+
+      assertEquals(sequential(prefs, flags, nick, plan), Telescope.all(flags, nick, plan).apply(prefs));
+    }
+
+    @Test
+    @DisplayName("empty containers and empty Optionals pass through the fused walk unchanged")
+    void emptyContainers() {
+      final var empty = new Prefs(java.util.Map.of(), java.util.Optional.empty(), "free");
+      final var flags = over(Telescope.of(Prefs.class).eachValue(Prefs::flags), (final String v) -> v + "!");
+      final var nick = over(Telescope.of(Prefs.class).whenPresent(Prefs::nickname), String::toUpperCase);
+
+      assertEquals(sequential(empty, flags, nick), Telescope.all(flags, nick).apply(empty));
+      assertEquals("free", Telescope.all(flags, nick).apply(empty).plan());
+    }
+
+    @Test
+    @DisplayName("a shared as(...) prefix narrows once and matches sequential")
+    void sharedNarrowPrefix() {
+      final var updated = Telescope.of(EventBox.class).field(EventBox::event).as(Updated.class);
+      final var diff = over(updated.field(Updated::diff), String::toUpperCase);
+      final var rev = over(updated.field(Updated::revision), (final Integer r) -> r + 1);
+
+      final var hit = new EventBox(new Updated("e1", "d", 1));
+      final var miss = new EventBox(new Created("e2"));
+      assertEquals(sequential(hit, diff, rev), Telescope.all(diff, rev).apply(hit));
+      assertEquals(sequential(miss, diff, rev), Telescope.all(diff, rev).apply(miss));
+      assertEquals(new Updated("e1", "D", 2), Telescope.all(diff, rev).apply(hit).event());
+    }
+
+    @Test
+    @DisplayName("bean-rooted paths fuse the shared prefix walk and match sequential")
+    void beanPaths() {
+      final var box = new MutableBox();
+      box.setLeft("l");
+      box.setRight("r");
+      final var left = over(Telescope.ofBean(MutableBox.class).field(MutableBox::getLeft), String::toUpperCase);
+      final var right = over(
+        Telescope.ofBean(MutableBox.class).field(MutableBox::getRight),
+        (final String v) -> v + "!"
+      );
+
+      final var fused = Telescope.all(left, right).apply(box);
+      final var seq = sequential(box, left, right);
+      assertEquals(seq.getLeft(), fused.getLeft());
+      assertEquals(seq.getRight(), fused.getRight());
+      assertEquals("L", fused.getLeft());
+      assertEquals("r!", fused.getRight());
+    }
+  }
+
+  sealed interface Event permits Created, Updated {}
+
+  record Created(String id) implements Event {}
+
+  record Updated(String id, String diff, int revision) implements Event {}
+
+  record EventBox(Event event) {}
+
+  static final class MutableBox {
+
+    private String left;
+    private String right;
+
+    public MutableBox() {}
+
+    public String getLeft() {
+      return left;
+    }
+
+    public void setLeft(final String left) {
+      this.left = left;
+    }
+
+    public String getRight() {
+      return right;
+    }
+
+    public void setRight(final String right) {
+      this.right = right;
     }
   }
 }


### PR DESCRIPTION
## What

Multi-edit fusion: `Telescope.all(over(...), over(...))` used to fold N edits into N sequential structural passes — k edits under a shared `.each(...)` prefix rebuilt the same container k times, k disjoint field edits on one record rebuilt that record k times. A new package-private `Fusion` engine (sibling of `DeepMap`/`Merge` — composes existing lattice ops, zero new public API) unions the edits' paths into a prefix trie and compiles one walk:

- **Prefix sharing** — a shared hop runs its `modify` once, fused sub-edits applied per focused value. Identity is kind-tagged `(kind, owner, component)` keys, so **separately-built paths share too** — no need to build off a common prefix instance.
- **Sibling slot fusion** — a trie node branching into same-owner, pairwise-distinct record components compiles to one positional rebuild (build-time-captured readers, one cached canonical-ctor call). Traverse branches fold in as their component's slot function, so a record level is rebuilt once no matter how many components are edited.
- **Telescope retains per-hop segments** (the fusion twin of the ADR-0013 introspection trail), threaded through `field`/`each`/`eachValue`/`whenPresent`/`as`/`filter` and the `of`/`ofBean` roots; everything else marks the path unfusible.

**Semantics bar: observationally identical to the sequential fold (pure functions).** Fusion declines — and the sequential fold runs — for user-implemented `Edit`s, hopless paths (`fieldByName`, bridges, custom lenses), strict-prefix overlaps, and branching across filter/narrow hops. Equal paths compose leaf fns in edit order. `Edit.identity()` is now a recognizable singleton so sparse-PATCH null slots skip instead of poisoning fusion.

## The review catch (and why filters are special)

The adversarial fleet round produced **two executed counterexamples**, one root cause: a filter's verdict is value-dependent — the sequential fold re-tests the predicate between passes, so an edit that changes what the predicate reads (demote Ann below `age >= 30`) must hide her from later edits. The fused pass tested once on the original element.

Fix: a filter node carrying ≥2 edits compiles to **per-edit replay** — each edit re-applies through its own filter test, in edit order, per element (exactly the sequential fold's per-element work) — while the container walk above the filter stays fused. Narrow hops need no replay (a `Function<B,B>` edit can't change the prism match); container traverses need none (`modify` preserves element shape). Both counterexamples are pinned as regression tests that fail on the unsound build. The re-verification round executed six adversarial probes (nested filters, equal-paths-ending-at-filter, tails completeness, engagement proof via evaluation-order recording) and returned CONVERGED.

## Gate numbers (`MultiEditBenchmark`, CI, fork=3, 5w/10m, n=30)

BEFORE = main ([run 29907834597](https://github.com/eschizoid/telescope/actions/runs/29907834597)), AFTER = this branch ([run 30094818028](https://github.com/eschizoid/telescope/actions/runs/30094818028)). The runner drifted ~7% between sessions (floors 36.2→38.7 / 3,478→3,646), so the floor-relative ratio is the honest comparison:

| Row | BEFORE (ns/op) | AFTER (ns/op) | vs hand-fused floor |
|---|---|---|---|
| `allFlat4Edits` | 242.3 ± 3.0 | **109.6 ± 1.4** | 6.7× → **2.8×** (2.2× faster) |
| `allFlat2Edits` | 115.9 ± 2.1 | **76.0 ± 0.3** | (1.5× faster) |
| `allTree3Edits` | 13,497.9 ± 564.3 | **7,472.9 ± 15.8** | 3.9× → **2.05×** (1.8× faster) |
| `allFlat1Edit` | 67.5 ± 4.0 | 72.2 ± 6.6 | floor-relative ratio identical (1.86 vs 1.87) — single edits fall back, unchanged |
| `allTree1Edit` | 4,754.1 ± 51.8 | 4,820.9 ± 26.8 | unchanged (drift) |
| floors | 36.2 / 3,477.7 | 38.7 / 3,646.4 | runner drift, both stable within-run |

k edits no longer cost ~k passes: flat 4-edit went from 3.6× the 1-edit cost to 1.5×; tree 3-edit from 2.8× to 1.55×. The remaining gap to the hand-fused floor is per-hop lens dispatch — the same reflective-vs-codegen story as everywhere else in the runtime tier.

## Positioning note

This is the update-path story, where MapStruct has no equivalent surface: multi-edit deep immutable update through compile-checked method references, now within ~2× of hand-written Java — with `explain()`, effectful variants, and native-image support riding the same paths.
