### PR TITLE
fix: follow-up to #316 — make the container tests gate, scope the comments to the truth

### DIFF
--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
@@ -2274,9 +2274,6 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
     return dot < 0 ? fqn : fqn.substring(dot + 1);
   }
 
-  // Whether the impl class exposes a capacity-presizing (int) constructor. The default impls do; an
-  // arbitrary concrete subtype (LinkedList, TreeSet, TreeMap, …) may not, so it is filled via the
-  // no-arg constructor instead.
   /**
    * Allocation expression for a container that will be filled with {@code src.size()} elements.
    *

--- a/codegen/src/test/java/io/github/eschizoid/telescope/codegen/BridgeProcessorTest.java
+++ b/codegen/src/test/java/io/github/eschizoid/telescope/codegen/BridgeProcessorTest.java
@@ -932,8 +932,9 @@ class BridgeProcessorTest {
       assertTrue(catalog.contains("__bwd_tags(t.tags())"), catalog);
       assertTrue(catalog.contains("import java.util.LinkedHashSet;"), catalog);
       assertTrue(catalog.contains("import java.util.Set;"), catalog);
-      // newLinkedHashSet, not the int constructor: that argument is table capacity, so a table
-      // sized for n elements resizes on the nth insert at the 0.75 load factor.
+      // newLinkedHashSet, not the int constructor: that argument is a table capacity, and a table
+      // built straight from an element count resizes once that count passes three quarters of the
+      // next power of two.
       assertTrue(catalog.contains("LinkedHashSet.<demo.TagDto>newLinkedHashSet(src.size())"), catalog);
       assertFalse(catalog.contains("new LinkedHashSet<demo.TagDto>(src.size())"), catalog);
       assertTrue(catalog.contains("TagToTagDtoBridge.forward(x)"), catalog);

--- a/core/src/main/java/io/github/eschizoid/telescope/ContainerLifts.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/ContainerLifts.java
@@ -238,13 +238,16 @@ final class ContainerLifts {
     if (raw == List.class || raw == Collection.class || raw == ArrayList.class) return input ->
       new ArrayList<>(((Collection<?>) input).size());
     if (raw == LinkedList.class) return ignored -> new LinkedList<>();
-    // Queue and Deque components never reach an allocator: PairingRules.containerViewOf recognises
-    // only Optional, List, Set and Map, so a component typed as one of these is rejected as an
-    // incompatible shape during resolution. The branches stay as a safety net for a future pairing
-    // rule, and deliberately skip source sizing that nothing can exercise.
+    // The next three never reach this method: containerViewOf yields LIST only for List subtypes,
+    // so a Queue- or Deque-typed component either pairs through the raw same-kind copy path (which
+    // allocates via Beans.intermediateAllocator) or is rejected outright when its element types
+    // differ. They stay as a safety net for a future pairing rule, unsized because nothing can
+    // exercise the sizing. Vector and Stack below are List subtypes and are fully reachable.
     if (raw == ArrayDeque.class) return ignored -> new ArrayDeque<>();
     if (raw == Vector.class) return input -> new Vector<>(((Collection<?>) input).size());
     if (raw == Stack.class) return ignored -> new Stack<>();
+    // PriorityQueue rejects a zero initial capacity outright, so a size-derived argument would
+    // throw on an empty source.
     if (raw == PriorityQueue.class) return ignored -> new PriorityQueue<>();
     // LinkedBlockingQueue's int argument is a hard capacity bound rather than a sizing hint, so a
     // size-derived value would make the rebuilt queue reject every later offer.
@@ -331,7 +334,7 @@ final class ContainerLifts {
    * everything already inserted, and the final table is the same size either way: this trades no
    * memory for removing that resize.
    */
-  private static int capacityFor(final int size) {
+  static int capacityFor(final int size) {
     return (int) Math.ceil(size / 0.75d);
   }
 

--- a/core/src/test/java/io/github/eschizoid/telescope/ContainerKindMappingTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/ContainerKindMappingTest.java
@@ -3,8 +3,8 @@ package io.github.eschizoid.telescope;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.lang.ref.Reference;
 import java.util.ArrayList;
 import java.util.Vector;
 import java.util.WeakHashMap;
@@ -17,9 +17,9 @@ import org.junit.jupiter.api.Test;
  * then fail at the constructor or setter — and each survives a null container and an empty one, the
  * two shapes a sizing hint derived from the source has to tolerate.
  *
- * <p>Queue and Deque implementations are absent because they cannot be reached: the pairing rules
- * recognise only Optional, List, Set and Map, so such a component is rejected as an incompatible
- * shape before any container lift runs.
+ * <p>Queue and Deque implementations are absent because the sized allocators never see them: a
+ * container view is derived as LIST only for List subtypes, so those components either take the raw
+ * same-kind copy path or are rejected outright when their element types differ.
  */
 class ContainerKindMappingTest {
 
@@ -49,6 +49,9 @@ class ContainerKindMappingTest {
       final var mapped = mapper.forward(new VectorHolder(vectorOf(size)));
       assertInstanceOf(Vector.class, mapped.tags());
       assertEquals(size, mapped.tags().size());
+      // capacity, not size, is what distinguishes a source-sized rebuild from a default-capacity
+      // one: the no-arg constructor starts at ten and doubles, so it reports 10 or 20 here.
+      assertEquals(size, mapped.tags().capacity(), "the rebuilt Vector is sized from its source");
       if (size > 0) assertEquals(new TagDto("t0"), mapped.tags().getFirst());
       assertEquals(new VectorHolder(vectorOf(size)), mapper.backward(mapped));
     }
@@ -74,8 +77,26 @@ class ContainerKindMappingTest {
       assertInstanceOf(WeakHashMap.class, mapped.tags());
       assertEquals(size, mapped.tags().size());
       for (var i = 0; i < size; i++) assertEquals(new TagDto("t" + i), mapped.tags().get(keys.get(i)));
-      assertTrue(keys.size() == size, "keys stay reachable through the assertions");
+      Reference.reachabilityFence(keys);
     }
     assertNull(mapper.forward(new WeakHolder(null)).tags());
+  }
+
+  @Test
+  @DisplayName("capacityFor sizes a table that holds its element count without resizing")
+  void capacityForHoldsItsElementCount() {
+    // The containers this backs take a table capacity, so the count has to be divided by the load
+    // factor: a table given the count itself resizes once the count passes three quarters of the
+    // next power of two.
+    assertEquals(0, ContainerLifts.capacityFor(0));
+    assertEquals(2, ContainerLifts.capacityFor(1));
+    assertEquals(16, ContainerLifts.capacityFor(12));
+    assertEquals(23, ContainerLifts.capacityFor(17));
+
+    for (final var count : new int[] { 1, 12, 13, 16, 17, 100, 1000 }) {
+      final var table = new WeakHashMap<Integer, Integer>(ContainerLifts.capacityFor(count));
+      for (var i = 0; i < count; i++) table.put(i, i);
+      assertEquals(count, table.size(), "every entry survives the fill at count " + count);
+    }
   }
 }


### PR DESCRIPTION
Follow-up to #316, which merged while its second review round was still in flight — these are that round's fixes, cherry-picked onto main.

The substance, from an adversarial verification pass that checked whether the new tests could actually fail:

- **`ContainerKindMappingTest` was not a gate.** Reverting both changed `ContainerLifts` allocators left it green, since size, contents, and runtime class hold either way. The Vector case now asserts `capacity()` — a sized rebuild reports the element count, the no-arg constructor reports 10 or 20 — and fails on a revert (verified by reverting). `WeakHashMap` exposes no capacity, so `capacityFor` is package-private and pinned directly, including a fill loop proving no entry is lost at the sizes where a mis-sized table would resize.
- **The corrected resize rationale had a fourth home** in `BridgeProcessorTest` still carrying the wrong "resizes on the nth insert" claim. Now consistent with the other three sites.
- **The deleted `hasPresizeCtor` left its comment behind**, sitting above `sizedAlloc` describing a different method. A maintainer following it could add a container to the hash case and emit a `newXxx` factory that does not exist — which ships green, because the processor harness parses generated sources without compiling them.
- **The Queue/Deque comment was over-broad and partly wrong.** Those components do reach mapping (via the raw same-kind copy path); they never reach `listAllocatorFor`, which is the narrower true claim. The comment also sat above `Vector` and `Stack`, both List subtypes and fully reachable — a reader would have taken the sized `Vector` branch for dead code. `PriorityQueue` now records the real reason it stays unsized: it rejects a zero initial capacity, so a size-derived argument would throw on an empty source.

No behaviour changes beyond the comment/test corrections; the allocator lines themselves merged in #316.
