### PR TITLE
ci: pin the docs version check to the latest release tag

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,11 +30,18 @@ jobs:
           exit $fail
       - name: Install snippets match the latest release
         run: |
-          # The README's telescope coordinates must pin the latest tag's version.
-          VERSION=$(git describe --tags --abbrev=0 | tr -d v)
-          if ! grep -q "io.github.eschizoid:telescope-core:${VERSION}" README.md; then
-            echo "README install snippet does not pin ${VERSION} (latest tag)"; exit 1
+          # The README's telescope coordinates must pin the latest RELEASE version. Select the
+          # highest semver tag explicitly — `git describe` returns the closest reachable tag, which
+          # picks up rolling markers like `early-access` that are not releases at all. Strip only a
+          # leading "v" (`tr -d v` would eat any "v" in the string).
+          VERSION=$(git tag -l 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname | head -1 | sed 's/^v//')
+          if [ -z "$VERSION" ]; then
+            echo "No release tag yet — nothing to check."; exit 0
           fi
+          if ! grep -q "io.github.eschizoid:telescope-core:${VERSION}" README.md; then
+            echo "README install snippet does not pin ${VERSION} (latest release tag)"; exit 1
+          fi
+          echo "README pins ${VERSION}"
 
   build:
     runs-on: ubuntu-latest

--- a/internal/src/main/java/io/github/eschizoid/telescope/internal/pairing/PairingRules.java
+++ b/internal/src/main/java/io/github/eschizoid/telescope/internal/pairing/PairingRules.java
@@ -108,13 +108,13 @@ public final class PairingRules<T> {
     if (args.isEmpty()) return null;
     final var raw = props.rawType(t);
     if (props.isSubtypeOf(raw, WellKnown.OPTIONAL)) {
-      return new ContainerView<>(ContainerView.Kind.OPTIONAL, args.get(0), null, raw);
+      return new ContainerView<>(ContainerView.Kind.OPTIONAL, args.getFirst(), null, raw);
     }
     if (props.isSubtypeOf(raw, WellKnown.LIST)) {
-      return new ContainerView<>(ContainerView.Kind.LIST, args.get(0), null, raw);
+      return new ContainerView<>(ContainerView.Kind.LIST, args.getFirst(), null, raw);
     }
     if (props.isSubtypeOf(raw, WellKnown.SET)) {
-      return new ContainerView<>(ContainerView.Kind.SET, args.get(0), null, raw);
+      return new ContainerView<>(ContainerView.Kind.SET, args.getFirst(), null, raw);
     }
     if (props.isSubtypeOf(raw, WellKnown.MAP)) {
       final var key = args.get(0);

--- a/internal/src/main/java/io/github/eschizoid/telescope/internal/pairing/PropertyNames.java
+++ b/internal/src/main/java/io/github/eschizoid/telescope/internal/pairing/PropertyNames.java
@@ -59,7 +59,7 @@ public final class PropertyNames {
    * nested-telescope variants return {@code null} by design rely on that.
    */
   public static String property(final String name) {
-    if (name == null) return name;
+    if (name == null) return null;
     final var get = afterGet(name);
     if (get != null) return get;
     final var is = afterIs(name);


### PR DESCRIPTION
The docs-integrity job used `git describe --tags --abbrev=0` (closest reachable tag). Once the rolling `early-access` tag landed on main's tip it became the "latest tag", so every PR failed with `README install snippet does not pin early-access` — including [#280](https://github.com/eschizoid/telescope/pull/280), which only bumps a Quarkus BOM.

Now selects the highest semver release tag (`v[0-9]*.[0-9]*.[0-9]*`, `--sort=-v:refname`), skips cleanly when no release exists, strips only a leading `v`, and logs the version it checked. Dry-run locally: resolves `1.4.0`, matches the README's pin.