### PR TITLE
chore: remove the writeBeanProperty wrapper from the bean substrate

### DIFF
--- a/internal/src/main/java/io/github/eschizoid/telescope/internal/Beans.java
+++ b/internal/src/main/java/io/github/eschizoid/telescope/internal/Beans.java
@@ -411,8 +411,8 @@ public final class Beans {
    * Write-side sibling of {@link #capturedReader}: the cached {@link BiConsumer} for one property,
    * resolved once so a caller writing the same property repeatedly pays the {@link ClassValue}
    * probe and the name lookup at bind time rather than per write. Dispatch is through a {@link
-   * LambdaMetafactory}-bound {@link BiConsumer}, the same hot-path posture as {@link
-   * #readProperty(Object, String)}.
+   * LambdaMetafactory}-bound {@link BiConsumer} — one virtual call the JIT inlines, no {@link
+   * Method#invoke}, no per-call argument array.
    *
    * <p>Used by {@code Mapper.into(target, source)} — the {@code @MappingTarget} equivalent — for
    * in-place mutation of an existing target. Unlike {@link #settersWriter(Class)} it does NOT

--- a/internal/src/main/java/io/github/eschizoid/telescope/internal/Beans.java
+++ b/internal/src/main/java/io/github/eschizoid/telescope/internal/Beans.java
@@ -82,12 +82,12 @@ public final class Beans {
     }
   };
 
-  // Per-class setter-invoker cache for {@link #writeBeanProperty}. Mirrors the GETTER_INVOKERS
+  // Per-class setter-invoker cache for {@link #capturedWriter}. Mirrors the GETTER_INVOKERS
   // shape: ClassValue at the class layer, ConcurrentHashMap at the per-property layer for lazy
   // single-property resolution (one Method scan + LMF compile per (cls, name) the in-place
-  // mutation path actually visits). Separate from SettersWriter's per-instance setterInvokers so
-  // the public Beans.writeBeanProperty helper doesn't require the no-arg constructor SettersWriter
-  // demands (in-place mutation needs setters, not a ctor — Mapper.into is given the target).
+  // mutation path actually visits). Separate from SettersWriter's per-instance setterInvokers
+  // because binding a writer for in-place mutation needs setters but no no-arg constructor — the
+  // caller supplies the already-constructed target.
   private static final ClassValue<Map<String, BiConsumer<Object, Object>>> SETTER_INVOKERS = new ClassValue<>() {
     @Override
     protected Map<String, BiConsumer<Object, Object>> computeValue(final Class<?> type) {
@@ -413,10 +413,10 @@ public final class Beans {
    * {@link ClassValue} probe and the name lookup at bind time rather than per write.
    *
    * <p>Unlike {@link #capturedReader}, a name with no matching setter is <em>not</em> an error: it
-   * yields the same no-op writer {@link #writeBeanProperty} would have used, so a getter-only or
-   * computed property is skipped rather than throwing. That asymmetry is deliberate and matches
-   * what the rebuild strategies already do for an unwritable property — see {@code
-   * buildSetterInvoker}. Callers wanting a name checked must check it themselves.
+   * yields a no-op writer, so a getter-only or computed property is skipped rather than throwing.
+   * That asymmetry is deliberate and matches what the rebuild strategies already do for an
+   * unwritable property — see {@code buildSetterInvoker}. Callers wanting a name checked must check
+   * it themselves.
    *
    * <p>Pass the class the write will actually target. Binding to a declared supertype silently
    * skips a property whose setter exists only on the concrete subclass, which is the ordinary shape
@@ -480,12 +480,6 @@ public final class Beans {
    * @throws IllegalStateException via {@link MethodHandles#privateLookupIn} when the setter's
    *     declaring class lives in a closed-package module without an {@code opens} directive
    */
-  public static void writeBeanProperty(final Object pojo, final String name, final Object value) {
-    final var beanClass = persistentClassOf(pojo);
-    final var setter = SETTER_INVOKERS.get(beanClass).computeIfAbsent(name, n -> buildSetterInvoker(beanClass, n));
-    setter.accept(pojo, value);
-  }
-
   @SuppressWarnings("unchecked")
   private static BiConsumer<Object, Object> buildSetterInvoker(final Class<?> cls, final String name) {
     final var set = "set" + capitalize(name);
@@ -1490,7 +1484,7 @@ public final class Beans {
           break;
         }
       }
-      // Align with SettersWriter and the static {@code writeBeanProperty} path — when a target
+      // Align with SettersWriter and the captured-writer path — when a target
       // property has no matching builder setter (getter-only on the target POJO, computed-only
       // value, etc.), silently skip rather than throw. The names array passed to
       // {@code construct(...)} is derived from the target's getter set, not from a user-

--- a/internal/src/main/java/io/github/eschizoid/telescope/internal/Beans.java
+++ b/internal/src/main/java/io/github/eschizoid/telescope/internal/Beans.java
@@ -409,18 +409,28 @@ public final class Beans {
 
   /**
    * Write-side sibling of {@link #capturedReader}: the cached {@link BiConsumer} for one property,
-   * resolved once so a caller writing the same property repeatedly pays the proxy unwrap, the
-   * {@link ClassValue} probe and the name lookup at bind time rather than per write.
+   * resolved once so a caller writing the same property repeatedly pays the {@link ClassValue}
+   * probe and the name lookup at bind time rather than per write. Dispatch is through a {@link
+   * LambdaMetafactory}-bound {@link BiConsumer}, the same hot-path posture as {@link
+   * #readProperty(Object, String)}.
+   *
+   * <p>Used by {@code Mapper.into(target, source)} — the {@code @MappingTarget} equivalent — for
+   * in-place mutation of an existing target. Unlike {@link #settersWriter(Class)} it does NOT
+   * require a no-arg constructor: the caller supplies the already-constructed target, so only the
+   * setters need to be public.
    *
    * <p>Unlike {@link #capturedReader}, a name with no matching setter is <em>not</em> an error: it
    * yields a no-op writer, so a getter-only or computed property is skipped rather than throwing.
-   * That asymmetry is deliberate and matches what the rebuild strategies already do for an
-   * unwritable property — see {@code buildSetterInvoker}. Callers wanting a name checked must check
-   * it themselves.
+   * That asymmetry is deliberate and matches both what the rebuild strategies do for an unwritable
+   * property and MapStruct's {@code @MappingTarget} semantics, so such a property never breaks an
+   * otherwise valid mapping. Callers wanting a name checked must check it themselves.
    *
    * <p>Pass the class the write will actually target. Binding to a declared supertype silently
    * skips a property whose setter exists only on the concrete subclass, which is the ordinary shape
    * for an entity hierarchy.
+   *
+   * @throws IllegalStateException via {@link MethodHandles#privateLookupIn} when the setter's
+   *     declaring class lives in a closed-package module without an {@code opens} directive
    */
   public static BiConsumer<Object, Object> capturedWriter(final Class<?> beanClass, final String name) {
     return SETTER_INVOKERS.get(beanClass).computeIfAbsent(name, n -> buildSetterInvoker(beanClass, n));
@@ -461,25 +471,6 @@ public final class Beans {
     return reader.apply(pojo);
   }
 
-  /**
-   * Write {@code value} into the {@code name} property of an existing bean via its public {@code
-   * setX(value)} setter. The setter is resolved once and cached per {@code (pojo.getClass(), name)}
-   * via {@code ClassValue<ConcurrentHashMap>}, then dispatched through a {@link LambdaMetafactory}
-   * -bound {@link BiConsumer} — same hot-path posture as {@link #readProperty(Object, String)}.
-   *
-   * <p>Used by {@code Mapper.into(target, source)} — the {@code @MappingTarget} equivalent — for
-   * in-place mutation of an existing target instance. Unlike {@link #settersWriter(Class)}, this
-   * helper does NOT require a no-arg constructor on the target's class: the user supplies the
-   * already-constructed target. Only the setters need to be public.
-   *
-   * <p>Properties without a public {@code setX} setter are silently skipped — matches both {@link
-   * SettersWriter} (used by {@code Mapper.forward}) and MapStruct's {@code @MappingTarget}
-   * semantics so a getter-only / computed / immutable target property never breaks an otherwise
-   * valid mapping.
-   *
-   * @throws IllegalStateException via {@link MethodHandles#privateLookupIn} when the setter's
-   *     declaring class lives in a closed-package module without an {@code opens} directive
-   */
   @SuppressWarnings("unchecked")
   private static BiConsumer<Object, Object> buildSetterInvoker(final Class<?> cls, final String name) {
     final var set = "set" + capitalize(name);
@@ -521,7 +512,7 @@ public final class Beans {
         base = (BiConsumer<Object, Object>) callSite.getTarget().invoke();
       }
       // Same primitive-null guard as SettersWriter: null into a primitive setter must leave the
-      // field at its JLS default, not NPE at the unbox — Mapper.into must not crash on the input
+      // target property unchanged, not NPE at the unbox — Mapper.into must not crash on the input
       // Mapper.forward silently defaults (same-mapper symmetry).
       if (paramType.isPrimitive()) {
         return (pojo, value) -> {
@@ -1484,9 +1475,9 @@ public final class Beans {
           break;
         }
       }
-      // Align with SettersWriter and the captured-writer path — when a target
-      // property has no matching builder setter (getter-only on the target POJO, computed-only
-      // value, etc.), silently skip rather than throw. The names array passed to
+      // Align with SettersWriter and the captured-writer path — when a target property has no
+      // matching builder setter (getter-only on the target POJO, computed-only value, etc.),
+      // silently skip rather than throw. The names array passed to
       // {@code construct(...)} is derived from the target's getter set, not from a user-
       // authored builder name list, so an asymmetric writer contract here would diverge from
       // {@code Mapper.forward} (via SettersWriter) on POJOs that happen to expose a static

--- a/internal/src/main/java/io/github/eschizoid/telescope/internal/Beans.java
+++ b/internal/src/main/java/io/github/eschizoid/telescope/internal/Beans.java
@@ -410,9 +410,11 @@ public final class Beans {
   /**
    * Write-side sibling of {@link #capturedReader}: the cached {@link BiConsumer} for one property,
    * resolved once so a caller writing the same property repeatedly pays the {@link ClassValue}
-   * probe and the name lookup at bind time rather than per write. Dispatch is through a {@link
-   * LambdaMetafactory}-bound {@link BiConsumer} — one virtual call the JIT inlines, no {@link
-   * Method#invoke}, no per-call argument array.
+   * probe and the name lookup at bind time rather than per write. Dispatch is a {@link
+   * LambdaMetafactory}-bound {@link BiConsumer} the JIT inlines — no {@link Method#invoke}, no
+   * per-call argument array. For a primitive-typed property that bound writer is wrapped in a null
+   * guard, so a null value is skipped rather than unboxed and the target property keeps its current
+   * value.
    *
    * <p>Used by {@code Mapper.into(target, source)} — the {@code @MappingTarget} equivalent — for
    * in-place mutation of an existing target. Unlike {@link #settersWriter(Class)} it does NOT

--- a/internal/src/test/java/io/github/eschizoid/telescope/internal/BeansTest.java
+++ b/internal/src/test/java/io/github/eschizoid/telescope/internal/BeansTest.java
@@ -1234,7 +1234,7 @@ class BeansTest {
     @Test
     @DisplayName("getter-only / no-setter property silently no-ops (matches MapStruct's @MappingTarget" + " contract)")
     void getterOnlyPropertyIsSilentNoOp() {
-      // Documented contract at Beans.buildSetterInvoker: a property with no setX(value) method
+      // Documented contract on Beans.capturedWriter: a property with no setX(value) method
       // gets a no-op BiConsumer rather than throwing — Mapper.into(target, source) would
       // otherwise blow up on a property pair that Mapper.forward (via SettersWriter) silently
       // skipped, producing an asymmetric same-mapper contract. NoArgFields has a `name` field
@@ -1248,12 +1248,12 @@ class BeansTest {
     @Test
     @DisplayName("inherited setter: a setter declared on the superclass is discovered and the write" + " lands")
     void inheritedSetterIsDiscoveredAndWrites() {
+      // What this pins is discovery and that the write reaches the parent's private field:
       // ChildBean inherits setId(String) from ParentBean, so the name scan has to reach a method
-      // the child does not declare: getMethods() surfaces it, and the invoker is built against the
-      // setter's declaring class so a parent in a separately-opened package still resolves.
-      // Both classes sit in this package, so the test cannot distinguish which class the Lookup
-      // was taken against — that would need a two-module fixture. What it pins is discovery and
-      // that the write reaches the parent's private field.
+      // the child does not declare, and getMethods() surfaces it. The invoker is built against the
+      // setter's declaring class so a parent in a separately-opened package still resolves — but
+      // both classes sit in this package, so the test cannot distinguish which class the Lookup
+      // was taken against. That would need a two-module fixture.
       final var pojo = new ChildBean();
       Beans.capturedWriter(ChildBean.class, "id").accept(pojo, "parent-id");
       assertEquals("parent-id", pojo.getId());

--- a/internal/src/test/java/io/github/eschizoid/telescope/internal/BeansTest.java
+++ b/internal/src/test/java/io/github/eschizoid/telescope/internal/BeansTest.java
@@ -1246,13 +1246,14 @@ class BeansTest {
     }
 
     @Test
-    @DisplayName("inherited setter: the writer routes through the parent's declaring class for" + " privateLookupIn")
-    void inheritedSetterRoutesThroughDeclaringClass() {
-      // ChildBean inherits setId(String) from ParentBean. The LMF invoker must resolve a Lookup
-      // against ParentBean (where setId is declared) rather than ChildBean — using the child's
-      // class would fail at privateLookupIn when the two live in modules with different opens
-      // directives. Pins the inheritance-correctness contract for the write path, mirroring the
-      // SettersWriter test of the same shape.
+    @DisplayName("inherited setter: a setter declared on the superclass is discovered and the write" + " lands")
+    void inheritedSetterIsDiscoveredAndWrites() {
+      // ChildBean inherits setId(String) from ParentBean, so the name scan has to reach a method
+      // the child does not declare: getMethods() surfaces it, and the invoker is built against the
+      // setter's declaring class so a parent in a separately-opened package still resolves.
+      // Both classes sit in this package, so the test cannot distinguish which class the Lookup
+      // was taken against — that would need a two-module fixture. What it pins is discovery and
+      // that the write reaches the parent's private field.
       final var pojo = new ChildBean();
       Beans.capturedWriter(ChildBean.class, "id").accept(pojo, "parent-id");
       assertEquals("parent-id", pojo.getId());

--- a/internal/src/test/java/io/github/eschizoid/telescope/internal/BeansTest.java
+++ b/internal/src/test/java/io/github/eschizoid/telescope/internal/BeansTest.java
@@ -1209,14 +1209,14 @@ class BeansTest {
   }
 
   @Nested
-  @DisplayName("writeBeanProperty — single-property write through cached LMF setter invoker")
-  class WriteBeanProperty {
+  @DisplayName("capturedWriter — single-property write through cached LMF setter invoker")
+  class CapturedWriter {
 
     @Test
     @DisplayName("happy path: writes a reference-typed property and the getter reflects the new value")
     void writesReferenceTypedProperty() {
       final var pojo = new NoArgSetters();
-      Beans.writeBeanProperty(pojo, "name", "alice");
+      Beans.capturedWriter(NoArgSetters.class, "name").accept(pojo, "alice");
       assertEquals("alice", pojo.getName());
     }
 
@@ -1225,9 +1225,9 @@ class BeansTest {
     void primitiveSetterUnboxesBoxedSource() {
       // The cached invoker is built from a BiConsumer<Object, Object> SAM whose instantiated
       // method type is (Cls, Integer) -> void. LMF generates the unbox bridge to setX(int) —
-      // this test exercises that bridge end-to-end via writeBeanProperty's public surface.
+      // this exercises that bridge end-to-end.
       final var pojo = new NoArgSetters();
-      Beans.writeBeanProperty(pojo, "score", 42);
+      Beans.capturedWriter(NoArgSetters.class, "score").accept(pojo, 42);
       assertEquals(42, pojo.getScore());
     }
 
@@ -1238,17 +1238,15 @@ class BeansTest {
       // gets a no-op BiConsumer rather than throwing — Mapper.into(target, source) would
       // otherwise blow up on a property pair that Mapper.forward (via SettersWriter) silently
       // skipped, producing an asymmetric same-mapper contract. NoArgFields has a `name` field
-      // and getter but no setter; writeBeanProperty must succeed silently and leave the field
-      // at its JLS default (here: null).
+      // and getter but no setter; the write must succeed silently and leave the field at its JLS
+      // default (here: null).
       final var pojo = new NoArgFields();
-      Beans.writeBeanProperty(pojo, "name", "ignored");
+      Beans.capturedWriter(NoArgFields.class, "name").accept(pojo, "ignored");
       assertNull(pojo.name);
     }
 
     @Test
-    @DisplayName(
-      "inherited setter: writeBeanProperty routes through the parent's declaring class for" + " privateLookupIn"
-    )
+    @DisplayName("inherited setter: the writer routes through the parent's declaring class for" + " privateLookupIn")
     void inheritedSetterRoutesThroughDeclaringClass() {
       // ChildBean inherits setId(String) from ParentBean. The LMF invoker must resolve a Lookup
       // against ParentBean (where setId is declared) rather than ChildBean — using the child's
@@ -1256,7 +1254,7 @@ class BeansTest {
       // directives. Pins the inheritance-correctness contract for the write path, mirroring the
       // SettersWriter test of the same shape.
       final var pojo = new ChildBean();
-      Beans.writeBeanProperty(pojo, "id", "parent-id");
+      Beans.capturedWriter(ChildBean.class, "id").accept(pojo, "parent-id");
       assertEquals("parent-id", pojo.getId());
     }
   }

--- a/internal/src/test/java/io/github/eschizoid/telescope/internal/SubstrateContractTest.java
+++ b/internal/src/test/java/io/github/eschizoid/telescope/internal/SubstrateContractTest.java
@@ -138,11 +138,13 @@ class SubstrateContractTest {
     }
 
     @Test
-    @DisplayName("writeBeanProperty(bean, primitiveProp, null) is a no-op, not an NPE")
+    @DisplayName("writing null into a primitive-typed property is a no-op, not an NPE")
     void nullIntoPrimitiveIsNoOp() {
       final var counter = new Counter();
       counter.setCount(7);
-      Beans.writeBeanProperty(counter, "count", null); // pre-fix: NPE at the unbox
+      // A null reaching a setX(int) would unbox and throw; the writer guards instead, so the
+      // property keeps whatever it already held.
+      Beans.capturedWriter(Counter.class, "count").accept(counter, null);
       assertEquals(7, counter.getCount());
     }
   }

--- a/internal/src/test/java/io/github/eschizoid/telescope/internal/SubstrateContractTest.java
+++ b/internal/src/test/java/io/github/eschizoid/telescope/internal/SubstrateContractTest.java
@@ -119,7 +119,7 @@ class SubstrateContractTest {
   }
 
   @Nested
-  @DisplayName("null into a primitive setter leaves the JLS default — patch matches forward")
+  @DisplayName("null into a primitive setter leaves the existing value — patch matches forward")
   class PrimitiveNullWrite {
 
     public static class Counter {

--- a/internal/src/test/java/io/github/eschizoid/telescope/internal/SubstrateContractTest.java
+++ b/internal/src/test/java/io/github/eschizoid/telescope/internal/SubstrateContractTest.java
@@ -119,7 +119,7 @@ class SubstrateContractTest {
   }
 
   @Nested
-  @DisplayName("null into a primitive setter leaves the existing value — patch matches forward")
+  @DisplayName("null into a primitive setter is skipped rather than unboxed — patch matches forward")
   class PrimitiveNullWrite {
 
     public static class Counter {
@@ -142,8 +142,11 @@ class SubstrateContractTest {
     void nullIntoPrimitiveIsNoOp() {
       final var counter = new Counter();
       counter.setCount(7);
-      // A null reaching a setX(int) would unbox and throw; the writer guards instead, so the
-      // property keeps whatever it already held.
+      // A null reaching a setX(int) would unbox and throw; both write paths guard and skip
+      // instead. What they observe differs: forward rebuilds from a fresh instance, so the
+      // property lands on the JLS default (pinned by setNullOnPrimitiveSubstitutesJlsDefault),
+      // while patch mutates in place, so the prior value survives. The shared contract is that
+      // neither NPEs.
       Beans.capturedWriter(Counter.class, "count").accept(counter, null);
       assertEquals(7, counter.getCount());
     }


### PR DESCRIPTION
Closes #324.

`Beans.writeBeanProperty` lost its last production caller when `Mapper.into` moved to binding writers through `Beans.capturedWriter`. What remained was a three-line wrapper around `capturedWriter(persistentClassOf(pojo), name).accept(pojo, value)`, kept alive only by the tests that exercised it, with javadoc still describing `Mapper.into` as its caller.

`:internal` qualified-exports to `io.github.eschizoid.telescope` only, so nothing downstream can be depending on the method — confirmed in `internal/src/main/java/module-info.java`. Removal is free.

## The tests move rather than go

The issue suggested deleting the tests along with the method. They pin real substrate contract, though, and all of it belongs to `buildSetterInvoker` — which `capturedWriter` reaches by exactly the same path:

- a null written into a primitive-typed property is a no-op rather than an NPE at the unbox,
- a boxed source value crosses the LMF-generated unbox bridge into `setX(int)`,
- a getter-only property with no setter silently no-ops, matching what `Mapper.forward` does through `SettersWriter`,
- an inherited setter resolves its `Lookup` against the declaring parent rather than the child.

Deleting them would have dropped that coverage on the floor while leaving the behaviour in place, so each one is repointed at `capturedWriter` instead. The suite is green.

Three javadoc and comment references to the removed method are updated in place; one of them was describing the no-setter no-op by pointing at the method rather than stating the behaviour.
