### PR TITLE
Runtime mapper correctness and allocation improvements

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -14,6 +14,12 @@ This module is not published. It depends on `:core` and `:codegen` and is only b
 Config (in `benchmarks/build.gradle.kts`): average time in nanoseconds, 3 warmup iterations, 5 measurement iterations, 1
 fork. Results are written to `benchmarks/build/results/jmh/`. A full run takes a few minutes.
 
+## Runtime allocation regression measurements
+
+See [the runtime mapper review measurements](../docs/perf-runtime-collections.md) for the cardinality benchmark, saved
+before/after JMH data, and an executable regression gate. These measure reused runtime mappers separately from mapper
+construction.
+
 ## What it measures
 
 The record benchmarks walk a `Company -> Department -> Address` tree and update the deeply-nested `Address::city`; the

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -16,9 +16,9 @@ fork. Results are written to `benchmarks/build/results/jmh/`. A full run takes a
 
 ## Runtime allocation regression measurements
 
-See [the runtime mapper review measurements](../docs/perf-runtime-collections.md) for the cardinality benchmark, saved
-before/after JMH data, and an executable regression gate. These measure reused runtime mappers separately from mapper
-construction.
+See [the runtime container mapping measurements](../docs/perf-runtime-collections.md) for the cardinality benchmark,
+saved before/after JMH data, and an executable regression gate. These measure reused runtime mappers separately from
+mapper construction.
 
 ## What it measures
 

--- a/benchmarks/src/jmh/java/io/github/eschizoid/telescope/benchmarks/ContainerAllocationBenchmark.java
+++ b/benchmarks/src/jmh/java/io/github/eschizoid/telescope/benchmarks/ContainerAllocationBenchmark.java
@@ -1,0 +1,82 @@
+package io.github.eschizoid.telescope.benchmarks;
+
+import io.github.eschizoid.telescope.Telescope;
+import io.github.eschizoid.telescope.conversion.Mapper;
+import java.util.*;
+import java.util.concurrent.CopyOnWriteArrayList;
+import org.openjdk.jmh.annotations.*;
+
+/** Reused runtime mappers: cardinality scaling and allocation, with setup excluded. */
+@State(Scope.Thread)
+public class ContainerAllocationBenchmark {
+
+  public record Value(int n) {}
+
+  public record ValueDto(int n) {}
+
+  public record Lists(List<Value> values) {}
+
+  public record ListsDto(List<ValueDto> values) {}
+
+  public record Copies(CopyOnWriteArrayList<Value> values) {}
+
+  public record CopiesDto(CopyOnWriteArrayList<ValueDto> values) {}
+
+  public record Maps(Map<Integer, Value> values) {}
+
+  public record MapsDto(Map<Integer, ValueDto> values) {}
+
+  public record Sets(Set<Value> values) {}
+
+  public record SetsDto(Set<ValueDto> values) {}
+
+  @Param({ "0", "1", "16", "256", "4096" })
+  public int size;
+
+  @Param({ "LIST", "COPY_ON_WRITE", "MAP", "SET" })
+  public String kind;
+
+  private Mapper<Object, Object> mapper;
+  private Object source;
+  private Object target;
+
+  @Setup
+  @SuppressWarnings({ "unchecked", "rawtypes" })
+  public void setup() {
+    var values = new ArrayList<Value>(size);
+    for (int i = 0; i < size; i++) values.add(new Value(i));
+    switch (kind) {
+      case "LIST" -> {
+        mapper = (Mapper) Telescope.mapper(Lists.class, ListsDto.class);
+        source = new Lists(values);
+      }
+      case "COPY_ON_WRITE" -> {
+        mapper = (Mapper) Telescope.mapper(Copies.class, CopiesDto.class);
+        source = new Copies(new CopyOnWriteArrayList<>(values));
+      }
+      case "MAP" -> {
+        var map = new LinkedHashMap<Integer, Value>();
+        for (var value : values) map.put(value.n(), value);
+        mapper = (Mapper) Telescope.mapper(Maps.class, MapsDto.class);
+        source = new Maps(map);
+      }
+      case "SET" -> {
+        mapper = (Mapper) Telescope.mapper(Sets.class, SetsDto.class);
+        source = new Sets(new LinkedHashSet<>(values));
+      }
+      default -> throw new IllegalArgumentException(kind);
+    }
+    target = mapper.forward(source);
+    if (!source.equals(mapper.backward(target))) throw new IllegalStateException("round trip failed");
+  }
+
+  @Benchmark
+  public Object forward() {
+    return mapper.forward(source);
+  }
+
+  @Benchmark
+  public Object backward() {
+    return mapper.backward(target);
+  }
+}

--- a/benchmarks/src/jmh/java/io/github/eschizoid/telescope/benchmarks/ContainerAllocationBenchmark.java
+++ b/benchmarks/src/jmh/java/io/github/eschizoid/telescope/benchmarks/ContainerAllocationBenchmark.java
@@ -2,9 +2,18 @@ package io.github.eschizoid.telescope.benchmarks;
 
 import io.github.eschizoid.telescope.Telescope;
 import io.github.eschizoid.telescope.conversion.Mapper;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
-import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
 
 /** Reused runtime mappers: cardinality scaling and allocation, with setup excluded. */
 @State(Scope.Thread)
@@ -43,7 +52,7 @@ public class ContainerAllocationBenchmark {
   @Setup
   @SuppressWarnings({ "unchecked", "rawtypes" })
   public void setup() {
-    var values = new ArrayList<Value>(size);
+    final var values = new ArrayList<Value>(size);
     for (int i = 0; i < size; i++) values.add(new Value(i));
     switch (kind) {
       case "LIST" -> {
@@ -55,8 +64,8 @@ public class ContainerAllocationBenchmark {
         source = new Copies(new CopyOnWriteArrayList<>(values));
       }
       case "MAP" -> {
-        var map = new LinkedHashMap<Integer, Value>();
-        for (var value : values) map.put(value.n(), value);
+        final var map = new LinkedHashMap<Integer, Value>();
+        for (final var value : values) map.put(value.n(), value);
         mapper = (Mapper) Telescope.mapper(Maps.class, MapsDto.class);
         source = new Maps(map);
       }

--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/MirrorProps.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/MirrorProps.java
@@ -85,6 +85,17 @@ final class MirrorProps implements PropertySystem<TypeMirror> {
   }
 
   @Override
+  public List<TypeMirror> typeArgumentsAs(final TypeMirror t, final WellKnown supertype) {
+    final var target = elements.getTypeElement(fqnOf(supertype));
+    if (target == null || !(t instanceof DeclaredType dt)) return List.of();
+    if (dt.asElement().equals(target)) return List.copyOf(dt.getTypeArguments());
+    for (final var parent : types.directSupertypes(t)) {
+      if (isSubtypeOf(parent, supertype)) return typeArgumentsAs(parent, supertype);
+    }
+    return List.of();
+  }
+
+  @Override
   public TypeMirror rawType(final TypeMirror t) {
     return types.erasure(t);
   }

--- a/codegen/src/test/java/io/github/eschizoid/telescope/codegen/MapperVerifierProcessorTest.java
+++ b/codegen/src/test/java/io/github/eschizoid/telescope/codegen/MapperVerifierProcessorTest.java
@@ -19,6 +19,45 @@ import org.junit.jupiter.api.Test;
  */
 class MapperVerifierProcessorTest {
 
+  @Test
+  void containerSubclassArgumentsAreResolvedThroughTheGenericSupertype() {
+    final var compilation = verify(
+      """
+      package demo;
+      import java.util.*;
+      import io.github.eschizoid.telescope.Telescope;
+      class StringMap<V> extends HashMap<String,V> {}
+      class Reordered<V,K> extends HashMap<K,V> {}
+      class Tagged<Tag,E> extends ArrayList<E> {}
+      class Nested<E> extends Tagged<String,List<E>> {}
+      record Value(int n) {}
+      record ValueDto(int n) {}
+      record Src(StringMap<Value> fixed, Reordered<Value,String> reordered, Nested<Value> nested) {}
+      record Tgt(HashMap<String,ValueDto> fixed, Map<String,ValueDto> reordered, List<List<ValueDto>> nested) {}
+      class Holder { static final Object M = Telescope.mapper(Src.class,Tgt.class); }
+      """
+    );
+    assertTrue(compilation.success(), compilation::errorMessages);
+  }
+
+  @Test
+  void inheritedMapKeyMismatchHasAFieldDiagnostic() {
+    final var compilation = verify(
+      """
+      package demo;
+      import java.util.*;
+      import io.github.eschizoid.telescope.Telescope;
+      class StringMap<V> extends HashMap<String,V> {}
+      record Src(StringMap<Integer> values) {}
+      record Tgt(HashMap<Long,Integer> values) {}
+      class Holder { static final Object M = Telescope.mapper(Src.class,Tgt.class); }
+      """
+    );
+    assertFalse(compilation.success());
+    assertTrue(compilation.hasError("values"), compilation::errorMessages);
+    assertTrue(compilation.hasError("key types"), compilation::errorMessages);
+  }
+
   private static ProcessorHarness.Compilation verify(final String code) {
     return verify(List.of(), code);
   }

--- a/core/src/main/java/io/github/eschizoid/telescope/ContainerLifts.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/ContainerLifts.java
@@ -17,6 +17,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.PriorityQueue;
 import java.util.Set;
+import java.util.SortedMap;
+import java.util.SortedSet;
 import java.util.Stack;
 import java.util.TreeMap;
 import java.util.TreeSet;
@@ -28,7 +30,7 @@ import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.LinkedBlockingQueue;
-import java.util.function.Supplier;
+import java.util.function.Function;
 
 /**
  * Container-shape lifting for {@link DeepMap}: element-copy Isos for raw same-kind container
@@ -112,65 +114,82 @@ final class ContainerLifts {
     final Class<?> srcRaw,
     final Class<?> tgtRaw
   ) {
-    final var srcAlloc = listAllocatorFor(srcRaw);
-    final var tgtAlloc = listAllocatorFor(tgtRaw);
-    // When the element is a composed-handle leaf, iterate with a MethodHandle loop over its raw
-    // element handle instead of dispatching elementIso.to(x) -> Function.apply per element. In a
-    // deep
-    // tree the shared Java-loop lambda's call site goes megamorphic across nesting levels and the
-    // JIT
-    // stops inlining the element conversion; a dedicated per-level loop handle stays monomorphic
-    // and
-    // inlines. Null for a scalar/array-leaf element; keep the plain Java loop for those.
-    final var mh = MhIso.liftCollection(elementIso, srcAlloc, tgtAlloc);
-    if (mh != null) return mh;
-    return Iso.of(
-      src -> {
-        if (src == null) return null;
-        final var fresh = (Collection) tgtAlloc.get();
-        for (final var x : (Collection<?>) src) fresh.add(elementIso.to(x));
-        return fresh;
-      },
-      tgt -> {
-        if (tgt == null) return null;
-        final var fresh = (Collection) srcAlloc.get();
-        for (final var y : (Collection<?>) tgt) fresh.add(elementIso.from(y));
-        return fresh;
-      }
-    );
+    return liftCollectionIntoTargetRaw(elementIso, srcRaw, tgtRaw, false);
   }
 
-  /**
-   * Set-level lift that writes into the target's concrete raw class. Mirror of {@link
-   * #liftListIntoTargetRaw} for Sets. Falls back to {@link LinkedHashSet} (preserving forward
-   * iteration order) when the raw class is the {@link Set} interface itself.
-   */
-  @SuppressWarnings({ "unchecked", "rawtypes" })
+  /** Set counterpart; custom sorted comparators cannot safely consume a changed element type. */
   static Iso<?, ?> liftSetIntoTargetRaw(
     final Iso<Object, Object> elementIso,
     final Class<?> srcRaw,
     final Class<?> tgtRaw
   ) {
-    final var srcAlloc = setAllocatorFor(srcRaw);
-    final var tgtAlloc = setAllocatorFor(tgtRaw);
-    // Same MethodHandle-loop sharpening as the List lift (Set is also Collection.add). Null element
-    // Iso => keep the Java loop.
+    return liftCollectionIntoTargetRaw(elementIso, srcRaw, tgtRaw, true);
+  }
+
+  @SuppressWarnings({ "unchecked", "rawtypes" })
+  private static Iso<?, ?> liftCollectionIntoTargetRaw(
+    final Iso<Object, Object> elementIso,
+    final Class<?> srcRaw,
+    final Class<?> tgtRaw,
+    final boolean set
+  ) {
+    final var srcAlloc = set ? setAllocatorFor(srcRaw) : listAllocatorFor(srcRaw);
+    final var tgtAlloc = set ? setAllocatorFor(tgtRaw) : listAllocatorFor(tgtRaw);
     final var mh = MhIso.liftCollection(elementIso, srcAlloc, tgtAlloc);
-    if (mh != null) return mh;
+    final Iso<Object, Object> loop =
+      mh != null
+        ? mh
+        : Iso.of(
+            src -> {
+              if (src == null) return null;
+              final var fresh = (Collection) tgtAlloc.apply(src);
+              for (final var x : (Collection<?>) src) fresh.add(elementIso.to(x));
+              return fresh;
+            },
+            tgt -> {
+              if (tgt == null) return null;
+              final var fresh = (Collection) srcAlloc.apply(tgt);
+              for (final var x : (Collection<?>) tgt) fresh.add(elementIso.from(x));
+              return fresh;
+            }
+          );
+    final boolean checkComparator = set && elementIso != Iso.<Object>identity();
+    final boolean finish = copyOnWrite(srcRaw) || copyOnWrite(tgtRaw);
+    if (!checkComparator && !finish) return loop;
     return Iso.of(
       src -> {
-        if (src == null) return null;
-        final var fresh = (Collection) tgtAlloc.get();
-        for (final var x : (Collection<?>) src) fresh.add(elementIso.to(x));
-        return fresh;
+        if (checkComparator) checkComparator(src);
+        return finishCollection(loop.to(src), tgtRaw);
       },
       tgt -> {
-        if (tgt == null) return null;
-        final var fresh = (Collection) srcAlloc.get();
-        for (final var y : (Collection<?>) tgt) fresh.add(elementIso.from(y));
-        return fresh;
+        if (checkComparator) checkComparator(tgt);
+        return finishCollection(loop.from(tgt), srcRaw);
       }
     );
+  }
+
+  private static void checkComparator(final Object input) {
+    if (input instanceof SortedSet<?> sorted && sorted.comparator() != null) {
+      throw new IllegalStateException(
+        "Deep map: a custom sorted-set comparator cannot be reused with changed " +
+          "element types. Supply an explicit Mapping.via(...) row with a target comparator."
+      );
+    }
+  }
+
+  private static boolean copyOnWrite(final Class<?> raw) {
+    return raw == CopyOnWriteArrayList.class || raw == CopyOnWriteArraySet.class;
+  }
+
+  private static Object finishCollection(final Object result, final Class<?> raw) {
+    if (result == null) return null;
+    if (
+      raw == CopyOnWriteArrayList.class && !(result instanceof CopyOnWriteArrayList<?>)
+    ) return new CopyOnWriteArrayList<>((Collection<?>) result);
+    if (
+      raw == CopyOnWriteArraySet.class && !(result instanceof CopyOnWriteArraySet<?>)
+    ) return new CopyOnWriteArraySet<>((Collection<?>) result);
+    return result;
   }
 
   /**
@@ -196,13 +215,13 @@ final class ContainerLifts {
     return Iso.of(
       src -> {
         if (src == null) return null;
-        final var fresh = (Map) tgtAlloc.get();
+        final var fresh = (Map) tgtAlloc.apply(src);
         for (final var e : ((Map<?, ?>) src).entrySet()) fresh.put(e.getKey(), elementIso.to(e.getValue()));
         return fresh;
       },
       tgt -> {
         if (tgt == null) return null;
-        final var fresh = (Map) srcAlloc.get();
+        final var fresh = (Map) srcAlloc.apply(tgt);
         for (final var e : ((Map<?, ?>) tgt).entrySet()) fresh.put(e.getKey(), elementIso.from(e.getValue()));
         return fresh;
       }
@@ -214,17 +233,21 @@ final class ContainerLifts {
   // Hard-code the common JDK Collection / Map raws so the allocator works for the standard
   // shapes, and fall back to `intermediateAllocator` for user-defined subclasses (where LMF DOES
   // work via the user's own package).
-  private static Supplier<Object> listAllocatorFor(final Class<?> raw) {
-    if (raw == List.class || raw == Collection.class || raw == ArrayList.class) return ArrayList::new;
-    if (raw == LinkedList.class) return LinkedList::new;
-    if (raw == ArrayDeque.class) return ArrayDeque::new;
-    if (raw == Vector.class) return Vector::new;
-    if (raw == Stack.class) return Stack::new;
-    if (raw == PriorityQueue.class) return PriorityQueue::new;
-    if (raw == LinkedBlockingQueue.class) return LinkedBlockingQueue::new;
-    if (raw == CopyOnWriteArrayList.class) return CopyOnWriteArrayList::new;
+  private static Function<Object, Object> listAllocatorFor(final Class<?> raw) {
+    if (raw == List.class || raw == Collection.class || raw == ArrayList.class) return input ->
+      new ArrayList<>(((Collection<?>) input).size());
+    if (raw == LinkedList.class) return ignored -> new LinkedList<>();
+    if (raw == ArrayDeque.class) return ignored -> new ArrayDeque<>();
+    if (raw == Vector.class) return ignored -> new Vector<>();
+    if (raw == Stack.class) return ignored -> new Stack<>();
+    if (raw == PriorityQueue.class) return ignored -> new PriorityQueue<>();
+    if (raw == LinkedBlockingQueue.class) return ignored -> new LinkedBlockingQueue<>();
+    if (raw == CopyOnWriteArrayList.class) return input -> {
+      final int size = ((Collection<?>) input).size();
+      return size <= 1 ? new CopyOnWriteArrayList<>() : new ArrayList<>(size);
+    };
     final var alloc = Beans.intermediateAllocator(raw);
-    if (alloc.get() != null) return alloc;
+    if (alloc.get() != null) return ignored -> alloc.get();
     // No usable allocator for a JDK java.base class we don't recognise. Falling back to ArrayList
     // would silently write the wrong runtime class into the target field and CCE at the setter.
     // Throw at plan-time with a precise diagnostic instead.
@@ -236,14 +259,18 @@ final class ContainerLifts {
     );
   }
 
-  private static Supplier<Object> setAllocatorFor(final Class<?> raw) {
-    if (raw == Set.class || raw == LinkedHashSet.class) return LinkedHashSet::new;
-    if (raw == HashSet.class) return HashSet::new;
-    if (raw == TreeSet.class) return TreeSet::new;
-    if (raw == ConcurrentSkipListSet.class) return ConcurrentSkipListSet::new;
-    if (raw == CopyOnWriteArraySet.class) return CopyOnWriteArraySet::new;
+  private static Function<Object, Object> setAllocatorFor(final Class<?> raw) {
+    if (raw == Set.class || raw == LinkedHashSet.class) return input ->
+      LinkedHashSet.newLinkedHashSet(((Collection<?>) input).size());
+    if (raw == HashSet.class) return input -> HashSet.newHashSet(((Collection<?>) input).size());
+    if (raw == TreeSet.class) return input -> new TreeSet<>(setComparator(input));
+    if (raw == ConcurrentSkipListSet.class) return input -> new ConcurrentSkipListSet<>(setComparator(input));
+    if (raw == CopyOnWriteArraySet.class) return input -> {
+      final int size = ((Collection<?>) input).size();
+      return size <= 1 ? new CopyOnWriteArraySet<>() : new ArrayList<>(size);
+    };
     final var alloc = Beans.intermediateAllocator(raw);
-    if (alloc.get() != null) return alloc;
+    if (alloc.get() != null) return ignored -> alloc.get();
     throw new IllegalStateException(
       "Deep map: no allocator for Set subtype " +
         raw.getName() +
@@ -260,26 +287,36 @@ final class ContainerLifts {
    * plan-time because its no-arg constructor doesn't exist (it needs the {@code Class<K>} arg);
    * adopters must use the codegen path or an explicit row.
    */
-  private static Supplier<Object> mapAllocatorFor(final Class<?> raw) {
-    if (raw == Map.class || raw == HashMap.class) return HashMap::new;
-    if (raw == LinkedHashMap.class) return LinkedHashMap::new;
-    if (raw == TreeMap.class) return TreeMap::new;
-    if (raw == ConcurrentHashMap.class) return ConcurrentHashMap::new;
-    if (raw == ConcurrentSkipListMap.class) return ConcurrentSkipListMap::new;
-    if (raw == IdentityHashMap.class) return IdentityHashMap::new;
-    if (raw == WeakHashMap.class) return WeakHashMap::new;
+  private static Function<Object, Object> mapAllocatorFor(final Class<?> raw) {
+    if (raw == Map.class || raw == HashMap.class) return input -> HashMap.newHashMap(((Map<?, ?>) input).size());
+    if (raw == LinkedHashMap.class) return input -> LinkedHashMap.newLinkedHashMap(((Map<?, ?>) input).size());
+    if (raw == TreeMap.class) return input -> new TreeMap<>(mapComparator(input));
+    if (raw == ConcurrentHashMap.class) return input -> new ConcurrentHashMap<>(((Map<?, ?>) input).size());
+    if (raw == ConcurrentSkipListMap.class) return input -> new ConcurrentSkipListMap<>(mapComparator(input));
+    if (raw == IdentityHashMap.class) return input -> new IdentityHashMap<>(((Map<?, ?>) input).size());
+    if (raw == WeakHashMap.class) return ignored -> new WeakHashMap<>();
     if (raw == EnumMap.class) throw new IllegalStateException(
       "Deep map: EnumMap targets are not supported via auto-Iso lift — EnumMap has no no-arg " +
         "constructor (it needs the Class<K> key class). Use the codegen path or supply an " +
         "explicit `Mapping.via(...)` row that constructs the EnumMap with its key class."
     );
     final var alloc = Beans.intermediateAllocator(raw);
-    if (alloc.get() != null) return alloc;
+    if (alloc.get() != null) return ignored -> alloc.get();
     throw new IllegalStateException(
       "Deep map: no allocator for Map subtype " +
         raw.getName() +
         ". Add it to mapAllocatorFor (java.base classes can't bind via LambdaMetafactory's " +
         "privateLookupIn) or supply an explicit `Mapping.via(...)` row."
     );
+  }
+
+  @SuppressWarnings("unchecked")
+  private static java.util.Comparator<Object> mapComparator(final Object input) {
+    return input instanceof SortedMap<?, ?> sorted ? (java.util.Comparator<Object>) sorted.comparator() : null;
+  }
+
+  @SuppressWarnings("unchecked")
+  private static java.util.Comparator<Object> setComparator(final Object input) {
+    return input instanceof SortedSet<?> sorted ? (java.util.Comparator<Object>) sorted.comparator() : null;
   }
 }

--- a/core/src/main/java/io/github/eschizoid/telescope/ContainerLifts.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/ContainerLifts.java
@@ -6,6 +6,7 @@ import io.github.eschizoid.telescope.internal.optics.Iso;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -311,12 +312,12 @@ final class ContainerLifts {
   }
 
   @SuppressWarnings("unchecked")
-  private static java.util.Comparator<Object> mapComparator(final Object input) {
-    return input instanceof SortedMap<?, ?> sorted ? (java.util.Comparator<Object>) sorted.comparator() : null;
+  private static Comparator<Object> mapComparator(final Object input) {
+    return input instanceof SortedMap<?, ?> sorted ? (Comparator<Object>) sorted.comparator() : null;
   }
 
   @SuppressWarnings("unchecked")
-  private static java.util.Comparator<Object> setComparator(final Object input) {
-    return input instanceof SortedSet<?> sorted ? (java.util.Comparator<Object>) sorted.comparator() : null;
+  private static Comparator<Object> setComparator(final Object input) {
+    return input instanceof SortedSet<?> sorted ? (Comparator<Object>) sorted.comparator() : null;
   }
 }

--- a/core/src/main/java/io/github/eschizoid/telescope/DeepMap.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/DeepMap.java
@@ -193,7 +193,14 @@ public final class DeepMap {
     topSteps.forEach((tgtName, step) ->
       patchTable.put(tgtName, new Mapper.PatchEntry(step.sourceName, v -> ((Iso<Object, Object>) step.iso).from(v)))
     );
-    return new Resolution<>(iso, patchTable, List.copyOf(trail));
+    final var rootKey = new TypePair(source, target);
+    final Iso<A, B> guarded = cyclicPairs.isEmpty()
+      ? iso
+      : Iso.of(
+          value -> inInvocation(FORWARD_SEEN, rootKey, value, iso::to),
+          value -> inInvocation(BACKWARD_SEEN, rootKey, value, iso::from)
+        );
+    return new Resolution<>(guarded, patchTable, List.copyOf(trail));
   }
 
   // ---------- Hint validation + writer eager construction ----------
@@ -1326,39 +1333,10 @@ public final class DeepMap {
 
   // ---------- Cycle-safe cache reader ----------
 
-  /**
-   * Per-thread identity-based seen sets for cycle interruption. The forward / backward maps are
-   * tracked separately so a forward call doesn't poison the backward traversal of the same object
-   * graph. {@link #lazyCacheIso} consults the matching set on entry: re-entry on the same instance
-   * returns {@code null}, snipping the cycle in the output graph rather than recursing forever.
-   *
-   * <p>This is a value-level guard on top of DeepMap's existing type-level cycle handling (the
-   * {@link TypePair} cache, which terminates {@code Iso} construction). Type-level guards stop the
-   * processor from re-entering an in-progress pair during build; the value-level guards here stop
-   * runtime traversal from recursing through a bidirectional persistence association (e.g.,
-   * Hibernate's {@code @ManyToOne manager} + {@code @OneToMany(mappedBy="manager") reports})
-   * forming a literal value cycle in the hydrated graph.
-   *
-   * <p><b>Semantics on revisit.</b> The first encounter of an instance traverses normally and
-   * records it in the seen set. A subsequent encounter on the same traversal returns {@code null} —
-   * the cycle is severed at the second occurrence. For a bidirectional self-association like {@code
-   * bob.manager == alice && alice.reports.contains(bob)}, this means the result is finite: the
-   * recursive {@code reports} list still includes the leaf entries, but {@code bob.manager
-   * .reports.contains(bob)} collapses to {@code bob.manager.reports} where the inner {@code bob}
-   * becomes {@code null}.
-   *
-   * <p>The seen sets clear when the outer {@link Iso#to} / {@link Iso#from} call unwinds, so
-   * subsequent independent {@code mapper.forward(otherTree)} invocations start fresh. The outermost
-   * guard belongs to whichever {@code lazyCacheIso} is reached first — re-entry into the same
-   * lazyCacheIso while still inside an outer call is what we're guarding against.
-   */
-  private static final ThreadLocal<IdentityHashMap<Object, Boolean>> FORWARD_SEEN = ThreadLocal.withInitial(
-    IdentityHashMap::new
-  );
+  /** Active identities per type pair, scoped to one public mapping invocation and direction. */
+  private static final ThreadLocal<Map<TypePair, IdentityHashMap<Object, Boolean>>> FORWARD_SEEN = new ThreadLocal<>();
 
-  private static final ThreadLocal<IdentityHashMap<Object, Boolean>> BACKWARD_SEEN = ThreadLocal.withInitial(
-    IdentityHashMap::new
-  );
+  private static final ThreadLocal<Map<TypePair, IdentityHashMap<Object, Boolean>>> BACKWARD_SEEN = new ThreadLocal<>();
 
   @SuppressWarnings("unchecked")
   private static Iso<?, ?> lazyCacheIso(
@@ -1386,29 +1364,46 @@ public final class DeepMap {
       );
     }
     return Iso.of(
-      v -> cycleSafe(FORWARD_SEEN, v, x -> ((Iso<Object, Object>) cache.get(key)).to(x)),
-      v -> cycleSafe(BACKWARD_SEEN, v, x -> ((Iso<Object, Object>) cache.get(key)).from(x))
+      v -> cycleSafe(FORWARD_SEEN, key, v, x -> ((Iso<Object, Object>) cache.get(key)).to(x)),
+      v -> cycleSafe(BACKWARD_SEEN, key, v, x -> ((Iso<Object, Object>) cache.get(key)).from(x))
     );
   }
 
-  /**
-   * Run {@code body} on {@code value} guarded by the per-thread identity-seen set in {@code
-   * seenRef}. Re-entry on the same instance returns {@code null} (cycle interruption). Cleans up
-   * the seen set when the outermost call unwinds so subsequent independent traversals start fresh.
-   */
-  private static <X, Y> Y cycleSafe(
-    final ThreadLocal<IdentityHashMap<Object, Boolean>> seenRef,
+  /** Reentrant public calls get independent paths; restore the caller even after an exception. */
+  private static <X, Y> Y inInvocation(
+    final ThreadLocal<Map<TypePair, IdentityHashMap<Object, Boolean>>> ref,
+    final TypePair key,
     final X value,
     final Function<X, Y> body
   ) {
     if (value == null) return null;
-    final var seen = seenRef.get();
-    final boolean outermost = seen.isEmpty();
-    if (seen.put(value, Boolean.TRUE) != null) return null; // re-entry on this instance — sever the cycle
+    final var previous = ref.get();
+    ref.set(new HashMap<>());
+    try {
+      return cycleSafe(ref, key, value, body);
+    } finally {
+      if (previous == null) ref.remove();
+      else ref.set(previous);
+    }
+  }
+
+  /** Only an identity already on the active path is a cycle; siblings map independently. */
+  private static <X, Y> Y cycleSafe(
+    final ThreadLocal<Map<TypePair, IdentityHashMap<Object, Boolean>>> ref,
+    final TypePair key,
+    final X value,
+    final Function<X, Y> body
+  ) {
+    if (value == null) return null;
+    final var context = ref.get();
+    // A patch entry can invoke a nested Iso without going through the public root.
+    if (context == null) return inInvocation(ref, key, value, body);
+    final var active = context.computeIfAbsent(key, ignored -> new IdentityHashMap<>());
+    if (active.put(value, Boolean.TRUE) != null) return null;
     try {
       return body.apply(value);
     } finally {
-      if (outermost) seen.clear(); // independent next call starts fresh
+      active.remove(value);
     }
   }
 

--- a/core/src/test/java/io/github/eschizoid/telescope/DeepMappingTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/DeepMappingTest.java
@@ -451,7 +451,7 @@ class DeepMappingTest {
     }
 
     @Test
-    @DisplayName("Value-level cycle in a bean graph severs at second encounter — no StackOverflowError")
+    @DisplayName("Value-level cycle in a bean graph severs at its first back-edge — no StackOverflowError")
     void valueCycleSeversCleanly() {
       // alice.ref → bob; bob.ref → alice. This is the literal-value cycle shape that bidirectional
       // Hibernate associations produce (entity.parent + entity.children pointing at the parent).
@@ -468,14 +468,8 @@ class DeepMappingTest {
       final var dto = mapper.forward(alice);
       assertEquals("alice", dto.getName());
       assertEquals("bob", dto.getRef().getName());
-      assertEquals("alice", dto.getRef().getRef().getName());
-      // Cycle severed on revisit — the inner alice→bob→alice→bob link collapses to null instead
-      // of recursing forever. The guard fires inside lazyCacheIso (the per-field recursive Iso);
-      // the top-level mapper.forward call doesn't go through the guard, so the cycle is finite
-      // but not the shortest possible (severing happens at the 4th level, not the 2nd). The graph
-      // is finite by construction; structure is lost on the second occurrence — acknowledged
-      // trade-off documented in the cycle guard's javadoc.
-      assertNull(dto.getRef().getRef().getRef(), "fourth encounter (bob revisited) should be severed");
+      // Root participates in the active path: the first back-edge to alice is severed.
+      assertNull(dto.getRef().getRef());
     }
 
     @Test

--- a/core/src/test/java/io/github/eschizoid/telescope/RuntimeMappingRegressionTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/RuntimeMappingRegressionTest.java
@@ -1,0 +1,267 @@
+package io.github.eschizoid.telescope;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import io.github.eschizoid.telescope.internal.MhIso;
+import java.util.*;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+/** Behavior regressions found in the runtime mapper review. */
+class RuntimeMappingRegressionTest {
+
+  private static final ThreadLocal<Runnable> ON_READ = new ThreadLocal<>();
+
+  record Node(String name, List<Node> children) {
+    @Override
+    public String name() {
+      var callback = ON_READ.get();
+      if (callback != null) callback.run();
+      return name;
+    }
+  }
+
+  record NodeDto(String name, List<NodeDto> children) {}
+
+  record Value(int n) {}
+
+  record ValueDto(int n) {}
+
+  public static class StringMap<V> extends HashMap<String, V> {
+
+    private static final long serialVersionUID = 1L;
+  }
+
+  public static class ReorderedMap<V, K> extends HashMap<K, V> {
+
+    private static final long serialVersionUID = 1L;
+  }
+
+  record Fixed(StringMap<Value> values) {}
+
+  record Reordered(ReorderedMap<Value, String> values) {}
+
+  record Plain(HashMap<String, ValueDto> values) {}
+
+  record Unknown(StringMap<?> values) {}
+
+  record Sorted(TreeMap<String, Value> values) {}
+
+  record SortedDto(TreeMap<String, ValueDto> values) {}
+
+  record Key(int n) {}
+
+  record KeyMap(TreeMap<Key, Value> values) {}
+
+  record KeyMapDto(TreeMap<Key, ValueDto> values) {}
+
+  record SortedValues(TreeSet<Value> values) {}
+
+  record SortedValuesDto(TreeSet<ValueDto> values) {}
+
+  record Copies(CopyOnWriteArrayList<Value> values) {}
+
+  record CopiesDto(CopyOnWriteArrayList<ValueDto> values) {}
+
+  record CopySets(CopyOnWriteArraySet<Value> values) {}
+
+  record CopySetsDto(CopyOnWriteArraySet<ValueDto> values) {}
+
+  public static class TaggedList<Tag, E> extends ArrayList<E> {
+
+    private static final long serialVersionUID = 1L;
+  }
+
+  public static class NestedList<E> extends TaggedList<String, List<E>> {
+
+    private static final long serialVersionUID = 1L;
+  }
+
+  record Nested(NestedList<Value> values) {}
+
+  record NestedDto(List<List<ValueDto>> values) {}
+
+  @AfterEach
+  void cleanup() {
+    ON_READ.remove();
+    System.clearProperty(MhIso.DISABLE_PROPERTY);
+    System.clearProperty(MhIso.CONTAINER_DISABLE_PROPERTY);
+  }
+
+  @Test
+  void sharedSiblingsAreMappedInBothDirections() {
+    var leaf = new Node("leaf", List.of());
+    var root = new Node("root", List.of(new Node("branch", List.of(leaf, leaf))));
+    var mapper = Telescope.mapper(Node.class, NodeDto.class);
+    var mapped = mapper.forward(root);
+    var siblings = mapped.children().getFirst().children();
+    assertNotNull(siblings.get(1));
+    assertEquals(siblings.getFirst(), siblings.get(1));
+    assertNotSame(siblings.getFirst(), siblings.get(1));
+    assertEquals(root, mapper.backward(mapped));
+    var dtoLeaf = new NodeDto("leaf", List.of());
+    var backward = mapper.backward(new NodeDto("root", List.of(new NodeDto("branch", List.of(dtoLeaf, dtoLeaf)))));
+    assertNotNull(backward.children().getFirst().children().get(1));
+  }
+
+  @Test
+  void fixedKeyGenericMapResolvesItsSupertype() {
+    var values = new StringMap<Value>();
+    values.put("one", new Value(1));
+    var mapper = Telescope.mapper(Fixed.class, Plain.class);
+    var mapped = mapper.forward(new Fixed(values));
+    assertEquals(Map.of("one", new ValueDto(1)), mapped.values());
+    assertEquals(new Fixed(values), mapper.backward(mapped));
+  }
+
+  @Test
+  void reorderedGenericMapResolvesItsSupertype() {
+    var values = new ReorderedMap<Value, String>();
+    values.put("one", new Value(1));
+    var mapper = Telescope.mapper(Reordered.class, Plain.class);
+    var mapped = mapper.forward(new Reordered(values));
+    assertEquals(Map.of("one", new ValueDto(1)), mapped.values());
+    assertEquals(new Reordered(values), mapper.backward(mapped));
+  }
+
+  @Test
+  void unresolvedContainerElementsFailWithAFieldDiagnostic() {
+    var failure = assertThrows(IllegalStateException.class, () -> Telescope.mapper(Unknown.class, Plain.class));
+    assertTrue(failure.getMessage().contains("values"));
+  }
+
+  @Test
+  void sortedMapsPreserveComparatorsInBothDirections() {
+    var values = new TreeMap<String, Value>(Comparator.reverseOrder());
+    values.put("a", new Value(1));
+    values.put("z", new Value(2));
+    var mapper = Telescope.mapper(Sorted.class, SortedDto.class);
+    var mapped = mapper.forward(new Sorted(values));
+    assertSame(values.comparator(), mapped.values().comparator());
+    assertEquals(List.of("z", "a"), new ArrayList<>(mapped.values().keySet()));
+    assertSame(values.comparator(), mapper.backward(mapped).values().comparator());
+  }
+
+  @Test
+  void cyclesStopAtTheFirstActiveBackEdgeInBothDirections() {
+    var children = new ArrayList<Node>();
+    var root = new Node("root", children);
+    children.add(root);
+    var mapper = Telescope.mapper(Node.class, NodeDto.class);
+    assertNull(mapper.forward(root).children().getFirst());
+    var dtoChildren = new ArrayList<NodeDto>();
+    var dto = new NodeDto("root", dtoChildren);
+    dtoChildren.add(dto);
+    assertNull(mapper.backward(dto).children().getFirst());
+    children.clear();
+    children.add(new Node("child", List.of(root)));
+    assertNull(mapper.forward(root).children().getFirst().children().getFirst());
+  }
+
+  @Test
+  void diamondBranchesAndConcurrentInvocationsDoNotLoseSharedLeaves() throws Exception {
+    var leaf = new Node("leaf", List.of());
+    var root = new Node("root", List.of(new Node("left", List.of(leaf)), new Node("right", List.of(leaf))));
+    var mapper = Telescope.mapper(Node.class, NodeDto.class);
+    try (var executor = Executors.newFixedThreadPool(4)) {
+      var tasks = new ArrayList<java.util.concurrent.Future<Node>>();
+      for (int i = 0; i < 32; i++) tasks.add(executor.submit(() -> mapper.backward(mapper.forward(root))));
+      for (var task : tasks) assertEquals(root, task.get());
+    }
+  }
+
+  @Test
+  void exceptionsAndReentrantCallsRestoreTheOuterActivePath() {
+    var leaf = new Node("leaf", List.of());
+    var root = new Node("root", List.of(new Node("branch", List.of(leaf, leaf))));
+    var mapper = Telescope.mapper(Node.class, NodeDto.class);
+    ON_READ.set(() -> {
+      throw new IllegalArgumentException("getter failure");
+    });
+    assertThrows(RuntimeException.class, () -> mapper.forward(root));
+    ON_READ.remove();
+    assertEquals(root, mapper.backward(mapper.forward(root)));
+
+    var entered = new AtomicBoolean();
+    var nested = new AtomicReference<NodeDto>();
+    ON_READ.set(() -> {
+      if (entered.compareAndSet(false, true)) nested.set(mapper.forward(root));
+    });
+    var mapped = mapper.forward(root);
+    ON_READ.remove();
+    assertEquals(mapped, nested.get());
+    assertNotNull(mapped.children().getFirst().children().get(1));
+  }
+
+  @Test
+  void comparatorOnlyKeysAndEmptyMapsKeepTheirComparator() {
+    var values = new TreeMap<Key, Value>(Comparator.comparingInt(Key::n).reversed());
+    var mapper = Telescope.mapper(KeyMap.class, KeyMapDto.class);
+    assertSame(values.comparator(), mapper.forward(new KeyMap(values)).values().comparator());
+    values.put(new Key(1), new Value(1));
+    values.put(new Key(2), new Value(2));
+    var mapped = mapper.forward(new KeyMap(values));
+    assertEquals(new Key(2), mapped.values().firstKey());
+    assertEquals(new KeyMap(values), mapper.backward(mapped));
+    assertNull(mapper.forward(new KeyMap(null)).values());
+  }
+
+  @Test
+  void changedSortedSetElementsRequireAnExplicitComparator() {
+    var values = new TreeSet<Value>(Comparator.comparingInt(Value::n));
+    values.add(new Value(1));
+    var mapper = Telescope.mapper(SortedValues.class, SortedValuesDto.class);
+    var failure = assertThrows(IllegalStateException.class, () -> mapper.forward(new SortedValues(values)));
+    assertTrue(failure.getMessage().contains("Mapping.via"));
+    var dto = new TreeSet<ValueDto>(Comparator.comparingInt(ValueDto::n));
+    assertThrows(IllegalStateException.class, () -> mapper.backward(new SortedValuesDto(dto)));
+  }
+
+  @Test
+  void inheritedNestedListArgumentsAreSubstituted() {
+    var values = new NestedList<Value>();
+    values.add(List.of(new Value(1)));
+    var mapper = Telescope.mapper(Nested.class, NestedDto.class);
+    var mapped = mapper.forward(new Nested(values));
+    assertEquals(List.of(List.of(new ValueDto(1))), mapped.values());
+    assertEquals(new Nested(values), mapper.backward(mapped));
+  }
+
+  @Test
+  void allExecutionStrategiesPassTheContainerAndGraphRegressions() {
+    for (var mode : List.of("default", "javaLoop", "array")) {
+      System.setProperty(MhIso.CONTAINER_DISABLE_PROPERTY, Boolean.toString(mode.equals("javaLoop")));
+      System.setProperty(MhIso.DISABLE_PROPERTY, Boolean.toString(mode.equals("array")));
+      sharedSiblingsAreMappedInBothDirections();
+      sortedMapsPreserveComparatorsInBothDirections();
+      fixedKeyGenericMapResolvesItsSupertype();
+      reorderedGenericMapResolvesItsSupertype();
+      comparatorOnlyKeysAndEmptyMapsKeepTheirComparator();
+      inheritedNestedListArgumentsAreSubstituted();
+      cyclesStopAtTheFirstActiveBackEdgeInBothDirections();
+      changedSortedSetElementsRequireAnExplicitComparator();
+      for (int size : new int[] { 0, 1, 16, 256, 4096 }) {
+        var values = new ArrayList<Value>();
+        for (int i = 0; i < size; i++) values.add(new Value(i));
+        var mapper = Telescope.mapper(Copies.class, CopiesDto.class);
+        var nonNullInput = new Copies(new CopyOnWriteArrayList<>(values));
+        assertEquals(nonNullInput, mapper.backward(mapper.forward(nonNullInput)));
+        values.add(null);
+        var input = new Copies(new CopyOnWriteArrayList<>(values));
+        var mapped = mapper.forward(input);
+        assertEquals(CopyOnWriteArrayList.class, mapped.values().getClass());
+        assertEquals(input, mapper.backward(mapped));
+        assertNull(mapper.forward(new Copies(null)).values());
+        var sets = Telescope.mapper(CopySets.class, CopySetsDto.class);
+        var setInput = new CopySets(new CopyOnWriteArraySet<>(values));
+        assertEquals(CopyOnWriteArraySet.class, sets.forward(setInput).values().getClass());
+        assertEquals(setInput, sets.backward(sets.forward(setInput)));
+      }
+    }
+  }
+}

--- a/core/src/test/java/io/github/eschizoid/telescope/RuntimeMappingRegressionTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/RuntimeMappingRegressionTest.java
@@ -3,16 +3,29 @@ package io.github.eschizoid.telescope;
 import static org.junit.jupiter.api.Assertions.*;
 
 import io.github.eschizoid.telescope.internal.MhIso;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.TreeSet;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
-/** Behavior regressions found in the runtime mapper review. */
+/**
+ * Contract pins for the runtime mapper: cycles sever only at active back-edges, shared acyclic
+ * references map independently, parameterized container subclasses resolve through their generic
+ * supertype, sorted containers keep or refuse comparators explicitly, and copy-on-write containers
+ * rebuild with their concrete runtime class — across every execution strategy (fused, Java-loop,
+ * array leaf).
+ */
 class RuntimeMappingRegressionTest {
 
   private static final ThreadLocal<Runnable> ON_READ = new ThreadLocal<>();
@@ -20,7 +33,7 @@ class RuntimeMappingRegressionTest {
   record Node(String name, List<Node> children) {
     @Override
     public String name() {
-      var callback = ON_READ.get();
+      final var callback = ON_READ.get();
       if (callback != null) callback.run();
       return name;
     }
@@ -95,53 +108,55 @@ class RuntimeMappingRegressionTest {
 
   @Test
   void sharedSiblingsAreMappedInBothDirections() {
-    var leaf = new Node("leaf", List.of());
-    var root = new Node("root", List.of(new Node("branch", List.of(leaf, leaf))));
-    var mapper = Telescope.mapper(Node.class, NodeDto.class);
-    var mapped = mapper.forward(root);
-    var siblings = mapped.children().getFirst().children();
+    final var leaf = new Node("leaf", List.of());
+    final var root = new Node("root", List.of(new Node("branch", List.of(leaf, leaf))));
+    final var mapper = Telescope.mapper(Node.class, NodeDto.class);
+    final var mapped = mapper.forward(root);
+    final var siblings = mapped.children().getFirst().children();
     assertNotNull(siblings.get(1));
     assertEquals(siblings.getFirst(), siblings.get(1));
     assertNotSame(siblings.getFirst(), siblings.get(1));
     assertEquals(root, mapper.backward(mapped));
-    var dtoLeaf = new NodeDto("leaf", List.of());
-    var backward = mapper.backward(new NodeDto("root", List.of(new NodeDto("branch", List.of(dtoLeaf, dtoLeaf)))));
+    final var dtoLeaf = new NodeDto("leaf", List.of());
+    final var backward = mapper.backward(
+      new NodeDto("root", List.of(new NodeDto("branch", List.of(dtoLeaf, dtoLeaf))))
+    );
     assertNotNull(backward.children().getFirst().children().get(1));
   }
 
   @Test
   void fixedKeyGenericMapResolvesItsSupertype() {
-    var values = new StringMap<Value>();
+    final var values = new StringMap<Value>();
     values.put("one", new Value(1));
-    var mapper = Telescope.mapper(Fixed.class, Plain.class);
-    var mapped = mapper.forward(new Fixed(values));
+    final var mapper = Telescope.mapper(Fixed.class, Plain.class);
+    final var mapped = mapper.forward(new Fixed(values));
     assertEquals(Map.of("one", new ValueDto(1)), mapped.values());
     assertEquals(new Fixed(values), mapper.backward(mapped));
   }
 
   @Test
   void reorderedGenericMapResolvesItsSupertype() {
-    var values = new ReorderedMap<Value, String>();
+    final var values = new ReorderedMap<Value, String>();
     values.put("one", new Value(1));
-    var mapper = Telescope.mapper(Reordered.class, Plain.class);
-    var mapped = mapper.forward(new Reordered(values));
+    final var mapper = Telescope.mapper(Reordered.class, Plain.class);
+    final var mapped = mapper.forward(new Reordered(values));
     assertEquals(Map.of("one", new ValueDto(1)), mapped.values());
     assertEquals(new Reordered(values), mapper.backward(mapped));
   }
 
   @Test
   void unresolvedContainerElementsFailWithAFieldDiagnostic() {
-    var failure = assertThrows(IllegalStateException.class, () -> Telescope.mapper(Unknown.class, Plain.class));
+    final var failure = assertThrows(IllegalStateException.class, () -> Telescope.mapper(Unknown.class, Plain.class));
     assertTrue(failure.getMessage().contains("values"));
   }
 
   @Test
   void sortedMapsPreserveComparatorsInBothDirections() {
-    var values = new TreeMap<String, Value>(Comparator.reverseOrder());
+    final var values = new TreeMap<String, Value>(Comparator.reverseOrder());
     values.put("a", new Value(1));
     values.put("z", new Value(2));
-    var mapper = Telescope.mapper(Sorted.class, SortedDto.class);
-    var mapped = mapper.forward(new Sorted(values));
+    final var mapper = Telescope.mapper(Sorted.class, SortedDto.class);
+    final var mapped = mapper.forward(new Sorted(values));
     assertSame(values.comparator(), mapped.values().comparator());
     assertEquals(List.of("z", "a"), new ArrayList<>(mapped.values().keySet()));
     assertSame(values.comparator(), mapper.backward(mapped).values().comparator());
@@ -149,13 +164,13 @@ class RuntimeMappingRegressionTest {
 
   @Test
   void cyclesStopAtTheFirstActiveBackEdgeInBothDirections() {
-    var children = new ArrayList<Node>();
-    var root = new Node("root", children);
+    final var children = new ArrayList<Node>();
+    final var root = new Node("root", children);
     children.add(root);
-    var mapper = Telescope.mapper(Node.class, NodeDto.class);
+    final var mapper = Telescope.mapper(Node.class, NodeDto.class);
     assertNull(mapper.forward(root).children().getFirst());
-    var dtoChildren = new ArrayList<NodeDto>();
-    var dto = new NodeDto("root", dtoChildren);
+    final var dtoChildren = new ArrayList<NodeDto>();
+    final var dto = new NodeDto("root", dtoChildren);
     dtoChildren.add(dto);
     assertNull(mapper.backward(dto).children().getFirst());
     children.clear();
@@ -165,21 +180,21 @@ class RuntimeMappingRegressionTest {
 
   @Test
   void diamondBranchesAndConcurrentInvocationsDoNotLoseSharedLeaves() throws Exception {
-    var leaf = new Node("leaf", List.of());
-    var root = new Node("root", List.of(new Node("left", List.of(leaf)), new Node("right", List.of(leaf))));
-    var mapper = Telescope.mapper(Node.class, NodeDto.class);
+    final var leaf = new Node("leaf", List.of());
+    final var root = new Node("root", List.of(new Node("left", List.of(leaf)), new Node("right", List.of(leaf))));
+    final var mapper = Telescope.mapper(Node.class, NodeDto.class);
     try (var executor = Executors.newFixedThreadPool(4)) {
-      var tasks = new ArrayList<java.util.concurrent.Future<Node>>();
+      final var tasks = new ArrayList<Future<Node>>();
       for (int i = 0; i < 32; i++) tasks.add(executor.submit(() -> mapper.backward(mapper.forward(root))));
-      for (var task : tasks) assertEquals(root, task.get());
+      for (final var task : tasks) assertEquals(root, task.get());
     }
   }
 
   @Test
   void exceptionsAndReentrantCallsRestoreTheOuterActivePath() {
-    var leaf = new Node("leaf", List.of());
-    var root = new Node("root", List.of(new Node("branch", List.of(leaf, leaf))));
-    var mapper = Telescope.mapper(Node.class, NodeDto.class);
+    final var leaf = new Node("leaf", List.of());
+    final var root = new Node("root", List.of(new Node("branch", List.of(leaf, leaf))));
+    final var mapper = Telescope.mapper(Node.class, NodeDto.class);
     ON_READ.set(() -> {
       throw new IllegalArgumentException("getter failure");
     });
@@ -187,12 +202,12 @@ class RuntimeMappingRegressionTest {
     ON_READ.remove();
     assertEquals(root, mapper.backward(mapper.forward(root)));
 
-    var entered = new AtomicBoolean();
-    var nested = new AtomicReference<NodeDto>();
+    final var entered = new AtomicBoolean();
+    final var nested = new AtomicReference<NodeDto>();
     ON_READ.set(() -> {
       if (entered.compareAndSet(false, true)) nested.set(mapper.forward(root));
     });
-    var mapped = mapper.forward(root);
+    final var mapped = mapper.forward(root);
     ON_READ.remove();
     assertEquals(mapped, nested.get());
     assertNotNull(mapped.children().getFirst().children().get(1));
@@ -200,12 +215,12 @@ class RuntimeMappingRegressionTest {
 
   @Test
   void comparatorOnlyKeysAndEmptyMapsKeepTheirComparator() {
-    var values = new TreeMap<Key, Value>(Comparator.comparingInt(Key::n).reversed());
-    var mapper = Telescope.mapper(KeyMap.class, KeyMapDto.class);
+    final var values = new TreeMap<Key, Value>(Comparator.comparingInt(Key::n).reversed());
+    final var mapper = Telescope.mapper(KeyMap.class, KeyMapDto.class);
     assertSame(values.comparator(), mapper.forward(new KeyMap(values)).values().comparator());
     values.put(new Key(1), new Value(1));
     values.put(new Key(2), new Value(2));
-    var mapped = mapper.forward(new KeyMap(values));
+    final var mapped = mapper.forward(new KeyMap(values));
     assertEquals(new Key(2), mapped.values().firstKey());
     assertEquals(new KeyMap(values), mapper.backward(mapped));
     assertNull(mapper.forward(new KeyMap(null)).values());
@@ -213,28 +228,28 @@ class RuntimeMappingRegressionTest {
 
   @Test
   void changedSortedSetElementsRequireAnExplicitComparator() {
-    var values = new TreeSet<Value>(Comparator.comparingInt(Value::n));
+    final var values = new TreeSet<Value>(Comparator.comparingInt(Value::n));
     values.add(new Value(1));
-    var mapper = Telescope.mapper(SortedValues.class, SortedValuesDto.class);
-    var failure = assertThrows(IllegalStateException.class, () -> mapper.forward(new SortedValues(values)));
+    final var mapper = Telescope.mapper(SortedValues.class, SortedValuesDto.class);
+    final var failure = assertThrows(IllegalStateException.class, () -> mapper.forward(new SortedValues(values)));
     assertTrue(failure.getMessage().contains("Mapping.via"));
-    var dto = new TreeSet<ValueDto>(Comparator.comparingInt(ValueDto::n));
+    final var dto = new TreeSet<ValueDto>(Comparator.comparingInt(ValueDto::n));
     assertThrows(IllegalStateException.class, () -> mapper.backward(new SortedValuesDto(dto)));
   }
 
   @Test
   void inheritedNestedListArgumentsAreSubstituted() {
-    var values = new NestedList<Value>();
+    final var values = new NestedList<Value>();
     values.add(List.of(new Value(1)));
-    var mapper = Telescope.mapper(Nested.class, NestedDto.class);
-    var mapped = mapper.forward(new Nested(values));
+    final var mapper = Telescope.mapper(Nested.class, NestedDto.class);
+    final var mapped = mapper.forward(new Nested(values));
     assertEquals(List.of(List.of(new ValueDto(1))), mapped.values());
     assertEquals(new Nested(values), mapper.backward(mapped));
   }
 
   @Test
   void allExecutionStrategiesPassTheContainerAndGraphRegressions() {
-    for (var mode : List.of("default", "javaLoop", "array")) {
+    for (final var mode : List.of("default", "javaLoop", "array")) {
       System.setProperty(MhIso.CONTAINER_DISABLE_PROPERTY, Boolean.toString(mode.equals("javaLoop")));
       System.setProperty(MhIso.DISABLE_PROPERTY, Boolean.toString(mode.equals("array")));
       sharedSiblingsAreMappedInBothDirections();
@@ -245,20 +260,20 @@ class RuntimeMappingRegressionTest {
       inheritedNestedListArgumentsAreSubstituted();
       cyclesStopAtTheFirstActiveBackEdgeInBothDirections();
       changedSortedSetElementsRequireAnExplicitComparator();
-      for (int size : new int[] { 0, 1, 16, 256, 4096 }) {
-        var values = new ArrayList<Value>();
+      for (final int size : new int[] { 0, 1, 16, 256, 4096 }) {
+        final var values = new ArrayList<Value>();
         for (int i = 0; i < size; i++) values.add(new Value(i));
-        var mapper = Telescope.mapper(Copies.class, CopiesDto.class);
-        var nonNullInput = new Copies(new CopyOnWriteArrayList<>(values));
+        final var mapper = Telescope.mapper(Copies.class, CopiesDto.class);
+        final var nonNullInput = new Copies(new CopyOnWriteArrayList<>(values));
         assertEquals(nonNullInput, mapper.backward(mapper.forward(nonNullInput)));
         values.add(null);
-        var input = new Copies(new CopyOnWriteArrayList<>(values));
-        var mapped = mapper.forward(input);
+        final var input = new Copies(new CopyOnWriteArrayList<>(values));
+        final var mapped = mapper.forward(input);
         assertEquals(CopyOnWriteArrayList.class, mapped.values().getClass());
         assertEquals(input, mapper.backward(mapped));
         assertNull(mapper.forward(new Copies(null)).values());
-        var sets = Telescope.mapper(CopySets.class, CopySetsDto.class);
-        var setInput = new CopySets(new CopyOnWriteArraySet<>(values));
+        final var sets = Telescope.mapper(CopySets.class, CopySetsDto.class);
+        final var setInput = new CopySets(new CopyOnWriteArraySet<>(values));
         assertEquals(CopyOnWriteArraySet.class, sets.forward(setInput).values().getClass());
         assertEquals(setInput, sets.backward(sets.forward(setInput)));
       }

--- a/docs/perf-runtime-collections.md
+++ b/docs/perf-runtime-collections.md
@@ -1,0 +1,52 @@
+# Runtime collection mapping measurements
+
+This benchmark isolates a reused `Telescope.mapper(...)` runtime mapper. Mapper construction is excluded: each JMH state
+creates one mapper in `@Setup`, then measures `forward` and `backward`. The fixture maps a container of `Value(int)` to
+`ValueDto(int)` with runtime structural mapping.
+
+The benchmark runs collection cardinalities 0, 1, 16, 256, and 4096 for `List`, `CopyOnWriteArrayList`, `Set`, and
+`Map`. It reports average time and allocation per operation. The functional regressions are in
+`RuntimeMappingRegressionTest`; they exercise the default fused path, the Java-loop path, and the legacy array leaf.
+
+## Reproducing
+
+```bash
+./gradlew :benchmarks:jmh -Pjmh.includes=ContainerAllocationBenchmark \
+  -Pjmh.fork=3 -Pjmh.warmup=3 -Pjmh.iterations=5 \
+  -Pjmh.warmupTime=500ms -Pjmh.timeOnIteration=500ms \
+  -Pjmh.profilers=gc
+```
+
+For a change that claims an improvement, save matching JMH JSON before and after, then run:
+
+```bash
+python3 scripts/compare-runtime-benchmarks.py before.json after.json --check
+```
+
+The comparator rejects differing JMH settings, material timing regressions with non-overlapping 99.9% confidence
+intervals, allocation regressions, and less than 5% allocation improvement for container cases of size 16 or more.
+
+## Measured result
+
+Baseline and updated artifacts were measured on an Apple M5 Pro, macOS 27.0, OpenJDK 25.0.3, JMH 1.36,
+`-Xms256m -Xmx256m`; every row used three forks, three warmups, five measurements, and 500 ms iterations. The table
+shows forward mapping; backward has the same allocation shape.
+
+| Container              |  Size | Before ns/op | After ns/op | Before B/op | After B/op |
+| ---------------------- | ----: | -----------: | ----------: | ----------: | ---------: |
+| `List`                 |    16 |        65.46 |       55.12 |         536 |        376 |
+| `List`                 |   256 |       893.88 |      789.03 |       8,688 |      5,208 |
+| `List`                 | 4,096 |    14,745.29 |   12,728.47 |     115,824 |     82,008 |
+| `CopyOnWriteArrayList` |    16 |       150.41 |       61.39 |       1,144 |        496 |
+| `CopyOnWriteArrayList` |   256 |     4,443.70 |      792.34 |     140,368 |      6,280 |
+| `CopyOnWriteArrayList` | 4,096 | 1,170,473.53 |   12,655.12 |  33,701,969 |     98,440 |
+| `Map`                  | 4,096 |    40,030.68 |   31,404.33 |     262,336 |    229,488 |
+| `Set`                  | 4,096 |    37,893.88 |   30,352.16 |     295,136 |    262,288 |
+
+Empty and singleton copy-on-write lists retain the previous allocation shape (56 B/op and 96 B/op) and statistically
+indistinguishable timing. The large copy-on-write result comes from mapping into a temporary pre-sized collection and
+performing one bulk copy into the final copy-on-write container, rather than copying its backing array after every
+`add`.
+
+Treat the exact nanoseconds as machine-specific. The allocation reduction and the quadratic copy-on-write behavior are
+the durable result; rerun the command above on the target JVM and hardware before publishing a performance claim.

--- a/docs/perf-runtime-collections.md
+++ b/docs/perf-runtime-collections.md
@@ -43,10 +43,14 @@ shows forward mapping; backward has the same allocation shape.
 | `Map`                  | 4,096 |    40,030.68 |   31,404.33 |     262,336 |    229,488 |
 | `Set`                  | 4,096 |    37,893.88 |   30,352.16 |     295,136 |    262,288 |
 
-Empty and singleton copy-on-write lists retain the previous allocation shape (56 B/op and 96 B/op) and statistically
-indistinguishable timing. The large copy-on-write result comes from mapping into a temporary pre-sized collection and
-performing one bulk copy into the final copy-on-write container, rather than copying its backing array after every
-`add`.
+Empty and singleton copy-on-write lists retain the previous allocation shape (56 B/op and 96 B/op); singleton inputs pay
+roughly 10 ns of finish-check overhead on some hardware — trivial in absolute terms, but not indistinguishable. The
+large copy-on-write result comes from mapping into a temporary pre-sized collection and performing one bulk copy into
+the final copy-on-write container, rather than copying its backing array after every `add`.
+
+A CI reproduction on GitHub Actions `ubuntu-latest` (same protocol, `gc` profiler) confirmed the shape: copy-on-write at
+4,096 elements improved 115× with the same 99.7% allocation cut, lists 1.3–1.75× with 29–40% less allocation, maps and
+sets 1.3–1.75× with 7–12% less.
 
 Treat the exact nanoseconds as machine-specific. The allocation reduction and the quadratic copy-on-write behavior are
 the durable result; rerun the command above on the target JVM and hardware before publishing a performance claim.

--- a/docs/type-conversion.md
+++ b/docs/type-conversion.md
@@ -40,6 +40,22 @@ Telescope.of(EntityPage.class)
 
 ## Deep recursive mapping (`Telescope.map(A.class, B.class, to(...)...)`)
 
+Runtime mapping cuts a cycle when an object is encountered again on the active recursion path, including the root. The
+back-edge becomes `null` (or an empty `Optional`). Shared objects in separate acyclic branches are mapped independently;
+their mapped copies do not share identity. Each public mapping invocation has independent tracking, including reentrant
+calls, and exceptions release that tracking. This replaces the earlier behavior that could turn a repeated sibling into
+`null` and expand the root twice.
+
+Parameterized container subclasses resolve their element/key types through their generic supertypes. For example,
+`StringMap<V> extends HashMap<String, V>` has a `String` key regardless of its own parameter count. Raw subclass pairs
+retain their existing shallow-copy behavior; use explicit rows when those element types differ.
+
+When mapping values into supported sorted maps, the input sorted map's comparator is retained because keys are
+unchanged. Mapping sorted-set elements to a different type cannot safely reuse a custom comparator: use an explicit
+`Mapping.via(...)` conversion that supplies the target comparator. Null containers continue to map to null. Standard
+list and hash-container lifts use input size for allocation; copy-on-write containers use bulk construction for larger
+inputs while retaining the small-input path for zero or one element.
+
 The recommended shape for record-to-record (and POJO↔POJO, and cross-paradigm) conversion: pass the source and target
 classes up front, then varargs of `MapStep` rows (`MapStep` is the sealed supertype of the `Mapping` field rows and the
 `WriteHint` / `NullHint` behavior hints — one varargs slot for all three). **Recursion is the default.** Same-named

--- a/internal/src/main/java/io/github/eschizoid/telescope/internal/LambdaIntrospection.java
+++ b/internal/src/main/java/io/github/eschizoid/telescope/internal/LambdaIntrospection.java
@@ -2,8 +2,6 @@ package io.github.eschizoid.telescope.internal;
 
 import java.io.Serializable;
 import java.lang.invoke.SerializedLambda;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Reflective extraction of method-reference metadata via {@link SerializedLambda}. The runtime
@@ -24,8 +22,31 @@ public final class LambdaIntrospection {
 
   private LambdaIntrospection() {}
 
-  private static final Map<Class<?>, String> METHOD_NAME_CACHE = new ConcurrentHashMap<>();
-  private static final Map<Class<?>, Class<?>> IMPL_CLASS_CACHE = new ConcurrentHashMap<>();
+  // Values belong to the lambda class and disappear with its loader. Never retain the lambda
+  // instance or SerializedLambda: a bound method reference can capture an entire application graph.
+  private static final ClassValue<MetadataSlot> CACHE = new ClassValue<>() {
+    @Override
+    protected MetadataSlot computeValue(final Class<?> type) {
+      return new MetadataSlot();
+    }
+  };
+
+  private record Metadata(String methodName, String implName) {}
+
+  private static final class MetadataSlot {
+
+    private volatile Metadata metadata;
+    private volatile Class<?> implClass;
+
+    Metadata get(final Serializable lambda) {
+      final var cached = metadata;
+      if (cached != null) return cached;
+      synchronized (this) {
+        if (metadata == null) metadata = decode(lambda);
+        return metadata;
+      }
+    }
+  }
 
   /**
    * The impl method name of a Serializable method reference (e.g. {@code "name"} from {@code
@@ -36,10 +57,10 @@ public final class LambdaIntrospection {
    *     starts with {@code "lambda$"})
    */
   public static String methodNameOf(final Serializable lambda) {
-    return METHOD_NAME_CACHE.computeIfAbsent(lambda.getClass(), __ -> resolveMethodName(lambda));
+    return CACHE.get(lambda.getClass()).get(lambda).methodName();
   }
 
-  private static String resolveMethodName(final Serializable lambda) {
+  private static Metadata decode(final Serializable lambda) {
     try {
       final var writeReplace = lambda.getClass().getDeclaredMethod("writeReplace");
       writeReplace.setAccessible(true);
@@ -48,7 +69,7 @@ public final class LambdaIntrospection {
       if (name.startsWith("lambda$")) throw new IllegalArgumentException(
         "Expected a method reference (e.g. User::name, User::getName), not a lambda. Got: " + name
       );
-      return name;
+      return new Metadata(name, serialized.getImplClass().replace('/', '.'));
     } catch (final ReflectiveOperationException e) {
       throw new IllegalArgumentException(
         "Expected a method reference to a record component / bean property accessor",
@@ -67,24 +88,17 @@ public final class LambdaIntrospection {
    */
   @SuppressWarnings("unchecked")
   public static <A> Class<A> implClassOf(final Serializable lambda) {
-    return (Class<A>) IMPL_CLASS_CACHE.computeIfAbsent(lambda.getClass(), __ -> resolveImplClass(lambda));
-  }
-
-  private static Class<?> resolveImplClass(final Serializable lambda) {
-    try {
-      final var writeReplace = lambda.getClass().getDeclaredMethod("writeReplace");
-      writeReplace.setAccessible(true);
-      final var serialized = (SerializedLambda) writeReplace.invoke(lambda);
-      if (serialized.getImplMethodName().startsWith("lambda$")) throw new IllegalArgumentException(
-        "Expected a method reference (e.g. User::name, User::getName), not a lambda. Got: " +
-          serialized.getImplMethodName()
-      );
-      // Resolve against the lambda's defining loader, not telescope's — under plugin/app-server
-      // deployments the impl class may be invisible to this library's loader.
-      final var implName = serialized.getImplClass().replace('/', '.');
-      return Class.forName(implName, false, lambda.getClass().getClassLoader());
-    } catch (final ReflectiveOperationException e) {
-      throw new IllegalArgumentException("Expected a method reference; got: " + lambda, e);
+    final var slot = CACHE.get(lambda.getClass());
+    final var metadata = slot.get(lambda);
+    var result = slot.implClass;
+    if (result == null) {
+      try {
+        result = Class.forName(metadata.implName(), false, lambda.getClass().getClassLoader());
+        slot.implClass = result;
+      } catch (final ClassNotFoundException e) {
+        throw new IllegalArgumentException("Expected a method reference; got: " + lambda, e);
+      }
     }
+    return (Class<A>) result;
   }
 }

--- a/internal/src/main/java/io/github/eschizoid/telescope/internal/MhIso.java
+++ b/internal/src/main/java/io/github/eschizoid/telescope/internal/MhIso.java
@@ -10,7 +10,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.function.Function;
-import java.util.function.Supplier;
 
 /**
  * MethodHandle-combinator assembly of a structural conversion {@link Iso} where each side is a
@@ -127,7 +126,7 @@ public final class MhIso {
   private static final MethodHandle MAP_PUT; //            (Object, Object, Object) -> Object Map.put
   private static final MethodHandle ENTRY_KEY; //          (Object) -> Object        Map.Entry.getKey
   private static final MethodHandle ENTRY_VALUE; //        (Object) -> Object      Map.Entry.getValue
-  private static final MethodHandle SUPPLIER_GET; //       (Supplier) -> Object      Supplier.get
+  private static final MethodHandle ALLOCATE; // (Function, Object) -> Object
   // (Throwable, Object, Class, Class) -> Object : relabels a fused nested-conversion failure.
   private static final MethodHandle THROW_CONVERSION;
 
@@ -155,9 +154,7 @@ public final class MhIso {
       ENTRY_VALUE = lk
         .findVirtual(Map.Entry.class, "getValue", MethodType.methodType(Object.class))
         .asType(MethodType.methodType(Object.class, Object.class));
-      SUPPLIER_GET = lk
-        .findVirtual(Supplier.class, "get", MethodType.methodType(Object.class))
-        .asType(MethodType.methodType(Object.class, Supplier.class));
+      ALLOCATE = lk.findVirtual(Function.class, "apply", MethodType.methodType(Object.class, Object.class));
       THROW_CONVERSION = lk.findStatic(
         MhIso.class,
         "throwConversion",
@@ -501,8 +498,8 @@ public final class MhIso {
    */
   public static Iso<Object, Object> liftCollection(
     final Iso<Object, Object> elementIso,
-    final Supplier<Object> srcAlloc,
-    final Supplier<Object> tgtAlloc
+    final Function<Object, Object> srcAlloc,
+    final Function<Object, Object> tgtAlloc
   ) {
     if (Boolean.getBoolean(CONTAINER_DISABLE_PROPERTY)) return null;
     if (!(elementIso instanceof Leaf<?, ?> leaf)) return null;
@@ -527,8 +524,8 @@ public final class MhIso {
    */
   public static Iso<Object, Object> liftMap(
     final Iso<Object, Object> valueIso,
-    final Supplier<Object> srcAlloc,
-    final Supplier<Object> tgtAlloc
+    final Function<Object, Object> srcAlloc,
+    final Function<Object, Object> tgtAlloc
   ) {
     if (Boolean.getBoolean(CONTAINER_DISABLE_PROPERTY)) return null;
     if (!(valueIso instanceof Leaf<?, ?> leaf)) return null;
@@ -620,10 +617,10 @@ public final class MhIso {
    * the source, and {@code add(element(x))} for each. {@code element} is the null-guarded raw
    * handle.
    */
-  private static MethodHandle collectionLoop(final MethodHandle element, final Supplier<Object> tgtAlloc) {
-    // init : (Object srcColl) -> Object tgtColl  == fresh target collection, ignoring the source
-    // arg.
-    final MethodHandle init = MethodHandles.dropArguments(supplierGet(tgtAlloc), 0, Object.class);
+  private static MethodHandle collectionLoop(final MethodHandle element, final Function<Object, Object> tgtAlloc) {
+    // init : (Object srcColl) -> Object tgtColl  == fresh target collection using source
+    // size/comparator.
+    final MethodHandle init = ALLOCATE.bindTo(tgtAlloc);
     // add(acc, element(x)) as a void side effect: (Object acc, Object x) -> void.
     final MethodHandle mapped = MethodHandles.filterArguments(COLLECTION_ADD, 1, element);
     final MethodHandle addVoid = mapped.asType(mapped.type().changeReturnType(void.class));
@@ -642,11 +639,11 @@ public final class MhIso {
    * source's entry set, and {@code put(entry.key, element(entry.value))} for each. Keys pass
    * through unchanged.
    */
-  private static MethodHandle mapLoop(final MethodHandle element, final Supplier<Object> tgtAlloc) {
+  private static MethodHandle mapLoop(final MethodHandle element, final Function<Object, Object> tgtAlloc) {
     // iterator : (Object srcMap) -> Iterator over the entry set.
     final MethodHandle iterator = MethodHandles.filterReturnValue(MAP_ENTRYSET, ITERABLE_ITERATOR);
     // init : (Object srcMap) -> Object tgtMap.
-    final MethodHandle init = MethodHandles.dropArguments(supplierGet(tgtAlloc), 0, Object.class);
+    final MethodHandle init = ALLOCATE.bindTo(tgtAlloc);
     // put(acc, entry.key, element(entry.value)) as a void side effect.
     final MethodHandle valFromEntry = MethodHandles.filterReturnValue(ENTRY_VALUE, element);
     final MethodHandle putFromEntries = MethodHandles.filterArguments(MAP_PUT, 1, ENTRY_KEY, valFromEntry);
@@ -665,11 +662,6 @@ public final class MhIso {
     final MethodHandle body2 = MethodHandles.foldArguments(retAcc, putEntry);
     final MethodHandle body = MethodHandles.dropArguments(body2, 2, Object.class);
     return MethodHandles.iteratedLoop(iterator, init, body).asType(MethodType.methodType(Object.class, Object.class));
-  }
-
-  /** {@code () -> Object} bound to {@code alloc.get()}, as a MethodHandle for loop {@code init}. */
-  private static MethodHandle supplierGet(final Supplier<Object> alloc) {
-    return SUPPLIER_GET.bindTo(alloc);
   }
 
   private static RuntimeException rethrow(final Class<?> from, final Class<?> to, final Throwable e) {

--- a/internal/src/main/java/io/github/eschizoid/telescope/internal/pairing/PairingRules.java
+++ b/internal/src/main/java/io/github/eschizoid/telescope/internal/pairing/PairingRules.java
@@ -104,22 +104,30 @@ public final class PairingRules<T> {
    * liftable container).
    */
   public ContainerView<T> containerViewOf(final T t) {
-    final var args = props.typeArguments(t);
-    if (args.isEmpty()) return null;
+    // Raw subclasses retain the explicit shallow-copy policy above. Parameterized subclasses
+    // must be viewed through the container supertype: their own parameters can be reordered,
+    // fixed, or unrelated to the element/key types.
+    if (props.typeArguments(t).isEmpty()) return null;
     final var raw = props.rawType(t);
-    if (props.isSubtypeOf(raw, WellKnown.OPTIONAL)) {
-      return new ContainerView<>(ContainerView.Kind.OPTIONAL, args.getFirst(), null, raw);
-    }
-    if (props.isSubtypeOf(raw, WellKnown.LIST)) {
-      return new ContainerView<>(ContainerView.Kind.LIST, args.getFirst(), null, raw);
-    }
-    if (props.isSubtypeOf(raw, WellKnown.SET)) {
-      return new ContainerView<>(ContainerView.Kind.SET, args.getFirst(), null, raw);
-    }
-    if (props.isSubtypeOf(raw, WellKnown.MAP)) {
-      final var key = args.get(0);
-      if (!props.isClassType(key)) return null;
-      return new ContainerView<>(ContainerView.Kind.MAP_VALUES, args.get(1), key, raw);
+    for (final var kind : List.of(WellKnown.OPTIONAL, WellKnown.LIST, WellKnown.SET, WellKnown.MAP)) {
+      if (!props.isSubtypeOf(raw, kind)) continue;
+      final var args = props.typeArgumentsAs(t, kind);
+      if (kind == WellKnown.MAP) {
+        if (args.size() != 2 || !props.isClassType(args.getFirst())) return null;
+        return new ContainerView<>(ContainerView.Kind.MAP_VALUES, args.get(1), args.getFirst(), raw);
+      }
+      if (args.size() != 1) return null;
+      return new ContainerView<>(
+        switch (kind) {
+          case OPTIONAL -> ContainerView.Kind.OPTIONAL;
+          case LIST -> ContainerView.Kind.LIST;
+          case SET -> ContainerView.Kind.SET;
+          default -> throw new AssertionError(kind);
+        },
+        args.getFirst(),
+        null,
+        raw
+      );
     }
     return null;
   }

--- a/internal/src/main/java/io/github/eschizoid/telescope/internal/pairing/PropertySystem.java
+++ b/internal/src/main/java/io/github/eschizoid/telescope/internal/pairing/PropertySystem.java
@@ -79,6 +79,11 @@ public interface PropertySystem<T> {
   /** Type arguments when {@code t} is parameterized; empty list otherwise. */
   List<T> typeArguments(T t);
 
+  /**
+   * Actual arguments of the specified generic supertype, after substituting inherited variables.
+   */
+  List<T> typeArgumentsAs(T t, WellKnown supertype);
+
   /** The raw/erased class handle of {@code t} ({@code List<X>} → {@code List}). */
   T rawType(T t);
 

--- a/internal/src/main/java/io/github/eschizoid/telescope/internal/pairing/ReflectionProps.java
+++ b/internal/src/main/java/io/github/eschizoid/telescope/internal/pairing/ReflectionProps.java
@@ -1,13 +1,19 @@
 package io.github.eschizoid.telescope.internal.pairing;
 
 import io.github.eschizoid.telescope.internal.Beans;
+import java.lang.reflect.Array;
+import java.lang.reflect.GenericArrayType;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.lang.reflect.TypeVariable;
 import java.time.temporal.Temporal;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Deque;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Queue;
 import java.util.Set;
@@ -79,6 +85,113 @@ public final class ReflectionProps implements PropertySystem<Type> {
   @Override
   public List<Type> typeArguments(final Type t) {
     return t instanceof ParameterizedType pt ? List.of(pt.getActualTypeArguments()) : List.of();
+  }
+
+  @Override
+  public List<Type> typeArgumentsAs(final Type t, final WellKnown supertype) {
+    return argumentsAs(t, classOf(supertype));
+  }
+
+  private List<Type> argumentsAs(final Type type, final Class<?> target) {
+    final var raw = rawType(type);
+    if (!(raw instanceof Class<?> cls) || !target.isAssignableFrom(cls)) return List.of();
+    if (cls == target) return typeArguments(type);
+    final var bindings = new HashMap<TypeVariable<?>, Type>();
+    bind(type, bindings);
+    for (final var parent : cls.getGenericInterfaces()) {
+      final var resolved = substitute(parent, bindings);
+      if (rawType(resolved) instanceof Class<?> c && target.isAssignableFrom(c)) {
+        return argumentsAs(resolved, target);
+      }
+    }
+    final var parent = cls.getGenericSuperclass();
+    return parent == null ? List.of() : argumentsAs(substitute(parent, bindings), target);
+  }
+
+  private static void bind(final Type type, final Map<TypeVariable<?>, Type> bindings) {
+    if (!(type instanceof ParameterizedType pt)) return;
+    bind(pt.getOwnerType(), bindings);
+    final var variables = ((Class<?>) pt.getRawType()).getTypeParameters();
+    final var arguments = pt.getActualTypeArguments();
+    for (int i = 0; i < variables.length; i++) bindings.put(variables[i], substitute(arguments[i], bindings));
+  }
+
+  private static Type substitute(final Type type, final Map<TypeVariable<?>, Type> bindings) {
+    if (type instanceof TypeVariable<?> variable) return bindings.getOrDefault(variable, variable);
+    if (type instanceof GenericArrayType array) {
+      final var component = substitute(array.getGenericComponentType(), bindings);
+      return component instanceof Class<?> cls ? Array.newInstance(cls, 0).getClass() : new ResolvedArray(component);
+    }
+    if (!(type instanceof ParameterizedType pt)) return type;
+    final var arguments = Arrays.stream(pt.getActualTypeArguments())
+      .map(t -> substitute(t, bindings))
+      .toList();
+    return new ResolvedType(pt.getRawType(), substitute(pt.getOwnerType(), bindings), arguments);
+  }
+
+  private record ResolvedArray(Type component) implements GenericArrayType {
+    @Override
+    public Type getGenericComponentType() {
+      return component;
+    }
+
+    @Override
+    public boolean equals(final Object other) {
+      return other instanceof GenericArrayType array && component.equals(array.getGenericComponentType());
+    }
+
+    @Override
+    public int hashCode() {
+      return component.hashCode();
+    }
+
+    @Override
+    public String getTypeName() {
+      return component.getTypeName() + "[]";
+    }
+  }
+
+  /** Structural equality with JDK ParameterizedType implementations, including nested arguments. */
+  private record ResolvedType(Type raw, Type owner, List<Type> arguments) implements ParameterizedType {
+    @Override
+    public Type getRawType() {
+      return raw;
+    }
+
+    @Override
+    public Type getOwnerType() {
+      return owner;
+    }
+
+    @Override
+    public Type[] getActualTypeArguments() {
+      return arguments.toArray(Type[]::new);
+    }
+
+    @Override
+    public boolean equals(final Object other) {
+      return (
+        other instanceof ParameterizedType pt &&
+        raw.equals(pt.getRawType()) &&
+        Objects.equals(owner, pt.getOwnerType()) &&
+        Arrays.equals(getActualTypeArguments(), pt.getActualTypeArguments())
+      );
+    }
+
+    @Override
+    public int hashCode() {
+      return Arrays.hashCode(getActualTypeArguments()) ^ Objects.hashCode(owner) ^ raw.hashCode();
+    }
+
+    @Override
+    public String getTypeName() {
+      return raw.getTypeName() + "<" + String.join(", ", arguments.stream().map(Type::getTypeName).toList()) + ">";
+    }
+
+    @Override
+    public String toString() {
+      return getTypeName();
+    }
   }
 
   @Override

--- a/internal/src/test/java/io/github/eschizoid/telescope/internal/LambdaIntrospectionTest.java
+++ b/internal/src/test/java/io/github/eschizoid/telescope/internal/LambdaIntrospectionTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.Serializable;
+import java.lang.ref.WeakReference;
 import java.util.function.Function;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -19,6 +20,38 @@ import org.junit.jupiter.api.Test;
  * where a method reference was expected — wording is load-bearing, not cosmetic.
  */
 class LambdaIntrospectionTest {
+
+  @Test
+  void methodReferenceMetadataDoesNotPinAnApplicationClassLoader() throws Exception {
+    final var loader = exerciseIsolatedLoader();
+    // Explicit GC is enabled in the test JVM. A static strong-key map keeps this alive forever;
+    // a ClassValue permits unloading once both the reference and its defining class are unused.
+    for (int i = 0; i < 100 && loader.get() != null; i++) {
+      System.gc();
+      Thread.sleep(10);
+    }
+    org.junit.jupiter.api.Assertions.assertNull(loader.get(), "method-reference metadata pinned the loader");
+  }
+
+  private static WeakReference<ClassLoader> exerciseIsolatedLoader() throws Exception {
+    final String name = UnloadableReference.class.getName();
+    final byte[] bytes;
+    try (var stream = UnloadableReference.class.getResourceAsStream("UnloadableReference.class")) {
+      bytes = java.util.Objects.requireNonNull(stream).readAllBytes();
+    }
+    final var loader = new ClassLoader(null) {
+      @Override
+      protected Class<?> findClass(final String requested) throws ClassNotFoundException {
+        if (!requested.equals(name)) throw new ClassNotFoundException(requested);
+        return defineClass(requested, bytes, 0, bytes.length);
+      }
+    };
+    final var fixture = loader.loadClass(name);
+    final var reference = (Serializable) fixture.getMethod("create").invoke(null);
+    assertEquals("trim", LambdaIntrospection.methodNameOf(reference));
+    assertSame(String.class, LambdaIntrospection.implClassOf(reference));
+    return new WeakReference<>(loader);
+  }
 
   record User(String name) {}
 

--- a/internal/src/test/java/io/github/eschizoid/telescope/internal/LambdaIntrospectionTest.java
+++ b/internal/src/test/java/io/github/eschizoid/telescope/internal/LambdaIntrospectionTest.java
@@ -2,12 +2,14 @@ package io.github.eschizoid.telescope.internal;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.Serializable;
 import java.lang.ref.WeakReference;
+import java.util.Objects;
 import java.util.function.Function;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -30,14 +32,14 @@ class LambdaIntrospectionTest {
       System.gc();
       Thread.sleep(10);
     }
-    org.junit.jupiter.api.Assertions.assertNull(loader.get(), "method-reference metadata pinned the loader");
+    assertNull(loader.get(), "method-reference metadata pinned the loader");
   }
 
   private static WeakReference<ClassLoader> exerciseIsolatedLoader() throws Exception {
     final String name = UnloadableReference.class.getName();
     final byte[] bytes;
     try (var stream = UnloadableReference.class.getResourceAsStream("UnloadableReference.class")) {
-      bytes = java.util.Objects.requireNonNull(stream).readAllBytes();
+      bytes = Objects.requireNonNull(stream).readAllBytes();
     }
     final var loader = new ClassLoader(null) {
       @Override

--- a/internal/src/test/java/io/github/eschizoid/telescope/internal/MhIsoTest.java
+++ b/internal/src/test/java/io/github/eschizoid/telescope/internal/MhIsoTest.java
@@ -7,6 +7,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.github.eschizoid.telescope.internal.optics.Iso;
+import java.util.Arrays;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -105,7 +107,42 @@ class MhIsoTest {
     final int[] bwd = { 0, 1 };
     final Iso<Object, Object>[] fwdIso = new Iso[] { identity, identity };
     final Iso<Object, Object>[] bwdIso = new Iso[] { identity, identity };
-    return MhIso.pair(source, target, fwd, fwdIso, bwd, bwdIso, identity);
+    return pair(source, target, fwd, fwdIso, bwd, bwdIso, identity);
+  }
+
+  private static List<String> names(final Class<?> type) {
+    return type.isRecord()
+      ? Arrays.stream(type.getRecordComponents()).map(java.lang.reflect.RecordComponent::getName).toList()
+      : List.of(Beans.propertyNames(type));
+  }
+
+  // Test inputs below use the readable logical order (name, age); translate to each side's slots.
+  @SuppressWarnings({ "unchecked", "rawtypes" })
+  private static <S, T> Iso<S, T> pair(
+    final Class<S> source,
+    final Class<T> target,
+    final int[] forward,
+    final Iso<Object, Object>[] fwdIso,
+    final int[] backward,
+    final Iso<Object, Object>[] bwdIso,
+    final Iso<Object, Object> identity
+  ) {
+    final var logical = List.of("name", "age");
+    final var srcNames = names(source);
+    final var tgtNames = names(target);
+    final int[] fwd = new int[2];
+    final int[] bwd = new int[2];
+    final Iso<Object, Object>[] fi = new Iso[2];
+    final Iso<Object, Object>[] bi = new Iso[2];
+    for (int i = 0; i < 2; i++) {
+      int t = logical.indexOf(tgtNames.get(i));
+      fwd[i] = forward[t] < 0 ? -1 : srcNames.indexOf(logical.get(forward[t]));
+      fi[i] = fwdIso[t];
+      int r = logical.indexOf(srcNames.get(i));
+      bwd[i] = backward[r] < 0 ? -1 : tgtNames.indexOf(logical.get(backward[r]));
+      bi[i] = bwdIso[r];
+    }
+    return MhIso.pair(source, target, fwd, fi, bwd, bi, identity);
   }
 
   @Nested
@@ -206,7 +243,7 @@ class MhIsoTest {
       final int[] bwd = { 0, 1 };
       final Iso<Object, Object>[] fwdIso = new Iso[] { upper, identity };
       final Iso<Object, Object>[] bwdIso = new Iso[] { upper, identity };
-      final Iso<RecUser, BeanUser> iso = MhIso.pair(RecUser.class, BeanUser.class, fwd, fwdIso, bwd, bwdIso, identity);
+      final Iso<RecUser, BeanUser> iso = pair(RecUser.class, BeanUser.class, fwd, fwdIso, bwd, bwdIso, identity);
       final var b = iso.to(new RecUser("dan", 7));
       assertEquals("DAN", b.getName());
       assertEquals(7, b.getAge());
@@ -225,7 +262,7 @@ class MhIsoTest {
       final int[] bwd = { 0, 1 };
       final Iso<Object, Object>[] fwdIso = new Iso[] { constant, identity };
       final Iso<Object, Object>[] bwdIso = new Iso[] { identity, identity };
-      final Iso<RecUser, BeanUser> iso = MhIso.pair(RecUser.class, BeanUser.class, fwd, fwdIso, bwd, bwdIso, identity);
+      final Iso<RecUser, BeanUser> iso = pair(RecUser.class, BeanUser.class, fwd, fwdIso, bwd, bwdIso, identity);
       final var b = iso.to(new RecUser("ignored", 9));
       assertEquals("CONST", b.getName());
       assertEquals(9, b.getAge());
@@ -244,7 +281,7 @@ class MhIsoTest {
       final int[] bwd = { 0, 1 };
       final Iso<Object, Object>[] fwdIso = new Iso[] { identity, nullify };
       final Iso<Object, Object>[] bwdIso = new Iso[] { identity, identity };
-      final Iso<RecUser, BeanUser> iso = MhIso.pair(RecUser.class, BeanUser.class, fwd, fwdIso, bwd, bwdIso, identity);
+      final Iso<RecUser, BeanUser> iso = pair(RecUser.class, BeanUser.class, fwd, fwdIso, bwd, bwdIso, identity);
       final var b = iso.to(new RecUser("zoe", 99));
       assertEquals("zoe", b.getName());
       assertEquals(0, b.getAge()); // skipped → JLS default, not an NPE
@@ -267,7 +304,7 @@ class MhIsoTest {
       final int[] bwd = { 0, 1 };
       final Iso<Object, Object>[] fwdIso = new Iso[] { boom, identity };
       final Iso<Object, Object>[] bwdIso = new Iso[] { identity, identity };
-      final Iso<RecUser, BeanUser> iso = MhIso.pair(RecUser.class, BeanUser.class, fwd, fwdIso, bwd, bwdIso, identity);
+      final Iso<RecUser, BeanUser> iso = pair(RecUser.class, BeanUser.class, fwd, fwdIso, bwd, bwdIso, identity);
       assertThrows(StackOverflowError.class, () -> iso.to(new RecUser("x", 1)));
     }
   }

--- a/internal/src/test/java/io/github/eschizoid/telescope/internal/MhIsoTest.java
+++ b/internal/src/test/java/io/github/eschizoid/telescope/internal/MhIsoTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.github.eschizoid.telescope.internal.optics.Iso;
+import java.lang.reflect.RecordComponent;
 import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
@@ -112,7 +113,7 @@ class MhIsoTest {
 
   private static List<String> names(final Class<?> type) {
     return type.isRecord()
-      ? Arrays.stream(type.getRecordComponents()).map(java.lang.reflect.RecordComponent::getName).toList()
+      ? Arrays.stream(type.getRecordComponents()).map(RecordComponent::getName).toList()
       : List.of(Beans.propertyNames(type));
   }
 
@@ -135,10 +136,10 @@ class MhIsoTest {
     final Iso<Object, Object>[] fi = new Iso[2];
     final Iso<Object, Object>[] bi = new Iso[2];
     for (int i = 0; i < 2; i++) {
-      int t = logical.indexOf(tgtNames.get(i));
+      final int t = logical.indexOf(tgtNames.get(i));
       fwd[i] = forward[t] < 0 ? -1 : srcNames.indexOf(logical.get(forward[t]));
       fi[i] = fwdIso[t];
-      int r = logical.indexOf(srcNames.get(i));
+      final int r = logical.indexOf(srcNames.get(i));
       bwd[i] = backward[r] < 0 ? -1 : tgtNames.indexOf(logical.get(backward[r]));
       bi[i] = bwdIso[r];
     }

--- a/internal/src/test/java/io/github/eschizoid/telescope/internal/ReflectiveStructuralIsoTest.java
+++ b/internal/src/test/java/io/github/eschizoid/telescope/internal/ReflectiveStructuralIsoTest.java
@@ -128,14 +128,17 @@ class ReflectiveStructuralIsoTest {
     @DisplayName("Beans — round-trip via Object[] populates and reads positional slots")
     void beanRoundTrip() {
       final var iso = Reflective.BEANS.structuralIsoArr(UserPojo.class);
-      final Object[] in = { "bob", 25 };
+      final var names = java.util.List.of(Beans.propertyNames(UserPojo.class));
+      final Object[] in = new Object[2];
+      in[names.indexOf("name")] = "bob";
+      in[names.indexOf("age")] = 25;
       final UserPojo built = iso.to(in);
       assertEquals("bob", built.getName());
       assertEquals(25, built.getAge());
 
       final Object[] out = iso.from(built);
-      assertEquals("bob", out[0]);
-      assertEquals(25, out[1]);
+      assertEquals("bob", out[names.indexOf("name")]);
+      assertEquals(25, out[names.indexOf("age")]);
     }
 
     @Test

--- a/internal/src/test/java/io/github/eschizoid/telescope/internal/ReflectiveStructuralIsoTest.java
+++ b/internal/src/test/java/io/github/eschizoid/telescope/internal/ReflectiveStructuralIsoTest.java
@@ -128,7 +128,7 @@ class ReflectiveStructuralIsoTest {
     @DisplayName("Beans — round-trip via Object[] populates and reads positional slots")
     void beanRoundTrip() {
       final var iso = Reflective.BEANS.structuralIsoArr(UserPojo.class);
-      final var names = java.util.List.of(Beans.propertyNames(UserPojo.class));
+      final var names = List.of(Beans.propertyNames(UserPojo.class));
       final Object[] in = new Object[2];
       in[names.indexOf("name")] = "bob";
       in[names.indexOf("age")] = 25;

--- a/internal/src/test/java/io/github/eschizoid/telescope/internal/UnloadableReference.java
+++ b/internal/src/test/java/io/github/eschizoid/telescope/internal/UnloadableReference.java
@@ -1,0 +1,14 @@
+package io.github.eschizoid.telescope.internal;
+
+import java.io.Serializable;
+import java.util.function.Function;
+
+/** Loaded in an isolated class loader by the cache-lifetime regression test. */
+public final class UnloadableReference {
+
+  private UnloadableReference() {}
+
+  public static Serializable create() {
+    return (Function<String, String> & Serializable) String::trim;
+  }
+}

--- a/internal/src/test/java/io/github/eschizoid/telescope/internal/pairing/PairingRulesTest.java
+++ b/internal/src/test/java/io/github/eschizoid/telescope/internal/pairing/PairingRulesTest.java
@@ -175,6 +175,11 @@ class PairingRulesTest {
     }
 
     @Override
+    public List<Type> typeArgumentsAs(final Type t, final WellKnown supertype) {
+      return delegate.typeArgumentsAs(t, supertype);
+    }
+
+    @Override
     public Type rawType(final Type t) {
       return delegate.rawType(t);
     }

--- a/internal/src/test/java/io/github/eschizoid/telescope/internal/pairing/ReflectionPropsTest.java
+++ b/internal/src/test/java/io/github/eschizoid/telescope/internal/pairing/ReflectionPropsTest.java
@@ -23,6 +23,33 @@ import org.junit.jupiter.api.Test;
  */
 class ReflectionPropsTest {
 
+  static class ArraysOf<E> extends ArrayList<E[]> {
+
+    private static final long serialVersionUID = 1L;
+  }
+
+  static class NestedElements<E> extends ArrayList<List<E>> {
+
+    private static final long serialVersionUID = 1L;
+  }
+
+  record GenericArrays(ArraysOf<String> values) {}
+
+  record NestedStrings(NestedElements<String> values, List<List<String>> expected) {}
+
+  @Test
+  void substitutesArraysAndNestedParameterizedTypesWithStructuralEquality() {
+    final var props = new ReflectionProps();
+    final var arrays = GenericArrays.class.getRecordComponents()[0].getGenericType();
+    assertEquals(List.of(String[].class), props.typeArgumentsAs(arrays, WellKnown.LIST));
+    final var fields = NestedStrings.class.getRecordComponents();
+    final var actual = props.typeArgumentsAs(fields[0].getGenericType(), WellKnown.LIST).getFirst();
+    final var expected = props.typeArguments(fields[1].getGenericType()).getFirst();
+    assertEquals(expected, actual);
+    assertEquals(actual, expected);
+    assertEquals(expected.hashCode(), actual.hashCode());
+  }
+
   public static class Urls extends ArrayList<String> {
 
     @Serial

--- a/scripts/compare-runtime-benchmarks.py
+++ b/scripts/compare-runtime-benchmarks.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Compare matching JMH JSON runs; optionally gate allocation and material latency regressions."""
+
+import argparse
+import json
+import math
+from pathlib import Path
+
+
+def load(path):
+    rows = json.loads(Path(path).read_text())
+    return {
+        (r["benchmark"], tuple(sorted(r.get("params", {}).items()))): r
+        for r in rows
+    }
+
+
+def allocated(row):
+    return next(
+        metric["score"]
+        for name, metric in row["secondaryMetrics"].items()
+        if name.endswith("gc.alloc.rate.norm")
+    )
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("before")
+    parser.add_argument("after")
+    parser.add_argument("--check", action="store_true")
+    args = parser.parse_args()
+    before, after = load(args.before), load(args.after)
+    if before.keys() != after.keys():
+        parser.error("Runs must contain exactly the same benchmark/parameter combinations")
+    failed = []
+    print("| Benchmark | Parameters | Before ns/op | After ns/op | Speedup | Before B/op | After B/op |")
+    print("|---|---|---:|---:|---:|---:|---:|")
+    for key, old in before.items():
+        new = after[key]
+        for setting in ("mode", "forks", "warmupIterations", "warmupTime", "measurementIterations", "measurementTime", "jvmArgs", "jdkVersion"):
+            if old.get(setting) != new.get(setting):
+                parser.error(f"Mismatched {setting} for {key}")
+        a, b = old["primaryMetric"], new["primaryMetric"]
+        if a["scoreUnit"] != "ns/op" or b["scoreUnit"] != "ns/op":
+            parser.error("Expected average-time measurements in ns/op")
+        av, bv = a["score"], b["score"]
+        ab, bb = allocated(old), allocated(new)
+        if not all(math.isfinite(v) for v in (av, bv, ab, bb)):
+            parser.error(f"Non-finite measurement for {key}")
+        label = key[0].split(".")[-2] + "." + key[0].split(".")[-1]
+        params = ", ".join(f"{k}={v}" for k, v in key[1]) or "—"
+        print(f"| {label} | {params} | {av:,.2f} | {bv:,.2f} | {av / bv:.2f}× | {ab:,.0f} | {bb:,.0f} |")
+        # Timing gates require separated 99.9% confidence intervals AND a material delta.
+        # The 2 ns absolute floor avoids treating sub-nanosecond wrapper variation as a regression.
+        separated = b["scoreConfidence"][0] > a["scoreConfidence"][1]
+        if separated and bv - av > max(2.0, av * 0.10):
+            failed.append(f"latency regression: {label} ({params})")
+        if bb - ab > max(8.0, ab * 0.05):
+            failed.append(f"allocation regression: {label} ({params})")
+        if "ContainerAllocationBenchmark" in key[0] and int(new["params"]["size"]) >= 16:
+            if bb >= ab * 0.95:
+                failed.append(f"less than 5% allocation improvement: {label} ({params})")
+    if args.check and failed:
+        parser.exit(1, "\n" + "\n".join(failed) + "\n")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

This change hardens runtime structural mapping and delivers a **92× throughput improvement with 99.7% less allocation** for 4,096-element `CopyOnWriteArrayList` mappings. It fixes correctness gaps in cycle handling, inherited generic containers, sorted-map comparators, and class-loader lifetime; adds regression coverage; and introduces a cardinality-based JMH benchmark plus a comparison gate for future performance claims.


## What was the issue

- Cycle tracking treated every repeated object in a traversal as a cycle. A shared object reached through two sibling branches could map as a value in the first branch and `null` in the second.
- Parameterized container subclasses used their own declared type parameters instead of the parameters of their `List`, `Set`, or `Map` supertype. For example, `StringMap<V> extends HashMap<String, V>` could fail with an `IndexOutOfBoundsException` or infer the wrong key type.
- Sorted-map lifts rebuilt a `TreeMap` without the input comparator, silently changing iteration and ordering semantics.
- Lambda metadata was held in global strong-key maps, which could retain application classes and class loaders.
- Container lifts allocated without input cardinality. `CopyOnWriteArrayList` was especially expensive because every mapped element triggered a backing-array copy.

## The outcome

- Active-path cycle tracking now severs only real back-edges. Shared acyclic references map independently, and tracking is isolated for forward/backward, concurrent, reentrant, and exceptional calls.
- Container generic arguments resolve through inherited supertypes in both runtime mapping and the compile-time verifier.
- Supported sorted maps retain their comparator. Changed sorted-set element types with a custom comparator now produce an explicit `Mapping.via(...)` diagnostic.
- Method-reference metadata uses `ClassValue`, allowing disposable application class loaders to unload.
- Lists, maps, and sets allocate using the source size. Large copy-on-write containers map into a temporary pre-sized collection and perform one bulk copy into the final container; empty and singleton inputs retain the lightweight path.

Measured with JMH 1.36, OpenJDK 25.0.3, Apple M5 Pro, three forks, three warmups, five 500 ms measurements:

| Forward runtime mapping | Before | After |
| --- | ---: | ---: |
| `List`, 4,096 elements | 14,745 ns / 115,824 B | 12,728 ns / 82,008 B |
| `CopyOnWriteArrayList`, 4,096 elements | 1,170,474 ns / 33.7 MB | 12,655 ns / 98 KB |
| `Map`, 4,096 elements | 40,031 ns / 262,336 B | 31,404 ns / 229,488 B |
| `Set`, 4,096 elements | 37,894 ns / 295,136 B | 30,352 ns / 262,288 B |

The full benchmark method, limitations, and reproduction command are in `docs/perf-runtime-collections.md`.

## How to review

Review the commits in this order:

1. `fix: track only active mapper cycles` — cycle-scoped identity tracking in `DeepMap`.
2. `fix: resolve inherited container type arguments` — shared pairing rules plus reflection/compiler adapters.
3. `perf: reduce runtime container allocations` — input-aware allocators and bulk copy-on-write construction.
4. `fix: release cached method-reference classes` — `ClassValue` metadata cache.
5. `test: cover runtime mapper regressions` — cycle, inherited generics, comparators, class unloading, and strategy parity.
6. `test: add runtime allocation benchmark gate` — JMH cardinality benchmark and JSON comparison script.
7. `docs: document runtime mapper semantics and benchmarks` — public semantics and measurement guidance.

Validation completed:

```bash
./gradlew check --no-configuration-cache
```

The JMH comparison script passes for container cardinalities 0, 1, 16, 256, and 4,096, as well as flat, nested, deep runtime mapping and mapper construction:

```bash
python3 scripts/compare-runtime-benchmarks.py before.json after.json --check
```

Co-Authored: Codex + Claude