### PR TITLE
bench: add the hash-container tier to the MapStruct comparison

### DIFF
--- a/benchmarks/src/jmh/java/io/github/eschizoid/telescope/benchmarks/MapStructComparisonBenchmark.java
+++ b/benchmarks/src/jmh/java/io/github/eschizoid/telescope/benchmarks/MapStructComparisonBenchmark.java
@@ -2,6 +2,8 @@ package io.github.eschizoid.telescope.benchmarks;
 
 import io.github.eschizoid.telescope.Telescope;
 import io.github.eschizoid.telescope.conversion.Mapper;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -83,6 +85,16 @@ public class MapStructComparisonBenchmark {
   private McCompanyRec deepRec;
   private Mapper<McCompanyBean, McCompanyRec> deepRuntimeMapper;
 
+  /** Past the top of a power-of-two band, where a table built from an element count resizes. */
+  private static final int CONTAINER_SIZE = 100;
+
+  private McSetBean setBean;
+  private McSetRec setRec;
+  private McMapBean mapBean;
+  private McMapRec mapRec;
+  private Mapper<McSetBean, McSetRec> setRuntimeMapper;
+  private Mapper<McMapBean, McMapRec> mapRuntimeMapper;
+
   @Setup
   public void setup() {
     // Flat tier — single object per direction.
@@ -99,6 +111,25 @@ public class MapStructComparisonBenchmark {
     deepBean = buildCompanyBean();
     deepRec = buildCompanyRec();
     deepRuntimeMapper = Telescope.mapper(McCompanyBean.class, McCompanyRec.class);
+
+    // Container tier — 100 elements, past the point where a table built from an element count
+    // has to resize. The list tiers cannot show this: a list has no table.
+    final var teams = LinkedHashSet.<McTeamBean>newLinkedHashSet(CONTAINER_SIZE);
+    final var teamsByName = LinkedHashMap.<String, McTeamBean>newLinkedHashMap(CONTAINER_SIZE);
+    final var teamRecs = LinkedHashSet.<McTeamRec>newLinkedHashSet(CONTAINER_SIZE);
+    final var teamRecsByName = LinkedHashMap.<String, McTeamRec>newLinkedHashMap(CONTAINER_SIZE);
+    for (var i = 0; i < CONTAINER_SIZE; i++) {
+      teams.add(new McTeamBean("team" + i, i));
+      teamsByName.put("k" + i, new McTeamBean("team" + i, i));
+      teamRecs.add(new McTeamRec("team" + i, i));
+      teamRecsByName.put("k" + i, new McTeamRec("team" + i, i));
+    }
+    setBean = new McSetBean("acme", teams);
+    setRec = new McSetRec("acme", teamRecs);
+    mapBean = new McMapBean("acme", teamsByName);
+    mapRec = new McMapRec("acme", teamRecsByName);
+    setRuntimeMapper = Telescope.mapper(McSetBean.class, McSetRec.class);
+    mapRuntimeMapper = Telescope.mapper(McMapBean.class, McMapRec.class);
   }
 
   // ---------- Flat — forward (bean → record) ----------
@@ -256,5 +287,61 @@ public class MapStructComparisonBenchmark {
     final var teamsB = List.of(new McTeamRec("Frontend", 6), new McTeamRec("Mobile", 4), new McTeamRec("Design", 3));
     final var departments = List.of(new McDeptRec("Engineering", teamsA), new McDeptRec("Product", teamsB));
     return new McCompanyRec("Acme", departments);
+  }
+
+  // ---------- Hash containers — the tier a list cannot exercise ----------
+  //
+  // A Set- and a Map-valued holder over the same leaf pair the deep tier uses. Rebuilding either
+  // allocates a table, so how the emitted helper sizes it is visible here and nowhere else in this
+  // class. Both directions, all three implementations, same shape as the tiers above.
+
+  @Benchmark
+  public void container_set_mapstruct_forward(final Blackhole bh) {
+    bh.consume(McContainerMapStruct.INSTANCE.toSetRec(setBean));
+  }
+
+  @Benchmark
+  public void container_set_telescope_codegen_forward(final Blackhole bh) {
+    bh.consume(McSetBeanBridge.BRIDGE.read(setBean));
+  }
+
+  @Benchmark
+  public void container_set_telescope_runtime_forward(final Blackhole bh) {
+    bh.consume(setRuntimeMapper.forward(setBean));
+  }
+
+  @Benchmark
+  public void container_set_mapstruct_backward(final Blackhole bh) {
+    bh.consume(McContainerMapStruct.INSTANCE.toSetBean(setRec));
+  }
+
+  @Benchmark
+  public void container_set_telescope_codegen_backward(final Blackhole bh) {
+    bh.consume(McSetBeanBridge.BRIDGE.set(setBean, setRec));
+  }
+
+  @Benchmark
+  public void container_map_mapstruct_forward(final Blackhole bh) {
+    bh.consume(McContainerMapStruct.INSTANCE.toMapRec(mapBean));
+  }
+
+  @Benchmark
+  public void container_map_telescope_codegen_forward(final Blackhole bh) {
+    bh.consume(McMapBeanBridge.BRIDGE.read(mapBean));
+  }
+
+  @Benchmark
+  public void container_map_telescope_runtime_forward(final Blackhole bh) {
+    bh.consume(mapRuntimeMapper.forward(mapBean));
+  }
+
+  @Benchmark
+  public void container_map_mapstruct_backward(final Blackhole bh) {
+    bh.consume(McContainerMapStruct.INSTANCE.toMapBean(mapRec));
+  }
+
+  @Benchmark
+  public void container_map_telescope_codegen_backward(final Blackhole bh) {
+    bh.consume(McMapBeanBridge.BRIDGE.set(mapBean, mapRec));
   }
 }

--- a/benchmarks/src/jmh/java/io/github/eschizoid/telescope/benchmarks/McContainerMapStruct.java
+++ b/benchmarks/src/jmh/java/io/github/eschizoid/telescope/benchmarks/McContainerMapStruct.java
@@ -1,0 +1,34 @@
+package io.github.eschizoid.telescope.benchmarks;
+
+import org.mapstruct.InheritInverseConfiguration;
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * MapStruct mapper for the hash-container tier: a {@code Set}-valued and a {@code Map}-valued
+ * holder over the same leaf pair the deep tier uses. The list tiers cannot see how a rebuild sizes
+ * a hash table, because a list has none — this pair is where an allocation difference in the
+ * emitted container helper becomes visible at all.
+ *
+ * <p>MapStruct synthesises the container bridges from the element-level method, the same way it
+ * does for lists.
+ */
+@Mapper
+public interface McContainerMapStruct {
+  McContainerMapStruct INSTANCE = Mappers.getMapper(McContainerMapStruct.class);
+
+  McSetRec toSetRec(McSetBean src);
+
+  McMapRec toMapRec(McMapBean src);
+
+  McTeamRec toTeamRec(McTeamBean src);
+
+  @InheritInverseConfiguration
+  McSetBean toSetBean(McSetRec src);
+
+  @InheritInverseConfiguration
+  McMapBean toMapBean(McMapRec src);
+
+  @InheritInverseConfiguration
+  McTeamBean toTeamBean(McTeamRec src);
+}

--- a/benchmarks/src/jmh/java/io/github/eschizoid/telescope/benchmarks/McMapBean.java
+++ b/benchmarks/src/jmh/java/io/github/eschizoid/telescope/benchmarks/McMapBean.java
@@ -1,0 +1,35 @@
+package io.github.eschizoid.telescope.benchmarks;
+
+import io.github.eschizoid.telescope.annotations.Bridge;
+import java.util.Map;
+
+/** Map-valued container tier, source side. Mirror of {@link McMapRec}. */
+@Bridge(McMapRec.class)
+public class McMapBean {
+
+  private String name;
+  private Map<String, McTeamBean> teams;
+
+  public McMapBean() {}
+
+  public McMapBean(final String name, final Map<String, McTeamBean> teams) {
+    this.name = name;
+    this.teams = teams;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(final String name) {
+    this.name = name;
+  }
+
+  public Map<String, McTeamBean> getTeams() {
+    return teams;
+  }
+
+  public void setTeams(final Map<String, McTeamBean> teams) {
+    this.teams = teams;
+  }
+}

--- a/benchmarks/src/jmh/java/io/github/eschizoid/telescope/benchmarks/McMapRec.java
+++ b/benchmarks/src/jmh/java/io/github/eschizoid/telescope/benchmarks/McMapRec.java
@@ -1,0 +1,6 @@
+package io.github.eschizoid.telescope.benchmarks;
+
+import java.util.Map;
+
+/** Map-valued container tier, target side. Mirror of {@link McMapBean}. */
+public record McMapRec(String name, Map<String, McTeamRec> teams) {}

--- a/benchmarks/src/jmh/java/io/github/eschizoid/telescope/benchmarks/McSetBean.java
+++ b/benchmarks/src/jmh/java/io/github/eschizoid/telescope/benchmarks/McSetBean.java
@@ -1,0 +1,35 @@
+package io.github.eschizoid.telescope.benchmarks;
+
+import io.github.eschizoid.telescope.annotations.Bridge;
+import java.util.Set;
+
+/** Set-valued container tier, source side. Mirror of {@link McSetRec}. */
+@Bridge(McSetRec.class)
+public class McSetBean {
+
+  private String name;
+  private Set<McTeamBean> teams;
+
+  public McSetBean() {}
+
+  public McSetBean(final String name, final Set<McTeamBean> teams) {
+    this.name = name;
+    this.teams = teams;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(final String name) {
+    this.name = name;
+  }
+
+  public Set<McTeamBean> getTeams() {
+    return teams;
+  }
+
+  public void setTeams(final Set<McTeamBean> teams) {
+    this.teams = teams;
+  }
+}

--- a/benchmarks/src/jmh/java/io/github/eschizoid/telescope/benchmarks/McSetRec.java
+++ b/benchmarks/src/jmh/java/io/github/eschizoid/telescope/benchmarks/McSetRec.java
@@ -1,0 +1,6 @@
+package io.github.eschizoid.telescope.benchmarks;
+
+import java.util.Set;
+
+/** Set-valued container tier, target side. Mirror of {@link McSetBean}. */
+public record McSetRec(String name, Set<McTeamRec> teams) {}


### PR DESCRIPTION
Closes the last item in #313.

`MapStructComparisonBenchmark` was List-only at every tier, and a list has no hash table — so nothing in it could observe how a rebuild sizes one. That is the gap the size-as-capacity defect in the Bridge emitter (#308) lived in: the benchmarked deep tier exercised the emitted list helper and never the Set or Map one, so generated bridges were allocating worse than the reflective path they exist to beat, with every benchmark green.

Adds a `Set`-valued and a `Map`-valued holder over the same leaf pair the deep tier already uses, at 100 elements — past the top of a power-of-two band, where a table built from an element count actually resizes. Same three implementations as the other tiers (MapStruct, telescope codegen, telescope runtime) and both directions.

Verified it reaches the intended code: the generated bridges emit

```java
LinkedHashSet.<McTeamRec>newLinkedHashSet(src.size())
HashMap.<java.lang.String, McTeamRec>newHashMap(src.size())
```

which are exactly the emitter branches #308 corrected. Before this tier, nothing in the comparison touched them.

No numbers claimed here — this is coverage, and the figures belong in the consolidated sweep that refreshes `docs/perf-mapstruct-comparison.md` once the audit's remaining fixes land.
