### PR TITLE
docs: mark ADR-0003's figures as predating ADR-0005 and ADR-0015

### DIFF
--- a/docs/adr/0003-reflection-over-method-handles.md
+++ b/docs/adr/0003-reflection-over-method-handles.md
@@ -9,6 +9,13 @@ The reflective runtime path — `Records` (cached `RecordComponent.getAccessor()
 `Field.setAccessible`. Periodically someone suggests swapping to `MethodHandles` ("MH invoke is faster than
 Method.invoke; modern JIT can fold it").
 
+> **Amendment (2026-09-10, after ADR-0005 and ADR-0015).** The figures below predate both. ADR-0005 narrowed this
+> decision — reflection stays for discovery, while the hot-path dispatch primitive became a `LambdaMetafactory`-built
+> functional interface — and ADR-0015 qualified it under AOT, where `MhAccessors` reaches fields, properties and
+> constructors through `MethodHandle.invokeExact` because LMF cannot define a class inside an image. What still binds
+> from this ADR is its rejection of raw per-call `MethodHandle.invoke` as the dispatch primitive, which ADR-0005 rejects
+> again on its own evidence. Read the numbers here as the state before that work.
+
 ## Decision
 
 Stay on cached `java.lang.reflect`. Do not migrate to `MethodHandles` for runtime field/property/constructor access.

--- a/docs/adr/0003-reflection-over-method-handles.md
+++ b/docs/adr/0003-reflection-over-method-handles.md
@@ -11,10 +11,13 @@ Method.invoke; modern JIT can fold it").
 
 > **Amendment (2026-09-10, after ADR-0005 and ADR-0015).** The figures below predate both. ADR-0005 narrowed this
 > decision — reflection stays for discovery, while the hot-path dispatch primitive became a `LambdaMetafactory`-built
-> functional interface — and ADR-0015 qualified it under AOT, where `MhAccessors` reaches fields, properties and
-> constructors through `MethodHandle.invokeExact` because LMF cannot define a class inside an image. What still binds
-> from this ADR is its rejection of raw per-call `MethodHandle.invoke` as the dispatch primitive, which ADR-0005 rejects
-> again on its own evidence. Read the numbers here as the state before that work.
+> functional interface — and ADR-0015 qualified it under AOT, where `MhAccessors` reaches record components, bean
+> properties and constructors through `MethodHandle.invokeExact` because LMF cannot define a class inside an image. The
+> exception is not AOT-only: on a stock JVM, field writes (`putField`) and the all-args constructor's spread adapter
+> also go through cached `MethodHandle`s, because LMF structurally cannot bind those handle kinds. What still binds from
+> this ADR is its rejection of raw per-call `MethodHandle.invoke` as the dispatch primitive, which ADR-0005 rejects
+> again, on the added ground that raw dispatch lacks the JIT-inlinable functional-interface shape. Read the numbers here
+> as the state before that work.
 
 ## Decision
 

--- a/docs/adr/0003-reflection-over-method-handles.md
+++ b/docs/adr/0003-reflection-over-method-handles.md
@@ -13,11 +13,14 @@ Method.invoke; modern JIT can fold it").
 > decision — reflection stays for discovery, while the hot-path dispatch primitive became a `LambdaMetafactory`-built
 > functional interface — and ADR-0015 qualified it under AOT, where `MhAccessors` reaches record components, bean
 > properties and constructors through `MethodHandle.invokeExact` because LMF cannot define a class inside an image. The
-> exception is not AOT-only: on a stock JVM, field writes (`putField`) and the all-args constructor's spread adapter
-> also go through cached `MethodHandle`s, because LMF structurally cannot bind those handle kinds. What still binds from
-> this ADR is its rejection of raw per-call `MethodHandle.invoke` as the dispatch primitive, which ADR-0005 rejects
-> again, on the added ground that raw dispatch lacks the JIT-inlinable functional-interface shape. Read the numbers here
-> as the state before that work.
+> exception is not AOT-only: on a stock JVM, field writes (`putField`) and every canonical-constructor rebuild — records
+> and the all-args bean constructor alike — also go through cached `MethodHandle`s, because LMF binds only direct method
+> or constructor handles. A field setter is a direct handle of the wrong kind; the spread adapter is not a direct handle
+> at all. The rule underneath is that LMF is the dispatch primitive wherever it can bind, cached `MethodHandle`s cover
+> the rest on every runtime, and AOT only widens which cases fall into "cannot bind". What still binds from this ADR is
+> its rejection of raw per-call `MethodHandle.invoke` as the dispatch primitive, which ADR-0005 rejects again, on the
+> added ground that raw dispatch lacks the JIT-inlinable functional-interface shape. Read the numbers here as the state
+> before that work.
 
 ## Decision
 

--- a/docs/adr/0003-reflection-over-method-handles.md
+++ b/docs/adr/0003-reflection-over-method-handles.md
@@ -16,11 +16,9 @@ Method.invoke; modern JIT can fold it").
 > exception is not AOT-only: on a stock JVM, field writes (`putField`) and every canonical-constructor rebuild — records
 > and the all-args bean constructor alike — also go through cached `MethodHandle`s, because LMF binds only direct method
 > or constructor handles. A field setter is a direct handle of the wrong kind; the spread adapter is not a direct handle
-> at all. The rule underneath is that LMF is the dispatch primitive wherever it can bind, cached `MethodHandle`s cover
-> the rest on every runtime, and AOT only widens which cases fall into "cannot bind". What still binds from this ADR is
-> its rejection of raw per-call `MethodHandle.invoke` as the dispatch primitive, which ADR-0005 rejects again, on the
-> added ground that raw dispatch lacks the JIT-inlinable functional-interface shape. Read the numbers here as the state
-> before that work.
+> at all. What still binds from this ADR is its rejection of raw per-call `MethodHandle.invoke` as the dispatch
+> primitive, which ADR-0005 rejects again, on the added ground that raw dispatch lacks the JIT-inlinable
+> functional-interface shape. Read the numbers here as the state before that work.
 
 ## Decision
 


### PR DESCRIPTION
A reader who opens `docs/adr/0003-reflection-over-method-handles.md` directly sees `~14.9 ns`, `~142 ns` and `~9.5x` with nothing marking them as historical. They predate the LambdaMetafactory migration and the native-image work, and the ADR's decision has been narrowed twice since — ADR-0005 kept reflection for discovery while swapping the hot-path dispatch primitive, and ADR-0015 qualified it under AOT, where `MhAccessors` reaches fields, properties and constructors through `MethodHandle.invokeExact` because LMF cannot define a class inside an image.

Until now `AGENTS.md` carried that warning on the ADR's behalf, which only helps a reader who arrives through `AGENTS.md`.

## What this does and does not touch

A dated amendment note above `## Decision`, using the idiom ADR-0015 already carries (`> **Amendment (date, context).**`). Context, Decision, Reasons and Consequences are untouched — those are the dated record.

**Status stays a bare `Accepted`, deliberately.** This repository records a relation once, on the *later* ADR, pointing back: ADR-0005 is `Accepted (refines ADR-0003)`, ADR-0006 is `Accepted (extends ADR-0004, refines ADR-0005)`, ADR-0015 is `Accepted (qualifies ADR-0005 under AOT)`. Being a *target* is never recorded on the target — ADR-0004 is a target of 0006 and carries a bare `Accepted`; ADR-0005 is a target of both 0006 and 0015 and records only its own backward pointer. Adding forward references would make every relation two-sided, so a future ADR-0016 would need edits to three files and a missed edit would read as "no relation". The `AGENTS.md` ADR index is already the forward index.

What still binds from ADR-0003 is its rejection of raw per-call `MethodHandle.invoke` as the dispatch primitive — ADR-0005's alternatives section rejects it again on its own evidence. The amendment says so, so the ADR is not read as fully superseded either.

Surfaced by the review round on #332, which found `AGENTS.md` describing this relation two different wrong ways before getting it right.