### PR TITLE
fix(release): publish before the README version-sync commit

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -70,31 +70,6 @@ jobs:
           echo "tagName=$TAG_VERSION" >> "$GITHUB_OUTPUT"
           echo "Releasing $RAW_VERSION (tag $TAG_VERSION)"
 
-      - name: Sync README install snippets to the released version
-        run: |
-          # The README pins the release version in its install snippets; rewrite every
-          # io.github.eschizoid:telescope-* coordinate and the Maven <version> block to the
-          # version just tagged, so the docs never trail the release.
-          VERSION="${{ steps.version.outputs.version }}"
-          for f in README.md docs/codegen.md; do
-            sed -i -E "s/(io\.github\.eschizoid:telescope-[a-z-]+:)[0-9]+\.[0-9]+\.[0-9]+/\1${VERSION}/g" "$f"
-            # XML <version> blocks: only the one directly following a telescope artifactId —
-            # a blanket replace would clobber unrelated pins (the Lombok processor path).
-            awk -v v="$VERSION" '
-              /<artifactId>telescope-/ { tele = 1; print; next }
-              tele && /<version>[0-9]+\.[0-9]+\.[0-9]+<\/version>/ {
-                sub(/<version>[0-9]+\.[0-9]+\.[0-9]+<\/version>/, "<version>" v "</version>")
-                tele = 0; print; next
-              }
-              { tele = 0; print }
-            ' "$f" > "$f.tmp" && mv "$f.tmp" "$f"
-          done
-          if ! git diff --quiet README.md docs/codegen.md; then
-            git add README.md docs/codegen.md
-            git commit -m "docs: bump README install snippets to ${VERSION}"
-            git push
-          fi
-
       - name: Build and publish artifacts
         # Single root `publish` task fans out to every subproject that applies maven-publish.
         # Matches the JReleaser stagingRepository discovery in build.gradle.kts — when a new
@@ -122,3 +97,32 @@ jobs:
         # in gradle.properties with `problems=fail`). Bypass config-cache just for this task —
         # the rest of the build still benefits from it.
         run: ./gradlew jreleaserFullRelease --stacktrace --no-configuration-cache
+
+      - name: Sync README install snippets to the released version
+        run: |
+          # Runs AFTER publishing: this step commits on top of the tagged commit, and
+          # axion-release derives the version from git position — a commit past the tag
+          # computes as next-version-SNAPSHOT, which makes JReleaser disable the Maven
+          # Central deployer and demote the GitHub release to the early-access prerelease.
+          # The README pins the release version in its install snippets; rewrite every
+          # io.github.eschizoid:telescope-* coordinate and the Maven <version> block to the
+          # version just tagged, so the docs never trail the release.
+          VERSION="${{ steps.version.outputs.version }}"
+          for f in README.md docs/codegen.md; do
+            sed -i -E "s/(io\.github\.eschizoid:telescope-[a-z-]+:)[0-9]+\.[0-9]+\.[0-9]+/\1${VERSION}/g" "$f"
+            # XML <version> blocks: only the one directly following a telescope artifactId —
+            # a blanket replace would clobber unrelated pins (the Lombok processor path).
+            awk -v v="$VERSION" '
+              /<artifactId>telescope-/ { tele = 1; print; next }
+              tele && /<version>[0-9]+\.[0-9]+\.[0-9]+<\/version>/ {
+                sub(/<version>[0-9]+\.[0-9]+\.[0-9]+<\/version>/, "<version>" v "</version>")
+                tele = 0; print; next
+              }
+              { tele = 0; print }
+            ' "$f" > "$f.tmp" && mv "$f.tmp" "$f"
+          done
+          if ! git diff --quiet README.md docs/codegen.md; then
+            git add README.md docs/codegen.md
+            git commit -m "docs: bump README install snippets to ${VERSION}"
+            git push
+          fi


### PR DESCRIPTION
Every release since v1.3.0 tagged, bumped the README, and published nothing. Maven Central's latest telescope artifact is still 1.3.0; v1.4.0/v1.5.0/v1.6.0 exist only as git tags, and the README currently pins an install version that does not resolve.

Cause: the README version-sync step (added after v1.3.0) commits on top of the tagged commit **before** the publish steps. axion-release derives the version from git position, so HEAD one commit past `vX.Y.Z` computes as `X.(Y+1).0-SNAPSHOT`. From the v1.6.0 run log:

```
[WARN] Deployer mavenCentral.sonatype disabled because project is snapshot
[INFO] Project version set to 1.7.0-SNAPSHOT
[INFO] Release is snapshot
```

JReleaser's snapshot mode also explains the rolling `early-access` prerelease refreshing on every release run instead of a versioned GitHub release being created.

Fix: run the sync step last, after `jreleaserFullRelease`, so HEAD stays on the tagged commit for the entire publish. The step's inputs (`steps.version.outputs.version`) are unchanged.

v1.6.0 itself will be republished from its tag separately — this PR only prevents the next occurrence.
