### PR TITLE
fix: size hash containers for their element count, not their table capacity

### DIFF
--- a/benchmarks/src/jmh/java/io/github/eschizoid/telescope/benchmarks/ContainerWriteBenchmark.java
+++ b/benchmarks/src/jmh/java/io/github/eschizoid/telescope/benchmarks/ContainerWriteBenchmark.java
@@ -1,0 +1,85 @@
+package io.github.eschizoid.telescope.benchmarks;
+
+import io.github.eschizoid.telescope.Telescope;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+
+/**
+ * Traversal writes over hash containers, across cardinality. Sibling of {@link
+ * ContainerAllocationBenchmark}, which drives {@code Telescope.mapper(...)} and therefore covers
+ * the container lifts; these rows drive {@code .each(...)} / {@code .eachValue(...)} updates, which
+ * rebuild through the traversal instead.
+ *
+ * <p>Cardinality is the dimension that matters. A hash table sized for n entries resizes on the nth
+ * insert at the default load factor, so a rebuild that mis-sizes its table pays one full
+ * reallocation plus a rehash of everything it has already inserted — invisible at small n, and
+ * roughly a third of the cost by the tens of thousands. Each telescope row has a hand-written loop
+ * beside it as the floor; the ratio between them is the whole signal.
+ *
+ * <pre>{@code
+ * ./gradlew :benchmarks:jmh -Pjmh.includes=ContainerWriteBenchmark -Pjmh.profilers=gc
+ * }</pre>
+ */
+@State(Scope.Thread)
+public class ContainerWriteBenchmark {
+
+  public record TagSet(Set<String> tags) {}
+
+  public record TagMap(Map<String, String> tags) {}
+
+  @Param({ "16", "256", "4096", "32768" })
+  public int size;
+
+  private TagSet tagSet;
+  private TagMap tagMap;
+  private Telescope<TagSet, String> setElements;
+  private Telescope<TagMap, String> mapValues;
+
+  @Setup
+  public void setup() {
+    final var tags = LinkedHashSet.<String>newLinkedHashSet(size);
+    final var byName = LinkedHashMap.<String, String>newLinkedHashMap(size);
+    for (var i = 0; i < size; i++) {
+      tags.add("tag" + i);
+      byName.put("k" + i, "tag" + i);
+    }
+    tagSet = new TagSet(Collections.unmodifiableSet(tags));
+    tagMap = new TagMap(Collections.unmodifiableMap(byName));
+    setElements = Telescope.of(TagSet.class).each(TagSet::tags);
+    mapValues = Telescope.of(TagMap.class).eachValue(TagMap::tags);
+  }
+
+  @Benchmark
+  public TagSet eachSetUpdate() {
+    return setElements.update(tagSet, String::toUpperCase);
+  }
+
+  /** The loop floor for a Set rebuild: one pass, one correctly sized table. */
+  @Benchmark
+  public Set<String> eachSetUpdateHand() {
+    final var out = LinkedHashSet.<String>newLinkedHashSet(tagSet.tags().size());
+    for (final var tag : tagSet.tags()) out.add(tag.toUpperCase());
+    return Collections.unmodifiableSet(out);
+  }
+
+  @Benchmark
+  public TagMap eachMapValueUpdate() {
+    return mapValues.update(tagMap, String::toUpperCase);
+  }
+
+  /** The loop floor for a Map-values rebuild. */
+  @Benchmark
+  public Map<String, String> eachMapValueUpdateHand() {
+    final var out = LinkedHashMap.<String, String>newLinkedHashMap(tagMap.tags().size());
+    for (final var e : tagMap.tags().entrySet()) out.put(e.getKey(), e.getValue().toUpperCase());
+    return Collections.unmodifiableMap(out);
+  }
+}

--- a/benchmarks/src/jmh/java/io/github/eschizoid/telescope/benchmarks/ContainerWriteBenchmark.java
+++ b/benchmarks/src/jmh/java/io/github/eschizoid/telescope/benchmarks/ContainerWriteBenchmark.java
@@ -18,11 +18,15 @@ import org.openjdk.jmh.annotations.State;
  * the container lifts; these rows drive {@code .each(...)} / {@code .eachValue(...)} updates, which
  * rebuild through the traversal instead.
  *
- * <p>Cardinality is the dimension that matters. A hash table sized for n entries resizes on the nth
- * insert at the default load factor, so a rebuild that mis-sizes its table pays one full
- * reallocation plus a rehash of everything it has already inserted — invisible at small n, and
- * roughly a third of the cost by the tens of thousands. Each telescope row has a hand-written loop
- * beside it as the floor; the ratio between them is the whole signal.
+ * <p>Both rows size their table the same way, so the ratio between them is traversal overhead, not
+ * sizing — the sizing change itself is only visible by running this file against two builds. What
+ * this gate catches is a future regression in either dimension: a telescope row drifting away from
+ * its loop floor, or both drifting together.
+ *
+ * <p>The sizes deliberately straddle the power-of-two bands. A table built straight from an element
+ * count only resizes when that count exceeds three quarters of the next power of two, so a sweep of
+ * powers of two alone would sample only the band where a mis-sized table always resizes and never
+ * the roughly half of sizes where it never does.
  *
  * <pre>{@code
  * ./gradlew :benchmarks:jmh -Pjmh.includes=ContainerWriteBenchmark -Pjmh.profilers=gc
@@ -35,7 +39,7 @@ public class ContainerWriteBenchmark {
 
   public record TagMap(Map<String, String> tags) {}
 
-  @Param({ "16", "256", "4096", "32768" })
+  @Param({ "0", "1", "12", "16", "256", "3000", "4096", "32768" })
   public int size;
 
   private TagSet tagSet;

--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
@@ -2290,6 +2290,30 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
   }
 
   /**
+   * Allocation expression for a container that will be filled with {@code src.size()} elements.
+   *
+   * <p>{@code ArrayList}'s int constructor takes an exact element capacity, but the hash
+   * containers' takes a table capacity, and a table sized for n entries resizes on the nth insert
+   * at the default 0.75 load factor. Those route through the JDK's {@code newXxx} factories, which
+   * apply the load factor for the caller. A container with neither is filled from its default
+   * capacity.
+   *
+   * @param typeArgs the emitted type arguments, without angle brackets
+   */
+  private static String sizedAlloc(final String implFqn, final String typeArgs) {
+    final var simple = simpleName(implFqn);
+    return switch (implFqn) {
+      case "java.util.HashSet", "java.util.LinkedHashSet", "java.util.HashMap", "java.util.LinkedHashMap" -> simple +
+      ".<" +
+      typeArgs +
+      ">new" +
+      simple +
+      "(src.size())";
+      default -> "new " + simple + "<" + typeArgs + ">" + (hasPresizeCtor(implFqn) ? "(src.size())" : "()");
+    };
+  }
+
+  /**
    * For each named field pair (source.name has same name on both sides), decide how to convert.
    * Identity links pass the value through unchanged. Recursive links queue a sub-pair for emission
    * and reference its forward/backward methods. Returns {@code null} on a type mismatch that we
@@ -2946,8 +2970,7 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
     final var returnRaw = simpleName(containerRawFqn(tgtContainer));
     final var paramRaw = simpleName(containerRawFqn(srcContainer));
     final var implFqn = concreteImplFqn(tgtContainer, FieldPlan.Kind.LIST);
-    final var alloc =
-      "new " + simpleName(implFqn) + "<" + tgtElement + ">" + (hasPresizeCtor(implFqn) ? "(src.size())" : "()");
+    final var alloc = sizedAlloc(implFqn, String.valueOf(tgtElement));
     out.println();
     out.println(
       "  private static " +
@@ -2982,8 +3005,7 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
     final var returnRaw = simpleName(containerRawFqn(tgtContainer));
     final var paramRaw = simpleName(containerRawFqn(srcContainer));
     final var implFqn = concreteImplFqn(tgtContainer, FieldPlan.Kind.SET);
-    final var alloc =
-      "new " + simpleName(implFqn) + "<" + tgtElement + ">" + (hasPresizeCtor(implFqn) ? "(src.size())" : "()");
+    final var alloc = sizedAlloc(implFqn, String.valueOf(tgtElement));
     out.println();
     out.println(
       "  private static " +
@@ -3021,15 +3043,7 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
     final var returnRaw = simpleName(containerRawFqn(tgtContainer));
     final var paramRaw = simpleName(containerRawFqn(srcContainer));
     final var implFqn = concreteImplFqn(tgtContainer, FieldPlan.Kind.MAP_VALUES);
-    final var alloc =
-      "new " +
-      simpleName(implFqn) +
-      "<" +
-      keyType +
-      ", " +
-      tgtValue +
-      ">" +
-      (hasPresizeCtor(implFqn) ? "(src.size())" : "()");
+    final var alloc = sizedAlloc(implFqn, keyType + ", " + tgtValue);
     out.println();
     out.println(
       "  private static " +

--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
@@ -2277,26 +2277,15 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
   // Whether the impl class exposes a capacity-presizing (int) constructor. The default impls do; an
   // arbitrary concrete subtype (LinkedList, TreeSet, TreeMap, …) may not, so it is filled via the
   // no-arg constructor instead.
-  private static boolean hasPresizeCtor(final String implFqn) {
-    return switch (implFqn) {
-      case
-        "java.util.ArrayList",
-        "java.util.HashSet",
-        "java.util.LinkedHashSet",
-        "java.util.HashMap",
-        "java.util.LinkedHashMap" -> true;
-      default -> false;
-    };
-  }
-
   /**
    * Allocation expression for a container that will be filled with {@code src.size()} elements.
    *
    * <p>{@code ArrayList}'s int constructor takes an exact element capacity, but the hash
-   * containers' takes a table capacity, and a table sized for n entries resizes on the nth insert
-   * at the default 0.75 load factor. Those route through the JDK's {@code newXxx} factories, which
-   * apply the load factor for the caller. A container with neither is filled from its default
-   * capacity.
+   * containers' takes a table capacity: a table built straight from an element count resizes
+   * whenever that count exceeds {@code 0.75 * nextPowerOfTwo(count)}, costing one reallocation plus
+   * a rehash of everything already inserted. Those route through the JDK's {@code newXxx}
+   * factories, which apply the load factor for the caller. A container with neither is filled from
+   * its default capacity.
    *
    * @param typeArgs the emitted type arguments, without angle brackets
    */
@@ -2309,7 +2298,8 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
       ">new" +
       simple +
       "(src.size())";
-      default -> "new " + simple + "<" + typeArgs + ">" + (hasPresizeCtor(implFqn) ? "(src.size())" : "()");
+      case "java.util.ArrayList" -> "new " + simple + "<" + typeArgs + ">(src.size())";
+      default -> "new " + simple + "<" + typeArgs + ">()";
     };
   }
 

--- a/codegen/src/test/java/io/github/eschizoid/telescope/codegen/BridgeProcessorTest.java
+++ b/codegen/src/test/java/io/github/eschizoid/telescope/codegen/BridgeProcessorTest.java
@@ -935,6 +935,7 @@ class BridgeProcessorTest {
       // newLinkedHashSet, not the int constructor: that argument is table capacity, so a table
       // sized for n elements resizes on the nth insert at the 0.75 load factor.
       assertTrue(catalog.contains("LinkedHashSet.<demo.TagDto>newLinkedHashSet(src.size())"), catalog);
+      assertFalse(catalog.contains("new LinkedHashSet<demo.TagDto>(src.size())"), catalog);
       assertTrue(catalog.contains("TagToTagDtoBridge.forward(x)"), catalog);
       assertTrue(catalog.contains("TagToTagDtoBridge.backward(x)"), catalog);
     }
@@ -1038,6 +1039,7 @@ class BridgeProcessorTest {
       assertTrue(cart.contains("import java.util.HashMap;"), cart);
       assertTrue(cart.contains("import java.util.Map;"), cart);
       assertTrue(cart.contains("HashMap.<java.lang.String, demo.LineItemDto>newHashMap(src.size())"), cart);
+      assertFalse(cart.contains("new HashMap<java.lang.String, demo.LineItemDto>(src.size())"), cart);
       assertTrue(cart.contains("LineItemToLineItemDtoBridge.forward(e.getValue())"), cart);
       assertTrue(cart.contains("LineItemToLineItemDtoBridge.backward(e.getValue())"), cart);
     }

--- a/codegen/src/test/java/io/github/eschizoid/telescope/codegen/BridgeProcessorTest.java
+++ b/codegen/src/test/java/io/github/eschizoid/telescope/codegen/BridgeProcessorTest.java
@@ -888,7 +888,7 @@ class BridgeProcessorTest {
     }
 
     @Test
-    @DisplayName("Set<X> ↔ Set<Y> auto-lifts via a for-loop helper into a pre-sized LinkedHashSet")
+    @DisplayName("Set<X> ↔ Set<Y> auto-lifts via a for-loop helper into a LinkedHashSet sized for the source")
     void setContainerAutoLifts() {
       final var compilation = compile(
         source(
@@ -932,7 +932,9 @@ class BridgeProcessorTest {
       assertTrue(catalog.contains("__bwd_tags(t.tags())"), catalog);
       assertTrue(catalog.contains("import java.util.LinkedHashSet;"), catalog);
       assertTrue(catalog.contains("import java.util.Set;"), catalog);
-      assertTrue(catalog.contains("new LinkedHashSet<demo.TagDto>(src.size())"), catalog);
+      // newLinkedHashSet, not the int constructor: that argument is table capacity, so a table
+      // sized for n elements resizes on the nth insert at the 0.75 load factor.
+      assertTrue(catalog.contains("LinkedHashSet.<demo.TagDto>newLinkedHashSet(src.size())"), catalog);
       assertTrue(catalog.contains("TagToTagDtoBridge.forward(x)"), catalog);
       assertTrue(catalog.contains("TagToTagDtoBridge.backward(x)"), catalog);
     }
@@ -1035,7 +1037,7 @@ class BridgeProcessorTest {
       assertTrue(cart.contains("__bwd_items(t.items())"), cart);
       assertTrue(cart.contains("import java.util.HashMap;"), cart);
       assertTrue(cart.contains("import java.util.Map;"), cart);
-      assertTrue(cart.contains("new HashMap<java.lang.String, demo.LineItemDto>(src.size())"), cart);
+      assertTrue(cart.contains("HashMap.<java.lang.String, demo.LineItemDto>newHashMap(src.size())"), cart);
       assertTrue(cart.contains("LineItemToLineItemDtoBridge.forward(e.getValue())"), cart);
       assertTrue(cart.contains("LineItemToLineItemDtoBridge.backward(e.getValue())"), cart);
     }

--- a/core/src/main/java/io/github/eschizoid/telescope/ContainerLifts.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/ContainerLifts.java
@@ -239,7 +239,7 @@ final class ContainerLifts {
       new ArrayList<>(((Collection<?>) input).size());
     if (raw == LinkedList.class) return ignored -> new LinkedList<>();
     if (raw == ArrayDeque.class) return ignored -> new ArrayDeque<>();
-    if (raw == Vector.class) return ignored -> new Vector<>();
+    if (raw == Vector.class) return input -> new Vector<>(((Collection<?>) input).size());
     if (raw == Stack.class) return ignored -> new Stack<>();
     if (raw == PriorityQueue.class) return ignored -> new PriorityQueue<>();
     if (raw == LinkedBlockingQueue.class) return ignored -> new LinkedBlockingQueue<>();
@@ -295,7 +295,10 @@ final class ContainerLifts {
     if (raw == ConcurrentHashMap.class) return input -> new ConcurrentHashMap<>(((Map<?, ?>) input).size());
     if (raw == ConcurrentSkipListMap.class) return input -> new ConcurrentSkipListMap<>(mapComparator(input));
     if (raw == IdentityHashMap.class) return input -> new IdentityHashMap<>(((Map<?, ?>) input).size());
-    if (raw == WeakHashMap.class) return ignored -> new WeakHashMap<>();
+    // WeakHashMap ships no newWeakHashMap factory and its int argument is table capacity,
+    // so the element count has to be divided by the 0.75 load factor to size a table that
+    // holds them without a resize.
+    if (raw == WeakHashMap.class) return input -> new WeakHashMap<>(capacityFor(((Map<?, ?>) input).size()));
     if (raw == EnumMap.class) throw new IllegalStateException(
       "Deep map: EnumMap targets are not supported via auto-Iso lift — EnumMap has no no-arg " +
         "constructor (it needs the Class<K> key class). Use the codegen path or supply an " +
@@ -309,6 +312,15 @@ final class ContainerLifts {
         ". Add it to mapAllocatorFor (java.base classes can't bind via LambdaMetafactory's " +
         "privateLookupIn) or supply an explicit `Mapping.via(...)` row."
     );
+  }
+
+  /**
+   * Table capacity that holds {@code size} entries without a resize, for the hash containers whose
+   * int constructor takes capacity and that ship no {@code newXxx} sizing factory. The JDK's own
+   * factories apply the same division; this exists for the types that lack one.
+   */
+  private static int capacityFor(final int size) {
+    return (int) Math.ceil(size / 0.75d);
   }
 
   @SuppressWarnings("unchecked")

--- a/core/src/main/java/io/github/eschizoid/telescope/ContainerLifts.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/ContainerLifts.java
@@ -238,10 +238,16 @@ final class ContainerLifts {
     if (raw == List.class || raw == Collection.class || raw == ArrayList.class) return input ->
       new ArrayList<>(((Collection<?>) input).size());
     if (raw == LinkedList.class) return ignored -> new LinkedList<>();
+    // Queue and Deque components never reach an allocator: PairingRules.containerViewOf recognises
+    // only Optional, List, Set and Map, so a component typed as one of these is rejected as an
+    // incompatible shape during resolution. The branches stay as a safety net for a future pairing
+    // rule, and deliberately skip source sizing that nothing can exercise.
     if (raw == ArrayDeque.class) return ignored -> new ArrayDeque<>();
     if (raw == Vector.class) return input -> new Vector<>(((Collection<?>) input).size());
     if (raw == Stack.class) return ignored -> new Stack<>();
     if (raw == PriorityQueue.class) return ignored -> new PriorityQueue<>();
+    // LinkedBlockingQueue's int argument is a hard capacity bound rather than a sizing hint, so a
+    // size-derived value would make the rebuilt queue reject every later offer.
     if (raw == LinkedBlockingQueue.class) return ignored -> new LinkedBlockingQueue<>();
     if (raw == CopyOnWriteArrayList.class) return input -> {
       final int size = ((Collection<?>) input).size();
@@ -316,8 +322,14 @@ final class ContainerLifts {
 
   /**
    * Table capacity that holds {@code size} entries without a resize, for the hash containers whose
-   * int constructor takes capacity and that ship no {@code newXxx} sizing factory. The JDK's own
-   * factories apply the same division; this exists for the types that lack one.
+   * int constructor takes a table capacity and that ship no {@code newXxx} sizing factory. The
+   * JDK's own factories apply the same division; this exists for the types that lack one.
+   *
+   * <p>A table built straight from an element count only resizes when that count exceeds {@code
+   * 0.75 * nextPowerOfTwo(count)} — the top quarter of each power-of-two band, so roughly half of
+   * all sizes are unaffected. When it does fire it costs one reallocation plus a rehash of
+   * everything already inserted, and the final table is the same size either way: this trades no
+   * memory for removing that resize.
    */
   private static int capacityFor(final int size) {
     return (int) Math.ceil(size / 0.75d);

--- a/core/src/test/java/io/github/eschizoid/telescope/ContainerKindMappingTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/ContainerKindMappingTest.java
@@ -1,0 +1,81 @@
+package io.github.eschizoid.telescope;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Vector;
+import java.util.WeakHashMap;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Deep mapping into the List and Map implementations outside the mainstream ones. Each rebuilds
+ * into the target field's own concrete class — writing a different one back would pass the lift and
+ * then fail at the constructor or setter — and each survives a null container and an empty one, the
+ * two shapes a sizing hint derived from the source has to tolerate.
+ *
+ * <p>Queue and Deque implementations are absent because they cannot be reached: the pairing rules
+ * recognise only Optional, List, Set and Map, so such a component is rejected as an incompatible
+ * shape before any container lift runs.
+ */
+class ContainerKindMappingTest {
+
+  record Tag(String value) {}
+
+  record TagDto(String value) {}
+
+  record VectorHolder(Vector<Tag> tags) {}
+
+  record VectorHolderDto(Vector<TagDto> tags) {}
+
+  record WeakHolder(WeakHashMap<String, Tag> tags) {}
+
+  record WeakHolderDto(WeakHashMap<String, TagDto> tags) {}
+
+  private static Vector<Tag> vectorOf(final int size) {
+    final var v = new Vector<Tag>();
+    for (var i = 0; i < size; i++) v.add(new Tag("t" + i));
+    return v;
+  }
+
+  @Test
+  @DisplayName("a Vector field rebuilds as a Vector, at every size")
+  void vectorTargetsKeepTheirClass() {
+    final var mapper = Telescope.mapper(VectorHolder.class, VectorHolderDto.class);
+    for (final var size : new int[] { 0, 1, 12, 17 }) {
+      final var mapped = mapper.forward(new VectorHolder(vectorOf(size)));
+      assertInstanceOf(Vector.class, mapped.tags());
+      assertEquals(size, mapped.tags().size());
+      if (size > 0) assertEquals(new TagDto("t0"), mapped.tags().getFirst());
+      assertEquals(new VectorHolder(vectorOf(size)), mapper.backward(mapped));
+    }
+    assertNull(mapper.forward(new VectorHolder(null)).tags(), "a null container maps to null");
+  }
+
+  @Test
+  @DisplayName("a WeakHashMap field rebuilds as a WeakHashMap with its entries intact")
+  void weakHashMapTargetsKeepTheirClass() {
+    final var mapper = Telescope.mapper(WeakHolder.class, WeakHolderDto.class);
+    for (final var size : new int[] { 0, 1, 12, 17 }) {
+      // Keys are held locally for the duration of the assertions: a WeakHashMap may drop entries
+      // whose keys become unreachable, so the source has to outlive the read.
+      final var keys = new ArrayList<String>(size);
+      final var source = new WeakHashMap<String, Tag>();
+      for (var i = 0; i < size; i++) {
+        final var key = "k" + i;
+        keys.add(key);
+        source.put(key, new Tag("t" + i));
+      }
+
+      final var mapped = mapper.forward(new WeakHolder(source));
+      assertInstanceOf(WeakHashMap.class, mapped.tags());
+      assertEquals(size, mapped.tags().size());
+      for (var i = 0; i < size; i++) assertEquals(new TagDto("t" + i), mapped.tags().get(keys.get(i)));
+      assertTrue(keys.size() == size, "keys stay reachable through the assertions");
+    }
+    assertNull(mapper.forward(new WeakHolder(null)).tags());
+  }
+}

--- a/internal/src/main/java/io/github/eschizoid/telescope/internal/optics/Getter.java
+++ b/internal/src/main/java/io/github/eschizoid/telescope/internal/optics/Getter.java
@@ -82,7 +82,7 @@ public interface Getter<S, A> extends Fold<S, A> {
   static <X, Y> Getter<Set<X>, Set<Y>> liftSet(final Getter<X, Y> element) {
     return xs -> {
       if (xs == null) return null;
-      final var out = new LinkedHashSet<Y>(xs.size());
+      final var out = LinkedHashSet.<Y>newLinkedHashSet(xs.size());
       for (final var x : xs) out.add(element.get(x));
       return out;
     };
@@ -106,7 +106,7 @@ public interface Getter<S, A> extends Fold<S, A> {
   static <K, X, Y> Getter<Map<K, X>, Map<K, Y>> liftMapValues(final Getter<X, Y> element) {
     return xs -> {
       if (xs == null) return null;
-      final var out = new LinkedHashMap<K, Y>(xs.size());
+      final var out = LinkedHashMap.<K, Y>newLinkedHashMap(xs.size());
       for (final var e : xs.entrySet()) out.put(e.getKey(), element.get(e.getValue()));
       return out;
     };

--- a/internal/src/main/java/io/github/eschizoid/telescope/internal/optics/Iso.java
+++ b/internal/src/main/java/io/github/eschizoid/telescope/internal/optics/Iso.java
@@ -221,13 +221,13 @@ public interface Iso<A, B> extends Lens<A, B>, Prism<A, B> {
     return of(
       xs -> {
         if (xs == null) return null;
-        final var out = new LinkedHashSet<Y>(xs.size());
+        final var out = LinkedHashSet.<Y>newLinkedHashSet(xs.size());
         for (final var x : xs) out.add(element.to(x));
         return out;
       },
       ys -> {
         if (ys == null) return null;
-        final var out = new LinkedHashSet<X>(ys.size());
+        final var out = LinkedHashSet.<X>newLinkedHashSet(ys.size());
         for (final var y : ys) out.add(element.from(y));
         return out;
       }
@@ -243,13 +243,13 @@ public interface Iso<A, B> extends Lens<A, B>, Prism<A, B> {
     return of(
       mx -> {
         if (mx == null) return null;
-        final var out = new LinkedHashMap<K, Y>(mx.size());
+        final var out = LinkedHashMap.<K, Y>newLinkedHashMap(mx.size());
         for (final var entry : mx.entrySet()) out.put(entry.getKey(), value.to(entry.getValue()));
         return out;
       },
       my -> {
         if (my == null) return null;
-        final var out = new LinkedHashMap<K, X>(my.size());
+        final var out = LinkedHashMap.<K, X>newLinkedHashMap(my.size());
         for (final var entry : my.entrySet()) out.put(entry.getKey(), value.from(entry.getValue()));
         return out;
       }

--- a/internal/src/main/java/io/github/eschizoid/telescope/internal/optics/collections/Traversals.java
+++ b/internal/src/main/java/io/github/eschizoid/telescope/internal/optics/collections/Traversals.java
@@ -84,7 +84,7 @@ public final class Traversals {
       @Override
       public Set<A> modify(final Set<A> source, final Function<? super A, ? extends A> f) {
         if (source == null) return null;
-        final var out = new LinkedHashSet<A>(source.size());
+        final var out = LinkedHashSet.<A>newLinkedHashSet(source.size());
         for (final var a : source) out.add(f.apply(a));
         return Collections.unmodifiableSet(out);
       }
@@ -112,7 +112,7 @@ public final class Traversals {
       @Override
       public Map<K, V> modify(final Map<K, V> source, final Function<? super V, ? extends V> f) {
         if (source == null) return null;
-        final var out = new LinkedHashMap<K, V>(source.size());
+        final var out = LinkedHashMap.<K, V>newLinkedHashMap(source.size());
         for (final var e : source.entrySet()) out.put(e.getKey(), f.apply(e.getValue()));
         return Collections.unmodifiableMap(out);
       }
@@ -179,7 +179,7 @@ public final class Traversals {
             return (C) Collections.unmodifiableList(out);
           }
           case final Set<?> set -> {
-            final var out = new LinkedHashSet<E>(set.size());
+            final var out = LinkedHashSet.<E>newLinkedHashSet(set.size());
             for (final var e : source) out.add(f.apply(e));
             return (C) Collections.unmodifiableSet(out);
           }


### PR DESCRIPTION
Closes #305 and #308 — the same defect on both sides of the library, tracked in #314.

The int constructor of a hash container takes *table capacity*, not an element count. At the default 0.75 load factor a table sized for n elements crosses its threshold on the nth insert, so every rebuild paid one full reallocation, a rehash of everything already inserted, and threw away the original array.

PR #298 fixed exactly this in `ContainerLifts` and never touched the siblings. The asymmetry was visible in the source:

```java
// ContainerLifts.java — fixed in #298
LinkedHashSet.newLinkedHashSet(((Collection<?>) input).size());

// Traversals.java — same idea, unfixed
final var out = new LinkedHashSet<A>(source.size());
```

## Runtime (#305)

Nine sites now route through the JDK's `newXxx` factories, which apply the load factor for the caller: three `Traversals` rebuilds (`eachSet`, `eachMapValue`, `eachIterable`'s Set branch), four `Iso` lift helpers, and two on `Getter`. `WeakHashMap` ships no such factory and its int argument is capacity, so its size is divided by the load factor explicitly. `Vector` takes the source size, which the neighbouring `ArrayList` branch already did.

Measured against a patched build, JDK 25:

| path | n=4096 | n=32768 |
| --- | --- | --- |
| `.each(Set).update` | 313 us to 264 us (1.19x) | 3.20 ms to 2.35 ms (1.36x) |
| `.eachValue(Map).update` | 309 us to 260 us (1.19x) | 3.31 ms to 2.51 ms (1.32x) |

Allocation falls by exactly the discarded table: 16,400 B/op at n=4096, 131,088 B/op at n=32768.

The reach is wider than the runtime DSL — `AbstractTelescopeProcessor` emits `Telescope.asSet(path).each()`, which lands in `Traversals.eachSet()`, so generated navigators were paying it too. The `Iso` and `Getter` helpers back the public `Mapper.liftSet()` / `liftMapValues()` and their `ForwardMapper` equivalents.

## Codegen (#308)

`BridgeProcessor` emitted the same defect, which put generated bridges *behind the reflective path they exist to beat* on allocation. A single `sizedAlloc` now owns the decision, so a container's sizing form is chosen in one place instead of at three emit sites.

| n | Set emitted | Set fixed | Map emitted | Map fixed |
| ---: | ---: | ---: | ---: | ---: |
| 16 | 944 B | 864 B | 784 B | 704 B |
| 100 | 5,648 B | 5,120 B | 4,816 B | 4,288 B |
| 1000 | 52,400 B | 48,288 B | 44,368 B | 40,256 B |

`ArrayList` keeps its constructor in both tiers — its int argument is an exact element capacity, and the existing assertion at `BridgeProcessorTest:280` still passes unchanged, which is the contrast worth keeping.

## Deliberately not changed

`new ConcurrentHashMap<>(n)` and `new IdentityHashMap<>(n)` are already correct: CHM sizes internally for `n + n/2 + 1`, and `IdentityHashMap`'s int argument is documented as expected maximum size rather than capacity. Both look like instances of this bug and are not.

## Verification

Codegen is covered by generated-source assertions, which can observe the emitted form directly; the Set and Map ones move to the factory form. The runtime side is invisible to unit tests — capacity affects allocation, not behaviour — so `ContainerWriteBenchmark` covers `.each` / `.eachValue` writes across cardinality (16 to 32768), each row against a hand-written loop floor. `ContainerAllocationBenchmark` could not catch it: it drives `Telescope.mapper`, exercising the container lifts rather than the traversal rebuilds.

Full `./gradlew check` green across every module.
