### PR TITLE
perf(internal): keep a composed Lens write linear in depth

### DIFF
--- a/internal/src/main/java/io/github/eschizoid/telescope/internal/optics/Iso.java
+++ b/internal/src/main/java/io/github/eschizoid/telescope/internal/optics/Iso.java
@@ -302,6 +302,13 @@ public interface Iso<A, B> extends Lens<A, B>, Prism<A, B> {
       public A set(final A source, final C value) {
         return self.from(next.set(self.to(source), value));
       }
+
+      // The set above converts and reads; Lens's default modify would then read again through get.
+      // Converting once and delegating to the inner modify keeps a composed write linear in depth.
+      @Override
+      public A modify(final A source, final Function<? super C, ? extends C> f) {
+        return self.from(next.modify(self.to(source), f));
+      }
     };
   }
 

--- a/internal/src/main/java/io/github/eschizoid/telescope/internal/optics/Lens.java
+++ b/internal/src/main/java/io/github/eschizoid/telescope/internal/optics/Lens.java
@@ -182,6 +182,15 @@ public interface Lens<S, A> extends Affine<S, A>, Getter<S, A> {
       public S set(final S source, final B value) {
         return self.set(source, next.set(self.get(source), value));
       }
+
+      // Without this, modify falls to Lens's default — set(source, f.apply(get(source))) — and the
+      // set above reads the outer focus a second time. Composed that way, one modify at depth d
+      // costs d(d+1)/2 leaf reads instead of d. Delegating to the outer modify keeps it linear, the
+      // way Affine and Traversal already do for their compositions.
+      @Override
+      public S modify(final S source, final Function<? super B, ? extends B> f) {
+        return self.modify(source, a -> next.modify(a, f));
+      }
     };
   }
 
@@ -197,6 +206,13 @@ public interface Lens<S, A> extends Affine<S, A>, Getter<S, A> {
       @Override
       public S set(final S source, final B value) {
         return self.set(source, next.from(value));
+      }
+
+      // Same reason as the Lens pairing above: route through the outer modify so the outer focus
+      // is read once. An Iso needs no read of its own — it converts in both directions.
+      @Override
+      public S modify(final S source, final Function<? super B, ? extends B> f) {
+        return self.modify(source, a -> next.from(f.apply(next.to(a))));
       }
     };
   }

--- a/internal/src/test/java/io/github/eschizoid/telescope/internal/optics/CompositionCostTest.java
+++ b/internal/src/test/java/io/github/eschizoid/telescope/internal/optics/CompositionCostTest.java
@@ -79,6 +79,22 @@ class CompositionCostTest {
   }
 
   @Test
+  @DisplayName("a chain rooted at an Iso reads each level once too")
+  void isoRootedChainIsLinear() {
+    // Iso.then(Lens) produces a Lens as well and carries the same hazard — but only when the lens
+    // it wraps is itself composed. A plain lens's set performs no read, so an Iso over one costs
+    // the same either way; the second read appears once the inner set has to rebuild through a
+    // level of its own. Compose the inner chain first, then root it at the Iso.
+    final var reads = new AtomicInteger();
+    final Iso<Level, Level> identity = Iso.of(level -> level, level -> level);
+    final var path = identity.then(innerLens(reads).then(leafLens(reads)));
+
+    path.modify(nest(1), leaf -> leaf + 1);
+
+    assertEquals(2, reads.get(), "the inner hop and the leaf, once each");
+  }
+
+  @Test
   @DisplayName("the composed write still produces the right value")
   void valueIsUnchangedByTheCostFix() {
     final var reads = new AtomicInteger();

--- a/internal/src/test/java/io/github/eschizoid/telescope/internal/optics/CompositionCostTest.java
+++ b/internal/src/test/java/io/github/eschizoid/telescope/internal/optics/CompositionCostTest.java
@@ -1,0 +1,91 @@
+package io.github.eschizoid.telescope.internal.optics;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * One write through a composed optic reads each level once. The composition table says a chain of
+ * lenses is a lens, which implies a write costs what the depth costs — but a composed {@code set}
+ * has to read the outer focus to rebuild it, so a {@code modify} that reaches its focus by reading
+ * and then writes by reading again pays for the depth twice over, quadratically as the chain grows.
+ *
+ * <p>Counting the reads is the only way to see it: the values are identical either way.
+ */
+class CompositionCostTest {
+
+  /** A level whose read is observable, so the cost of reaching it can be counted. */
+  private record Level(Level inner, int leaf) {}
+
+  private static Lens<Level, Level> innerLens(final AtomicInteger reads) {
+    return Lens.of(
+      source -> {
+        reads.incrementAndGet();
+        return source.inner();
+      },
+      (source, value) -> new Level(value, source.leaf())
+    );
+  }
+
+  private static Lens<Level, Integer> leafLens(final AtomicInteger reads) {
+    return Lens.of(
+      source -> {
+        reads.incrementAndGet();
+        return source.leaf();
+      },
+      (source, value) -> new Level(source.inner(), value)
+    );
+  }
+
+  private static Level nest(final int depth) {
+    var level = new Level(null, 0);
+    for (var i = 0; i < depth; i++) level = new Level(level, 0);
+    return level;
+  }
+
+  private static Lens<Level, Integer> chain(final int depth, final AtomicInteger reads) {
+    Lens<Level, Level> path = Lens.of(source -> source, (source, value) -> value);
+    for (var i = 0; i < depth; i++) path = path.then(innerLens(reads));
+    return path.then(leafLens(reads));
+  }
+
+  @Test
+  @DisplayName("a composed modify reads each level once, at every depth")
+  void modifyReadsAreLinearInDepth() {
+    for (final var depth : new int[] { 1, 2, 3, 4, 5, 8 }) {
+      final var reads = new AtomicInteger();
+      final var path = chain(depth, reads);
+
+      path.modify(nest(depth), leaf -> leaf + 1);
+
+      // depth inner hops plus the leaf: one read each. The quadratic shape would give
+      // (depth + 1)(depth + 2) / 2 — 45 at depth 8 rather than 9.
+      assertEquals(depth + 1, reads.get(), "modify at depth " + depth + " must read each level once");
+    }
+  }
+
+  @Test
+  @DisplayName("composing through an Iso does not add a read")
+  void isoHopIsFree() {
+    final var reads = new AtomicInteger();
+    final Iso<Integer, Integer> boxed = Iso.of(leaf -> leaf, leaf -> leaf);
+    final var path = chain(3, reads).then(boxed);
+
+    path.modify(nest(3), leaf -> leaf + 1);
+
+    assertEquals(4, reads.get(), "an Iso converts rather than reading");
+  }
+
+  @Test
+  @DisplayName("the composed write still produces the right value")
+  void valueIsUnchangedByTheCostFix() {
+    final var reads = new AtomicInteger();
+    final var updated = chain(3, reads).modify(nest(3), leaf -> leaf + 7);
+
+    var level = updated;
+    for (var i = 0; i < 3; i++) level = level.inner();
+    assertEquals(7, level.leaf(), "the innermost leaf carries the applied function");
+  }
+}


### PR DESCRIPTION
Closes #311.

A composed `Lens` overrides `get` and `set` but not `modify`, so `modify` falls to the interface default — `set(source, f.apply(get(source)))` — and the composed `set` reads the outer focus *again* to rebuild it. Those reads recurse, so one `modify` at depth d costs `d(d+1)/2` leaf reads instead of d:

| depth | reads before | after |
| ---: | ---: | ---: |
| 2 | 3 | 2 |
| 3 | 6 | 3 |
| 5 | 15 | 5 |
| 8 | 45 | 8 |

`Affine.then` and `Traversal.then` already carry the linear `self.modify(source, a -> next.modify(a, f))` override. `Lens` was the one rung of the lattice that did not. The three pairings that produce a `Lens` — `Lens.then(Lens)`, `Lens.then(Iso)`, `Iso.then(Lens)` — now delegate the same way.

## Why it was latent, and why that is not a reason to leave it

Nothing in production builds a composed `Lens` today: `Telescope.optic` is declared `Traversal<S, A>`, so every DSL composition binds to `Traversal.then` and the narrowing rules in the composition table never fire. That is also why this could sit here unnoticed.

It stops being latent the moment anything restores that narrowing — which is exactly what #303's deeper fix would have done, and what a future attempt at it will do again. Landing the override first means that work does not have to discover this as a regression in its own numbers.

## Gate

`CompositionCostTest` counts leaf reads through a chain whose levels report when they are read, at depths 1 through 8, and asserts the count equals the depth. Values are identical either way — the count is the only observable — so a test that asserted results would pass on the quadratic version. Verified as a gate: reverting the `Lens.then(Lens)` override fails two of its three cases; restoring it passes all three.

It also pins that an `Iso` hop adds no read, and that the composed write still produces the right value.
