### PR TITLE
perf(core): bind into()'s accessors once per mapper

### DIFF
--- a/benchmarks/src/jmh/java/io/github/eschizoid/telescope/benchmarks/IntoBenchmark.java
+++ b/benchmarks/src/jmh/java/io/github/eschizoid/telescope/benchmarks/IntoBenchmark.java
@@ -1,0 +1,369 @@
+package io.github.eschizoid.telescope.benchmarks;
+
+import io.github.eschizoid.telescope.Telescope;
+import io.github.eschizoid.telescope.conversion.Mapper;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+
+/**
+ * {@code Mapper.into(target, source)} against {@code forward(source)} on the same pair. Both walk
+ * the same fields; {@code into} additionally reads each produced value back and writes it onto a
+ * caller-supplied target, so it should cost a constant multiple of {@code forward} and scale the
+ * same way with property count. A ratio that grows with arity means per-property work that belongs
+ * at bind time is being redone per call.
+ *
+ * <pre>{@code
+ * ./gradlew :benchmarks:jmh -Pjmh.includes=IntoBenchmark -Pjmh.profilers=gc
+ * }</pre>
+ */
+@State(Scope.Thread)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+public class IntoBenchmark {
+
+  /** Five-property bean; the twenty-property shape is {@link IntoWide}. */
+  public static class IntoNarrow {
+
+    private String a;
+    private String b;
+    private String c;
+    private String d;
+    private String e;
+
+    public String getA() {
+      return a;
+    }
+
+    public void setA(final String a) {
+      this.a = a;
+    }
+
+    public String getB() {
+      return b;
+    }
+
+    public void setB(final String b) {
+      this.b = b;
+    }
+
+    public String getC() {
+      return c;
+    }
+
+    public void setC(final String c) {
+      this.c = c;
+    }
+
+    public String getD() {
+      return d;
+    }
+
+    public void setD(final String d) {
+      this.d = d;
+    }
+
+    public String getE() {
+      return e;
+    }
+
+    public void setE(final String e) {
+      this.e = e;
+    }
+  }
+
+  public record NarrowRec(String a, String b, String c, String d, String e) {}
+
+  /** Twenty-property bean: the arity at which per-property rebinding becomes visible. */
+  public static class IntoWide {
+
+    private String f0;
+
+    public String getF0() {
+      return f0;
+    }
+
+    public void setF0(final String f0) {
+      this.f0 = f0;
+    }
+
+    private String f1;
+
+    public String getF1() {
+      return f1;
+    }
+
+    public void setF1(final String f1) {
+      this.f1 = f1;
+    }
+
+    private String f2;
+
+    public String getF2() {
+      return f2;
+    }
+
+    public void setF2(final String f2) {
+      this.f2 = f2;
+    }
+
+    private String f3;
+
+    public String getF3() {
+      return f3;
+    }
+
+    public void setF3(final String f3) {
+      this.f3 = f3;
+    }
+
+    private String f4;
+
+    public String getF4() {
+      return f4;
+    }
+
+    public void setF4(final String f4) {
+      this.f4 = f4;
+    }
+
+    private String f5;
+
+    public String getF5() {
+      return f5;
+    }
+
+    public void setF5(final String f5) {
+      this.f5 = f5;
+    }
+
+    private String f6;
+
+    public String getF6() {
+      return f6;
+    }
+
+    public void setF6(final String f6) {
+      this.f6 = f6;
+    }
+
+    private String f7;
+
+    public String getF7() {
+      return f7;
+    }
+
+    public void setF7(final String f7) {
+      this.f7 = f7;
+    }
+
+    private String f8;
+
+    public String getF8() {
+      return f8;
+    }
+
+    public void setF8(final String f8) {
+      this.f8 = f8;
+    }
+
+    private String f9;
+
+    public String getF9() {
+      return f9;
+    }
+
+    public void setF9(final String f9) {
+      this.f9 = f9;
+    }
+
+    private String f10;
+
+    public String getF10() {
+      return f10;
+    }
+
+    public void setF10(final String f10) {
+      this.f10 = f10;
+    }
+
+    private String f11;
+
+    public String getF11() {
+      return f11;
+    }
+
+    public void setF11(final String f11) {
+      this.f11 = f11;
+    }
+
+    private String f12;
+
+    public String getF12() {
+      return f12;
+    }
+
+    public void setF12(final String f12) {
+      this.f12 = f12;
+    }
+
+    private String f13;
+
+    public String getF13() {
+      return f13;
+    }
+
+    public void setF13(final String f13) {
+      this.f13 = f13;
+    }
+
+    private String f14;
+
+    public String getF14() {
+      return f14;
+    }
+
+    public void setF14(final String f14) {
+      this.f14 = f14;
+    }
+
+    private String f15;
+
+    public String getF15() {
+      return f15;
+    }
+
+    public void setF15(final String f15) {
+      this.f15 = f15;
+    }
+
+    private String f16;
+
+    public String getF16() {
+      return f16;
+    }
+
+    public void setF16(final String f16) {
+      this.f16 = f16;
+    }
+
+    private String f17;
+
+    public String getF17() {
+      return f17;
+    }
+
+    public void setF17(final String f17) {
+      this.f17 = f17;
+    }
+
+    private String f18;
+
+    public String getF18() {
+      return f18;
+    }
+
+    public void setF18(final String f18) {
+      this.f18 = f18;
+    }
+
+    private String f19;
+
+    public String getF19() {
+      return f19;
+    }
+
+    public void setF19(final String f19) {
+      this.f19 = f19;
+    }
+  }
+
+  public record WideRec(
+    String f0,
+    String f1,
+    String f2,
+    String f3,
+    String f4,
+    String f5,
+    String f6,
+    String f7,
+    String f8,
+    String f9,
+    String f10,
+    String f11,
+    String f12,
+    String f13,
+    String f14,
+    String f15,
+    String f16,
+    String f17,
+    String f18,
+    String f19
+  ) {}
+
+  private Mapper<NarrowRec, IntoNarrow> narrow;
+  private NarrowRec narrowSource;
+  private IntoNarrow narrowTarget;
+  private Mapper<WideRec, IntoWide> wide;
+  private WideRec wideSource;
+  private IntoWide wideTarget;
+
+  @Setup
+  public void setup() {
+    narrow = Telescope.mapper(NarrowRec.class, IntoNarrow.class);
+    narrowSource = new NarrowRec("a", "b", "c", "d", "e");
+    narrowTarget = new IntoNarrow();
+    narrow.into(narrowTarget, narrowSource);
+
+    wide = Telescope.mapper(WideRec.class, IntoWide.class);
+    wideSource = new WideRec(
+      "f0",
+      "f1",
+      "f2",
+      "f3",
+      "f4",
+      "f5",
+      "f6",
+      "f7",
+      "f8",
+      "f9",
+      "f10",
+      "f11",
+      "f12",
+      "f13",
+      "f14",
+      "f15",
+      "f16",
+      "f17",
+      "f18",
+      "f19"
+    );
+    wideTarget = new IntoWide();
+    wide.into(wideTarget, wideSource);
+  }
+
+  @Benchmark
+  public IntoNarrow forwardOnly() {
+    return narrow.forward(narrowSource);
+  }
+
+  @Benchmark
+  public IntoNarrow intoExisting() {
+    return narrow.into(narrowTarget, narrowSource);
+  }
+
+  @Benchmark
+  public IntoWide forwardOnlyWide() {
+    return wide.forward(wideSource);
+  }
+
+  @Benchmark
+  public IntoWide intoExistingWide() {
+    return wide.into(wideTarget, wideSource);
+  }
+}

--- a/core/src/main/java/io/github/eschizoid/telescope/conversion/Mapper.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/conversion/Mapper.java
@@ -11,11 +11,11 @@ import io.github.eschizoid.telescope.mapping.MapStep;
 import java.lang.System.Logger;
 import java.lang.System.Logger.Level;
 import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
@@ -50,6 +50,7 @@ public final class Mapper<A, B> {
   private final Class<B> targetClass;
   private final Reflective sourceRefl;
   private final Reflective targetRefl;
+  private volatile IntoSlot[] intoSlots;
   private final Map<String, PatchEntry> patchByTargetField;
   // Folded hook chains — null = no hook. Composed by repeated calls to before*/after*. Each side
   // is a single Function/BiFunction reference at call time so HotSpot stays monomorphic regardless
@@ -456,14 +457,38 @@ public final class Mapper<A, B> {
       "This mapper does not support into() — Telescope.merge produces a forward-only mapper " +
         "(the multi-source case has no general inverse). Use Mapper.forward(...) only."
     );
-    final var staged = new LinkedHashMap<String, Object>(patchByTargetField.size());
-    for (final var name : patchByTargetField.keySet()) {
-      staged.put(name, targetRefl.read(produced, name));
-    }
-    for (final var e : staged.entrySet()) {
-      Beans.writeBeanProperty(target, e.getKey(), e.getValue());
-    }
+    final var slots = intoSlots();
+    final var staged = new Object[slots.length];
+    for (var i = 0; i < slots.length; i++) staged[i] = slots[i].read().apply(produced);
+    for (var i = 0; i < slots.length; i++) slots[i].write().accept(target, staged[i]);
     return target;
+  }
+
+  /** One target property's bound accessor pair, resolved once per mapper. */
+  private record IntoSlot(Function<Object, Object> read, BiConsumer<Object, Object> write) {}
+
+  /**
+   * The bound accessor pair for every property {@link #into} writes. Both sides are constant once
+   * the mapper exists — the target class is fixed and the patch table's keys are fixed — so
+   * resolving them per property per call re-paid two proxy unwraps, two {@code ClassValue} probes
+   * and two name lookups for work whose inputs never change.
+   *
+   * <p>Resolved on first use rather than at construction: a mapper whose target has no setters is
+   * legal as long as nobody calls {@code into}, and binding eagerly would reject it at build time.
+   * The race between two first callers is benign — both produce equivalent arrays, and publishing
+   * either is correct.
+   */
+  private IntoSlot[] intoSlots() {
+    final var cached = intoSlots;
+    if (cached != null) return cached;
+    final var names = patchByTargetField.keySet();
+    final var built = new IntoSlot[names.size()];
+    var i = 0;
+    for (final var name : names) {
+      built[i++] = new IntoSlot(Beans.capturedReader(targetClass, name), Beans.capturedWriter(targetClass, name));
+    }
+    intoSlots = built;
+    return built;
   }
 
   /** Backward conversion {@code B → A}. See {@link #forward(Object)}. */

--- a/core/src/main/java/io/github/eschizoid/telescope/conversion/Mapper.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/conversion/Mapper.java
@@ -50,7 +50,7 @@ public final class Mapper<A, B> {
   private final Class<B> targetClass;
   private final Reflective sourceRefl;
   private final Reflective targetRefl;
-  private volatile IntoSlot[] intoSlots;
+  private volatile IntoPlan intoPlan;
   private final Map<String, PatchEntry> patchByTargetField;
   // Folded hook chains — null = no hook. Composed by repeated calls to before*/after*. Each side
   // is a single Function/BiFunction reference at call time so HotSpot stays monomorphic regardless
@@ -457,7 +457,19 @@ public final class Mapper<A, B> {
       "This mapper does not support into() — Telescope.merge produces a forward-only mapper " +
         "(the multi-source case has no general inverse). Use Mapper.forward(...) only."
     );
-    final var slots = intoSlots();
+    // Writers bind to the target's persistent class, not the declared one: a mapper declared
+    // against a base or @MappedSuperclass type is routinely handed a concrete subclass, and the
+    // setter that matters may exist only there. persistentClassOf collapses a proxy back to its
+    // entity class so the cache stays one entry per real class.
+    final var writeClass = Beans.persistentClassOf(target);
+    if (produced == null) {
+      // preForward and postForward may map to null by contract, and a null product wrote null to
+      // every mapped property rather than failing. Readers are never bound here: there is nothing
+      // to read from.
+      for (final var name : patchByTargetField.keySet()) Beans.capturedWriter(writeClass, name).accept(target, null);
+      return target;
+    }
+    final var slots = intoSlots(Beans.persistentClassOf(produced), writeClass);
     final var staged = new Object[slots.length];
     for (var i = 0; i < slots.length; i++) staged[i] = slots[i].read().apply(produced);
     for (var i = 0; i < slots.length; i++) slots[i].write().accept(target, staged[i]);
@@ -467,27 +479,34 @@ public final class Mapper<A, B> {
   /** One target property's bound accessor pair, resolved once per mapper. */
   private record IntoSlot(Function<Object, Object> read, BiConsumer<Object, Object> write) {}
 
+  /** The class pair a bound slot array is valid for, alongside the array. */
+  private record IntoPlan(Class<?> readClass, Class<?> writeClass, IntoSlot[] slots) {}
+
   /**
-   * The bound accessor pair for every property {@link #into} writes. Both sides are constant once
-   * the mapper exists — the target class is fixed and the patch table's keys are fixed — so
-   * resolving them per property per call re-paid two proxy unwraps, two {@code ClassValue} probes
-   * and two name lookups for work whose inputs never change.
+   * The bound accessor pair for every property {@link #into} writes. The patch table's keys are
+   * fixed for the life of the mapper, so the only thing that can vary between calls is the pair of
+   * runtime classes — and in the overwhelming case it does not vary at all. One memoised plan
+   * therefore serves every call, and resolving accessors per property per call re-paid two proxy
+   * unwraps, two {@code ClassValue} probes and two name lookups for constant work.
    *
-   * <p>Resolved on first use rather than at construction: a mapper whose target has no setters is
-   * legal as long as nobody calls {@code into}, and binding eagerly would reject it at build time.
-   * The race between two first callers is benign — both produce equivalent arrays, and publishing
-   * either is correct.
+   * <p>Resolved on use rather than at construction because a record target reaches construction
+   * routinely — {@code Telescope.mapper(Dto.class, SomeRecord.class)} is ordinary — and a record's
+   * accessors are not bean getters, so binding eagerly would fail at build time for a mapper whose
+   * {@code into} is never called and correctly rejects records anyway.
+   *
+   * <p>The race between two callers is benign: both build equivalent arrays for the same class
+   * pair, and publishing either is correct.
    */
-  private IntoSlot[] intoSlots() {
-    final var cached = intoSlots;
-    if (cached != null) return cached;
+  private IntoSlot[] intoSlots(final Class<?> readClass, final Class<?> writeClass) {
+    final var cached = intoPlan;
+    if (cached != null && cached.readClass() == readClass && cached.writeClass() == writeClass) return cached.slots();
     final var names = patchByTargetField.keySet();
     final var built = new IntoSlot[names.size()];
     var i = 0;
     for (final var name : names) {
-      built[i++] = new IntoSlot(Beans.capturedReader(targetClass, name), Beans.capturedWriter(targetClass, name));
+      built[i++] = new IntoSlot(Beans.capturedReader(readClass, name), Beans.capturedWriter(writeClass, name));
     }
-    intoSlots = built;
+    intoPlan = new IntoPlan(readClass, writeClass, built);
     return built;
   }
 

--- a/core/src/main/java/io/github/eschizoid/telescope/conversion/Mapper.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/conversion/Mapper.java
@@ -496,6 +496,12 @@ public final class Mapper<A, B> {
    *
    * <p>The race between two callers is benign: both build equivalent arrays for the same class
    * pair, and publishing either is correct.
+   *
+   * <p>One slot assumes a caller passes targets of one concrete class, which is the ordinary shape.
+   * A caller alternating across an entity hierarchy misses every time and rebinds per call — still
+   * faster than resolving per property per call, but it turns this field into a volatile store on
+   * every call, and a mapper is a shared singleton in both framework starters. Key the memo by
+   * class if that pattern ever shows up in a profile.
    */
   private IntoSlot[] intoSlots(final Class<?> readClass, final Class<?> writeClass) {
     final var cached = intoPlan;

--- a/core/src/test/java/io/github/eschizoid/telescope/conversion/IntoTargetShapeTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/conversion/IntoTargetShapeTest.java
@@ -2,6 +2,7 @@ package io.github.eschizoid.telescope.conversion;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.github.eschizoid.telescope.Telescope;
@@ -83,7 +84,11 @@ class IntoTargetShapeTest {
 
     final var returned = mapper.into(target, new Dto("ORD-2", "mapped"));
 
-    assertEquals(target, returned, "into returns the same reference it was given");
+    assertSame(target, returned, "into returns the same reference it was given");
     assertNull(target.getId(), "a mapped property is written null rather than left alone");
+    // The null path resolves its own writers, so it needs the same subclass reach the mapped path
+    // has: asserting only a base-declared property would pass with writers bound to the supertype.
+    assertTrue(target.labelWritten(), "the subclass setter is reached on the null path too");
+    assertNull(target.getLabel());
   }
 }

--- a/core/src/test/java/io/github/eschizoid/telescope/conversion/IntoTargetShapeTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/conversion/IntoTargetShapeTest.java
@@ -1,0 +1,89 @@
+package io.github.eschizoid.telescope.conversion;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.github.eschizoid.telescope.Telescope;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * {@code into} writes onto the object it was handed, whatever its runtime shape, and survives a
+ * forward hook that produces nothing. Both are properties of the accessors it resolves: a writer
+ * bound to a declared supertype cannot reach a setter that a subclass introduces, and a reader is
+ * only safe to invoke on something that exists.
+ */
+class IntoTargetShapeTest {
+
+  record Dto(String id, String label) {}
+
+  /** Declared target: {@code label} is readable here but only writable on the subclass. */
+  public static class Base {
+
+    private String id;
+    private String label = "from-declared-target";
+
+    public String getId() {
+      return id;
+    }
+
+    public void setId(final String id) {
+      this.id = id;
+    }
+
+    public String getLabel() {
+      return label;
+    }
+  }
+
+  /** The concrete shape a caller actually passes — an entity hierarchy in miniature. */
+  public static class Sub extends Base {
+
+    private String subLabel = "untouched";
+    private boolean labelWritten;
+
+    @Override
+    public String getLabel() {
+      return subLabel;
+    }
+
+    public void setLabel(final String label) {
+      this.labelWritten = true;
+      this.subLabel = label;
+    }
+
+    boolean labelWritten() {
+      return labelWritten;
+    }
+  }
+
+  @Test
+  @DisplayName("a setter introduced by the runtime subclass is used, not skipped")
+  void writesReachTheRuntimeClassSetters() {
+    final var mapper = Telescope.mapper(Dto.class, Base.class);
+    final var target = new Sub();
+
+    mapper.into(target, new Dto("ORD-1", "mapped"));
+
+    assertEquals("ORD-1", target.getId(), "the base setter still runs");
+    // The declared target has no setter for `label`, so the value that reaches the subclass is
+    // whatever the produced instance carried. Whether the subclass setter is invoked at all is the
+    // property: a writer bound to the declared type would not find it and the write would vanish.
+    assertTrue(target.labelWritten(), "the subclass setter is reachable from a base-typed mapper");
+    assertEquals("from-declared-target", target.getLabel(), "and it receives what the declared target carried");
+  }
+
+  @Test
+  @DisplayName("a forward hook that produces nothing writes nulls rather than failing")
+  void nullProductWritesNulls() {
+    final var mapper = Telescope.mapper(Dto.class, Base.class).beforeForward(dto -> null);
+    final var target = new Sub();
+    target.setId("pre-existing");
+
+    final var returned = mapper.into(target, new Dto("ORD-2", "mapped"));
+
+    assertEquals(target, returned, "into returns the same reference it was given");
+    assertNull(target.getId(), "a mapped property is written null rather than left alone");
+  }
+}

--- a/internal/src/main/java/io/github/eschizoid/telescope/internal/Beans.java
+++ b/internal/src/main/java/io/github/eschizoid/telescope/internal/Beans.java
@@ -412,19 +412,18 @@ public final class Beans {
    * resolved once so a caller writing the same property repeatedly pays the proxy unwrap, the
    * {@link ClassValue} probe and the name lookup at bind time rather than per write.
    *
-   * <p>Binding to {@code beanClass} rather than the runtime class is deliberate, for the reason
-   * {@link #capturedReader} documents: a Hibernate proxy subclass still writes correctly through a
-   * writer bound to the declared class, and binding once keeps the invoker cache from accumulating
-   * an entry per proxy subclass.
+   * <p>Unlike {@link #capturedReader}, a name with no matching setter is <em>not</em> an error: it
+   * yields the same no-op writer {@link #writeBeanProperty} would have used, so a getter-only or
+   * computed property is skipped rather than throwing. That asymmetry is deliberate and matches
+   * what the rebuild strategies already do for an unwritable property — see {@code
+   * buildSetterInvoker}. Callers wanting a name checked must check it themselves.
    *
-   * <p>Throws {@link IllegalArgumentException} at build time if the named property has no setter.
+   * <p>Pass the class the write will actually target. Binding to a declared supertype silently
+   * skips a property whose setter exists only on the concrete subclass, which is the ordinary shape
+   * for an entity hierarchy.
    */
   public static BiConsumer<Object, Object> capturedWriter(final Class<?> beanClass, final String name) {
-    final var writer = SETTER_INVOKERS.get(beanClass).computeIfAbsent(name, n -> buildSetterInvoker(beanClass, n));
-    if (writer == null) throw new IllegalArgumentException(
-      "No setter for property '" + name + "' on " + beanClass.getName()
-    );
-    return writer;
+    return SETTER_INVOKERS.get(beanClass).computeIfAbsent(name, n -> buildSetterInvoker(beanClass, n));
   }
 
   /**

--- a/internal/src/main/java/io/github/eschizoid/telescope/internal/Beans.java
+++ b/internal/src/main/java/io/github/eschizoid/telescope/internal/Beans.java
@@ -408,6 +408,26 @@ public final class Beans {
   }
 
   /**
+   * Write-side sibling of {@link #capturedReader}: the cached {@link BiConsumer} for one property,
+   * resolved once so a caller writing the same property repeatedly pays the proxy unwrap, the
+   * {@link ClassValue} probe and the name lookup at bind time rather than per write.
+   *
+   * <p>Binding to {@code beanClass} rather than the runtime class is deliberate, for the reason
+   * {@link #capturedReader} documents: a Hibernate proxy subclass still writes correctly through a
+   * writer bound to the declared class, and binding once keeps the invoker cache from accumulating
+   * an entry per proxy subclass.
+   *
+   * <p>Throws {@link IllegalArgumentException} at build time if the named property has no setter.
+   */
+  public static BiConsumer<Object, Object> capturedWriter(final Class<?> beanClass, final String name) {
+    final var writer = SETTER_INVOKERS.get(beanClass).computeIfAbsent(name, n -> buildSetterInvoker(beanClass, n));
+    if (writer == null) throw new IllegalArgumentException(
+      "No setter for property '" + name + "' on " + beanClass.getName()
+    );
+    return writer;
+  }
+
+  /**
    * Read a bean property by name via its {@code getX()} / {@code isX()} accessor. Throws if no
    * getter matches {@code name}.
    *


### PR DESCRIPTION
Closes #306, from the audit tracked in #314. Supersedes #320, which was closed while its review round was still in flight — this carries the same work plus that round's fixes.

`Mapper.into` resolved a reader and a writer for every property on every call, though both are constant once the mapper exists. Each property paid two proxy unwraps, two `ClassValue` probes, a name lookup and a `computeIfAbsent` — per call, for work whose inputs never change.

## Measured, CI A/B

| benchmark | before | after | | B/op before | after |
| --- | ---: | ---: | ---: | ---: | ---: |
| `intoExisting` (5 properties) | 185.7 ns | 51.3 ns | **3.6×** | 448 | **72** |
| `intoExistingWide` (20 properties) | 763.1 ns | 144.7 ns | **5.3×** | 1,448 | **192** |
| `forwardOnly` (control) | 7.2 ns | 7.5 ns | 0.96× | 32 | 32 |
| `forwardOnlyWide` (control) | 15.0 ns | 16.0 ns | 0.94× | 96 | 96 |

The controls did not move, so no normalisation is applied. The scaling signature is the real evidence: `into` does a bounded multiple of `forward`'s work, so their ratio should be flat in property count. Before it was 25.8× at five properties and 51.0× at twenty — the ratio doubled when the count quadrupled, which is what per-call per-property rebinding looks like. After: 6.8× and 9.1×.

## Two regressions the review round caught

Both were found by differential runs against the previous implementation, and both are now pinned by tests verified to fail on the unfixed code.

**Writers bound to the declared target class.** A mapper declared against a base or `@MappedSuperclass` type is routinely handed a concrete subclass, and a setter introduced by that subclass is invisible from the supertype — the write vanished silently rather than failing. Writers now bind to `persistentClassOf(target)`, which is what the dynamic path resolved and what `into`'s own javadoc promises. A Hibernate proxy still collapses to its entity class, so the cache stays one entry per real class.

**Readers lost a null guard.** `forward()` may produce null by contract — `beforeForward` and `afterForward` can both map to it — and that used to write null to every mapped property. Through a captured accessor it threw an unattributable NPE instead. The null product is now handled before any reader is bound, since there is nothing to read from.

The slot cache keys on the pair of runtime classes it was built for, so a target of a different concrete class rebinds rather than reusing accessors bound for another.

## Also corrected

`capturedWriter`'s javadoc claimed an `IllegalArgumentException` the code could not reach: a name with no setter yields the same no-op the rebuild strategies use, deliberately, so a getter-only property is skipped rather than throwing. And the lazy-binding rationale named the wrong invariant — record targets are why binding cannot be eager, since they reach construction routinely and their accessors are not bean getters.
