### PR TITLE
perf(codegen): hoist each navigator hop's lens and trail node to statics

### DIFF
--- a/benchmarks/src/jmh/java/io/github/eschizoid/telescope/benchmarks/NavigatorBuildBenchmark.java
+++ b/benchmarks/src/jmh/java/io/github/eschizoid/telescope/benchmarks/NavigatorBuildBenchmark.java
@@ -1,0 +1,66 @@
+package io.github.eschizoid.telescope.benchmarks;
+
+import io.github.eschizoid.telescope.Telescope;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+
+/**
+ * Building a generated navigator path at the call site, which is the idiom the codegen docs show.
+ * The existing navigator rows measure a path built once in setup, so nothing covered what a hop
+ * costs to construct — the dimension where a per-call lens rebuild hides.
+ *
+ * <p>{@code prebuiltRead} is the floor: the same path, constructed once. The gap between it and the
+ * inline rows is construction, and it should be the composition itself rather than the lens, whose
+ * inputs are constant for a field.
+ *
+ * <pre>{@code
+ * ./gradlew :benchmarks:jmh -Pjmh.includes=NavigatorBuildBenchmark -Pjmh.profilers=gc
+ * }</pre>
+ */
+@State(Scope.Thread)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+public class NavigatorBuildBenchmark {
+
+  private BenchHolderSrc source;
+  private Telescope<BenchHolderSrc, String> prebuiltCity;
+
+  @Setup
+  public void setup() {
+    source = new BenchHolderSrc(
+      "acme",
+      new BenchHolderDeptSrc("eng", 12, new BenchHolderAddressSrc("austin", "78701"))
+    );
+    prebuiltCity = BenchHolderSrcTelescope.of().department().address().city();
+  }
+
+  /** One hop, built inline. */
+  @Benchmark
+  public Object buildOneHop() {
+    return BenchHolderSrcTelescope.of().name();
+  }
+
+  /** Three hops, built inline — the shape the docs show at a call site. */
+  @Benchmark
+  public Object buildThreeHops() {
+    return BenchHolderSrcTelescope.of().department().address().city();
+  }
+
+  /** Build and read, the whole call-site idiom. */
+  @Benchmark
+  public String buildThreeHopsAndRead() {
+    return BenchHolderSrcTelescope.of().department().address().city().read(source);
+  }
+
+  /** The floor: same read, path constructed once. */
+  @Benchmark
+  public String prebuiltRead() {
+    return prebuiltCity.read(source);
+  }
+}


### PR DESCRIPTION
Closes #307, from the audit tracked in #314.

A generated navigator hop rebuilt its lens on every call, though the lens is constant for a field — the same accessor pair, re-decoded through the `SerializedLambda` cache each time, plus a fresh `OpticNode.Focus` alongside it. The documented idiom builds these paths inline at the call site (`docs/codegen.md`, `README.md`), so this was per-operation cost rather than setup.

Both are class-init statics now:

```java
private static final Telescope<FocusEntity, String> __lens_id = Telescope.lens(FocusEntity::id, ...);
private static final OpticNode __focus_id = new OpticNode.Focus("id");
```

A hop then allocates only what composition genuinely needs.

## Measured, CI A/B

Both branches carry the identical benchmark; the baseline runs it against the pre-hoist emitter.

**Allocation is the trustworthy half** — it is deterministic, and the control confirms it:

| benchmark | before | after | saved |
| --- | ---: | ---: | ---: |
| `buildOneHop` | 232 B/op | 152 B/op | 80 B |
| `buildThreeHops` | 780 B/op | 600 B/op | 180 B |
| `buildThreeHopsAndRead` | 912 B/op | 712 B/op | 200 B |
| `prebuiltRead` (control) | 112 B/op | 112 B/op | **unchanged** |

The control builds nothing, so it should not move, and it does not. Roughly 60 B per hop stops being allocated.

**Timing needs a caveat.** The same control moved 1.20× on wall time, which it cannot have earned — it reads a path constructed in `@Setup`, identical on both branches. So the two runs did not land on equal-speed hardware, and the raw ratios (2.43× one-hop, 1.49× three-hop) are inflated by roughly that factor. Normalised against the control: about **2× on a one-hop build** and **1.2–1.25× on three hops**. I would rather state the smaller normalised figure than a raw number the control contradicts.

## Why not the FieldOptics holder

The issue proposed referencing the generated holder's constant, which would have been a smaller diff. It does not hold: the bean holder bails for an entire type when any property type is un-emittable as a typed constant — its own comment notes "the Path navigator is unaffected — it has its own type handling." A navigator can therefore outlive its holder, and referencing one would emit code that fails to compile for exactly those types. Each navigator carrying its own statics costs one extra `Telescope` instance per field at class-init and works for records, beans, and Lombok alike.

## Coverage

`NavigatorBuildBenchmark` measures path construction, which nothing did — the existing navigator rows build in `@Setup` and measure only traversal, which is precisely why a per-call lens rebuild could hide there. It carries a `prebuiltRead` floor so construction cost is separable, and that floor is what exposed the hardware skew above.

Behaviour is unchanged and already covered: `:core`, `:codegen`, `:internal` and `:lombok` suites all pass, including the generated-navigator tests that compile and run real emitted code.
