### PR TITLE
fix: 13 probe-confirmed findings from the architecture inspection

### DIFF
--- a/core/src/main/java/io/github/eschizoid/telescope/Edit.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/Edit.java
@@ -43,6 +43,11 @@ public interface Edit<S> {
    *     Edit<S>})
    */
   static <S, X> Edit<S> over(final Telescope<S, X> path, final Function<X, X> fn) {
+    if (path.hasPendingEdits()) throw new IllegalArgumentException(
+      "over(...) received a telescope carrying pending chain edits (built via .with(...) / " +
+        ".update(path, fn) / Telescope.all(...)); the edit would run against the bare path and " +
+        "silently drop them. Run them with .apply(source) first, or pass the pure path."
+    );
     return new EditImpl<>(path, fn);
   }
 

--- a/core/src/main/java/io/github/eschizoid/telescope/FromMap.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/FromMap.java
@@ -8,8 +8,11 @@ import io.github.eschizoid.telescope.internal.Records;
 import io.github.eschizoid.telescope.internal.pairing.PropertyNames;
 import io.github.eschizoid.telescope.mapping.Extract;
 import io.github.eschizoid.telescope.mapping.MapExtractStep;
+import java.lang.reflect.RecordComponent;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
@@ -21,10 +24,11 @@ import java.util.function.Function;
  *
  * <p>Rows are matched to target components / properties once at build time, into positional arrays.
  * On the record path the per-call forward is fully positional: a source {@code Map.get} plus
- * converter per extracted slot, a JLS default per unmatched slot, and one cached
- * canonical-constructor invocation — no name lookup survives. On the bean path the writer's {@code
- * construct} contract stays name-driven, so one {@code name→index} lookup per property remains
- * (down from the two the old engine paid — the row map and the defaults map).
+ * converter per extracted slot, a type default per unmatched slot (the NullDefaults table: "" for
+ * String, empty containers — not bare null), and one cached canonical-constructor invocation — no
+ * name lookup survives. On the bean path the writer's {@code construct} contract stays name-driven,
+ * so one {@code name→index} lookup per property remains (down from the two the old engine paid —
+ * the row map and the defaults map).
  */
 final class FromMap {
 
@@ -44,6 +48,22 @@ final class FromMap {
         "Telescope.fromMap: duplicate extract row for target field '" + fieldName + "'"
       );
     }
+    // Fail loud on a row that matches no target component/property — the slot alignment below
+    // would otherwise silently ignore it (the extract key never read, the converter never run).
+    final var known = target.isRecord()
+      ? Arrays.stream(target.getRecordComponents()).map(RecordComponent::getName).toList()
+      : List.of(Beans.propertyNames(target));
+    for (final var fieldName : byField.keySet()) {
+      if (!known.contains(fieldName)) throw new IllegalArgumentException(
+        "Telescope.fromMap: extract row targets '" +
+          fieldName +
+          "', which is not a component/property of " +
+          target.getSimpleName() +
+          ". Known fields: " +
+          known +
+          "."
+      );
+    }
     final Function<Map<String, Object>, T> forward = target.isRecord()
       ? recordForward(target, byField)
       : beanForward(target, byField);
@@ -52,7 +72,7 @@ final class FromMap {
 
   /**
    * Record path — the full positional bind. Each canonical component resolves at build time to
-   * either its extract row (source key + converter) or its JLS default; the forward call fills a
+   * either its extract row (source key + converter) or its type default; the forward call fills a
    * positional args array and invokes the cached canonical-constructor handle via {@link
    * Records#construct(Class, Object[])}. No name-keyed dispatch survives to the hot path.
    */

--- a/core/src/main/java/io/github/eschizoid/telescope/Merge.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/Merge.java
@@ -66,7 +66,9 @@ final class Merge {
       );
     };
 
-    return Mapper.create(forward, backward, Sources.class, target, Map.of());
+    // A null patch table signals "patch unsupported" — Mapper.patch then throws the same
+    // UnsupportedOperationException shape backward does, instead of silently no-op-ing.
+    return Mapper.create(forward, backward, Sources.class, target, null);
   }
 
   /**
@@ -169,6 +171,21 @@ final class Merge {
       final Class<?> srcClass = LambdaIntrospection.implClassOf(r.src());
       final Getter<Object, Object> srcAccessor = asGetter(r.src());
       final String tgtName = targetRefl.normalize(LambdaIntrospection.methodNameOf(r.tgt()));
+      // Fail loud at build time when the target accessor is not a canonical component / writable
+      // property: the positional bind aligns rows by target name, so an unmatched row would never
+      // bind a slot — its source accessor never read, its source class never checked at forward
+      // time — a silent drop that also swallowed the missing-source diagnostic.
+      if (!List.of(targetRefl.names(targetClass)).contains(tgtName)) throw new IllegalArgumentException(
+        "Telescope.merge: step at index " +
+          index +
+          " targets '" +
+          tgtName +
+          "', which is not a settable component/property of " +
+          targetClass.getSimpleName() +
+          ". Known fields: " +
+          List.of(targetRefl.names(targetClass)) +
+          "."
+      );
       claimTarget(tgtName, index, claimedTgt);
       out.add(new ResolvedStep(srcClass, srcAccessor, tgtName));
       return;

--- a/core/src/main/java/io/github/eschizoid/telescope/Telescope.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/Telescope.java
@@ -144,12 +144,27 @@ public sealed class Telescope<
   // Package-private so that the conversion-builder classes (From, To, Mapper, …) — extracted to
   // sibling files to keep Telescope.java navigable — can construct Telescope instances without
   // needing us to expose internals through the JPMS export.
+  // The one shared identity chain: a Telescope whose chain IS this reference carries no pending
+  // .with()/.update(path, fn) edits. Reference identity is the detector — Function.identity()
+  // allocates a fresh lambda per call, so equality would be undecidable without the constant.
+  static final Function<Object, Object> IDENTITY_CHAIN = Function.identity();
+
+  @SuppressWarnings("unchecked")
+  private static <S> Function<S, S> identityChain() {
+    return (Function<S, S>) IDENTITY_CHAIN;
+  }
+
+  /** Whether this telescope carries pending chain edits that only {@link #apply} runs. */
+  final boolean hasPendingEdits() {
+    return chain != IDENTITY_CHAIN;
+  }
+
   Telescope(final Traversal<S, A> optic) {
-    this(optic, RecordFieldOptics.INSTANCE, Function.identity(), null, List.of(), null);
+    this(optic, RecordFieldOptics.INSTANCE, identityChain(), null, List.of(), null);
   }
 
   private Telescope(final Traversal<S, A> optic, final FieldOptics fieldOptics) {
-    this(optic, fieldOptics, Function.identity(), null, List.of(), null);
+    this(optic, fieldOptics, identityChain(), null, List.of(), null);
   }
 
   Telescope(final Traversal<S, A> optic, final FieldOptics fieldOptics, final Function<S, S> chain) {
@@ -248,7 +263,7 @@ public sealed class Telescope<
    * @see #ofBean(Class)
    */
   public static <S> Telescope<S, S> of(final Class<S> rootType) {
-    return new Telescope<>(Iso.identity(), RecordFieldOptics.INSTANCE, Function.identity(), null, List.of(), List.of());
+    return new Telescope<>(Iso.identity(), RecordFieldOptics.INSTANCE, identityChain(), null, List.of(), List.of());
   }
 
   /**
@@ -273,7 +288,7 @@ public sealed class Telescope<
   static <S, A> Telescope<S, A> mapped(final Iso<S, A> iso, final List<OpticNode> trail) {
     // The one boundary that takes a caller-owned list — copy it immutable so the constructor can
     // store every trail as-is.
-    return new Telescope<>(iso, RecordFieldOptics.INSTANCE, Function.identity(), null, List.copyOf(trail));
+    return new Telescope<>(iso, RecordFieldOptics.INSTANCE, identityChain(), null, List.copyOf(trail));
   }
 
   /**
@@ -340,22 +355,56 @@ public sealed class Telescope<
    * }</pre>
    */
   public static <S, X> ListTelescope<S, X> asList(final Telescope<S, List<X>> path) {
-    return new ListTelescope<>(path.optic, path.fieldOptics, path.chain);
+    // Preserve the promoted path's name/trail/hops — the promotion previously erased all three,
+    // leaving explain() blank on a path that was fully described a call earlier.
+    return new ListTelescope<>(
+      path.optic,
+      path.fieldOptics,
+      path.chain,
+      path.firstHopName,
+      path.trail,
+      path.hops,
+      ContainerHop.promotion()
+    );
   }
 
   /** Pre-built-fragment companion to {@link #asList} for {@code Set&lt;X&gt;} paths. */
   public static <S, X> SetTelescope<S, X> asSet(final Telescope<S, Set<X>> path) {
-    return new SetTelescope<>(path.optic, path.fieldOptics, path.chain);
+    return new SetTelescope<>(
+      path.optic,
+      path.fieldOptics,
+      path.chain,
+      path.firstHopName,
+      path.trail,
+      path.hops,
+      ContainerHop.promotion()
+    );
   }
 
   /** Pre-built-fragment companion to {@link #asList} for {@code Map&lt;K, V&gt;} paths. */
   public static <S, K, V> MapTelescope<S, K, V> asMap(final Telescope<S, Map<K, V>> path) {
-    return new MapTelescope<>(path.optic, path.fieldOptics, path.chain);
+    return new MapTelescope<>(
+      path.optic,
+      path.fieldOptics,
+      path.chain,
+      path.firstHopName,
+      path.trail,
+      path.hops,
+      ContainerHop.promotion()
+    );
   }
 
   /** Pre-built-fragment companion to {@link #asList} for {@code Optional&lt;X&gt;} paths. */
   public static <S, X> OptionalTelescope<S, X> asOptional(final Telescope<S, Optional<X>> path) {
-    return new OptionalTelescope<>(path.optic, path.fieldOptics, path.chain);
+    return new OptionalTelescope<>(
+      path.optic,
+      path.fieldOptics,
+      path.chain,
+      path.firstHopName,
+      path.trail,
+      path.hops,
+      ContainerHop.promotion()
+    );
   }
 
   /**
@@ -441,7 +490,7 @@ public sealed class Telescope<
    * both kinds and any cross-paradigm mix.
    */
   public static <P> Telescope<P, P> ofBean(final Class<P> pojoClass) {
-    return new Telescope<>(Iso.identity(), BeanFieldOptics.INSTANCE, Function.identity(), null, List.of(), List.of());
+    return new Telescope<>(Iso.identity(), BeanFieldOptics.INSTANCE, identityChain(), null, List.of(), List.of());
   }
 
   /**
@@ -487,7 +536,7 @@ public sealed class Telescope<
     return new Telescope<>(
       Lens.of(getter, setter),
       RecordFieldOptics.INSTANCE,
-      Function.identity(),
+      identityChain(),
       LambdaIntrospection.methodNameOf(getter)
     );
   }
@@ -900,9 +949,22 @@ public sealed class Telescope<
    * deps.each().field(Department::name).update(co, fn);
    * }</pre>
    */
+  @SuppressWarnings("unchecked")
   public <X> ListTelescope<S, X> list(final Accessor<A, List<X>> getter) {
     final Lens<A, List<X>> lens = lensForAccessor(getter);
-    return new ListTelescope<>(optic.then(lens), fieldOptics, chain, hopName(getter));
+    final var owner = LambdaIntrospection.implClassOf(getter);
+    final var name = fieldNameOf(getter);
+    final var lensErased = (Traversal<Object, Object>) (Traversal<?, ?>) lens;
+    final var fieldHop = owner == null ? null : Fusion.Hop.field(owner, name, lensErased);
+    return new ListTelescope<>(
+      optic.then(lens),
+      fieldOptics,
+      chain,
+      hopName(getter),
+      plus(new OpticNode.Focus(name)),
+      plusHops(fieldHop),
+      new ContainerHop<>(trail, hops, owner, name, lensErased)
+    );
   }
 
   /**
@@ -913,9 +975,22 @@ public sealed class Telescope<
    * terminal {@link #set(Object, Object)} — they take different argument types, but the shared verb
    * load is real enough that disambiguation pays off at the call site.
    */
+  @SuppressWarnings("unchecked")
   public <X> SetTelescope<S, X> setField(final Accessor<A, Set<X>> getter) {
     final Lens<A, Set<X>> lens = lensForAccessor(getter);
-    return new SetTelescope<>(optic.then(lens), fieldOptics, chain, hopName(getter));
+    final var owner = LambdaIntrospection.implClassOf(getter);
+    final var name = fieldNameOf(getter);
+    final var lensErased = (Traversal<Object, Object>) (Traversal<?, ?>) lens;
+    final var fieldHop = owner == null ? null : Fusion.Hop.field(owner, name, lensErased);
+    return new SetTelescope<>(
+      optic.then(lens),
+      fieldOptics,
+      chain,
+      hopName(getter),
+      plus(new OpticNode.Focus(name)),
+      plusHops(fieldHop),
+      new ContainerHop<>(trail, hops, owner, name, lensErased)
+    );
   }
 
   /**
@@ -927,9 +1002,22 @@ public sealed class Telescope<
    * io.github.eschizoid.telescope.mapping.MapStep...)} — those do conceptually different things and
    * share the same verb otherwise.
    */
+  @SuppressWarnings("unchecked")
   public <K, V> MapTelescope<S, K, V> mapField(final Accessor<A, Map<K, V>> getter) {
     final Lens<A, Map<K, V>> lens = lensForAccessor(getter);
-    return new MapTelescope<>(optic.then(lens), fieldOptics, chain, hopName(getter));
+    final var owner = LambdaIntrospection.implClassOf(getter);
+    final var name = fieldNameOf(getter);
+    final var lensErased = (Traversal<Object, Object>) (Traversal<?, ?>) lens;
+    final var fieldHop = owner == null ? null : Fusion.Hop.field(owner, name, lensErased);
+    return new MapTelescope<>(
+      optic.then(lens),
+      fieldOptics,
+      chain,
+      hopName(getter),
+      plus(new OpticNode.Focus(name)),
+      plusHops(fieldHop),
+      new ContainerHop<>(trail, hops, owner, name, lensErased)
+    );
   }
 
   /**
@@ -937,9 +1025,22 @@ public sealed class Telescope<
    * an {@link OptionalTelescope} carrying the optional type for later {@link
    * OptionalTelescope#present()} navigation.
    */
+  @SuppressWarnings("unchecked")
   public <X> OptionalTelescope<S, X> optional(final Accessor<A, Optional<X>> getter) {
     final Lens<A, Optional<X>> lens = lensForAccessor(getter);
-    return new OptionalTelescope<>(optic.then(lens), fieldOptics, chain, hopName(getter));
+    final var owner = LambdaIntrospection.implClassOf(getter);
+    final var name = fieldNameOf(getter);
+    final var lensErased = (Traversal<Object, Object>) (Traversal<?, ?>) lens;
+    final var fieldHop = owner == null ? null : Fusion.Hop.field(owner, name, lensErased);
+    return new OptionalTelescope<>(
+      optic.then(lens),
+      fieldOptics,
+      chain,
+      hopName(getter),
+      plus(new OpticNode.Focus(name)),
+      plusHops(fieldHop),
+      new ContainerHop<>(trail, hops, owner, name, lensErased)
+    );
   }
 
   /**
@@ -1252,6 +1353,11 @@ public sealed class Telescope<
     // Both sides' trails are already immutable, so when one side is empty (common on codegen paths,
     // where the hop is appended after composition) reuse the other directly — no allocation. Only a
     // genuine two-sided join builds a fresh list.
+    if (next.hasPendingEdits()) throw new IllegalArgumentException(
+      "then(...) received a telescope carrying pending chain edits (built via .with(...) / " +
+        ".update(path, fn) / Telescope.all(...)); composition would silently drop them. " +
+        "Run them with .apply(source) first, or compose the pure paths and apply edits after."
+    );
     final List<OpticNode> joinedTrail;
     if (next.trail.isEmpty()) joinedTrail = trail;
     else if (trail.isEmpty()) joinedTrail = next.trail;
@@ -2254,22 +2360,91 @@ public sealed class Telescope<
    */
   public static final class ListTelescope<S, X> extends Telescope<S, List<X>> {
 
-    ListTelescope(final Traversal<S, List<X>> optic, final FieldOptics fieldOptics, final Function<S, S> chain) {
-      super(optic, fieldOptics, chain);
-    }
+    // Provenance of the container hop, so each() can emit the SAME trail node and fusion hop the
+    // fused each(getter) form produces — the split form must not be invisible to explain()/fusion.
+    // Null owner marks a promotion (asList) of an arbitrary path: the promoted trail/hops are
+    // preserved as-is, and each() keeps the trail but degrades hops to null (identity unknown).
+    private final ContainerHop<S> origin;
 
     ListTelescope(
       final Traversal<S, List<X>> optic,
       final FieldOptics fieldOptics,
       final Function<S, S> chain,
-      final String firstHopName
+      final String firstHopName,
+      final List<OpticNode> trail,
+      final List<Fusion.Hop> hops,
+      final ContainerHop<S> origin
     ) {
-      super(optic, fieldOptics, chain, firstHopName);
+      super(optic, fieldOptics, chain, firstHopName, trail, hops);
+      this.origin = origin;
     }
 
     /** Step into list elements. Pure lattice composition; no reflection. */
     public Telescope<S, X> each() {
-      return new Telescope<>(this.optic.then(Traversals.eachList()), this.fieldOptics, this.chain, this.firstHopName);
+      return origin.descend(this, Traversals.eachList(), "each", "collection");
+    }
+  }
+
+  /**
+   * Provenance of a typed-container step ({@code list}/{@code setField}/{@code mapField}/{@code
+   * optional}): the pre-field trail/hops plus the field's owner, component name, and lens — enough
+   * for the container terminal to emit the exact trail node and fusion hop the fused {@code
+   * each(getter)} form produces. A promotion ({@code asList(...)} etc.) has no provenance: {@code
+   * descend} then preserves the promoted trail and degrades hops to null.
+   */
+  record ContainerHop<S>(
+    List<OpticNode> preTrail,
+    List<Fusion.Hop> preHops,
+    Class<?> owner,
+    String component,
+    Traversal<Object, Object> lens
+  ) {
+    static <S> ContainerHop<S> promotion() {
+      return new ContainerHop<>(null, null, null, null, null);
+    }
+
+    @SuppressWarnings("unchecked")
+    <A, E> Telescope<S, E> descend(
+      final Telescope<S, A> step,
+      final Traversal<?, ?> elements,
+      final String kind,
+      final String containerLabel
+    ) {
+      final var composed = step.optic.then((Traversal<A, E>) elements);
+      if (owner == null) {
+        // Promotion of an arbitrary path: keep the (possibly partial) trail, no fusion identity.
+        return new Telescope<>(composed, step.fieldOptics, step.chain, step.firstHopName, step.trail, null);
+      }
+      final var trailOut = new ArrayList<OpticNode>(preTrail.size() + 1);
+      trailOut.addAll(preTrail);
+      trailOut.add(new OpticNode.Traverse(component, containerLabel));
+      final var segment = (Traversal<Object, Object>) (Traversal<?, ?>) lens.then(
+        (Traversal<Object, Object>) (Traversal<?, ?>) elements
+      );
+      final var hop = Fusion.Hop.traverse(
+        owner,
+        component,
+        kind,
+        segment,
+        (Traversal<Object, Object>) (Traversal<?, ?>) elements
+      );
+      final List<Fusion.Hop> hopsOut;
+      if (preHops == null) {
+        hopsOut = null;
+      } else {
+        final var h = new ArrayList<Fusion.Hop>(preHops.size() + 1);
+        h.addAll(preHops);
+        h.add(hop);
+        hopsOut = Collections.unmodifiableList(h);
+      }
+      return new Telescope<>(
+        composed,
+        step.fieldOptics,
+        step.chain,
+        step.firstHopName,
+        Collections.unmodifiableList(trailOut),
+        hopsOut
+      );
     }
   }
 
@@ -2280,22 +2455,24 @@ public sealed class Telescope<
    */
   public static final class SetTelescope<S, X> extends Telescope<S, Set<X>> {
 
-    SetTelescope(final Traversal<S, Set<X>> optic, final FieldOptics fieldOptics, final Function<S, S> chain) {
-      super(optic, fieldOptics, chain);
-    }
+    private final ContainerHop<S> origin;
 
     SetTelescope(
       final Traversal<S, Set<X>> optic,
       final FieldOptics fieldOptics,
       final Function<S, S> chain,
-      final String firstHopName
+      final String firstHopName,
+      final List<OpticNode> trail,
+      final List<Fusion.Hop> hops,
+      final ContainerHop<S> origin
     ) {
-      super(optic, fieldOptics, chain, firstHopName);
+      super(optic, fieldOptics, chain, firstHopName, trail, hops);
+      this.origin = origin;
     }
 
     /** Step into set elements. Output is iteration-order-preserving (LinkedHashSet). */
     public Telescope<S, X> each() {
-      return new Telescope<>(this.optic.then(Traversals.eachSet()), this.fieldOptics, this.chain, this.firstHopName);
+      return origin.descend(this, Traversals.eachSet(), "each", "collection");
     }
   }
 
@@ -2306,27 +2483,24 @@ public sealed class Telescope<
    */
   public static final class MapTelescope<S, K, V> extends Telescope<S, Map<K, V>> {
 
-    MapTelescope(final Traversal<S, Map<K, V>> optic, final FieldOptics fieldOptics, final Function<S, S> chain) {
-      super(optic, fieldOptics, chain);
-    }
+    private final ContainerHop<S> origin;
 
     MapTelescope(
       final Traversal<S, Map<K, V>> optic,
       final FieldOptics fieldOptics,
       final Function<S, S> chain,
-      final String firstHopName
+      final String firstHopName,
+      final List<OpticNode> trail,
+      final List<Fusion.Hop> hops,
+      final ContainerHop<S> origin
     ) {
-      super(optic, fieldOptics, chain, firstHopName);
+      super(optic, fieldOptics, chain, firstHopName, trail, hops);
+      this.origin = origin;
     }
 
     /** Step into map values; keys remain on the map. Pure lattice composition. */
     public Telescope<S, V> values() {
-      return new Telescope<>(
-        this.optic.then(Traversals.eachMapValue()),
-        this.fieldOptics,
-        this.chain,
-        this.firstHopName
-      );
+      return origin.descend(this, Traversals.eachMapValue(), "eachValue", "map values");
     }
   }
 
@@ -2337,31 +2511,24 @@ public sealed class Telescope<
    */
   public static final class OptionalTelescope<S, X> extends Telescope<S, Optional<X>> {
 
-    OptionalTelescope(
-      final Traversal<S, Optional<X>> optic,
-      final FieldOptics fieldOptics,
-      final Function<S, S> chain
-    ) {
-      super(optic, fieldOptics, chain);
-    }
+    private final ContainerHop<S> origin;
 
     OptionalTelescope(
       final Traversal<S, Optional<X>> optic,
       final FieldOptics fieldOptics,
       final Function<S, S> chain,
-      final String firstHopName
+      final String firstHopName,
+      final List<OpticNode> trail,
+      final List<Fusion.Hop> hops,
+      final ContainerHop<S> origin
     ) {
-      super(optic, fieldOptics, chain, firstHopName);
+      super(optic, fieldOptics, chain, firstHopName, trail, hops);
+      this.origin = origin;
     }
 
     /** Step into the Optional's payload. Empty Optional is a write no-op (Affine semantics). */
     public Telescope<S, X> present() {
-      return new Telescope<>(
-        this.optic.then(Traversals.eachOptional()),
-        this.fieldOptics,
-        this.chain,
-        this.firstHopName
-      );
+      return origin.descend(this, Traversals.eachOptional(), "whenPresent", "optional");
     }
   }
 

--- a/core/src/main/java/io/github/eschizoid/telescope/Telescope.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/Telescope.java
@@ -969,7 +969,16 @@ public sealed class Telescope<
     // Records.fieldLens that fails at call time because the focus type isn't a record.
     final Lens<A, B> fieldLens =
       fieldOptics == BeanFieldOptics.INSTANCE ? Beans.fieldLens(fieldName) : Records.fieldLens(fieldName);
-    return new Telescope<>(optic.then(fieldLens), fieldOptics, chain, null, plus(new OpticNode.Focus(fieldName)));
+    // Propagate (or establish) the first-hop name: resetting it to null mid-path made the NEXT
+    // typed hop falsely claim first-hop status — wrong empty-read messages, and DeepMap routes
+    // telescope-mapping rows by this name. The string itself is a perfectly good first hop.
+    return new Telescope<>(
+      optic.then(fieldLens),
+      fieldOptics,
+      chain,
+      firstHopName != null ? firstHopName : fieldName,
+      plus(new OpticNode.Focus(fieldName))
+    );
   }
 
   /**
@@ -1133,7 +1142,7 @@ public sealed class Telescope<
       optic.then(prism),
       fieldOptics,
       chain,
-      null,
+      firstHopName,
       plus(new OpticNode.Narrow(subType.getSimpleName())),
       plusHops(Fusion.Hop.narrow(subType, (Traversal<Object, Object>) prism))
     );
@@ -1162,7 +1171,7 @@ public sealed class Telescope<
       optic.filter(predicate),
       fieldOptics,
       chain,
-      null,
+      firstHopName,
       plus(new OpticNode.Filter("predicate")),
       plusHops(Fusion.Hop.filter(predicate, (Traversal<Object, Object>) segment))
     );
@@ -1636,10 +1645,23 @@ public sealed class Telescope<
    * }</pre>
    */
   public List<Indexed<A>> toListIndexed(final S source) {
+    // Mirror toList's normalization exactly: the two terminals must agree on every input. The
+    // Lens branch also catches Iso-rooted telescopes (Iso IS-A Lens), whose unguarded identity
+    // visit would otherwise materialize a null root as [Indexed[0, null]] while toList says [].
+    if (optic instanceof final Lens<S, A> lens) {
+      if (source == null) return List.of();
+      return java.util.Collections.singletonList(new Indexed<>(0, lens.get(source)));
+    }
+    if (optic instanceof final Affine<S, A> affine) {
+      return affine
+        .getOption(source)
+        .map(a -> List.of(new Indexed<>(0, a)))
+        .orElseGet(List::of);
+    }
     final var out = new ArrayList<Indexed<A>>();
     final var i = new int[] { 0 };
     optic.forEach(source, a -> out.add(new Indexed<>(i[0]++, a)));
-    return List.copyOf(out);
+    return java.util.Collections.unmodifiableList(out);
   }
 
   /**

--- a/core/src/main/java/io/github/eschizoid/telescope/Telescope.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/Telescope.java
@@ -1756,7 +1756,7 @@ public sealed class Telescope<
     // visit would otherwise materialize a null root as [Indexed[0, null]] while toList says [].
     if (optic instanceof final Lens<S, A> lens) {
       if (source == null) return List.of();
-      return java.util.Collections.singletonList(new Indexed<>(0, lens.get(source)));
+      return Collections.singletonList(new Indexed<>(0, lens.get(source)));
     }
     if (optic instanceof final Affine<S, A> affine) {
       return affine
@@ -1767,7 +1767,7 @@ public sealed class Telescope<
     final var out = new ArrayList<Indexed<A>>();
     final var i = new int[] { 0 };
     optic.forEach(source, a -> out.add(new Indexed<>(i[0]++, a)));
-    return java.util.Collections.unmodifiableList(out);
+    return Collections.unmodifiableList(out);
   }
 
   /**

--- a/core/src/main/java/io/github/eschizoid/telescope/conversion/Mapper.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/conversion/Mapper.java
@@ -123,7 +123,8 @@ public final class Mapper<A, B> {
     this.sourceRefl = Reflective.of(sourceClass);
     this.targetRefl = Reflective.of(targetClass);
     // Defensive copy — patch behavior must not mutate after construction.
-    this.patchByTargetField = Map.copyOf(patchByTargetField);
+    // null = patch unsupported (see patch()); copyOf would NPE on the sentinel.
+    this.patchByTargetField = patchByTargetField == null ? null : Map.copyOf(patchByTargetField);
     this.preForward = preForward;
     this.postForward = postForward;
     this.preBackward = preBackward;
@@ -336,6 +337,14 @@ public final class Mapper<A, B> {
    */
   @SuppressWarnings("unchecked")
   public A patch(final A base, final B partial) {
+    // A null table means the producing factory does not support patching at all (multi-source
+    // merge); an EMPTY table means a legitimate mapper with no patchable rows. Conflating the two
+    // made merge's patch a silent no-op while its backward threw loudly — same contract, opposite
+    // failure modes.
+    if (patchByTargetField == null) throw new UnsupportedOperationException(
+      "This mapper does not support patch() — Telescope.merge produces a forward-only mapper " +
+        "(the multi-source case has no general inverse). Use Mapper.forward(...) only."
+    );
     if (base == null || partial == null) return base;
     if (patchByTargetField.isEmpty()) return base;
     final var patched = new HashMap<String, Object>();

--- a/core/src/main/java/io/github/eschizoid/telescope/conversion/Mapper.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/conversion/Mapper.java
@@ -450,6 +450,12 @@ public final class Mapper<A, B> {
     // entity, defeating the "load-mutate-save" idiom; and (2) stage pointless reads for read-only
     // computed getters (e.g. getFullName() derived from firstName + lastName) whose writes would
     // silently no-op — work for a property the user never asked us to map.
+    // Same null-table sentinel as patch(): the producing factory does not support target-mutating
+    // operations at all (multi-source merge) — throw the UOE, don't NPE on the sentinel.
+    if (patchByTargetField == null) throw new UnsupportedOperationException(
+      "This mapper does not support into() — Telescope.merge produces a forward-only mapper " +
+        "(the multi-source case has no general inverse). Use Mapper.forward(...) only."
+    );
     final var staged = new LinkedHashMap<String, Object>(patchByTargetField.size());
     for (final var name : patchByTargetField.keySet()) {
       staged.put(name, targetRefl.read(produced, name));

--- a/core/src/test/java/io/github/eschizoid/telescope/ContainerStepParityTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/ContainerStepParityTest.java
@@ -1,0 +1,110 @@
+package io.github.eschizoid.telescope;
+
+import static io.github.eschizoid.telescope.Edit.over;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pins the typed-container tier ({@code .list()/.setField()/.mapField()/.optional()} + terminals)
+ * to full parity with the fused {@code each(getter)}/{@code eachValue}/{@code whenPresent} forms:
+ * the split form must produce the same introspection trail and participate in multi-edit fusion
+ * identically, and a promotion ({@code asList(...)}) must preserve — not erase — the trail it was
+ * handed. Before these fixes the whole tier produced partial-but-authoritative-looking {@code
+ * explain()} output and was invisible to {@code Telescope.all} fusion.
+ */
+class ContainerStepParityTest {
+
+  record User(String name, String email) {}
+
+  record Team(String label, List<User> users, Map<String, Integer> scores, Optional<String> motto) {}
+
+  static final Team TEAM = new Team(
+    "core",
+    List.of(new User("Ann", "ANN@x.io"), new User("Bo", "BO@x.io")),
+    Map.of("a", 1),
+    Optional.of("go")
+  );
+
+  @Nested
+  @DisplayName("the split form explains identically to the fused form")
+  class TrailParity {
+
+    @Test
+    @DisplayName("list(...).each() renders the same trail as each(getter)")
+    void listStepTrailMatchesEach() {
+      final var fused = Telescope.of(Team.class).each(Team::users).field(User::email);
+      final var split = Telescope.of(Team.class).list(Team::users).each().field(User::email);
+      assertEquals(fused.explain().hops(), split.explain().hops());
+    }
+
+    @Test
+    @DisplayName("mapField(...).values() renders the same trail as eachValue(getter)")
+    void mapStepTrailMatchesEachValue() {
+      final var fused = Telescope.of(Team.class).eachValue(Team::scores);
+      final var split = Telescope.of(Team.class).mapField(Team::scores).values();
+      assertEquals(fused.explain().hops(), split.explain().hops());
+    }
+
+    @Test
+    @DisplayName("optional(...).present() renders the same trail as whenPresent(getter)")
+    void optionalStepTrailMatchesWhenPresent() {
+      final var fused = Telescope.of(Team.class).whenPresent(Team::motto);
+      final var split = Telescope.of(Team.class).optional(Team::motto).present();
+      assertEquals(fused.explain().hops(), split.explain().hops());
+    }
+
+    @Test
+    @DisplayName("the un-descended container step itself explains as a field focus")
+    void containerStepAloneIsAFocus() {
+      final var step = Telescope.of(Team.class).list(Team::users);
+      assertFalse(step.explain().hops().isEmpty());
+    }
+  }
+
+  @Nested
+  @DisplayName("the split form participates in fusion like the fused form")
+  class FusionParity {
+
+    @Test
+    @DisplayName("a split-form edit and a fused-form edit share the container prefix")
+    void splitAndFusedShareThePrefix() {
+      // Both edits traverse users; if the split form carries the fused form's hop identity, they
+      // fuse into one container pass and the result equals sequential application either way.
+      final var names = over(Telescope.of(Team.class).list(Team::users).each().field(User::name), String::toLowerCase);
+      final var emails = over(Telescope.of(Team.class).each(Team::users).field(User::email), String::toLowerCase);
+
+      final var fusedResult = Telescope.all(names, emails).apply(TEAM);
+      var sequential = TEAM;
+      sequential = names.apply(sequential);
+      sequential = emails.apply(sequential);
+      assertEquals(sequential, fusedResult);
+      assertEquals("ann", fusedResult.users().get(0).name());
+      assertEquals("ann@x.io", fusedResult.users().get(0).email());
+    }
+  }
+
+  @Nested
+  @DisplayName("promotions preserve what they are handed")
+  class PromotionPreservation {
+
+    @Test
+    @DisplayName("asList keeps the promoted path's trail instead of erasing it")
+    void asListKeepsTrail() {
+      final var built = Telescope.of(Team.class).field(Team::users);
+      final var promoted = Telescope.asList(built);
+      assertEquals(built.explain().hops(), promoted.explain().hops());
+
+      // Descending after a promotion keeps the (possibly partial) trail rather than fabricating
+      // container nodes it cannot verify; fusion identity is unknown, so such paths fall back.
+      final var descended = promoted.each();
+      assertEquals(built.explain().hops(), descended.explain().hops());
+    }
+  }
+}

--- a/core/src/test/java/io/github/eschizoid/telescope/MergeTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/MergeTest.java
@@ -296,6 +296,28 @@ class MergeTest {
   class ForwardTimeGuards {
 
     @Test
+    @DisplayName("a row targeting a non-component method fails at build time, naming the known fields")
+    void unknownTargetFailsAtBuild() {
+      // Pre-fix: the positional bind silently dropped such a row — its source accessor never read,
+      // its source class never checked — and the missing-source diagnostic vanished with it.
+      final var ex = assertThrows(IllegalArgumentException.class, () ->
+        Telescope.merge(Profile.class, from(Customer::id, Profile::toString))
+      );
+      assertTrue(ex.getMessage().contains("toString"), ex.getMessage());
+      assertTrue(ex.getMessage().contains("Known fields"), ex.getMessage());
+    }
+
+    @Test
+    @DisplayName("patch on a merge mapper throws like backward does — no silent no-op")
+    void patchThrowsLikeBackward() {
+      final var mapper = Telescope.merge(Profile.class, from(Customer::id, Profile::id));
+      final var ex = assertThrows(UnsupportedOperationException.class, () ->
+        mapper.patch(Sources.of(new Customer("c", "e")), new Profile("x", "y", "z", "w"))
+      );
+      assertTrue(ex.getMessage().contains("forward-only"), ex.getMessage());
+    }
+
+    @Test
     @DisplayName("forward called with a Sources bag missing one of the row source classes throws naming the class")
     void missingSourceClassThrows() {
       final Mapper<Sources, Profile> mapper = Telescope.merge(

--- a/core/src/test/java/io/github/eschizoid/telescope/MergeTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/MergeTest.java
@@ -308,6 +308,19 @@ class MergeTest {
     }
 
     @Test
+    @DisplayName("into on a merge mapper throws like backward does — no NPE on the sentinel")
+    void intoThrowsLikeBackward() {
+      // A BEAN target passes into()'s record-immutability check and reaches the patch-table
+      // sentinel — pre-guard this NPE'd on the null table instead of throwing the honest UOE.
+      final var mapper = Telescope.merge(SettersProfile.class, from(Customer::id, SettersProfile::getId));
+      final var target = new SettersProfile();
+      final var ex = assertThrows(UnsupportedOperationException.class, () ->
+        mapper.into(target, Sources.of(new Customer("c", "e")))
+      );
+      assertTrue(ex.getMessage().contains("forward-only"), ex.getMessage());
+    }
+
+    @Test
     @DisplayName("patch on a merge mapper throws like backward does — no silent no-op")
     void patchThrowsLikeBackward() {
       final var mapper = Telescope.merge(Profile.class, from(Customer::id, Profile::id));

--- a/core/src/test/java/io/github/eschizoid/telescope/TelescopeFromMapTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/TelescopeFromMapTest.java
@@ -180,6 +180,17 @@ class TelescopeFromMapTest {
   class Validation {
 
     @Test
+    @DisplayName("an extract row targeting a non-component method is rejected at build time")
+    void unknownTargetRowIsRejected() {
+      // Pre-fix: such a row was silently ignored — key never read, converter never run.
+      final var ex = assertThrows(IllegalArgumentException.class, () ->
+        Telescope.fromMap(CaseListRequest.class, extract("k", CaseListRequest::toString, Object::toString))
+      );
+      assertTrue(ex.getMessage().contains("toString"), ex.getMessage());
+      assertTrue(ex.getMessage().contains("Known fields"), ex.getMessage());
+    }
+
+    @Test
     @DisplayName("two extract rows naming the same target component throw at factory construction")
     void duplicateExtractRowIsRejected() {
       // Without this check, the second row would silently win and the first row's converter

--- a/core/src/test/java/io/github/eschizoid/telescope/TelescopeTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/TelescopeTest.java
@@ -144,6 +144,37 @@ class TelescopeTest {
     }
 
     @Test
+    @DisplayName("toListIndexed agrees with toList on every null shape — same telescope, same answer")
+    void toListIndexedAgreesWithToList() {
+      // Pre-fix: toListIndexed bypassed the fast-path normalization, so an Iso-rooted telescope
+      // materialized a null root as [Indexed[0, null]] while toList said []. The two terminals
+      // must never disagree.
+      final var root = Telescope.of(User.class);
+      assertEquals(List.of(), root.toList(null));
+      assertEquals(List.of(), root.toListIndexed(null));
+
+      final var userName = Telescope.of(User.class).field(User::name);
+      assertEquals(List.of(), userName.toListIndexed(null));
+
+      final var nullFocus = new User(null, 30, null);
+      assertEquals(1, userName.toListIndexed(nullFocus).size());
+      assertNull(userName.toListIndexed(nullFocus).get(0).value());
+    }
+
+    @Test
+    @DisplayName("filter and as() keep the path's first-hop name for empty-read diagnostics")
+    void filterKeepsFirstHopName() {
+      // Pre-fix: filter()/as() reset firstHopName to null mid-path, so the NEXT hop falsely
+      // claimed first-hop status and the empty-read message named the wrong field.
+      final var adults = Telescope.of(Team.class)
+        .each(Team::users)
+        .filter(u -> u.age() >= 30)
+        .field(User::name);
+      final var ex = assertThrows(NoSuchElementException.class, () -> adults.read(new Team("t", List.of())));
+      assertTrue(ex.getMessage().contains("'users'"), ex.getMessage());
+    }
+
+    @Test
     @DisplayName("eachValue(getter) over a record's Map<K, V> updates every value")
     void eachOverMapValues() {
       record Index(Map<String, Integer> byKey) {}

--- a/internal/src/main/java/io/github/eschizoid/telescope/internal/Beans.java
+++ b/internal/src/main/java/io/github/eschizoid/telescope/internal/Beans.java
@@ -472,7 +472,9 @@ public final class Beans {
     final var set = "set" + capitalize(name);
     Method setter = null;
     for (final var m : cls.getMethods()) {
-      if (m.getParameterCount() == 1 && m.getName().equals(set)) {
+      if (
+        m.getParameterCount() == 1 && m.getName().equals(set) && !Modifier.isStatic(m.getModifiers()) && !m.isBridge()
+      ) {
         setter = m;
         break;
       }
@@ -491,16 +493,30 @@ public final class Beans {
       // Native-image path: a MethodHandle closure, no runtime class synthesis — see MhAccessors.
       // asType relaxes the receiver to Object and unboxes a primitive param from the boxed value,
       // matching the auto-unbox the LMF instantiatedMethodType installs below.
-      if (NativeImage.IN_IMAGE) return MhAccessors.biConsumer(handle);
-      final var callSite = LambdaMetafactory.metafactory(
-        lookup,
-        "accept",
-        MethodType.methodType(BiConsumer.class),
-        MethodType.methodType(void.class, Object.class, Object.class),
-        handle,
-        MethodType.methodType(void.class, declaringClass, instantiatedParamType)
-      );
-      return (BiConsumer<Object, Object>) callSite.getTarget().invoke();
+      final BiConsumer<Object, Object> base;
+      if (NativeImage.IN_IMAGE) {
+        base = MhAccessors.biConsumer(handle);
+      } else {
+        final var callSite = LambdaMetafactory.metafactory(
+          lookup,
+          "accept",
+          MethodType.methodType(BiConsumer.class),
+          MethodType.methodType(void.class, Object.class, Object.class),
+          handle,
+          MethodType.methodType(void.class, declaringClass, instantiatedParamType)
+        );
+        base = (BiConsumer<Object, Object>) callSite.getTarget().invoke();
+      }
+      // Same primitive-null guard as SettersWriter: null into a primitive setter must leave the
+      // field at its JLS default, not NPE at the unbox — Mapper.into must not crash on the input
+      // Mapper.forward silently defaults (same-mapper symmetry).
+      if (paramType.isPrimitive()) {
+        return (pojo, value) -> {
+          if (value == null) return;
+          base.accept(pojo, value);
+        };
+      }
+      return base;
     } catch (final Throwable t) {
       throw new RuntimeException("Failed to set '" + name + "' on " + cls.getName(), t);
     }
@@ -660,6 +676,12 @@ public final class Beans {
     final var map = new LinkedHashMap<String, Method>();
     for (final var m : cls.getMethods()) {
       if (m.getParameterCount() != 0 || m.getDeclaringClass() == Object.class) continue;
+      // Static getter-shaped methods (getInstance(), getLogger()) are not bean properties — and
+      // scanning one poisons the whole class: the eager LMF invoker build fails on the arity
+      // mismatch and takes every property down with it. Bridge/synthetic methods are the erased
+      // Object-typed duplicates of generic accessors; keeping them makes the winning method (and
+      // therefore the property TYPE) dependent on getMethods() order, which is unspecified.
+      if (Modifier.isStatic(m.getModifiers()) || m.isBridge() || m.isSynthetic()) continue;
       // Skip inherited methods declared in platform modules (java.*, jdk.*). A class extending
       // ArrayList would otherwise surface `isEmpty()` → property `empty` and the LMF binder
       // would then fail `privateLookupIn(ArrayList.class)` because `java.base` doesn't grant
@@ -1049,7 +1071,16 @@ public final class Beans {
 
   private static boolean hasAnySetter(final Class<?> cls) {
     for (final var m : cls.getMethods()) {
-      if (m.getParameterCount() == 1 && m.getName().length() > 3 && m.getName().startsWith("set")) return true;
+      // The shared setter-shape rule: setCity qualifies, setup/settle do not. Without it, an
+      // unrelated set*-named method flipped the write strategy to SETTERS, whose per-property
+      // no-ops then silently lost every field of a getter-only bean.
+      if (
+        m.getParameterCount() == 1 &&
+        !Modifier.isStatic(m.getModifiers()) &&
+        PropertyNames.afterSet(m.getName()) != null
+      ) {
+        return true;
+      }
     }
     return false;
   }

--- a/internal/src/main/java/io/github/eschizoid/telescope/internal/LambdaIntrospection.java
+++ b/internal/src/main/java/io/github/eschizoid/telescope/internal/LambdaIntrospection.java
@@ -79,7 +79,10 @@ public final class LambdaIntrospection {
         "Expected a method reference (e.g. User::name, User::getName), not a lambda. Got: " +
           serialized.getImplMethodName()
       );
-      return Class.forName(serialized.getImplClass().replace('/', '.'));
+      // Resolve against the lambda's defining loader, not telescope's — under plugin/app-server
+      // deployments the impl class may be invisible to this library's loader.
+      final var implName = serialized.getImplClass().replace('/', '.');
+      return Class.forName(implName, false, lambda.getClass().getClassLoader());
     } catch (final ReflectiveOperationException e) {
       throw new IllegalArgumentException("Expected a method reference; got: " + lambda, e);
     }

--- a/internal/src/main/java/io/github/eschizoid/telescope/internal/Records.java
+++ b/internal/src/main/java/io/github/eschizoid/telescope/internal/Records.java
@@ -369,7 +369,9 @@ public final class Records {
       final MethodHandles.Lookup lookup
     ) {
       try {
-        return lookup.unreflectConstructor(ctor);
+        // asFixedArity for the same reason as buildCtorFn: MhIso composes this handle
+        // per-parameter with filterArguments, and a varargs-collector handle would re-collect.
+        return lookup.unreflectConstructor(ctor).asFixedArity();
       } catch (final IllegalAccessException e) {
         throw new IllegalStateException("Failed to build constructor handle for " + cls.getName(), e);
       }
@@ -472,8 +474,12 @@ public final class Records {
       final MethodHandles.Lookup lookup
     ) {
       try {
+        // asFixedArity: unreflecting a varargs canonical constructor yields a varargs-collector
+        // handle, and asSpreader on a collector re-collects the spread argument as a single
+        // element — every write on a `record R(int... xs)` then dies with a ClassCastException.
         final var spread = lookup
           .unreflectConstructor(ctor)
+          .asFixedArity()
           .asSpreader(Object[].class, ctor.getParameterCount())
           .asType(MethodType.methodType(Object.class, Object[].class));
         return args -> {

--- a/internal/src/main/java/io/github/eschizoid/telescope/internal/optics/Fold.java
+++ b/internal/src/main/java/io/github/eschizoid/telescope/internal/optics/Fold.java
@@ -66,7 +66,14 @@ public interface Fold<S, A> {
     return out;
   }
 
-  /** First focused value matching {@code predicate}, or empty if none. */
+  /**
+   * First focused value matching {@code predicate}, or empty if none.
+   *
+   * <p><b>Null collapse.</b> {@link Optional} cannot carry {@code null}, so a null focus that
+   * matches the predicate (e.g. {@code Objects::isNull}) returns {@code empty} — indistinguishable
+   * from "no match" — while {@link #any} answers {@code true} for the same inputs. Callers that
+   * must distinguish a null match use {@link #visitWhile} directly.
+   */
   default Optional<A> findFirst(final S source, final Predicate<? super A> predicate) {
     final var box = new Object[1];
     final var found = !visitWhile(source, a -> {

--- a/internal/src/main/java/io/github/eschizoid/telescope/internal/optics/Prism.java
+++ b/internal/src/main/java/io/github/eschizoid/telescope/internal/optics/Prism.java
@@ -2,8 +2,6 @@ package io.github.eschizoid.telescope.internal.optics;
 
 import java.util.Optional;
 import java.util.function.Function;
-import java.util.function.Predicate;
-import java.util.stream.Stream;
 
 /**
  * At-most-one + reconstruct: focuses on at-most-one {@code A} inside an {@code S}, and given an
@@ -60,17 +58,8 @@ public interface Prism<S, A> extends Affine<S, A> {
     return reverseGet(f.apply(current.get()));
   }
 
-  @Override
-  default Stream<A> getAll(final S source) {
-    return getOption(source).stream();
-  }
-
-  /** Fold view: visit the focused value when the case matches, otherwise focus nothing. */
-  @Override
-  default boolean visitWhile(final S source, final Predicate<? super A> visitor) {
-    final var focus = getOption(source);
-    return focus.isEmpty() || visitor.test(focus.get());
-  }
+  // getAll / visitWhile are inherited from Affine unchanged — re-declaring the byte-identical
+  // defaults here only doubled the lockstep surface of the dual read primitives.
 
   /** Build a Prism from a partial getter and a reconstructor (must satisfy the round-trip law). */
   static <S, A> Prism<S, A> of(

--- a/internal/src/main/java/io/github/eschizoid/telescope/internal/pairing/PropertyNames.java
+++ b/internal/src/main/java/io/github/eschizoid/telescope/internal/pairing/PropertyNames.java
@@ -31,6 +31,18 @@ public final class PropertyNames {
   }
 
   /**
+   * The property behind a {@code set}-prefixed name, or {@code null} when the name is not
+   * setter-shaped: {@code setCity} → {@code city}, {@code setup} → {@code null}, {@code settle} →
+   * {@code null}. The uppercase-after-prefix rule is the same one {@link #afterGet} applies — a
+   * method that merely starts with the letters {@code set} is not a property setter.
+   */
+  public static String afterSet(final String name) {
+    if (name == null || name.length() <= 3 || !name.startsWith("set")) return null;
+    if (!Character.isUpperCase(name.charAt(3))) return null;
+    return decapitalize(name.substring(3));
+  }
+
+  /**
    * The property behind an {@code is}-prefixed name, or {@code null} when the name is not
    * getter-shaped: {@code isActive} → {@code active}, {@code isbn} → {@code null}.
    */

--- a/internal/src/main/java/io/github/eschizoid/telescope/internal/pairing/ReflectionProps.java
+++ b/internal/src/main/java/io/github/eschizoid/telescope/internal/pairing/ReflectionProps.java
@@ -89,12 +89,20 @@ public final class ReflectionProps implements PropertySystem<Type> {
 
   @Override
   public Allocability copyAllocability(final Type src, final Type tgt) {
-    final var allocable =
-      src instanceof Class<?> srcCls &&
-      tgt instanceof Class<?> tgtCls &&
-      Beans.intermediateAllocator(srcCls).get() != null &&
-      Beans.intermediateAllocator(tgtCls).get() != null;
-    return allocable ? Allocability.ALLOCABLE : Allocability.NOT_ALLOCABLE;
+    // The allocator probe invokes a real constructor/builder; a type whose no-arg path throws is
+    // simply not allocable — the failure must resolve the decision, not escape mid-analysis.
+    // (The probe allocating at all is a known cost of proving constructibility; side-effectful
+    // constructors should not be intermediate-allocated anyway, and this catch keeps them out.)
+    try {
+      final var allocable =
+        src instanceof Class<?> srcCls &&
+        tgt instanceof Class<?> tgtCls &&
+        Beans.intermediateAllocator(srcCls).get() != null &&
+        Beans.intermediateAllocator(tgtCls).get() != null;
+      return allocable ? Allocability.ALLOCABLE : Allocability.NOT_ALLOCABLE;
+    } catch (final RuntimeException e) {
+      return Allocability.NOT_ALLOCABLE;
+    }
   }
 
   @Override

--- a/internal/src/test/java/io/github/eschizoid/telescope/internal/SubstrateContractTest.java
+++ b/internal/src/test/java/io/github/eschizoid/telescope/internal/SubstrateContractTest.java
@@ -1,0 +1,174 @@
+package io.github.eschizoid.telescope.internal;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.github.eschizoid.telescope.internal.pairing.PropertyNames;
+import java.io.Serializable;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pins for the substrate contracts an architecture inspection found broken — each nested class is
+ * one bug, and each pin failed before its fix. These are the adversarial bean/record shapes real
+ * codebases carry: singleton accessors, {@code set*}-named non-setters, varargs canonical
+ * constructors, and null flowing into primitive setters.
+ */
+class SubstrateContractTest {
+
+  @Nested
+  @DisplayName("a static getter-shaped method is not a property and cannot poison the bean")
+  class StaticGetterExcluded {
+
+    public static class WithFactory {
+
+      private String name;
+
+      public WithFactory() {}
+
+      public static WithFactory getInstance() {
+        return new WithFactory();
+      }
+
+      public String getName() {
+        return name;
+      }
+
+      public void setName(final String name) {
+        this.name = name;
+      }
+    }
+
+    @Test
+    @DisplayName("getInstance() is skipped; every real property stays readable")
+    void staticGetterSkipped() {
+      final var names = List.of(Beans.propertyNames(WithFactory.class));
+      assertFalse(names.contains("instance"), "static getInstance() must not become a property");
+      assertTrue(names.contains("name"));
+
+      final var bean = new WithFactory();
+      bean.setName("ann");
+      assertEquals("ann", Beans.readProperty(bean, "name")); // pre-fix: ISE, whole bean poisoned
+    }
+  }
+
+  @Nested
+  @DisplayName("a set*-named non-setter cannot flip the write strategy")
+  class SetterShapeRule {
+
+    public static class GetterOnlyWithSetup {
+
+      private String name;
+
+      public GetterOnlyWithSetup() {}
+
+      public String getName() {
+        return name;
+      }
+
+      // Not a property setter — no uppercase after the prefix. Pre-fix this flipped autoWriter to
+      // SETTERS, whose no-op per property silently lost every field.
+      public void setup(final String ignored) {}
+    }
+
+    @Test
+    @DisplayName("setup(String) does not select the setters strategy; fields still write")
+    void setupDoesNotFlipStrategy() {
+      final var writer = Beans.autoWriter(GetterOnlyWithSetup.class);
+      final var built = writer.construct(new String[] { "name" }, name -> "VALUE");
+      assertEquals("VALUE", built.getName()); // pre-fix: null — SettersWriter no-op'd it
+    }
+
+    @Test
+    @DisplayName("the shared setter-shape rule: setCity yes, setup/settle no")
+    void afterSetRule() {
+      assertEquals("city", PropertyNames.afterSet("setCity"));
+      assertNull(PropertyNames.afterSet("setup"));
+      assertNull(PropertyNames.afterSet("settle"));
+      assertNull(PropertyNames.afterSet("set"));
+    }
+  }
+
+  @Nested
+  @DisplayName("records with a varargs canonical constructor construct and rebuild")
+  class VarargsRecords {
+
+    record Tags(String name, String... labels) {}
+
+    @Test
+    @DisplayName("positional construct spreads the args instead of re-collecting them")
+    void positionalConstruct() {
+      final var built = Records.construct(Tags.class, new Object[] { "a", new String[] { "x", "y" } });
+      assertEquals("a", built.name());
+      assertArrayEquals(new String[] { "x", "y" }, built.labels()); // pre-fix: CCE wrapped in "Failed to construct"
+    }
+
+    @Test
+    @DisplayName("lens writes rebuild through the canonical constructor")
+    void lensWrite() {
+      final var r = new Tags("a", "x");
+      final var renamed = Records.<Tags, String>fieldLens(Tags.class, "name").set(r, "b");
+      assertEquals("b", renamed.name()); // pre-fix: every write on a varargs record threw
+      assertArrayEquals(new String[] { "x" }, renamed.labels());
+    }
+  }
+
+  @Nested
+  @DisplayName("null into a primitive setter leaves the JLS default — patch matches forward")
+  class PrimitiveNullWrite {
+
+    public static class Counter {
+
+      private int count;
+
+      public Counter() {}
+
+      public int getCount() {
+        return count;
+      }
+
+      public void setCount(final int count) {
+        this.count = count;
+      }
+    }
+
+    @Test
+    @DisplayName("writeBeanProperty(bean, primitiveProp, null) is a no-op, not an NPE")
+    void nullIntoPrimitiveIsNoOp() {
+      final var counter = new Counter();
+      counter.setCount(7);
+      Beans.writeBeanProperty(counter, "count", null); // pre-fix: NPE at the unbox
+      assertEquals(7, counter.getCount());
+    }
+  }
+
+  @Nested
+  @DisplayName("method-reference decode resolves against the lambda's own classloader")
+  class ClassloaderResolution {
+
+    @Test
+    @DisplayName("implClassOf uses the reference's defining loader (same-loader smoke)")
+    void implClassResolves() {
+      // The cross-classloader shape needs a child URLClassLoader harness; this pin locks the
+      // resolution path signature (three-arg forName against the lambda's loader) via the
+      // same-loader case, which must keep working identically.
+      interface Acc extends Serializable {
+        String apply(Counter c);
+      }
+      final Acc acc = Counter::getCount0;
+      assertEquals(Counter.class, LambdaIntrospection.implClassOf(acc));
+    }
+
+    public static class Counter {
+
+      public String getCount0() {
+        return "0";
+      }
+    }
+  }
+}


### PR DESCRIPTION
## What

Fixes for all 13 confirmed findings from the four-territory architecture inspection (engines, lattice, facade, substrate) — every bug was probe-confirmed before fixing, and every fix carries a pin that fails on the pre-fix code.

### Substrate (`SubstrateContractTest`, 6 fixes)
1. `scanGetters` skips static/bridge/synthetic methods — a `public static getInstance()` no longer poisons every property read on the bean; property types no longer depend on unspecified `getMethods()` order
2. `hasAnySetter` uses the new shared `PropertyNames.afterSet` rule — `setup(String)` no longer flips the write strategy into silent total data loss
3. Varargs canonical constructors: `asFixedArity()` before `asSpreader`/composition — writes on `record R(int... xs)` no longer throw
4. `copyAllocability` resolves NOT_ALLOCABLE on probe failure instead of letting a throwing constructor escape mid-analysis
5. `implClassOf` resolves against the lambda's defining classloader — `auto()` inference works under plugin/app-server deployments
6. `writeBeanProperty` carries the primitive-null guard — `Mapper.into` no longer NPEs on the input `forward` silently defaults

### Facade + lattice (pins in `TelescopeTest`, 4 fixes)
7. `toListIndexed` mirrors `toList`'s normalization — no more `[Indexed[0, null]]` vs `[]` disagreement on the same telescope
8. `filter()`/`as()`/`fieldByName()` propagate `firstHopName` — empty-read diagnostics name the real entry field; DeepMap telescope-row routing gets the right name
9. `Fold.findFirst` documents its null-collapse vs `any`; `Prism` drops its byte-identical duplicate overrides
10. **Container-tier parity** (`ContainerStepParityTest`): `list()/setField()/mapField()/optional()` + terminals now produce the same trail and fusion-hop identity as the fused forms — a split-form edit and a fused-form edit share a fusion prefix, `explain()` renders identically for both spellings, and promotions preserve (not erase) what they're handed

### Engines (pins in `MergeTest`/`TelescopeFromMapTest`, 3 fixes)
11. Merge validates row targets at build time — restores the missing-source diagnostic the positional bind lost (a row to a non-component was silently dropped, its source never checked)
12. FromMap applies the same fail-loud validation; its "JLS default" javadoc now tells the truth (NullDefaults type defaults)
13. `Mapper.patch` distinguishes "no patchable rows" from "patch unsupported" — a merge mapper's `patch` throws like its `backward` instead of silently no-op-ing

### Guards (chain-drop, pins via existing suites)
- Shared `IDENTITY_CHAIN` sentinel; `then(...)` and `Edit.over(...)` throw pointedly when handed a chain-carrying telescope instead of silently dropping its pending edits

Full `:core` + `:internal` suites green. No public API added; two behavior changes are fail-loud conversions of probe-confirmed silent drops (merge/fromMap unknown-target rows, chain-carrier composition).
