### PR TITLE
perf(core): bind into()'s accessors once per mapper

### DIFF
--- a/benchmarks/src/jmh/java/io/github/eschizoid/telescope/benchmarks/IntoBenchmark.java
+++ b/benchmarks/src/jmh/java/io/github/eschizoid/telescope/benchmarks/IntoBenchmark.java
@@ -1,0 +1,369 @@
+package io.github.eschizoid.telescope.benchmarks;
+
+import io.github.eschizoid.telescope.Telescope;
+import io.github.eschizoid.telescope.conversion.Mapper;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+
+/**
+ * {@code Mapper.into(target, source)} against {@code forward(source)} on the same pair. Both walk
+ * the same fields; {@code into} additionally reads each produced value back and writes it onto a
+ * caller-supplied target, so it should cost a constant multiple of {@code forward} and scale the
+ * same way with property count. A ratio that grows with arity means per-property work that belongs
+ * at bind time is being redone per call.
+ *
+ * <pre>{@code
+ * ./gradlew :benchmarks:jmh -Pjmh.includes=IntoBenchmark -Pjmh.profilers=gc
+ * }</pre>
+ */
+@State(Scope.Thread)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+public class IntoBenchmark {
+
+  /** Five-property bean; the twenty-property shape is {@link IntoWide}. */
+  public static class IntoNarrow {
+
+    private String a;
+    private String b;
+    private String c;
+    private String d;
+    private String e;
+
+    public String getA() {
+      return a;
+    }
+
+    public void setA(final String a) {
+      this.a = a;
+    }
+
+    public String getB() {
+      return b;
+    }
+
+    public void setB(final String b) {
+      this.b = b;
+    }
+
+    public String getC() {
+      return c;
+    }
+
+    public void setC(final String c) {
+      this.c = c;
+    }
+
+    public String getD() {
+      return d;
+    }
+
+    public void setD(final String d) {
+      this.d = d;
+    }
+
+    public String getE() {
+      return e;
+    }
+
+    public void setE(final String e) {
+      this.e = e;
+    }
+  }
+
+  public record NarrowRec(String a, String b, String c, String d, String e) {}
+
+  /** Twenty-property bean: the arity at which per-property rebinding becomes visible. */
+  public static class IntoWide {
+
+    private String f0;
+
+    public String getF0() {
+      return f0;
+    }
+
+    public void setF0(final String f0) {
+      this.f0 = f0;
+    }
+
+    private String f1;
+
+    public String getF1() {
+      return f1;
+    }
+
+    public void setF1(final String f1) {
+      this.f1 = f1;
+    }
+
+    private String f2;
+
+    public String getF2() {
+      return f2;
+    }
+
+    public void setF2(final String f2) {
+      this.f2 = f2;
+    }
+
+    private String f3;
+
+    public String getF3() {
+      return f3;
+    }
+
+    public void setF3(final String f3) {
+      this.f3 = f3;
+    }
+
+    private String f4;
+
+    public String getF4() {
+      return f4;
+    }
+
+    public void setF4(final String f4) {
+      this.f4 = f4;
+    }
+
+    private String f5;
+
+    public String getF5() {
+      return f5;
+    }
+
+    public void setF5(final String f5) {
+      this.f5 = f5;
+    }
+
+    private String f6;
+
+    public String getF6() {
+      return f6;
+    }
+
+    public void setF6(final String f6) {
+      this.f6 = f6;
+    }
+
+    private String f7;
+
+    public String getF7() {
+      return f7;
+    }
+
+    public void setF7(final String f7) {
+      this.f7 = f7;
+    }
+
+    private String f8;
+
+    public String getF8() {
+      return f8;
+    }
+
+    public void setF8(final String f8) {
+      this.f8 = f8;
+    }
+
+    private String f9;
+
+    public String getF9() {
+      return f9;
+    }
+
+    public void setF9(final String f9) {
+      this.f9 = f9;
+    }
+
+    private String f10;
+
+    public String getF10() {
+      return f10;
+    }
+
+    public void setF10(final String f10) {
+      this.f10 = f10;
+    }
+
+    private String f11;
+
+    public String getF11() {
+      return f11;
+    }
+
+    public void setF11(final String f11) {
+      this.f11 = f11;
+    }
+
+    private String f12;
+
+    public String getF12() {
+      return f12;
+    }
+
+    public void setF12(final String f12) {
+      this.f12 = f12;
+    }
+
+    private String f13;
+
+    public String getF13() {
+      return f13;
+    }
+
+    public void setF13(final String f13) {
+      this.f13 = f13;
+    }
+
+    private String f14;
+
+    public String getF14() {
+      return f14;
+    }
+
+    public void setF14(final String f14) {
+      this.f14 = f14;
+    }
+
+    private String f15;
+
+    public String getF15() {
+      return f15;
+    }
+
+    public void setF15(final String f15) {
+      this.f15 = f15;
+    }
+
+    private String f16;
+
+    public String getF16() {
+      return f16;
+    }
+
+    public void setF16(final String f16) {
+      this.f16 = f16;
+    }
+
+    private String f17;
+
+    public String getF17() {
+      return f17;
+    }
+
+    public void setF17(final String f17) {
+      this.f17 = f17;
+    }
+
+    private String f18;
+
+    public String getF18() {
+      return f18;
+    }
+
+    public void setF18(final String f18) {
+      this.f18 = f18;
+    }
+
+    private String f19;
+
+    public String getF19() {
+      return f19;
+    }
+
+    public void setF19(final String f19) {
+      this.f19 = f19;
+    }
+  }
+
+  public record WideRec(
+    String f0,
+    String f1,
+    String f2,
+    String f3,
+    String f4,
+    String f5,
+    String f6,
+    String f7,
+    String f8,
+    String f9,
+    String f10,
+    String f11,
+    String f12,
+    String f13,
+    String f14,
+    String f15,
+    String f16,
+    String f17,
+    String f18,
+    String f19
+  ) {}
+
+  private Mapper<NarrowRec, IntoNarrow> narrow;
+  private NarrowRec narrowSource;
+  private IntoNarrow narrowTarget;
+  private Mapper<WideRec, IntoWide> wide;
+  private WideRec wideSource;
+  private IntoWide wideTarget;
+
+  @Setup
+  public void setup() {
+    narrow = Telescope.mapper(NarrowRec.class, IntoNarrow.class);
+    narrowSource = new NarrowRec("a", "b", "c", "d", "e");
+    narrowTarget = new IntoNarrow();
+    narrow.into(narrowTarget, narrowSource);
+
+    wide = Telescope.mapper(WideRec.class, IntoWide.class);
+    wideSource = new WideRec(
+      "f0",
+      "f1",
+      "f2",
+      "f3",
+      "f4",
+      "f5",
+      "f6",
+      "f7",
+      "f8",
+      "f9",
+      "f10",
+      "f11",
+      "f12",
+      "f13",
+      "f14",
+      "f15",
+      "f16",
+      "f17",
+      "f18",
+      "f19"
+    );
+    wideTarget = new IntoWide();
+    wide.into(wideTarget, wideSource);
+  }
+
+  @Benchmark
+  public IntoNarrow forwardOnly() {
+    return narrow.forward(narrowSource);
+  }
+
+  @Benchmark
+  public IntoNarrow intoExisting() {
+    return narrow.into(narrowTarget, narrowSource);
+  }
+
+  @Benchmark
+  public IntoWide forwardOnlyWide() {
+    return wide.forward(wideSource);
+  }
+
+  @Benchmark
+  public IntoWide intoExistingWide() {
+    return wide.into(wideTarget, wideSource);
+  }
+}


### PR DESCRIPTION
Closes #306, from the audit tracked in #314.

`Mapper.into` resolved a reader **and** a writer for every property on every call, though both are constant once the mapper exists: the target class is fixed and the patch table's keys are fixed. Each property paid two proxy unwraps, two `ClassValue` probes, a name→reader lookup and a `computeIfAbsent` — per call, for work whose inputs never change.

## Measured, CI A/B

Both branches carry the identical benchmark; the baseline runs it against the pre-fix implementation, so the comparison isolates the change. Two forks, 3 warmup, 5×2s, `gc` profiler.

| benchmark | before | after | | B/op before | after |
| --- | ---: | ---: | ---: | ---: | ---: |
| `intoExisting` (5 properties) | 185.7 ns | 51.3 ns | **3.6×** | 448 | **72** |
| `intoExistingWide` (20 properties) | 763.1 ns | 144.7 ns | **5.3×** | 1,448 | **192** |
| `forwardOnly` (control) | 7.2 ns | 7.5 ns | 0.96× | 32 | 32 |
| `forwardOnlyWide` (control) | 15.0 ns | 16.0 ns | 0.94× | 96 | 96 |

The `forward` controls are unchanged, which is what makes the rest trustworthy: both runs landed on comparable hardware, so no normalisation is being applied.

The scaling signature is the real evidence. `into` does a bounded multiple of `forward`'s work, so their ratio should be roughly flat in property count:

| | 5 properties | 20 properties | growth |
| --- | ---: | ---: | ---: |
| before | 25.8× | 51.0× | **1.98×** |
| after | 6.8× | 9.1× | 1.32× |

Before, quadrupling the property count doubled the ratio — per-property work being redone per call. After, the ratio is close to flat; the residual 1.32× is the genuine per-property read and write.

## Change

The reader/writer pair binds once into a slot array on first use. Two decisions worth stating:

- **Lazy, not eager.** A mapper whose target has no setters is legal as long as nobody calls `into()`; binding at construction would reject it at build time. The race between two first callers is benign — both produce equivalent arrays.
- **The documented two-phase apply is preserved verbatim.** `into`'s contract stages every read before any write so a read that throws leaves the target untouched. Same order, same guarantee, now over an `Object[]` rather than a per-call `LinkedHashMap` — which is most of the allocation drop.

`Beans` gains `capturedWriter`, the write-side sibling of the existing `capturedReader`, binding to the declared class for the reason that method already documents: a proxy subclass still writes correctly through virtual dispatch, and the invoker cache stays one entry per declared class instead of one per proxy subclass.

## Coverage

No new behavioural test: `into`'s semantics are unchanged and already covered — the existing suite exercises the patch-table scoping, the record-target rejection, the merge-mapper `UnsupportedOperationException`, and the two-phase staging. The property this PR adds is a performance one, and `IntoBenchmark`'s ratio rows are its gate.
