### PR TITLE
fix: a self-referential record has no default, rather than no bound

### DIFF
--- a/core/src/main/java/io/github/eschizoid/telescope/Placeholders.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/Placeholders.java
@@ -4,7 +4,7 @@ import io.github.eschizoid.telescope.internal.Beans;
 import io.github.eschizoid.telescope.internal.Records;
 import io.github.eschizoid.telescope.internal.optics.Iso;
 import java.lang.reflect.Modifier;
-import java.util.HashMap;
+import java.util.function.Supplier;
 
 /**
  * Placeholder / default-value machinery for {@link DeepMap}'s permissive modes. When a target field
@@ -78,14 +78,46 @@ final class Placeholders {
    * possible in principle but the no-arg ctor doesn't recurse into fields, so a self-referencing
    * bean is handled with a single allocation regardless of its field shape.
    */
-  @SuppressWarnings({ "rawtypes", "unchecked" })
   private static Object recursiveDefault(final Class<?> type) {
-    if (type.isPrimitive()) return primitiveDefault(type);
+    return PLANS.get(type).get();
+  }
+
+  /**
+   * The default-tree plan for a type, resolved once per class. Everything reflective about building
+   * a default lives here — the component list, the primitive lookup, and the constructor probe — so
+   * a conversion pays a supplier call per component rather than re-deriving the shape.
+   *
+   * <p>The plan is cached, not the value. Today's write paths rebuild rather than mutate, so a
+   * shared instance would not be observable through them — but a default is a mutable object handed
+   * to arbitrary downstream writes on any thread, and one shared across every conversion of a type
+   * is a hazard waiting for the first write path that does mutate in place. Building per call costs
+   * one allocation and removes the question.
+   */
+  private static final ClassValue<Supplier<Object>> PLANS = new ClassValue<>() {
+    @Override
+    protected Supplier<Object> computeValue(final Class<?> type) {
+      return planFor(type);
+    }
+  };
+
+  @SuppressWarnings({ "rawtypes", "unchecked" })
+  private static Supplier<Object> planFor(final Class<?> type) {
+    if (type.isPrimitive()) {
+      final var value = primitiveDefault(type);
+      return () -> value;
+    }
     if (type.isRecord()) {
+      // Canonical order, so the component plans fill a positional array directly. Records cannot
+      // form a construction cycle — every canonical constructor needs its component types already
+      // constructible — so resolving a component's plan here cannot re-enter this type.
       final var comps = type.getRecordComponents();
-      final var byName = new HashMap<String, Object>(comps.length);
-      for (final var comp : comps) byName.put(comp.getName(), recursiveDefault(comp.getType()));
-      return Records.construct((Class) type, byName::get);
+      final var parts = (Supplier<Object>[]) new Supplier<?>[comps.length];
+      for (var i = 0; i < comps.length; i++) parts[i] = PLANS.get(comps[i].getType());
+      return () -> {
+        final var args = new Object[parts.length];
+        for (var i = 0; i < parts.length; i++) args[i] = parts[i].get();
+        return Records.construct((Class) type, args);
+      };
     }
     // Bean intermediate: try the public no-arg ctor first, falling back to the static builder()
     // pattern (Lombok @Builder, Immutables-style). Skip JDK scalars / containers entirely so the
@@ -95,10 +127,12 @@ final class Placeholders {
     // same behaviour as before bean-intermediate support, but no per-call
     // `getDeclaredConstructor` / `getMethod("builder")` reflection: both shapes are LMF-cached
     // per class via {@link Beans#intermediateAllocator}.
-    if (beanIntermediateAllocatable(type)) {
-      return Beans.intermediateAllocator(type).get();
-    }
-    return null;
+    // The allocator is already cached per class and hands back a fresh instance per call, which a
+    // bean intermediate needs: telescope-row writes go through its setters, so two conversions
+    // must not share one. The probe that decides whether a type has a usable strategy costs two
+    // thrown exceptions for a type with neither, and it runs here rather than per conversion.
+    if (beanIntermediateAllocatable(type)) return Beans.intermediateAllocator(type)::get;
+    return () -> null;
   }
 
   static Object primitiveDefault(final Class<?> p) {

--- a/core/src/main/java/io/github/eschizoid/telescope/Placeholders.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/Placeholders.java
@@ -4,6 +4,8 @@ import io.github.eschizoid.telescope.internal.Beans;
 import io.github.eschizoid.telescope.internal.Records;
 import io.github.eschizoid.telescope.internal.optics.Iso;
 import java.lang.reflect.Modifier;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.function.Supplier;
 
 /**
@@ -41,7 +43,7 @@ final class Placeholders {
    */
   static Iso<Object, Object> placeholderIsoFor(final Class<?> fieldType, final boolean claimedByTelescopeWrite) {
     if (fieldType == null) return NULLING_ISO;
-    if (claimedByTelescopeWrite && (fieldType.isRecord() || beanIntermediateAllocatable(fieldType))) {
+    if (claimedByTelescopeWrite && (fieldType.isRecord() || BEAN_ALLOCATABLE.get(fieldType))) {
       return defaultAllocatorIso(fieldType);
     }
     if (fieldType.isPrimitive()) {
@@ -67,25 +69,33 @@ final class Placeholders {
     return Iso.of(__ -> recursiveDefault(type), __ -> null);
   }
 
-  /**
-   * Construct a default-tree instance of {@code type} — primitives get their JLS default (0, false,
-   * etc.), records recurse via their canonical constructor with the same scheme, beans get a fresh
-   * instance from their public no-arg constructor (uninitialised fields default to null/zero, which
-   * the telescope-row write then overwrites). Anything else returns {@code null}.
-   *
-   * <p>Cycles between record types can't arise in practice: each canonical ctor needs every other
-   * type already constructible, so a record cycle would fail at compile time. Bean cycles are
-   * possible in principle but the no-arg ctor doesn't recurse into fields, so a self-referencing
-   * bean is handled with a single allocation regardless of its field shape.
-   */
+  /** A default-tree instance of {@code type}, built from its cached plan. */
   private static Object recursiveDefault(final Class<?> type) {
     return PLANS.get(type).get();
   }
 
   /**
-   * The default-tree plan for a type, resolved once per class. Everything reflective about building
-   * a default lives here — the component list, the primitive lookup, and the constructor probe — so
-   * a conversion pays a supplier call per component rather than re-deriving the shape.
+   * Whether a type has a usable intermediate-construction strategy. Cached because the probe costs
+   * two thrown exceptions for a type with neither a no-arg constructor nor a {@code builder()} —
+   * {@code LocalDate}, {@code UUID}, most JDK value types — and both the plan and the placeholder
+   * factory need the answer.
+   */
+  private static final ClassValue<Boolean> BEAN_ALLOCATABLE = new ClassValue<>() {
+    @Override
+    protected Boolean computeValue(final Class<?> type) {
+      return beanIntermediateAllocatable(type);
+    }
+  };
+
+  /** Types whose plan is mid-resolution on this thread, so a self-reference can be recognised. */
+  private static final ThreadLocal<Set<Class<?>>> IN_PROGRESS = ThreadLocal.withInitial(HashSet::new);
+
+  /**
+   * The default-tree plan for a type, resolved once per class: primitives yield their JLS default,
+   * records their canonical constructor filled with the same scheme, beans a fresh instance from a
+   * public no-arg constructor or a static {@code builder()}, and anything else {@code null}.
+   * Everything reflective lives here — the component list, the primitive lookup, the constructor
+   * probe — so a conversion pays a supplier call per component rather than re-deriving the shape.
    *
    * <p>The plan is cached, not the value. Today's write paths rebuild rather than mutate, so a
    * shared instance would not be observable through them — but a default is a mutable object handed
@@ -107,32 +117,39 @@ final class Placeholders {
       return () -> value;
     }
     if (type.isRecord()) {
-      // Canonical order, so the component plans fill a positional array directly. Records cannot
-      // form a construction cycle — every canonical constructor needs its component types already
-      // constructible — so resolving a component's plan here cannot re-enter this type.
-      final var comps = type.getRecordComponents();
-      final var parts = (Supplier<Object>[]) new Supplier<?>[comps.length];
-      for (var i = 0; i < comps.length; i++) parts[i] = PLANS.get(comps[i].getType());
-      return () -> {
-        final var args = new Object[parts.length];
-        for (var i = 0; i < parts.length; i++) args[i] = parts[i].get();
-        return Records.construct((Class) type, args);
-      };
+      // A record CAN reference itself, directly or mutually — `record Node(Node next, String v)`
+      // compiles — and no instance of one can be constructed without an instance of it, so it has
+      // no default. Resolving component plans would otherwise re-enter this type forever, so a
+      // type already being resolved on this thread yields the same null a type with no usable
+      // construction strategy yields.
+      if (!IN_PROGRESS.get().add(type)) return () -> null;
+      try {
+        return recordPlan(type);
+      } finally {
+        IN_PROGRESS.get().remove(type);
+      }
     }
-    // Bean intermediate: try the public no-arg ctor first, falling back to the static builder()
-    // pattern (Lombok @Builder, Immutables-style). Skip JDK scalars / containers entirely so the
-    // records path stays unchanged. Telescope-row writes go through the bean's setters at each
-    // hop, so each intermediate just needs to be non-null; the setters overwrite the
-    // default-initialised fields. If neither strategy works, the cached supplier yields null —
-    // same behaviour as before bean-intermediate support, but no per-call
-    // `getDeclaredConstructor` / `getMethod("builder")` reflection: both shapes are LMF-cached
-    // per class via {@link Beans#intermediateAllocator}.
-    // The allocator is already cached per class and hands back a fresh instance per call, which a
-    // bean intermediate needs: telescope-row writes go through its setters, so two conversions
-    // must not share one. The probe that decides whether a type has a usable strategy costs two
-    // thrown exceptions for a type with neither, and it runs here rather than per conversion.
-    if (beanIntermediateAllocatable(type)) return Beans.intermediateAllocator(type)::get;
+    // Bean intermediate: a public no-arg constructor, or a static builder() (Lombok @Builder,
+    // Immutables). JDK scalars and containers are excluded so the records path is unchanged. A
+    // telescope-row write goes through the bean's setters at each hop, so an intermediate only has
+    // to be non-null and fresh — the allocator is cached per class and hands back a new instance
+    // per call, which two conversions writing through the same type both need. A type with neither
+    // strategy yields null, the same filler the unannotated path produces.
+    if (BEAN_ALLOCATABLE.get(type)) return Beans.intermediateAllocator(type)::get;
     return () -> null;
+  }
+
+  /** Component plans in canonical order, filling a positional argument array per call. */
+  @SuppressWarnings({ "rawtypes", "unchecked" })
+  private static Supplier<Object> recordPlan(final Class<?> type) {
+    final var comps = type.getRecordComponents();
+    final var parts = (Supplier<Object>[]) new Supplier<?>[comps.length];
+    for (var i = 0; i < comps.length; i++) parts[i] = PLANS.get(comps[i].getType());
+    return () -> {
+      final var args = new Object[parts.length];
+      for (var i = 0; i < parts.length; i++) args[i] = parts[i].get();
+      return Records.construct((Class) type, args);
+    };
   }
 
   static Object primitiveDefault(final Class<?> p) {

--- a/core/src/test/java/io/github/eschizoid/telescope/PlaceholderIsolationTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/PlaceholderIsolationTest.java
@@ -1,0 +1,87 @@
+package io.github.eschizoid.telescope;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+
+import io.github.eschizoid.telescope.mapping.Mapping;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * A target field with no same-name source is filled with a default-tree placeholder, and the
+ * telescope row then writes into it. Caching the plan for building one must not collapse into
+ * caching a built one: repeated conversions have to keep producing independent, correct results.
+ *
+ * <p>Note what this does <em>not</em> prove. The bean write path rebuilds through the writer rather
+ * than mutating the placeholder, so a shared instance would not be visible through it and these
+ * assertions pass either way. The reason for building per call is stated on the plan cache and is a
+ * safety argument about handing one mutable default to every conversion on every thread, not a
+ * behaviour these tests can gate.
+ */
+class PlaceholderIsolationTest {
+
+  record Slim(String value) {}
+
+  public static class Holder {
+
+    private Leaf leaf;
+
+    public Leaf getLeaf() {
+      return leaf;
+    }
+
+    public void setLeaf(final Leaf leaf) {
+      this.leaf = leaf;
+    }
+  }
+
+  public static class Leaf {
+
+    private String value;
+
+    public String getValue() {
+      return value;
+    }
+
+    public void setValue(final String value) {
+      this.value = value;
+    }
+  }
+
+  @Test
+  @DisplayName("each conversion gets its own placeholder instance")
+  void placeholdersAreNotSharedBetweenConversions() {
+    final var mapper = Telescope.mapper(
+      Slim.class,
+      Holder.class,
+      Mapping.to(Slim::value, Telescope.ofBean(Holder.class).field(Holder::getLeaf).field(Leaf::getValue))
+    );
+
+    final var first = mapper.forward(new Slim("first"));
+    final var second = mapper.forward(new Slim("second"));
+
+    assertNotNull(first.getLeaf());
+    assertNotNull(second.getLeaf());
+    assertNotSame(first.getLeaf(), second.getLeaf(), "conversions do not hand back one instance");
+    assertEquals("first", first.getLeaf().getValue(), "the earlier conversion keeps its own value");
+    assertEquals("second", second.getLeaf().getValue());
+  }
+
+  @Test
+  @DisplayName("a placeholder built once is still built on every later conversion")
+  void repeatedConversionsKeepBuilding() {
+    final var mapper = Telescope.mapper(
+      Slim.class,
+      Holder.class,
+      Mapping.to(Slim::value, Telescope.ofBean(Holder.class).field(Holder::getLeaf).field(Leaf::getValue))
+    );
+
+    // Ten conversions, ten distinct leaves: caching the plan must not collapse into caching one
+    // instance, however many times the plan is reused.
+    final var leaves = new java.util.IdentityHashMap<Leaf, Boolean>();
+    for (var i = 0; i < 10; i++) leaves.put(mapper.forward(new Slim("v" + i)).getLeaf(), Boolean.TRUE);
+
+    assertEquals(10, leaves.size(), "every conversion allocated its own placeholder");
+  }
+}

--- a/core/src/test/java/io/github/eschizoid/telescope/PlaceholderIsolationTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/PlaceholderIsolationTest.java
@@ -3,6 +3,7 @@ package io.github.eschizoid.telescope;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import io.github.eschizoid.telescope.mapping.Mapping;
 import org.junit.jupiter.api.DisplayName;
@@ -22,6 +23,16 @@ import org.junit.jupiter.api.Test;
 class PlaceholderIsolationTest {
 
   record Slim(String value) {}
+
+  record Node(Node next, String value) {}
+
+  record NodeHolder(String label, Node node) {}
+
+  record Ping(Pong pong) {}
+
+  record Pong(Ping ping) {}
+
+  record PingHolder(String label, Ping ping) {}
 
   public static class Holder {
 
@@ -69,19 +80,34 @@ class PlaceholderIsolationTest {
   }
 
   @Test
-  @DisplayName("a placeholder built once is still built on every later conversion")
-  void repeatedConversionsKeepBuilding() {
+  @DisplayName("a self-referential record has no default, rather than no bound")
+  void selfReferentialRecordYieldsNoDefault() {
+    // No instance of Node can be built without an instance of Node, so it has no default tree.
+    // Resolving its component plans re-enters the same type, which without a guard descends until
+    // the stack ends. It yields the null a type with no construction strategy yields instead.
     final var mapper = Telescope.mapper(
       Slim.class,
-      Holder.class,
-      Mapping.to(Slim::value, Telescope.ofBean(Holder.class).field(Holder::getLeaf).field(Leaf::getValue))
+      NodeHolder.class,
+      Mapping.to(Slim::value, Telescope.of(NodeHolder.class).field(NodeHolder::node).field(Node::value))
     );
 
-    // Ten conversions, ten distinct leaves: caching the plan must not collapse into caching one
-    // instance, however many times the plan is reused.
-    final var leaves = new java.util.IdentityHashMap<Leaf, Boolean>();
-    for (var i = 0; i < 10; i++) leaves.put(mapper.forward(new Slim("v" + i)).getLeaf(), Boolean.TRUE);
+    // The write lands on nothing because there is nothing to land on: Node has no default tree, so
+    // the placeholder is null and the row's set has no instance to rebuild. Terminating with that
+    // null is the property — the alternative is descending until the stack ends.
+    assertNull(mapper.forward(new Slim("x")).node(), "a record that cannot be defaulted stays null");
+  }
 
-    assertEquals(10, leaves.size(), "every conversion allocated its own placeholder");
+  @Test
+  @DisplayName("mutually referential records terminate the same way")
+  void mutualReferenceTerminates() {
+    final var mapper = Telescope.mapper(
+      Slim.class,
+      PingHolder.class,
+      Mapping.to(Slim::value, Telescope.of(PingHolder.class).field(PingHolder::label))
+    );
+
+    // The row claims `label`, but resolving the target still plans a placeholder for `ping`, whose
+    // component type resolves back to it.
+    assertEquals("y", mapper.forward(new Slim("y")).label());
   }
 }


### PR DESCRIPTION
Closes #310. Started as the last per-call-reflection item from the audit tracked in #314 and turned into a crash fix along the way.

## The crash

`record Node(Node next, String value) {}` compiles, and so does a mutual pair. Building a default tree for one descended until the stack ended — a target field of such a type, claimed by a telescope row, threw `StackOverflowError`. That is true on `main` today; the review round found it while attacking a comment of mine that asserted the opposite.

No instance of a self-referential record can be built without an instance of it, so it has no default tree. A type already being resolved on this thread now yields the same `null` a type with no construction strategy yields, which the surrounding path already handles.

## The original change

Building a placeholder re-derived its whole shape on every conversion:

- `getRecordComponents()` — not cached by the JDK, allocates a fresh array per call;
- a `HashMap` sized by element count rather than capacity;
- a constructor probe costing **two thrown exceptions** for any type with neither a public no-arg constructor nor a static `builder()` — `LocalDate`, `UUID`, most JDK value types.

The shape is now a per-class plan in a `ClassValue`, with records filling their canonical constructor positionally. Instrumented counts across 100 conversions: probes 100 → 0, `getRecordComponents` 100 → 0. The probe also moved behind its own cache, which closes the second site the review found — mapper *construction* was still paying it per call.

## The plan is cached; the value is not

Worth stating because the tempting version caches the built placeholder. Today's write paths rebuild rather than mutate, so a shared instance genuinely would not be observable — I verified that by making the mutation and watching the tests pass. But a default is a mutable object handed to arbitrary downstream writes on any thread, and one shared across every conversion of a type is a hazard waiting for the first write path that mutates in place.

## Tests

The isolation test this replaces **gated nothing** — it passed with the change reverted and with a value-caching implementation, while its name and assertion message described what it did not measure. The cycle cases fail on `main` with `StackOverflowError` and pass here.

Verified by the review round rather than asserted: a differential probe across 45 types (all primitives, boxed types, enums, arrays, JDK containers and value types, records with compact and validating canonical constructors, builder beans, and records wrapping each) produced identical values on both sides; component order is canonical by construction, since `planFor` and `RecordInfo.of` call the same `getRecordComponents()`; and 32 threads × 500 conversions yielded 16000 distinct instances with no errors.
