### PR TITLE
build: bump google-java-format to 1.30.0 for the JVM 25 floor

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 junit = "6.1.3"
 graphqlJava = "26.0"
 spotless = "8.9.0"
-googleJavaFormat = "1.28.0"
+googleJavaFormat = "1.30.0"
 prettier = "3.8.1"
 prettierPluginJava = "2.8.1"
 testcontainers = "2.0.5"


### PR DESCRIPTION
Spotless 8.10.0 adds a JVM-version guard — on JVM 25 it requires google-java-format ≥ 1.30.0. The build pins 1.28.0, so [#290](https://github.com/eschizoid/telescope/pull/290) (spotless 8.9.0 → 8.10.0) fails every module with:

```
(jvm-version) You are running Spotless on JVM 25. This requires
google-java-format of at least 1.30.0 (you are using 1.28.0)
```

reported as a `ConfigurationCacheError`, which hides the real cause.

Verified locally on JDK 25 with the **current** spotless (8.9.0): `spotlessCheck` passes across every module and needs no reformatting — so this lands safely on its own and unblocks #290 on rebase.