### PR TITLE
docs: refresh the comparison figures from one CI run

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,9 +415,9 @@ performance class:
 No codegen? `Telescope.mapper(...)` composes each record/bean pair into a single MethodHandle: zero annotations, no
 build step, within ~1.04–3.3× of MapStruct in the same workloads (flat ~3.3×, nested ~2.7×, deep ~1.3×, container fields
 ~1.04–1.06× — the ratio narrows as the work per call grows: a fixed ~7 ns per-call cost is essentially the whole gap on
-flat and nested, and the container shapes add a sub-nanosecond per-element cost on top, so the absolute gap grows while
-the ratio falls). That's sub-microsecond conversion; whether it's fast enough is your call, and when a loop turns hot,
-`@Bridge` puts you back in the codegen class. Reproduce any of it from the
+flat and nested, and the deep and container shapes add roughly 0.4–1.2 ns per converted element on top, so the absolute
+gap grows while the ratio falls). That's sub-microsecond conversion; whether it's fast enough is your call, and when a
+loop turns hot, `@Bridge` puts you back in the codegen class. Reproduce any of it from the
 [`Benchmarks`](.github/workflows/benchmarks.yaml) GitHub Action; the full matrix is in
 [`benchmarks/README.md`](benchmarks/README.md#mapstruct-comparison-apples-to-apples).
 

--- a/README.md
+++ b/README.md
@@ -401,20 +401,21 @@ To be precise about what a stale string costs, because the failure modes differ:
 
 #### Performance, measured
 
-In the included JMH workloads (MapStruct 1.6.3, CI hardware, JDK 25 —
-[methodology, environment, and both runs](docs/perf-mapstruct-comparison.md)), telescope codegen and MapStruct codegen
-land in the same performance class:
+In the included JMH workloads (MapStruct 1.6.3, CI hardware, JDK 25 — all figures from one run, so they are comparable;
+[methodology and history](docs/perf-mapstruct-comparison.md)), telescope codegen and MapStruct codegen land in the same
+performance class:
 
-| Tier (codegen vs codegen)   | telescope vs MapStruct                                        |
-| --------------------------- | ------------------------------------------------------------- |
-| flat (5 scalars)            | ~1.1× — a fraction of a nanosecond                            |
-| nested (one nested type)    | ~1.2×                                                         |
-| deep (3 levels + list hops) | ~1.15× — a few ns on a ~50 ns conversion, same 376 B/op floor |
+| Tier (codegen vs codegen)   | telescope vs MapStruct                                          |
+| --------------------------- | --------------------------------------------------------------- |
+| flat (5 scalars)            | ~1.07× — a fifth of a nanosecond                                |
+| nested (one nested type)    | 1.04×–1.42× across runs — a microbenchmark, not a service shape |
+| deep (3 levels + list hops) | ~1.07× — 4 ns on a 62 ns conversion, same 376 B/op floor        |
+| Set or Map field, 100 items | a tie on time, and ~11% less allocated on the Map shape         |
 
 No codegen? `Telescope.mapper(...)` composes each record/bean pair into a single MethodHandle: zero annotations, no
-build step, within ~1.3–4× of MapStruct in the same workloads (flat ~4×, nested ~2×, deep ~1.3–1.9× — closest where
-trees are deepest). That's sub-microsecond conversion; whether it's fast enough is your call, and when a loop turns hot,
-`@Bridge` puts you back in the codegen class. Reproduce any of it from the
+build step, within ~1.3–3.3× of MapStruct in the same workloads (flat ~3.3×, nested ~2.7×, deep ~1.3× — closest where
+trees are deepest, and a tie on container fields). That's sub-microsecond conversion; whether it's fast enough is your
+call, and when a loop turns hot, `@Bridge` puts you back in the codegen class. Reproduce any of it from the
 [`Benchmarks`](.github/workflows/benchmarks.yaml) GitHub Action; the full matrix is in
 [`benchmarks/README.md`](benchmarks/README.md#mapstruct-comparison-apples-to-apples).
 

--- a/README.md
+++ b/README.md
@@ -413,9 +413,9 @@ performance class:
 | Set or Map field, 100 items | a tie on time, and ~11% less allocated on the Map shape         |
 
 No codegen? `Telescope.mapper(...)` composes each record/bean pair into a single MethodHandle: zero annotations, no
-build step, within ~1.3–3.3× of MapStruct in the same workloads (flat ~3.3×, nested ~2.7×, deep ~1.3× — closest where
-trees are deepest, and a tie on container fields). That's sub-microsecond conversion; whether it's fast enough is your
-call, and when a loop turns hot, `@Bridge` puts you back in the codegen class. Reproduce any of it from the
+build step, within ~1.04–3.3× of MapStruct in the same workloads (flat ~3.3×, nested ~2.7×, deep ~1.3×, container fields
+~1.04–1.06× — the gap closes as the work per call grows). That's sub-microsecond conversion; whether it's fast enough is
+your call, and when a loop turns hot, `@Bridge` puts you back in the codegen class. Reproduce any of it from the
 [`Benchmarks`](.github/workflows/benchmarks.yaml) GitHub Action; the full matrix is in
 [`benchmarks/README.md`](benchmarks/README.md#mapstruct-comparison-apples-to-apples).
 

--- a/README.md
+++ b/README.md
@@ -414,9 +414,10 @@ performance class:
 
 No codegen? `Telescope.mapper(...)` composes each record/bean pair into a single MethodHandle: zero annotations, no
 build step, within ~1.04–3.3× of MapStruct in the same workloads (flat ~3.3×, nested ~2.7×, deep ~1.3×, container fields
-~1.04–1.06× — the ratio narrows as the work per call grows, since a roughly fixed dispatch overhead amortizes against a
-larger conversion; the absolute gap grows). That's sub-microsecond conversion; whether it's fast enough is your call,
-and when a loop turns hot, `@Bridge` puts you back in the codegen class. Reproduce any of it from the
+~1.04–1.06× — the ratio narrows as the work per call grows: a fixed ~7 ns per-call cost is essentially the whole gap on
+flat and nested, and the container shapes add a sub-nanosecond per-element cost on top, so the absolute gap grows while
+the ratio falls). That's sub-microsecond conversion; whether it's fast enough is your call, and when a loop turns hot,
+`@Bridge` puts you back in the codegen class. Reproduce any of it from the
 [`Benchmarks`](.github/workflows/benchmarks.yaml) GitHub Action; the full matrix is in
 [`benchmarks/README.md`](benchmarks/README.md#mapstruct-comparison-apples-to-apples).
 

--- a/README.md
+++ b/README.md
@@ -405,17 +405,18 @@ In the included JMH workloads (MapStruct 1.6.3, CI hardware, JDK 25 — all figu
 [methodology and history](docs/perf-mapstruct-comparison.md)), telescope codegen and MapStruct codegen land in the same
 performance class:
 
-| Tier (codegen vs codegen)   | telescope vs MapStruct                                          |
-| --------------------------- | --------------------------------------------------------------- |
-| flat (5 scalars)            | ~1.07× — a fifth of a nanosecond                                |
-| nested (one nested type)    | 1.04×–1.42× across runs — a microbenchmark, not a service shape |
-| deep (3 levels + list hops) | ~1.07× — 4 ns on a 62 ns conversion, same 376 B/op floor        |
-| Set or Map field, 100 items | a tie on time, and ~11% less allocated on the Map shape         |
+| Tier (codegen vs codegen)   | telescope vs MapStruct                                              |
+| --------------------------- | ------------------------------------------------------------------- |
+| flat (5 scalars)            | ~1.07× — a fifth of a nanosecond                                    |
+| nested (one nested type)    | 1.04×–1.46× across runs — a microbenchmark, not a service shape     |
+| deep (3 levels + list hops) | 1.07×–1.19× across runs — 4 ns on a 62 ns conversion at the low end |
+| Set or Map field, 100 items | a tie on time, and ~11% less allocated on the Map shape             |
 
 No codegen? `Telescope.mapper(...)` composes each record/bean pair into a single MethodHandle: zero annotations, no
 build step, within ~1.04–3.3× of MapStruct in the same workloads (flat ~3.3×, nested ~2.7×, deep ~1.3×, container fields
-~1.04–1.06× — the gap closes as the work per call grows). That's sub-microsecond conversion; whether it's fast enough is
-your call, and when a loop turns hot, `@Bridge` puts you back in the codegen class. Reproduce any of it from the
+~1.04–1.06× — the ratio narrows as the work per call grows, since a roughly fixed dispatch overhead amortizes against a
+larger conversion; the absolute gap grows). That's sub-microsecond conversion; whether it's fast enough is your call,
+and when a loop turns hot, `@Bridge` puts you back in the codegen class. Reproduce any of it from the
 [`Benchmarks`](.github/workflows/benchmarks.yaml) GitHub Action; the full matrix is in
 [`benchmarks/README.md`](benchmarks/README.md#mapstruct-comparison-apples-to-apples).
 

--- a/README.md
+++ b/README.md
@@ -401,7 +401,8 @@ To be precise about what a stale string costs, because the failure modes differ:
 
 #### Performance, measured
 
-In the included JMH workloads (MapStruct 1.6.3, CI hardware, JDK 25 — all figures from one run, so they are comparable;
+In the included JMH workloads (MapStruct 1.6.3, CI hardware, JDK 25 — single-run figures are comparable with each other,
+and the ranges are what the same benchmark has produced across runs;
 [methodology and history](docs/perf-mapstruct-comparison.md)), telescope codegen and MapStruct codegen land in the same
 performance class:
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -241,6 +241,10 @@ difference between same-tier rows is the dispatch path. Reproducible: re-run the
 | deep   | bean → record |     48.68 ± 0.106 |             55.04 ± 0.522 |                    54.71 ± 0.375 |              90.1 ± 2.5\* |
 | deep   | record → bean |     48.54 ± 0.273 |             54.81 ± 0.418 |                                — |              95.0 ± 2.5\* |
 
+> **This table predates the current figures and has no container tier.** Where it disagrees with the text below, the
+> text is the more recent measurement (Actions run 34470676359);
+> [`docs/perf-mapstruct-comparison.md`](../docs/perf-mapstruct-comparison.md) carries the full current set.
+
 \* The nested and deep runtime cells were re-measured on a laptop after two lattice sharpenings landed. **Deep** — the
 container-element MethodHandle loop (a nested `List`/`Set`/`Map` element loops over the leaf's raw handle instead of
 dispatching `Iso.to` per element): same-machine A/B main **205.4 / 207.2 ns** → **90.1 / 95.0 ns** (**~2.2×**), from
@@ -310,14 +314,11 @@ runtime path is now within ~1.04–3.3× of MapStruct with **no annotations and 
 per-call conversion work is largest, which is the deep tier and the hash-container fields — close enough for most
 service code, and `@Bridge` codegen is there when a loop turns hot.
 
-The table above predates the current headline figures and has no container rows; where it disagrees with the prose
-below, the prose is the more recent measurement (Actions run 34470676359) and
-[`docs/perf-mapstruct-comparison.md`](../docs/perf-mapstruct-comparison.md) carries the full current set. All four
-columns in it are from the same run; the codegen/MapStruct ratios reproduce across confirming runs within error (the
-runtime rows carry wider bands but the same magnitude).
+All four columns in that table are from the same run; the codegen/MapStruct ratios reproduce across confirming runs
+within error (the runtime rows carry wider bands but the same magnitude).
 
 A quick decision guide. If the problem is "convert this entity to this DTO and back, both directions known at build
-time, no nested-list iteration, only scalars," MapStruct's bytecode is ~1.07× faster on the row (3.17 vs 3.39 ns, ~0.2
+time, no nested-list iteration, only scalars," MapStruct's bytecode is ~1.07× faster on the row (3.155 vs 3.362 ns, ~0.2
 ns absolute). On realistic deep workloads — nested records with list-of-records inside — telescope codegen matches
 MapStruct.
 
@@ -326,8 +327,8 @@ Where MapStruct stops being an option entirely: sealed-narrow paradigm hop, effe
 scope for a mapping-only model and demoed end-to-end in `examples/springboot/`. Capability wins, not perf wins, but
 they're the reason you'd pick telescope in the first place.
 
-Even the slowest telescope row — deep runtime backward at ~0.87 μs — is fine for typical request handling. One or a few
-conversions per request, not millions per second.
+Even the slowest telescope row — a hundred-element Set converted through the runtime path, ~1.5 μs — is fine for typical
+request handling. One or a few conversions per request, not millions per second.
 
 One implementation note: the telescope `_codegen_backward` rows use `BRIDGE.set(placeholderBean, rec)`, which discards
 the placeholder and invokes the underlying `iso.from(rec)`. The `set` wrapper adds a small constant overhead vs a direct

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -274,40 +274,41 @@ cycle is possible; cyclic SCCs keep the full guard).
 #### What the numbers say
 
 **Codegen-for-codegen, telescope and MapStruct are the same performance class — a tie at realistic depth.** On flat
-(3.17 vs 3.39 ns) telescope is **~1.07×**, ~0.2 ns absolute; on deep (48.68 vs 55.04 ns) **~1.13× — a tie, ~6 ns on a
-~50 ns op**, both directions, stable across CI runs. The nested single-hop tier swings 1.04×–1.42× run-to-run — its
-MapStruct baseline is JMH-noisy (±0.35) — so it's a framework-overhead microbench, not a number to publish. The deeper
-the tree, the more the per-level conversion work dominates the fixed dispatch overhead; at the flat scale you're
-choosing on API and capability, not nanoseconds.
+(3.155 vs 3.362 ns) telescope is **~1.07×**, ~0.2 ns absolute; on deep (62.38 vs 66.57 ns) **~1.07× — ~4 ns on a ~62 ns
+op**, stable across CI runs. The nested single-hop tier swings 1.04×–1.46× run-to-run — its MapStruct baseline is
+JMH-noisy (±0.35) — so it's a framework-overhead microbench, not a number to publish. The deeper the tree, the more the
+per-level conversion work dominates the fixed dispatch overhead; at the flat scale you're choosing on API and
+capability, not nanoseconds.
 
 The gap decomposes into a tiny dispatch tax plus the generated body. The `static` column (zero-dispatch
-`<Source>Bridge.forward(s)`) is the floor; the `BRIDGE.read` lattice path sits a wrapper tax above it that grows with
-nesting depth but stays ≤0.8 ns, and on deep the residual over MapStruct is mostly the generated body — six leaf
-conversions and two list allocations — not dispatch. The full two-run decomposition, all four call shapes (`static` /
-`BRIDGE_FN` / `BRIDGE.read` / MapStruct) at each tier, plus the JMH-artifact history, lives in
+`<Source>Bridge.forward(s)`) is the floor; the `BRIDGE.read` lattice path sits a sub-nanosecond wrapper tax above it
+(its size, and on one run its sign, move between runs — see the doc), and on deep the residual over MapStruct is mostly
+the generated body — six leaf conversions and two list allocations — not dispatch. The full decomposition, all four call
+shapes (`static` / `BRIDGE_FN` / `BRIDGE.read` / MapStruct) at each tier, plus the JMH-artifact history, lives in
 [`docs/perf-mapstruct-comparison.md`](../docs/perf-mapstruct-comparison.md).
 
 Where the flat-tier gap comes from. MapStruct emits one hand-templated method body per pair, fully monomorphic, and the
 JIT inlines the whole conversion into a single basic block. Telescope's `@Bridge` codegen emits the same shape — a
 direct constructor call — wrapped in a `Telescope` for composability. On a flat ~3 ns conversion that composability
 costs ~0.2 ns total; on deep, where element-by-element list conversion dominates and the workload climbs past 50 ns, it
-is a ~1.15× tie. If you're in a tight inner loop that doesn't need composition, call `<Source>Bridge.forward(s)` — or
+is a ~1.07× tie. If you're in a tight inner loop that doesn't need composition, call `<Source>Bridge.forward(s)` — or
 the directly-callable `BRIDGE_FN` constant — and pay the zero-dispatch floor.
 
 Runtime conversion (`Telescope.mapper(...)`) composes each record/bean pair into a single MethodHandle (see above), so
 the hot path is one `invokeExact` through the fused handle rather than an `Object[]` gather with boxed per-field
-dispatch. That lands the forward direction at **~3.9× MapStruct on flat, ~2× on nested, ~1.3–1.9× on deep**. Nested and
-deep both used to trail far worse (~6.2× and ~4.4×); two lattice sharpenings closed them. The container-element
-MethodHandle loop (a nested `List`/`Set`/`Map` element loops over the leaf's raw handle instead of dispatching `Iso.to`
-→ `Function.apply` per element, which also un-megamorphizes the shared lift call site) roughly halved deep —
-same-machine 205 → 90 ns. Full-tree fusion (a scalar nested-pair slot inlines the sub-leaf's raw handle directly into
-the parent's composed handle, so the whole acyclic subtree collapses to one `invokeExact`) did the same for nested — 25
-→ 15 ns. The backward (record → bean) direction — previously the pathological case (allocate a bean, then N boxed setter
-calls, ~48× MapStruct on flat) — is now **~3.5× on flat** via the unboxed setter-fold, matching forward instead of
-trailing it. Allocation drops to the result-object floor (flat 32 B/op, the array + every primitive box gone).
-Sub-microsecond everywhere. Reach for codegen on the hottest paths; the runtime path is now within ~1.3–4× of MapStruct
-with **no annotations and no build step** — and closest exactly where it matters most, on the deep container-heavy trees
-— close enough for most service code, and `@Bridge` codegen is there when a loop turns hot.
+dispatch. That lands the forward direction at **~3.3× MapStruct on flat, ~2.7× on nested, ~1.3× on deep**, and
+~1.04–1.06× on hash-container fields. Nested and deep both used to trail far worse (~6.2× and ~4.4×); two lattice
+sharpenings closed them. The container-element MethodHandle loop (a nested `List`/`Set`/`Map` element loops over the
+leaf's raw handle instead of dispatching `Iso.to` → `Function.apply` per element, which also un-megamorphizes the shared
+lift call site) roughly halved deep — same-machine 205 → 90 ns. Full-tree fusion (a scalar nested-pair slot inlines the
+sub-leaf's raw handle directly into the parent's composed handle, so the whole acyclic subtree collapses to one
+`invokeExact`) did the same for nested — 25 → 15 ns. The backward (record → bean) direction — previously the
+pathological case (allocate a bean, then N boxed setter calls, ~48× MapStruct on flat) — is now **~3.5× on flat** via
+the unboxed setter-fold, matching forward instead of trailing it. Allocation drops to the result-object floor (flat 32
+B/op, the array + every primitive box gone). Sub-microsecond everywhere. Reach for codegen on the hottest paths; the
+runtime path is now within ~1.3–4× of MapStruct with **no annotations and no build step** — and closest exactly where it
+matters most, on the deep container-heavy trees — close enough for most service code, and `@Bridge` codegen is there
+when a loop turns hot.
 
 All four columns above are from the same run; the codegen/MapStruct ratios reproduce across confirming runs within error
 (the runtime rows carry wider bands but the same magnitude).

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -275,10 +275,10 @@ cycle is possible; cyclic SCCs keep the full guard).
 
 **Codegen-for-codegen, telescope and MapStruct are the same performance class — a tie at realistic depth.** On flat
 (3.155 vs 3.362 ns) telescope is **~1.07×**, ~0.2 ns absolute; on deep (62.38 vs 66.57 ns) **~1.07× — ~4 ns on a ~62 ns
-op**, stable across CI runs. The nested single-hop tier swings 1.04×–1.46× run-to-run — its MapStruct baseline is
-JMH-noisy (±0.35) — so it's a framework-overhead microbench, not a number to publish. The deeper the tree, the more the
-per-level conversion work dominates the fixed dispatch overhead; at the flat scale you're choosing on API and
-capability, not nanoseconds.
+op** on the most recent run, 1.07×–1.19× across runs. The nested single-hop tier swings 1.04×–1.46× run-to-run — its
+MapStruct baseline is JMH-noisy (±0.35) — so it's a framework-overhead microbench, not a number to publish. The deeper
+the tree, the more the per-level conversion work dominates the fixed dispatch overhead; at the flat scale you're
+choosing on API and capability, not nanoseconds.
 
 The gap decomposes into a tiny dispatch tax plus the generated body. The `static` column (zero-dispatch
 `<Source>Bridge.forward(s)`) is the floor; the `BRIDGE.read` lattice path sits a sub-nanosecond wrapper tax above it
@@ -306,9 +306,9 @@ sub-leaf's raw handle directly into the parent's composed handle, so the whole a
 pathological case (allocate a bean, then N boxed setter calls, ~48× MapStruct on flat) — is now **~3.5× on flat** via
 the unboxed setter-fold, matching forward instead of trailing it. Allocation drops to the result-object floor (flat 32
 B/op, the array + every primitive box gone). Sub-microsecond everywhere. Reach for codegen on the hottest paths; the
-runtime path is now within ~1.3–4× of MapStruct with **no annotations and no build step** — and closest exactly where it
-matters most, on the deep container-heavy trees — close enough for most service code, and `@Bridge` codegen is there
-when a loop turns hot.
+runtime path is now within ~1.04–3.3× of MapStruct with **no annotations and no build step** — closest where the
+per-call conversion work is largest, which is the deep tier and the hash-container fields — close enough for most
+service code, and `@Bridge` codegen is there when a loop turns hot.
 
 All four columns above are from the same run; the codegen/MapStruct ratios reproduce across confirming runs within error
 (the runtime rows carry wider bands but the same magnitude).

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -295,8 +295,9 @@ Where the flat-tier gap comes from. MapStruct emits one hand-templated method bo
 JIT inlines the whole conversion into a single basic block. Telescope's `@Bridge` codegen emits the same shape — a
 direct constructor call — wrapped in a `Telescope` for composability. On a flat ~3 ns conversion that composability
 costs ~0.2 ns total; on deep, where element-by-element list conversion dominates and the workload climbs past 50 ns, it
-is a ~1.07× tie. If you're in a tight inner loop that doesn't need composition, call `<Source>Bridge.forward(s)` — or
-the directly-callable `BRIDGE_FN` constant — and pay the zero-dispatch floor.
+is a ~1.07× tie on the most recent run, 1.07×–1.19× across runs. If you're in a tight inner loop that doesn't need
+composition, call `<Source>Bridge.forward(s)` — or the directly-callable `BRIDGE_FN` constant — and pay the
+zero-dispatch floor.
 
 Runtime conversion (`Telescope.mapper(...)`) composes each record/bean pair into a single MethodHandle (see above), so
 the hot path is one `invokeExact` through the fused handle rather than an `Object[]` gather with boxed per-field
@@ -327,8 +328,9 @@ Where MapStruct stops being an option entirely: sealed-narrow paradigm hop, effe
 scope for a mapping-only model and demoed end-to-end in `examples/springboot/`. Capability wins, not perf wins, but
 they're the reason you'd pick telescope in the first place.
 
-Even the slowest telescope row — a hundred-element Set converted through the runtime path, ~1.5 μs — is fine for typical
-request handling. One or a few conversions per request, not millions per second.
+Even the slowest telescope row — a hundred-element Set rebuilt backward through the codegen bridge, ~3.2 μs, where
+MapStruct is ~3.1 μs on the same shape — is fine for typical request handling. One or a few conversions per request, not
+millions per second.
 
 One implementation note: the telescope `_codegen_backward` rows use `BRIDGE.set(placeholderBean, rec)`, which discards
 the placeholder and invokes the underlying `iso.from(rec)`. The `set` wrapper adds a small constant overhead vs a direct

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -310,8 +310,11 @@ runtime path is now within ~1.04–3.3× of MapStruct with **no annotations and 
 per-call conversion work is largest, which is the deep tier and the hash-container fields — close enough for most
 service code, and `@Bridge` codegen is there when a loop turns hot.
 
-All four columns above are from the same run; the codegen/MapStruct ratios reproduce across confirming runs within error
-(the runtime rows carry wider bands but the same magnitude).
+The table above predates the current headline figures and has no container rows; where it disagrees with the prose
+below, the prose is the more recent measurement (Actions run 34470676359) and
+[`docs/perf-mapstruct-comparison.md`](../docs/perf-mapstruct-comparison.md) carries the full current set. All four
+columns in it are from the same run; the codegen/MapStruct ratios reproduce across confirming runs within error (the
+runtime rows carry wider bands but the same magnitude).
 
 A quick decision guide. If the problem is "convert this entity to this DTO and back, both directions known at build
 time, no nested-list iteration, only scalars," MapStruct's bytecode is ~1.07× faster on the row (3.17 vs 3.39 ns, ~0.2

--- a/docs/perf-mapstruct-comparison.md
+++ b/docs/perf-mapstruct-comparison.md
@@ -9,32 +9,36 @@ and propose remediations where the gap is structural.
 run so every figure below is comparable — separate runs land on runners of different speeds, which has produced
 misleading ratios here before.
 
-| Tier (forward, codegen vs codegen)  | MapStruct | telescope | ratio | allocation              |
-| ----------------------------------- | --------: | --------: | ----: | ----------------------- |
-| flat (5 scalars)                    |  3.155 ns |  3.362 ns | 1.07x | 32 B/op both            |
-| nested (one nested type)            |  4.361 ns |  5.604 ns | 1.29x | 48 B/op both            |
-| deep (3 levels + 2 list hops)       | 62.378 ns | 66.572 ns | 1.07x | 376 B/op both           |
-| container, Map-valued (100 entries) | 1261.7 ns | 1243.5 ns |   tie | **7,528 vs 6,712 B/op** |
-| container, Set-valued (100 entries) | 1454.8 ns | 1444.7 ns |   tie | 7,576 B/op both         |
+| Tier (forward, codegen vs codegen)  |        MapStruct |        telescope | ratio | allocation              |
+| ----------------------------------- | ---------------: | ---------------: | ----: | ----------------------- |
+| flat (5 scalars)                    | 3.155 ± 0.019 ns | 3.362 ± 0.011 ns | 1.07x | 32 B/op both            |
+| nested (one nested type)            | 4.361 ± 0.045 ns | 5.604 ± 0.033 ns | 1.29x | 48 B/op both            |
+| deep (3 levels + 2 list hops)       |  62.38 ± 0.18 ns |  66.57 ± 0.52 ns | 1.07x | 376 B/op both           |
+| container, Map-valued (100 entries) |     1262 ± 11 ns |     1244 ± 10 ns |   tie | **7,528 vs 6,712 B/op** |
+| container, Set-valued (100 entries) |     1455 ± 21 ns |      1445 ± 9 ns |   tie | 7,576 B/op both         |
 
-Read the two container rows carefully. Their confidence intervals overlap, so **the timings are a tie, not a win** —
-telescope's mean is marginally lower and that means nothing. What is real is the allocation: 6,712 against 7,528 bytes
-per operation on the Map tier, about 11% less, and allocation is deterministic rather than hardware-dependent.
+Read the two container rows carefully — telescope's mean is marginally lower on both, and on neither does that mean it
+won. On Set the intervals overlap almost entirely (telescope's sits inside MapStruct's), which is a clean tie. On Map
+they overlap by under 3 ns, so call it a tie but not a settled one: tighter bands could separate them either way. What
+is real on that row is the allocation — 6,712 against 7,528 bytes per operation, about 11% less — and allocation is
+deterministic rather than hardware-dependent, which makes it the durable result.
 
 The scalar tiers are unchanged in character: a 0.2 ns difference on flat, 4 ns on a 62 ns deep conversion, and both
-outside their error bars so the ratios are real rather than noise. Nested remains the unstable one — measured at 1.04x,
-1.42x, 1.20x, 1.21x and now 1.29x across five runs of the same benchmark. It is a framework-overhead microbenchmark
+outside their error bars so the ratios are real rather than noise. Nested remains the unstable one — across CI runs of
+this benchmark it has ranged from 1.04x to 1.46x, and it lands at 1.29x here. It is a framework-overhead microbenchmark
 rather than a service-shaped workload; treat flat and deep as the publishable figures and nested as a range.
 
-Runtime tier, same run: flat 3.34x, nested 2.66x, deep 1.27x of MapStruct. That tier has no MapStruct equivalent to
-compare against — it is what you get with no annotations and no build step.
+Runtime tier, same run: flat 3.34x, nested 2.66x, deep 1.27x, and 1.04x–1.06x on the two container shapes. MapStruct has
+no equivalent to this tier — it is what you get with no annotations and no build step — so these ratios say what the
+convenience costs, not who wins.
 
 ### What the container tier is for
 
 It did not exist until recently, and its absence is why a defect shipped: every tier here was List-only, a list has no
-hash table, and the Bridge emitter was sizing Set and Map rebuilds by element count rather than table capacity. Every
-benchmark was green while generated bridges allocated more than the reflective path they exist to beat. The tier was
-added so that class of defect fails a measurement instead of passing one.
+hash table, and the Bridge emitter passed the source element count straight into the hash container's `int` constructor
+— which takes a table capacity, not an element count. Every benchmark was green while generated bridges allocated more
+than the reflective path they exist to beat. The tier was added so that class of defect fails a measurement instead of
+passing one.
 
 ## Methodology
 
@@ -92,14 +96,16 @@ three tiers (earlier revisions measured it on flat only).
 | nested | 5.079 ± 0.468 |        5.023 ± 1.219 |             0.99× |
 | deep   | 42.11 ± 1.575 |        49.54 ± 1.312 |             1.18× |
 
-**What reproduces, and what doesn't.** Flat (1.065× / 1.072×) and deep (1.185× / 1.137×) are stable — publishable at
-~1.07× and ~1.15×. Nested swings 1.043× → 1.424×: the `nested_mapstruct_forward` baseline carries a wide ±0.35 band both
-runs, so the nested ratio is a JMH-noisy figure, not a real regression or improvement — don't publish a single number
-for it. On the dispatch spread, both runs agree: `BRIDGE_FN` tracks `static forward` within error (run 2 flat: identical
-at 3.183), while `BRIDGE.read` sits a wrapper tax above the floor that grows with depth — 0.14 → 0.31 → 0.77 ns across
-flat/nested/deep on the tight-band run, each outside its error band. So `BRIDGE_FN` is the floor; the lattice wrapper is
-a small (≤0.8 ns) tax that scales with nesting depth; and the deep residual over MapStruct is mostly the generated body
-(`static forward` alone is ~1.12× on deep, ~5.6 ns of the ~6.3 ns gap).
+**What reproduces, and what doesn't** — as read at the time, from these two runs alone. Flat (1.065× / 1.072×) and deep
+(1.185× / 1.137×) are stable across the pair; deep has since come down to ~1.07× on the headline run, so treat ~1.15× as
+the figure these two runs supported rather than the current one. Nested swings 1.043× → 1.424×: the
+`nested_mapstruct_forward` baseline carries a wide ±0.35 band both runs, so the nested ratio is a JMH-noisy figure, not
+a real regression or improvement — don't publish a single number for it. On the dispatch spread, both runs agree:
+`BRIDGE_FN` tracks `static forward` within error (run 2 flat: identical at 3.183), while `BRIDGE.read` sits a wrapper
+tax above the floor that grows with depth — 0.14 → 0.31 → 0.77 ns across flat/nested/deep on the tight-band run, each
+outside its error band. So `BRIDGE_FN` is the floor; the lattice wrapper is a small (≤0.8 ns) tax that scales with
+nesting depth; and the deep residual over MapStruct is mostly the generated body (`static forward` alone is ~1.12× on
+deep, ~5.6 ns of the ~6.3 ns gap).
 
 Runtime path forward: flat 40.14, nested 64.37, deep 315.23 ns/op — ~16× / ~14× / ~8× of MapStruct. The backward
 direction stays higher (flat 108.31, nested 148.63, deep 626.39) because building a bean (allocate + N setters) is
@@ -108,7 +114,7 @@ through a structural-Iso build per `Telescope.mapper(...)` call site and a refle
 invocation; it's not in the dethrone-MapStruct lane, it's the convenience surface for "I don't want to write codegen for
 this one mapper".
 
-## Dispatch — `BRIDGE_FN` is the floor, the lattice wrapper is a ≤0.8 ns tax that scales with depth
+## Dispatch — `BRIDGE_FN` is the floor, and the lattice wrapper is a sub-nanosecond tax
 
 The `*_codegen_static_forward` (zero dispatch), `*_bridgefn_forward` (one interface hop), and `*_codegen_forward`
 (`BRIDGE.read`, full lattice) benchmarks isolate the dispatch cost by call shape. The `wrapper tax` column is the raw
@@ -122,6 +128,9 @@ The `*_codegen_static_forward` (zero dispatch), `*_bridgefn_forward` (one interf
 | R2 nested |                    5.902 |               5.896 |                   6.207 |     0.31 ns | yes (±0.04–0.09) |
 | R1 deep   |                    47.40 |               48.41 |                   47.72 |     0.32 ns | no (±1.5–3.2)    |
 | R2 deep   |                    51.92 |               52.59 |                   52.68 |     0.77 ns | yes (±0.12–0.16) |
+| R3 flat   |                    3.161 |               3.162 |                   3.362 |     0.20 ns | yes (±0.01–0.03) |
+| R3 nested |                    5.913 |               5.908 |                   5.604 |    −0.31 ns | yes (±0.03)      |
+| R3 deep   |                    66.27 |               69.22 |                   66.57 |     0.30 ns | no (±0.27–0.52)  |
 
 Read the tight-band run (R2) — its bands are 3–30× narrower, so it's the one that resolves anything. Two things hold:
 
@@ -130,12 +139,16 @@ tied on R2 nested (5.896 vs 5.902), and on R2 deep its ±0.675 band overlaps sta
 51.92). The one-interface-hop constant is monomorphic (one concrete `Fn` per bridge) and the JIT inlines it to the raw
 static call — it is the floor, there is nothing faster to reach.
 
-Second, **the full-lattice `BRIDGE.read` sits a wrapper tax above that floor, and the tax grows with depth**: on R2 it
-is 0.14 ns (flat) → 0.31 ns (nested) → 0.77 ns (deep), each outside the tight error bands. That monotonic climb is the
-lattice composition depth showing through — more nesting, more `Iso.then(...)` hops the wrapper carries. It stays small
-in absolute terms (≤0.8 ns), and on deep it is dwarfed by the ~5.6 ns generated-body gap anyway (see next section). On
-the wide-band R1 run the same gaps sit inside the noise, so R1 alone couldn't see them — which is exactly why we ran
-twice.
+Second, **the full-lattice `BRIDGE.read` sits a small wrapper tax above that floor** — on R2, 0.14 ns (flat) → 0.31 ns
+(nested) → 0.77 ns (deep), each outside the tight error bands, which read as the lattice composition depth showing
+through: more nesting, more `Iso.then(...)` hops the wrapper carries.
+
+**R3 does not reproduce that climb, so treat the depth-scaling as provisional.** On the same clean CI hardware it
+measures +0.20 ns on flat (real), −0.31 ns on nested — the lattice value _below_ the static floor, outside the bands,
+which is the "static-slower-than-lattice" inversion the lesson below files under laptop noise — and +0.30 ns on deep,
+inside the bands and therefore not a measurement at all. What survives all three runs is the magnitude: the tax is under
+a nanosecond wherever it is resolvable, and on deep it is dwarfed by the generated-body gap anyway (see next section).
+What does not survive is the monotonic ordering.
 
 An earlier run reported a ~0.3–0.7 ns "lattice slice" and proposed closing it by emitting a directly-callable
 `BRIDGE_FN` constant. `BRIDGE_FN` shipped (#182) — and it lands at the `static forward` floor, so an adopter who wants
@@ -146,19 +159,22 @@ the composable value while refusing to switch to `BRIDGE_FN`. Not worth it.
 The lesson stands: **smoke runs lie, and one CI run can too.** Run 1's 1.04× nested looked like a headline until run 2
 returned 1.42× on the same branch — the nested MapStruct baseline is JMH-noisy (±0.35). Laptop smoke runs earlier
 produced a 2.9–3.6× "forward gap", a "telescope-faster-on-backward" claim, and a "static-slower-than-lattice" inversion,
-all wrong. Trust the numbers that reproduce across runs: flat ~1.07×, deep ~1.15×, and `BRIDGE_FN` at the floor.
+all wrong — though R3 above measures that same inversion on nested with disjoint bands, so the shape is not exclusively
+a laptop artifact. Trust the numbers that reproduce across runs: flat ~1.07×, deep ~1.07×–1.15×, and `BRIDGE_FN` at the
+floor.
 
 ## So is there a real gap?
 
-**A small one, only on deep: ~1.15× forward, and it is mostly not dispatch.** Flat is ~1.07× (both runs). The deep
-`BRIDGE.read` gap is ~6.3 ns, and it splits: the zero-dispatch `static forward` floor is _already_ ~1.12× on deep (~5.6
-ns, the generated **body** — six leaf conversions, two list allocations, and per-field null-guards vs MapStruct's
-directly-inlined field sequence), with the lattice wrapper adding ~0.8 ns on top. Body dominates ~7:1. Whether it
-matters to an adopter:
+**A small one on deep, and it is mostly not dispatch.** On the headline run deep is ~1.07× forward — a 4.19 ns gap on a
+62 ns conversion — down from the ~1.15× the two earlier runs supported. The split is the durable part: the zero-dispatch
+`static forward` floor is _already_ ~1.06× on deep (3.90 ns of the 4.19, the generated **body** — six leaf conversions,
+two list allocations, and per-field null-guards vs MapStruct's directly-inlined field sequence), with the lattice
+wrapper adding the remainder. Body dominates by roughly 13:1 here and ~7:1 on the earlier runs; either way the wrapper
+is not what an adopter would be paying for. Whether it matters at all:
 
 - At <10M ops/sec on a hot mapper: invisible against application work.
-- At >100M ops/sec on the deep tier: a ~6 ns per-call structural cost — measurable on a flame graph, rarely dominant.
-- On flat: no gap to speak of (~1.07×). On nested the ratio is JMH-noisy run-to-run (1.04×–1.42×) — near-parity, but the
+- At >100M ops/sec on the deep tier: a ~4 ns per-call structural cost — measurable on a flame graph, rarely dominant.
+- On flat: no gap to speak of (~1.07×). On nested the ratio is JMH-noisy run-to-run (1.04×–1.46×) — near-parity, but the
   noisy MapStruct baseline means no single figure is trustworthy.
 
 ## Remediations — status
@@ -198,22 +214,23 @@ residual.
   MapStruct — on each run and pin `BRIDGE_FN` to the floor.
 - **This analysis doc, corrected against two runs.** Prior revisions claimed a ~0.3–0.7 ns lattice slice and proposed
   two remediations to close it; a first fresh run then over-corrected to "dispatch is free everywhere". A confirmation
-  run settled it: `BRIDGE_FN` is the floor, the lattice wrapper is a ≤0.8 ns tax that grows with nesting depth, and the
-  nested ratio is JMH-noisy. The doc records the reproducible parity result and the measured-and-declined subclass
-  decision.
+  run settled it: `BRIDGE_FN` is the floor, the lattice wrapper is a sub-nanosecond tax, and the nested ratio is
+  JMH-noisy. The doc records the reproducible parity result and the measured-and-declined subclass decision.
 - **No production code changed.** `BRIDGE_FN` already ships; the codegen is at parity as-is.
 
 ## Bottom line
 
 Telescope codegen is in MapStruct's performance class: 1.07x flat, 1.07x deep, and a tie on both hash-container tiers
-where it also allocates about 11% less on the Map shape. Nested stays the unstable measurement — five runs of the same
-benchmark have produced 1.04x, 1.42x, 1.20x, 1.21x and 1.29x — so it is reported as a range rather than a figure.
+where it also allocates about 11% less on the Map shape. Nested stays the unstable measurement — across CI runs of this
+benchmark it has ranged from 1.04x to 1.46x — so it is reported as a range rather than a figure.
 
-On dispatch the question is settled. `BRIDGE_FN` is the floor: it tracks the zero-dispatch `static forward` within error
-on every tier, because the JIT inlines the monomorphic hop. The full-lattice `BRIDGE.read` carries a wrapper tax that
-grows with depth, 0.14 to 0.77 ns across the three scalar tiers, each outside its error band. That settles both proposed
-remediations — `BRIDGE_FN` shipped and lands at the floor, and the type-specialized subclass would remove only that
-sub-nanosecond tax, swamped roughly seven to one by the body gap on deep. Declined.
+On dispatch, one half is settled and one is not. `BRIDGE_FN` is the floor: it tracks the zero-dispatch `static forward`
+within error on every tier and on every run, because the JIT inlines the monomorphic hop. The full-lattice `BRIDGE.read`
+carries a wrapper tax under a nanosecond wherever it resolves at all — but its size and even its sign move between runs
+(R2 read 0.14 → 0.31 → 0.77 ns with depth; R3 read +0.20, −0.31, and an unresolvable +0.30), so the depth-scaling story
+is provisional and the magnitude is the only durable part. Either way both proposed remediations are settled:
+`BRIDGE_FN` shipped and lands at the floor, and the type-specialized subclass would remove only that sub-nanosecond tax,
+swamped an order of magnitude over by the body gap on deep. Declined.
 
 What remains over MapStruct on the deep tier is a few nanoseconds of generated-body work rather than dispatch —
 `static forward` alone is above parity — and closing it means matching MapStruct's inlined body. That stays

--- a/docs/perf-mapstruct-comparison.md
+++ b/docs/perf-mapstruct-comparison.md
@@ -9,17 +9,17 @@ and propose remediations where the gap is structural.
 run so every figure below is comparable — separate runs land on runners of different speeds, which has produced
 misleading ratios here before.
 
-| Tier (forward, codegen vs codegen)  |        MapStruct |        telescope | ratio | across runs   | allocation              |
-| ----------------------------------- | ---------------: | ---------------: | ----: | ------------- | ----------------------- |
-| flat (5 scalars)                    | 3.155 ± 0.019 ns | 3.362 ± 0.011 ns | 1.07x | ~1.07x stable | 32 B/op both            |
-| nested (one nested type)            | 4.361 ± 0.045 ns | 5.604 ± 0.033 ns | 1.29x | 1.04x–1.46x   | 48 B/op both            |
-| deep (3 levels + 2 list hops)       |  62.38 ± 0.18 ns |  66.57 ± 0.52 ns | 1.07x | 1.07x–1.19x   | 376 B/op both           |
-| container, Map-valued (100 entries) |     1262 ± 11 ns |     1244 ± 10 ns |   tie | measured once | **7,528 vs 6,712 B/op** |
-| container, Set-valued (100 entries) |     1455 ± 21 ns |      1445 ± 9 ns |   tie | measured once | 7,576 B/op both         |
+| Tier (forward, codegen vs codegen)  |        MapStruct |        telescope | ratio | across runs            | allocation              |
+| ----------------------------------- | ---------------: | ---------------: | ----: | ---------------------- | ----------------------- |
+| flat (5 scalars)                    | 3.155 ± 0.019 ns | 3.362 ± 0.011 ns | 1.07x | ~1.07x (one run 1.13x) | 32 B/op both            |
+| nested (one nested type)            | 4.361 ± 0.045 ns | 5.604 ± 0.033 ns | 1.29x | 1.04x–1.46x            | 48 B/op both            |
+| deep (3 levels + 2 list hops)       |  62.38 ± 0.18 ns |  66.57 ± 0.52 ns | 1.07x | 1.07x–1.19x            | 376 B/op both           |
+| container, Map-valued (100 entries) |     1262 ± 11 ns |     1244 ± 10 ns |   tie | measured once          | **7,528 vs 6,712 B/op** |
+| container, Set-valued (100 entries) |     1455 ± 21 ns |      1445 ± 9 ns |   tie | measured once          | 7,576 B/op both         |
 
-The `ratio` column is this run alone, so every figure in it is comparable with every other. The `across runs` column is
-what keeps a single cell from travelling out of context: only flat holds its value between runs, and the container tiers
-exist on one run so far.
+GitHub Actions run 34470676359, `ubuntu-latest`, 10 measured iterations. The `ratio` column is this run alone, so every
+figure in it is comparable with every other. The `across runs` column is what keeps a single cell from travelling out of
+context: only flat holds its value between runs, and the container tiers exist on one run so far.
 
 Read the two container rows carefully — telescope's mean is marginally lower on both, and on neither does that mean it
 won. On Set the intervals overlap almost entirely (telescope's sits inside MapStruct's), which is a clean tie. On Map
@@ -32,8 +32,8 @@ outside their error bars, so each ratio is real within its own run. Only flat is
 ~1.07x. Deep is not: this run's 1.07x is the low end of a 1.07x–1.19x spread whose middle sits nearer 1.14x, so read it
 as a range too, and read this run as its optimistic edge. Nested is the widest of the three — 1.04x to 1.46x across CI
 runs of this benchmark (the 1.46x end from Actions run 34148517680; this run is 34470676359), landing at 1.29x here. It
-is a framework-overhead microbenchmark rather than a service-shaped workload; treat flat and deep as the publishable
-figures and nested as a range.
+is a framework-overhead microbenchmark rather than a service-shaped workload; treat flat as the publishable figure, and
+deep and nested as ranges.
 
 Runtime tier, same run: flat 3.34x, nested 2.66x, deep 1.27x, and 1.04x–1.06x on the two container shapes. MapStruct has
 no equivalent to this tier — it is what you get with no annotations and no build step — so these ratios say what the
@@ -195,22 +195,23 @@ about 7:1. Either way the wrapper is not what an adopter would be paying for. Wh
 
 `public static final BridgeFn<S, T> BRIDGE_FN = new Fn();` ships per generated bridge (asserted in
 `BridgeProcessorTest`). It gives adopters a passable one-hop mapper value instead of a static method. The benchmark
-tables above show it measures **at the `static forward` floor** in both runs (run 2 flat: identical at 3.183) — the JIT
-inlines the monomorphic hop to the raw static call, so it is the fastest passable value there is. It is _faster_ than
-`BRIDGE.read` by the ≤0.8 ns lattice-wrapper tax (largest on deep), so it is both the ergonomic value (a `BridgeFn` you
-can pass around) and, marginally, the fast one.
+tables above show it measures **at the `static forward` floor** on every run (run 2 flat: identical at 3.183) — the JIT
+inlines the monomorphic hop to the raw static call, so it is the fastest passable value there is. Against `BRIDGE.read`
+it is usually the faster of the two by the sub-nanosecond lattice-wrapper tax, though not always: on R3 nested the
+lattice value measured below it with disjoint bands. So it is the ergonomic value (a `BridgeFn` you can pass around)
+and, on most rows, marginally the fast one.
 
 ### 2. Type-specialized bridge subclass whose `read(S)` is the inlined body — **measured and declined**
 
 The idea was to emit a `Telescope`/bridge subclass that removes the `BridgeFn` field and the `invokeinterface` wrapper
 so `read(S)` _is_ the generated body. The data shrinks the premise to nothing worth building: the wrapper tax it would
-remove is ≤0.8 ns (the `BRIDGE.read − static forward` gap, largest on deep), and it applies **only to the composable
-`BRIDGE.read` value** — adopters who want the floor already have `BRIDGE_FN`, which sits there. Worse, on the deep tier
-where the tax is largest (~0.8 ns) it is swamped ~7:1 by the generated-body gap (~5.6 ns), so removing it barely moves
-the ratio. It would add ~100 LOC of `BridgeProcessor` complexity to shave ≤0.8 ns off one of two already-shipped call
-shapes. **Not building it.** The only thing that would move the deep number vs MapStruct is matching its generated
-_body_ (fewer null-guards, inlined leaf conversions) — a separate, finer optimization, adopter-gated on someone actually
-hitting the deep tier above 100M ops/sec.
+remove is sub-nanosecond wherever it resolves at all, and it applies **only to the composable `BRIDGE.read` value** —
+adopters who want the floor already have `BRIDGE_FN`, which sits there. Worse, on R2's deep tier, where the tax was at
+its largest (~0.8 ns), the generated-body gap (~5.6 ns) led it about 7:1; on R3's deep tier the tax does not separate
+from zero at all. Either way removing it barely moves the ratio. It would add ~100 LOC of `BridgeProcessor` complexity
+to shave ≤0.8 ns off one of two already-shipped call shapes. **Not building it.** The only thing that would move the
+deep number vs MapStruct is matching its generated _body_ (fewer null-guards, inlined leaf conversions) — a separate,
+finer optimization, adopter-gated on someone actually hitting the deep tier above 100M ops/sec.
 
 ### 3. The CI-reproducible matrix is the baseline
 
@@ -224,10 +225,14 @@ residual.
 - **`BRIDGE_FN` benchmarked across all three tiers** (`nested_*_bridgefn_forward`, `deep_*_bridgefn_forward`; flat
   already existed). This is what lets the forward tables compare all four call shapes — static, one-hop, lattice,
   MapStruct — on each run and pin `BRIDGE_FN` to the floor.
-- **This analysis doc, corrected against two runs.** Prior revisions claimed a ~0.3–0.7 ns lattice slice and proposed
-  two remediations to close it; a first fresh run then over-corrected to "dispatch is free everywhere". A confirmation
-  run settled it: `BRIDGE_FN` is the floor, the lattice wrapper is a sub-nanosecond tax, and the nested ratio is
-  JMH-noisy. The doc records the reproducible parity result and the measured-and-declined subclass decision.
+- **The container tier**, Set- and Map-valued, which is where this revision's actual finding lives: a tie on time and
+  about 11% less allocated on the Map shape. Every tier before it was List-only, which is how a sizing defect in the
+  container emitter shipped green.
+- **This analysis doc, corrected against three runs.** Prior revisions claimed a ~0.3–0.7 ns lattice slice and proposed
+  two remediations to close it; a first fresh run then over-corrected to "dispatch is free everywhere". What is settled
+  now is one half of that: `BRIDGE_FN` is the floor on every run, and the nested ratio is JMH-noisy. The lattice
+  wrapper's tax is sub-nanosecond wherever it resolves, but its depth-scaling did not survive the third run and is
+  marked provisional. The doc records the parity result, the ranges, and the measured-and-declined subclass decision.
 - **No production code changed.** `BRIDGE_FN` already ships; the codegen is at parity as-is.
 
 ## Bottom line
@@ -251,7 +256,8 @@ What remains over MapStruct on the deep tier is a few nanoseconds of generated-b
 `static forward` alone is above parity — and closing it means matching MapStruct's inlined body. That stays
 adopter-gated on a real deep-tier hot loop that measures it.
 
-Two things in this document's history are worth keeping visible. The 2.9-3.6x forward gap, the telescope-faster-on-
-backward claim, and the static-slower-than-lattice inversion were all laptop noise that clean CI hardware dissolved. And
-every tier here was List-only until recently, which let a sizing defect in the container emitter ship green — the
-container rows exist so that class of defect fails a measurement rather than passing one.
+Two things in this document's history are worth keeping visible. The 2.9-3.6x forward gap and the
+telescope-faster-on-backward claim were laptop noise that clean CI hardware dissolved; the static-slower-than-lattice
+inversion was not, since R3 later measured it on nested with disjoint bands. And every tier here was List-only until
+recently, which let a sizing defect in the container emitter ship green — the container rows exist so that class of
+defect fails a measurement rather than passing one.

--- a/docs/perf-mapstruct-comparison.md
+++ b/docs/perf-mapstruct-comparison.md
@@ -5,9 +5,9 @@ and propose remediations where the gap is structural.
 
 ## Headline finding
 
-**Telescope codegen is in MapStruct's performance class, and on a hash container it allocates less.** The `ratio` column
-comes from a single CI run, so its figures are comparable with each other — separate runs land on runners of different
-speeds, and a ratio built from two of them is not a measurement.
+**Telescope codegen is in MapStruct's performance class, and on a hash container it allocates less.** Separate runs land
+on runners of different speeds, so a ratio built from two of them is not a measurement — hence the two columns below,
+read as the caption describes.
 
 | Tier (forward, codegen vs codegen)  |        MapStruct |        telescope | ratio | across runs            | allocation              |
 | ----------------------------------- | ---------------: | ---------------: | ----: | ---------------------- | ----------------------- |
@@ -163,9 +163,10 @@ next section). What does not survive is the monotonic ordering.
 
 An earlier run reported a ~0.3–0.7 ns "lattice slice" and proposed closing it by emitting a directly-callable
 `BRIDGE_FN` constant. `BRIDGE_FN` shipped (#182) — and it lands at the `static forward` floor, so an adopter who wants
-the fastest passable value already has it. The tax that remains sits only on the _composable_ `BRIDGE.read` value and is
-sub-nanosecond wherever it resolves at all; the type-specialized subclass (remediation #2) would remove only that, for
-only the narrow case of hot-looping the composable value while refusing to switch to `BRIDGE_FN`. Not worth it.
+the fastest passable value already has it on every row but R3 nested. The tax that remains sits only on the _composable_
+`BRIDGE.read` value and is sub-nanosecond wherever it resolves at all; the type-specialized subclass (remediation #2)
+would remove only that, for only the narrow case of hot-looping the composable value while refusing to switch to
+`BRIDGE_FN`. Not worth it.
 
 The lesson stands: **smoke runs lie, and one CI run can too.** Run 1's 1.04× nested looked like a headline until run 2
 returned 1.42× on the same branch — the nested MapStruct baseline is JMH-noisy (±0.35). Laptop smoke runs earlier
@@ -257,8 +258,10 @@ What remains over MapStruct on the deep tier is a few nanoseconds of generated-b
 `static forward` alone is above parity — and closing it means matching MapStruct's inlined body. That stays
 adopter-gated on a real deep-tier hot loop that measures it.
 
-Two things in this document's history are worth keeping visible. The 2.9-3.6x forward gap and the
-telescope-faster-on-backward claim were laptop noise that clean CI hardware dissolved; the static-slower-than-lattice
-inversion was not, since R3 later measured it on nested with disjoint bands. And every tier here was List-only until
-recently, which let a sizing defect in the container emitter ship green — the container rows exist so that class of
-defect fails a measurement rather than passing one.
+Two things in this document's history are worth keeping visible. Of the three claims a laptop produced, only the
+2.9-3.6x forward gap dissolved on clean CI hardware. The other two survived it: R3 measured the
+static-slower-than-lattice inversion on nested with disjoint bands, and telescope does measure faster than MapStruct on
+nested backward — 5.355 against 5.983 ns, disjoint — though not on flat or deep backward, which is what makes the
+blanket wording fail rather than the claim. And every tier here was List-only until recently, which let a sizing defect
+in the container emitter ship green — the container rows exist so that class of defect fails a measurement rather than
+passing one.

--- a/docs/perf-mapstruct-comparison.md
+++ b/docs/perf-mapstruct-comparison.md
@@ -5,9 +5,9 @@ and propose remediations where the gap is structural.
 
 ## Headline finding
 
-**Telescope codegen is in MapStruct's performance class, and on a hash container it allocates less.** From a single CI
-run so every figure below is comparable — separate runs land on runners of different speeds, which has produced
-misleading ratios here before.
+**Telescope codegen is in MapStruct's performance class, and on a hash container it allocates less.** The `ratio` column
+comes from a single CI run, so its figures are comparable with each other — separate runs land on runners of different
+speeds, and a ratio built from two of them is not a measurement.
 
 | Tier (forward, codegen vs codegen)  |        MapStruct |        telescope | ratio | across runs            | allocation              |
 | ----------------------------------- | ---------------: | ---------------: | ----: | ---------------------- | ----------------------- |
@@ -115,13 +115,13 @@ outside its error band. So `BRIDGE_FN` is the floor; the lattice wrapper is a sm
 nesting depth; and the deep residual over MapStruct is mostly the generated body (`static forward` alone is ~1.12× on
 deep, ~5.6 ns of the ~6.3 ns gap).
 
-Runtime path forward, **as measured on these two runs and since superseded** — the tier now lands at ~3.3× / ~2.7× /
-~1.3×, see the headline: flat 40.14, nested 64.37, deep 315.23 ns/op — ~16× / ~14× / ~8× of MapStruct. The backward
-direction stays higher (flat 108.31, nested 148.63, deep 626.39) because building a bean (allocate + N setters) is
-structurally heavier than a record's canonical-ctor invoke and its read side was already optimal. The runtime path goes
-through a structural-Iso build per `Telescope.mapper(...)` call site and a reflective dispatch chain on every
-invocation; it's not in the dethrone-MapStruct lane, it's the convenience surface for "I don't want to write codegen for
-this one mapper".
+**The whole of the following paragraph is superseded** — the runtime tier now lands at ~3.3× / ~2.7× / ~1.3× and
+~1.04–1.06× on containers, and backward no longer trails forward. It is kept because the dispatch analysis below was
+written against it. As measured on these two runs: forward flat 40.14, nested 64.37, deep 315.23 ns/op — ~16× / ~14× /
+~8× of MapStruct — with backward higher still (flat 108.31, nested 148.63, deep 626.39), because building a bean
+(allocate + N setters) is structurally heavier than a record's canonical-ctor invoke. At those numbers the runtime path
+was the convenience surface for "I don't want to write codegen for this one mapper" rather than a contender; the lattice
+sharpenings that closed the gap are recorded in `benchmarks/README.md`.
 
 ## Dispatch — `BRIDGE_FN` is the floor, and the lattice wrapper is a sub-nanosecond tax
 
@@ -148,7 +148,7 @@ disagree on nested, which is itself the finding. Two things hold:
 First, **`BRIDGE_FN` tracks the `static forward` floor within error on every tier**: identical on R2 flat (both 3.183),
 tied on R2 nested (5.896 vs 5.902), and on R2 deep its ±0.675 band overlaps static (52.586 − 0.675 = 51.91 ≈ static
 51.92). The one-interface-hop constant is monomorphic (one concrete `Fn` per bridge) and the JIT inlines it to the raw
-static call — it is the floor, there is nothing faster to reach.
+static call. On R1 and R2 nothing measures below it; R3 nested is the one row where the lattice value does.
 
 Second, **the full-lattice `BRIDGE.read` sits a small wrapper tax above that floor** — on R2, 0.14 ns (flat) → 0.31 ns
 (nested) → 0.77 ns (deep), each outside the tight error bands, which read as the lattice composition depth showing
@@ -156,16 +156,16 @@ through: more nesting, more `Iso.then(...)` hops the wrapper carries.
 
 **R3 does not reproduce that climb, so treat the depth-scaling as provisional.** On the same clean CI hardware it
 measures +0.20 ns on flat (real), −0.31 ns on nested — the lattice value _below_ the static floor, outside the bands,
-which is the "static-slower-than-lattice" inversion the lesson below files under laptop noise — and +0.30 ns on deep,
-inside the bands and therefore not a measurement at all. What survives all three runs is the magnitude: the tax is under
-a nanosecond wherever it is resolvable, and on deep it is dwarfed by the generated-body gap anyway (see next section).
-What does not survive is the monotonic ordering.
+which is the "static-slower-than-lattice" shape the lesson below separates from the genuine laptop artifacts — and +0.30
+ns on deep, inside the bands and therefore not a measurement at all. What survives all three runs is the magnitude: the
+tax is under a nanosecond wherever it is resolvable, and on deep it is dwarfed by the generated-body gap anyway (see
+next section). What does not survive is the monotonic ordering.
 
 An earlier run reported a ~0.3–0.7 ns "lattice slice" and proposed closing it by emitting a directly-callable
 `BRIDGE_FN` constant. `BRIDGE_FN` shipped (#182) — and it lands at the `static forward` floor, so an adopter who wants
 the fastest passable value already has it. The tax that remains sits only on the _composable_ `BRIDGE.read` value and is
-≤0.8 ns; the type-specialized subclass (remediation #2) would remove only that, for only the narrow case of hot-looping
-the composable value while refusing to switch to `BRIDGE_FN`. Not worth it.
+sub-nanosecond wherever it resolves at all; the type-specialized subclass (remediation #2) would remove only that, for
+only the narrow case of hot-looping the composable value while refusing to switch to `BRIDGE_FN`. Not worth it.
 
 The lesson stands: **smoke runs lie, and one CI run can too.** Run 1's 1.04× nested looked like a headline until run 2
 returned 1.42× on the same branch — the nested MapStruct baseline is JMH-noisy (±0.35). Laptop smoke runs earlier
@@ -195,11 +195,12 @@ about 7:1. Either way the wrapper is not what an adopter would be paying for. Wh
 
 `public static final BridgeFn<S, T> BRIDGE_FN = new Fn();` ships per generated bridge (asserted in
 `BridgeProcessorTest`). It gives adopters a passable one-hop mapper value instead of a static method. The benchmark
-tables above show it measures **at the `static forward` floor** on every run (run 2 flat: identical at 3.183) — the JIT
-inlines the monomorphic hop to the raw static call, so it is the fastest passable value there is. Against `BRIDGE.read`
-it is usually the faster of the two by the sub-nanosecond lattice-wrapper tax, though not always: on R3 nested the
-lattice value measured below it with disjoint bands. So it is the ergonomic value (a `BridgeFn` you can pass around)
-and, on most rows, marginally the fast one.
+tables above show it measures **at the `static forward` floor** on every run (run 2 flat: identical at 3.183; on R3 deep
+only within a ±5.3 ns band, so that cell settles little either way) — the JIT inlines the monomorphic hop to the raw
+static call, so it is the fastest passable value there is. Against `BRIDGE.read` it is usually the faster of the two by
+the sub-nanosecond lattice-wrapper tax, though not always: on R3 nested the lattice value measured below it with
+disjoint bands. So it is the ergonomic value (a `BridgeFn` you can pass around) and, on most rows, marginally the fast
+one.
 
 ### 2. Type-specialized bridge subclass whose `read(S)` is the inlined body — **measured and declined**
 
@@ -209,9 +210,9 @@ remove is sub-nanosecond wherever it resolves at all, and it applies **only to t
 adopters who want the floor already have `BRIDGE_FN`, which sits there. Worse, on R2's deep tier, where the tax was at
 its largest (~0.8 ns), the generated-body gap (~5.6 ns) led it about 7:1; on R3's deep tier the tax does not separate
 from zero at all. Either way removing it barely moves the ratio. It would add ~100 LOC of `BridgeProcessor` complexity
-to shave ≤0.8 ns off one of two already-shipped call shapes. **Not building it.** The only thing that would move the
-deep number vs MapStruct is matching its generated _body_ (fewer null-guards, inlined leaf conversions) — a separate,
-finer optimization, adopter-gated on someone actually hitting the deep tier above 100M ops/sec.
+to shave a sub-nanosecond tax off one of two already-shipped call shapes. **Not building it.** The only thing that would
+move the deep number vs MapStruct is matching its generated _body_ (fewer null-guards, inlined leaf conversions) — a
+separate, finer optimization, adopter-gated on someone actually hitting the deep tier above 100M ops/sec.
 
 ### 3. The CI-reproducible matrix is the baseline
 

--- a/docs/perf-mapstruct-comparison.md
+++ b/docs/perf-mapstruct-comparison.md
@@ -170,9 +170,8 @@ would remove only that, for only the narrow case of hot-looping the composable v
 
 The lesson stands: **smoke runs lie, and one CI run can too.** Run 1's 1.04× nested looked like a headline until run 2
 returned 1.42× on the same branch — the nested MapStruct baseline is JMH-noisy (±0.35). Laptop smoke runs earlier
-produced a 2.9–3.6× "forward gap", a "telescope-faster-on-backward" claim, and a "static-slower-than-lattice" inversion,
-all wrong — though R3 above measures that same inversion on nested with disjoint bands, so the shape is not exclusively
-a laptop artifact. Trust the numbers that reproduce across runs: flat ~1.07×, deep 1.07×–1.19×, and `BRIDGE_FN` at the
+produced a 2.9–3.6× "forward gap" that clean CI hardware dissolved, plus two claims that survived it — see the bottom
+line for which. Trust the numbers that reproduce across runs: flat ~1.07×, deep 1.07×–1.19×, and `BRIDGE_FN` at the
 floor.
 
 ## So is there a real gap?
@@ -260,8 +259,9 @@ adopter-gated on a real deep-tier hot loop that measures it.
 
 Two things in this document's history are worth keeping visible. Of the three claims a laptop produced, only the
 2.9-3.6x forward gap dissolved on clean CI hardware. The other two survived it: R3 measured the
-static-slower-than-lattice inversion on nested with disjoint bands, and telescope does measure faster than MapStruct on
-nested backward — 5.355 against 5.983 ns, disjoint — though not on flat or deep backward, which is what makes the
+static-slower-than-lattice inversion on nested with disjoint bands, and telescope codegen measures faster than MapStruct
+on nested backward on the `benchmarks/README` run — 5.355 against 5.983 ns, disjoint — where this document's Run 1 table
+shows the same direction at 0.99× without resolving it. Flat and deep backward go the other way, which is what makes the
 blanket wording fail rather than the claim. And every tier here was List-only until recently, which let a sizing defect
 in the container emitter ship green — the container rows exist so that class of defect fails a measurement rather than
 passing one.

--- a/docs/perf-mapstruct-comparison.md
+++ b/docs/perf-mapstruct-comparison.md
@@ -9,13 +9,17 @@ and propose remediations where the gap is structural.
 run so every figure below is comparable — separate runs land on runners of different speeds, which has produced
 misleading ratios here before.
 
-| Tier (forward, codegen vs codegen)  |        MapStruct |        telescope | ratio | allocation              |
-| ----------------------------------- | ---------------: | ---------------: | ----: | ----------------------- |
-| flat (5 scalars)                    | 3.155 ± 0.019 ns | 3.362 ± 0.011 ns | 1.07x | 32 B/op both            |
-| nested (one nested type)            | 4.361 ± 0.045 ns | 5.604 ± 0.033 ns | 1.29x | 48 B/op both            |
-| deep (3 levels + 2 list hops)       |  62.38 ± 0.18 ns |  66.57 ± 0.52 ns | 1.07x | 376 B/op both           |
-| container, Map-valued (100 entries) |     1262 ± 11 ns |     1244 ± 10 ns |   tie | **7,528 vs 6,712 B/op** |
-| container, Set-valued (100 entries) |     1455 ± 21 ns |      1445 ± 9 ns |   tie | 7,576 B/op both         |
+| Tier (forward, codegen vs codegen)  |        MapStruct |        telescope | ratio | across runs   | allocation              |
+| ----------------------------------- | ---------------: | ---------------: | ----: | ------------- | ----------------------- |
+| flat (5 scalars)                    | 3.155 ± 0.019 ns | 3.362 ± 0.011 ns | 1.07x | ~1.07x stable | 32 B/op both            |
+| nested (one nested type)            | 4.361 ± 0.045 ns | 5.604 ± 0.033 ns | 1.29x | 1.04x–1.46x   | 48 B/op both            |
+| deep (3 levels + 2 list hops)       |  62.38 ± 0.18 ns |  66.57 ± 0.52 ns | 1.07x | 1.07x–1.19x   | 376 B/op both           |
+| container, Map-valued (100 entries) |     1262 ± 11 ns |     1244 ± 10 ns |   tie | measured once | **7,528 vs 6,712 B/op** |
+| container, Set-valued (100 entries) |     1455 ± 21 ns |      1445 ± 9 ns |   tie | measured once | 7,576 B/op both         |
+
+The `ratio` column is this run alone, so every figure in it is comparable with every other. The `across runs` column is
+what keeps a single cell from travelling out of context: only flat holds its value between runs, and the container tiers
+exist on one run so far.
 
 Read the two container rows carefully — telescope's mean is marginally lower on both, and on neither does that mean it
 won. On Set the intervals overlap almost entirely (telescope's sits inside MapStruct's), which is a clean tie. On Map
@@ -25,7 +29,7 @@ deterministic rather than hardware-dependent, which makes it the durable result.
 
 The scalar tiers are unchanged in character: a 0.2 ns difference on flat, 4 ns on a 62 ns deep conversion, and both
 outside their error bars, so each ratio is real within its own run. Only flat is also stable across runs, clustering at
-~1.07x. Deep is not: this run's 1.07x is the low end of a 1.07x–1.19x spread whose middle sits nearer 1.13x, so read it
+~1.07x. Deep is not: this run's 1.07x is the low end of a 1.07x–1.19x spread whose middle sits nearer 1.14x, so read it
 as a range too, and read this run as its optimistic edge. Nested is the widest of the three — 1.04x to 1.46x across CI
 runs of this benchmark (the 1.46x end from Actions run 34148517680; this run is 34470676359), landing at 1.29x here. It
 is a framework-overhead microbenchmark rather than a service-shaped workload; treat flat and deep as the publishable
@@ -137,8 +141,9 @@ The `*_codegen_static_forward` (zero dispatch), `*_bridgefn_forward` (one interf
 | R3 nested |                    5.913 |               5.908 |                   5.604 |    −0.31 ns | yes (±0.03)      |
 | R3 deep   |                    66.27 |               69.22 |                   66.57 |     0.30 ns | no (±0.27–0.52)  |
 
-R1's bands are 3–30× wider than the others', too wide to resolve any of these gaps. R2 and R3 both resolve them — and on
-nested they disagree, which is itself the finding. Two things hold:
+R1's bands are 2–27× wider than the others' and every one of its rows reads "no" — too wide to resolve any of these
+gaps. R2 resolves all three tiers; R3 resolves flat and nested but not deep. Where both resolve they agree on flat and
+disagree on nested, which is itself the finding. Two things hold:
 
 First, **`BRIDGE_FN` tracks the `static forward` floor within error on every tier**: identical on R2 flat (both 3.183),
 tied on R2 nested (5.896 vs 5.902), and on R2 deep its ±0.675 band overlaps static (52.586 − 0.675 = 51.91 ≈ static
@@ -166,13 +171,13 @@ The lesson stands: **smoke runs lie, and one CI run can too.** Run 1's 1.04× ne
 returned 1.42× on the same branch — the nested MapStruct baseline is JMH-noisy (±0.35). Laptop smoke runs earlier
 produced a 2.9–3.6× "forward gap", a "telescope-faster-on-backward" claim, and a "static-slower-than-lattice" inversion,
 all wrong — though R3 above measures that same inversion on nested with disjoint bands, so the shape is not exclusively
-a laptop artifact. Trust the numbers that reproduce across runs: flat ~1.07×, deep ~1.07×–1.15×, and `BRIDGE_FN` at the
+a laptop artifact. Trust the numbers that reproduce across runs: flat ~1.07×, deep 1.07×–1.19×, and `BRIDGE_FN` at the
 floor.
 
 ## So is there a real gap?
 
-**A small one on deep, and it is mostly not dispatch.** On the headline run deep is ~1.07× forward — a 4.19 ns gap on a
-62 ns conversion — down from the ~1.15× the two earlier runs supported. The split is the durable part: the zero-dispatch
+**A small one on deep, and it is mostly not dispatch.** On the headline run deep measured ~1.07× forward — a 4.19 ns gap
+on a 62 ns conversion, the low end of the 1.07×–1.19× spread. The split is the durable part: the zero-dispatch
 `static forward` floor is _already_ ~1.06× on deep (3.90 ns of the 4.19, the generated **body** — six leaf conversions,
 two list allocations, and per-field null-guards vs MapStruct's directly-inlined field sequence), with the lattice
 wrapper adding the remainder. That remainder is 0.30 ns and sits inside the error bands, so on this run it cannot be
@@ -239,7 +244,8 @@ full-lattice `BRIDGE.read` carries a wrapper tax under a nanosecond wherever it 
 its sign move between runs (R2 read 0.14 → 0.31 → 0.77 ns with depth; R3 read +0.20, −0.31, and an unresolvable +0.30),
 so the depth-scaling story is provisional and the magnitude is the only durable part. Either way both proposed
 remediations are settled: `BRIDGE_FN` shipped and lands at the floor, and the type-specialized subclass would remove
-only that sub-nanosecond tax, swamped an order of magnitude over by the body gap on deep. Declined.
+only that sub-nanosecond tax, swamped several-fold by the body gap on deep — about 7:1 on R2, and on R3 not separable
+from zero at all. Declined.
 
 What remains over MapStruct on the deep tier is a few nanoseconds of generated-body work rather than dispatch —
 `static forward` alone is above parity — and closing it means matching MapStruct's inlined body. That stays

--- a/docs/perf-mapstruct-comparison.md
+++ b/docs/perf-mapstruct-comparison.md
@@ -5,29 +5,36 @@ and propose remediations where the gap is structural.
 
 ## Headline finding
 
-**Telescope codegen is at effective MapStruct parity: ~1.07× flat and ~1.15× deep forward, both stable across two CI
-runs.** The realistic deep tier — 3-level nesting + list hops — is a ~1.15× near-tie (1.19× / 1.14× across the two
-runs), and flat is ~1.07× (1.065× / 1.072×). The nested-tier ratio is JMH-noisy run-to-run (1.04× then 1.42×; the
-`nested_mapstruct_forward` baseline carries a wide ±0.35 band), so no single nested figure is publishable — call it
-near-parity and lean on the stable flat/deep numbers. The deep residual is **mostly generated-body work, not dispatch**:
-the zero-dispatch `static forward` floor is itself ~1.12× on deep (~5.6 ns of the ~6.3 ns gap), with the lattice wrapper
-~0.8 ns on top.
+**Telescope codegen is in MapStruct's performance class, and on a hash container it allocates less.** From a single CI
+run so every figure below is comparable — separate runs land on runners of different speeds, which has produced
+misleading ratios here before.
 
-Two dispatch-shape claims from earlier revisions of this doc were **measured and settled** across both runs (see the
-results table and the "dispatch" section):
+| Tier (forward, codegen vs codegen)  | MapStruct | telescope | ratio | allocation              |
+| ----------------------------------- | --------: | --------: | ----: | ----------------------- |
+| flat (5 scalars)                    |  3.155 ns |  3.362 ns | 1.07x | 32 B/op both            |
+| nested (one nested type)            |  4.361 ns |  5.604 ns | 1.29x | 48 B/op both            |
+| deep (3 levels + 2 list hops)       | 62.378 ns | 66.572 ns | 1.07x | 376 B/op both           |
+| container, Map-valued (100 entries) | 1261.7 ns | 1243.5 ns |   tie | **7,528 vs 6,712 B/op** |
+| container, Set-valued (100 entries) | 1454.8 ns | 1444.7 ns |   tie | 7,576 B/op both         |
 
-- **`BRIDGE_FN` sits at the zero-dispatch floor.** The one-interface-hop constant measures within error of
-  `static forward` on every tier in both runs (run 2 flat: `BRIDGE_FN` == `static forward` to three digits). It is the
-  fastest a passable mapper value can be — there is nothing to recover past it.
-- **The full-lattice `BRIDGE.read` adds a ≤0.8 ns wrapper tax that grows with depth** — 0.14 ns (flat) → 0.31 ns
-  (nested) → 0.77 ns (deep) on the tight-band run, each outside the error bands. The proposed type-specialized subclass
-  (remediation #2 below) exists only to shave that off the _composable_ value — but `BRIDGE_FN` already ships the floor
-  as a passable value, and on deep the tax is swamped by the body gap, so **it is not worth building.**
+Read the two container rows carefully. Their confidence intervals overlap, so **the timings are a tie, not a win** —
+telescope's mean is marginally lower and that means nothing. What is real is the allocation: 6,712 against 7,528 bytes
+per operation on the Map tier, about 11% less, and allocation is deterministic rather than hardware-dependent.
 
-Earlier smoke-confidence laptop runs reported a 2.9–3.6× forward gap, a "telescope-faster-on-backward" inversion, and a
-"static-slower-than-lattice" inversion — all three were JMH noise artifacts that clean CI hardware dissolved. The
-runtime path is a different conversation (~1.3–4× after the leaf-rebuild campaign — see the runtime tier in
-[benchmarks/README.md](../benchmarks/README.md); the ~8–20× figure predates it).
+The scalar tiers are unchanged in character: a 0.2 ns difference on flat, 4 ns on a 62 ns deep conversion, and both
+outside their error bars so the ratios are real rather than noise. Nested remains the unstable one — measured at 1.04x,
+1.42x, 1.20x, 1.21x and now 1.29x across five runs of the same benchmark. It is a framework-overhead microbenchmark
+rather than a service-shaped workload; treat flat and deep as the publishable figures and nested as a range.
+
+Runtime tier, same run: flat 3.34x, nested 2.66x, deep 1.27x of MapStruct. That tier has no MapStruct equivalent to
+compare against — it is what you get with no annotations and no build step.
+
+### What the container tier is for
+
+It did not exist until recently, and its absence is why a defect shipped: every tier here was List-only, a list has no
+hash table, and the Bridge emitter was sizing Set and Map rebuilds by element count rather than table capacity. Every
+benchmark was green while generated bridges allocated more than the reflective path they exist to beat. The tier was
+added so that class of defect fails a measurement instead of passing one.
 
 ## Methodology
 
@@ -50,7 +57,11 @@ Four call shapes per tier:
 - **`*_telescope_runtime_*`** — `Telescope.mapper(BeanCls.class, RecCls.class).forward/backward`. The runtime
   structural-Iso build path (no codegen).
 
-## Results — two CI-reproducible runs (GitHub Actions `ubuntu-latest`, 3W + 5I × 3s @ 1 fork)
+## Results — earlier CI runs
+
+> The tables in this section predate the current headline and are kept for the dispatch analysis that follows, which
+> they are the evidence for. Where they disagree with the headline table, the headline is the current measurement. Both
+> were GitHub Actions `ubuntu-latest`, 3 warmup + 5 iterations at 3s, single fork.
 
 Two runs of the manual `Benchmarks` workflow on dedicated runners, taken because the first run's nested ratio looked too
 good to publish on one sample. Absolute numbers differ between the runs (different runner generation) — read the ratios
@@ -194,16 +205,21 @@ residual.
 
 ## Bottom line
 
-Telescope codegen is at **effective MapStruct parity — ~1.07× flat and ~1.15× deep forward, both stable across two CI
-runs** (nested is near-parity but JMH-noisy run-to-run, 1.04×–1.42×, so no single figure is publishable). On dispatch,
-**`BRIDGE_FN` is the floor**: it tracks the zero-dispatch `static forward` within error on every tier (identical on
-run-2 flat), because the JIT inlines the monomorphic hop. The full-lattice `BRIDGE.read` carries a wrapper tax that
-grows with depth — 0.14 → 0.31 → 0.77 ns across flat/nested/deep on the tight run, each outside the error band. That
-settles both proposed remediations: `BRIDGE_FN` shipped and lands at the floor (ergonomic _and_ marginally the fast
-value), and the type-specialized subclass would remove only that ≤0.8 ns tax from the composable `BRIDGE.read` —
-**declined**, since on deep (where the tax is largest) it is swamped ~7:1 by the body gap. The only real gap over
-MapStruct is ~5.6 ns of generated-body work on the deep tier (`static forward` alone is ~1.12×), not dispatch; closing
-it means matching MapStruct's inlined body, adopter-gated on a real deep-tier hot loop. The 2.9–3.6× forward "gap", the
-"telescope faster on backward" claim, and the "static slower than lattice" inversion from laptop smoke runs were all JMH
-noise. Measuring the dispatch claim to a conclusion — through two runs, not one — and declining the optimization it
-implied, is the deliverable here.
+Telescope codegen is in MapStruct's performance class: 1.07x flat, 1.07x deep, and a tie on both hash-container tiers
+where it also allocates about 11% less on the Map shape. Nested stays the unstable measurement — five runs of the same
+benchmark have produced 1.04x, 1.42x, 1.20x, 1.21x and 1.29x — so it is reported as a range rather than a figure.
+
+On dispatch the question is settled. `BRIDGE_FN` is the floor: it tracks the zero-dispatch `static forward` within error
+on every tier, because the JIT inlines the monomorphic hop. The full-lattice `BRIDGE.read` carries a wrapper tax that
+grows with depth, 0.14 to 0.77 ns across the three scalar tiers, each outside its error band. That settles both proposed
+remediations — `BRIDGE_FN` shipped and lands at the floor, and the type-specialized subclass would remove only that
+sub-nanosecond tax, swamped roughly seven to one by the body gap on deep. Declined.
+
+What remains over MapStruct on the deep tier is a few nanoseconds of generated-body work rather than dispatch —
+`static forward` alone is above parity — and closing it means matching MapStruct's inlined body. That stays
+adopter-gated on a real deep-tier hot loop that measures it.
+
+Two things in this document's history are worth keeping visible. The 2.9-3.6x forward gap, the telescope-faster-on-
+backward claim, and the static-slower-than-lattice inversion were all laptop noise that clean CI hardware dissolved. And
+every tier here was List-only until recently, which let a sizing defect in the container emitter ship green — the
+container rows exist so that class of defect fails a measurement rather than passing one.

--- a/docs/perf-mapstruct-comparison.md
+++ b/docs/perf-mapstruct-comparison.md
@@ -24,9 +24,12 @@ is real on that row is the allocation — 6,712 against 7,528 bytes per operatio
 deterministic rather than hardware-dependent, which makes it the durable result.
 
 The scalar tiers are unchanged in character: a 0.2 ns difference on flat, 4 ns on a 62 ns deep conversion, and both
-outside their error bars so the ratios are real rather than noise. Nested remains the unstable one — across CI runs of
-this benchmark it has ranged from 1.04x to 1.46x, and it lands at 1.29x here. It is a framework-overhead microbenchmark
-rather than a service-shaped workload; treat flat and deep as the publishable figures and nested as a range.
+outside their error bars, so each ratio is real within its own run. Only flat is also stable across runs, clustering at
+~1.07x. Deep is not: this run's 1.07x is the low end of a 1.07x–1.19x spread whose middle sits nearer 1.13x, so read it
+as a range too, and read this run as its optimistic edge. Nested is the widest of the three — 1.04x to 1.46x across CI
+runs of this benchmark (the 1.46x end from Actions run 34148517680; this run is 34470676359), landing at 1.29x here. It
+is a framework-overhead microbenchmark rather than a service-shaped workload; treat flat and deep as the publishable
+figures and nested as a range.
 
 Runtime tier, same run: flat 3.34x, nested 2.66x, deep 1.27x, and 1.04x–1.06x on the two container shapes. MapStruct has
 no equivalent to this tier — it is what you get with no annotations and no build step — so these ratios say what the
@@ -97,8 +100,9 @@ three tiers (earlier revisions measured it on flat only).
 | deep   | 42.11 ± 1.575 |        49.54 ± 1.312 |             1.18× |
 
 **What reproduces, and what doesn't** — as read at the time, from these two runs alone. Flat (1.065× / 1.072×) and deep
-(1.185× / 1.137×) are stable across the pair; deep has since come down to ~1.07× on the headline run, so treat ~1.15× as
-the figure these two runs supported rather than the current one. Nested swings 1.043× → 1.424×: the
+(1.185× / 1.137×) are stable across the pair. The headline run later measured deep at ~1.07×, the low end of a
+1.07×–1.19× spread across all runs — so ~1.15× is what these two runs supported and roughly where the middle of that
+spread still sits, not a figure that has since been superseded by a lower one. Nested swings 1.043× → 1.424×: the
 `nested_mapstruct_forward` baseline carries a wide ±0.35 band both runs, so the nested ratio is a JMH-noisy figure, not
 a real regression or improvement — don't publish a single number for it. On the dispatch spread, both runs agree:
 `BRIDGE_FN` tracks `static forward` within error (run 2 flat: identical at 3.183), while `BRIDGE.read` sits a wrapper
@@ -107,7 +111,8 @@ outside its error band. So `BRIDGE_FN` is the floor; the lattice wrapper is a sm
 nesting depth; and the deep residual over MapStruct is mostly the generated body (`static forward` alone is ~1.12× on
 deep, ~5.6 ns of the ~6.3 ns gap).
 
-Runtime path forward: flat 40.14, nested 64.37, deep 315.23 ns/op — ~16× / ~14× / ~8× of MapStruct. The backward
+Runtime path forward, **as measured on these two runs and since superseded** — the tier now lands at ~3.3× / ~2.7× /
+~1.3×, see the headline: flat 40.14, nested 64.37, deep 315.23 ns/op — ~16× / ~14× / ~8× of MapStruct. The backward
 direction stays higher (flat 108.31, nested 148.63, deep 626.39) because building a bean (allocate + N setters) is
 structurally heavier than a record's canonical-ctor invoke and its read side was already optimal. The runtime path goes
 through a structural-Iso build per `Telescope.mapper(...)` call site and a reflective dispatch chain on every
@@ -132,7 +137,8 @@ The `*_codegen_static_forward` (zero dispatch), `*_bridgefn_forward` (one interf
 | R3 nested |                    5.913 |               5.908 |                   5.604 |    −0.31 ns | yes (±0.03)      |
 | R3 deep   |                    66.27 |               69.22 |                   66.57 |     0.30 ns | no (±0.27–0.52)  |
 
-Read the tight-band run (R2) — its bands are 3–30× narrower, so it's the one that resolves anything. Two things hold:
+R1's bands are 3–30× wider than the others', too wide to resolve any of these gaps. R2 and R3 both resolve them — and on
+nested they disagree, which is itself the finding. Two things hold:
 
 First, **`BRIDGE_FN` tracks the `static forward` floor within error on every tier**: identical on R2 flat (both 3.183),
 tied on R2 nested (5.896 vs 5.902), and on R2 deep its ±0.675 band overlaps static (52.586 − 0.675 = 51.91 ≈ static
@@ -169,8 +175,9 @@ floor.
 62 ns conversion — down from the ~1.15× the two earlier runs supported. The split is the durable part: the zero-dispatch
 `static forward` floor is _already_ ~1.06× on deep (3.90 ns of the 4.19, the generated **body** — six leaf conversions,
 two list allocations, and per-field null-guards vs MapStruct's directly-inlined field sequence), with the lattice
-wrapper adding the remainder. Body dominates by roughly 13:1 here and ~7:1 on the earlier runs; either way the wrapper
-is not what an adopter would be paying for. Whether it matters at all:
+wrapper adding the remainder. That remainder is 0.30 ns and sits inside the error bands, so on this run it cannot be
+separated from zero and the body is effectively the whole gap; on R2, where the wrapper did resolve, the body led it
+about 7:1. Either way the wrapper is not what an adopter would be paying for. Whether it matters at all:
 
 - At <10M ops/sec on a hot mapper: invisible against application work.
 - At >100M ops/sec on the deep tier: a ~4 ns per-call structural cost — measurable on a flame graph, rarely dominant.
@@ -220,17 +227,19 @@ residual.
 
 ## Bottom line
 
-Telescope codegen is in MapStruct's performance class: 1.07x flat, 1.07x deep, and a tie on both hash-container tiers
-where it also allocates about 11% less on the Map shape. Nested stays the unstable measurement — across CI runs of this
-benchmark it has ranged from 1.04x to 1.46x — so it is reported as a range rather than a figure.
+Telescope codegen is in MapStruct's performance class: 1.07x flat, 1.07x deep on this run against a 1.07x–1.19x spread
+across runs, a tie on the Set container and a near-tie on Map, where it also allocates about 11% less. Nested stays the
+unstable measurement — across CI runs of this benchmark it has ranged from 1.04x to 1.46x — so it is reported as a range
+rather than a figure.
 
 On dispatch, one half is settled and one is not. `BRIDGE_FN` is the floor: it tracks the zero-dispatch `static forward`
-within error on every tier and on every run, because the JIT inlines the monomorphic hop. The full-lattice `BRIDGE.read`
-carries a wrapper tax under a nanosecond wherever it resolves at all — but its size and even its sign move between runs
-(R2 read 0.14 → 0.31 → 0.77 ns with depth; R3 read +0.20, −0.31, and an unresolvable +0.30), so the depth-scaling story
-is provisional and the magnitude is the only durable part. Either way both proposed remediations are settled:
-`BRIDGE_FN` shipped and lands at the floor, and the type-specialized subclass would remove only that sub-nanosecond tax,
-swamped an order of magnitude over by the body gap on deep. Declined.
+within error on every tier and on every run, because the JIT inlines the monomorphic hop — though on R3 deep it clears
+that bar only on a ±5.3 ns band, some twenty times wider than `static forward`'s, so that one cell proves little. The
+full-lattice `BRIDGE.read` carries a wrapper tax under a nanosecond wherever it resolves at all — but its size and even
+its sign move between runs (R2 read 0.14 → 0.31 → 0.77 ns with depth; R3 read +0.20, −0.31, and an unresolvable +0.30),
+so the depth-scaling story is provisional and the magnitude is the only durable part. Either way both proposed
+remediations are settled: `BRIDGE_FN` shipped and lands at the floor, and the type-specialized subclass would remove
+only that sub-nanosecond tax, swamped an order of magnitude over by the body gap on deep. Declined.
 
 What remains over MapStruct on the deep tier is a few nanoseconds of generated-body work rather than dispatch —
 `static forward` alone is above parity — and closing it means matching MapStruct's inlined body. That stays


### PR DESCRIPTION
Refreshes the published comparison figures from a single CI dispatch on `main` at `426061ee`, so every row in the headline table is comparable with every other. Separate runs land on runners of different speeds — that has produced misleading ratios in this document before, and a table whose rows came from different machines reads as though they did not.

| Tier (forward, codegen vs codegen) | MapStruct | telescope | ratio | allocation |
| --- | ---: | ---: | ---: | --- |
| flat | 3.155 ns | 3.362 ns | 1.07× | 32 B/op both |
| nested | 4.361 ns | 5.604 ns | 1.29× | 48 B/op both |
| deep | 62.378 ns | 66.572 ns | 1.07× | 376 B/op both |
| container, Map-valued | 1261.7 ns | 1243.5 ns | tie | **7,528 → 6,712 B/op** |
| container, Set-valued | 1454.8 ns | 1444.7 ns | tie | 7,576 B/op both |

Three things worth reading closely:

**The container rows are a tie, and the doc says so.** Telescope's mean is marginally lower on both, and the confidence intervals overlap, so that means nothing. What is real is the allocation — 6,712 against 7,528 bytes per operation on the Map shape, about 11% less — because allocation is deterministic rather than hardware-dependent. Reporting the lower mean as a win would have been exactly the mistake the control rows in these benchmarks exist to prevent.

**Nested is now stated as a range.** Five runs of the same benchmark have produced 1.04×, 1.42×, 1.20×, 1.21× and 1.29×. It is a framework-overhead microbenchmark rather than a service-shaped workload, and pretending any single figure is the answer has been wrong every time.

**The container tier exists because its absence let a defect ship.** Every tier was List-only, a list has no hash table, and the Bridge emitter was sizing Set and Map rebuilds by element count rather than table capacity — generated bridges allocated more than the reflective path they exist to beat, with every benchmark green. The doc now says that, so the tier's purpose survives the next person to wonder why it is there.

The earlier result tables are kept and marked historical, since the dispatch analysis that follows is built on them. The runtime-tier figures in the README come from the same run (flat 3.34×, nested 2.66×, deep 1.27×).
