### PR TITLE
docs: describe the emission the Lombok processor actually performs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -341,11 +341,12 @@ member list (no synthesised getters / setters / builder) → "no readable proper
 Two shapes handle it, and which one a processor needs depends on whether its output has to be resolvable from
 same-module main code. `LombokFocusProcessor` retries every round and emits as soon as the bean surface reads complete
 (`emitBeanNavigatorIfReady`), using `processingOver()` only to turn a target that never became readable into a
-diagnostic rather than silence — nothing is emitted there. Deferring emission itself to that round is what breaks: a
-navigator emitted only then does not exist yet when same-module main code is resolved, which `examples/library`'s
-`LombokDemo` holds in place by importing the generated navigators directly. `BridgeProcessor` and `FromMapProcessor`
-defer only the targets carrying a Lombok trigger, to `processingOver()`. **Any future processor reading synthesised
-members of Lombok-annotated types must do one or the other; reading them in round one gets an un-patched view.**
+diagnostic rather than silence — nothing is emitted there. Deferring emission itself to that round is what breaks **for
+this processor**: a navigator emitted only then does not exist yet when same-module main code is resolved, which
+`examples/library`'s `LombokDemo` holds in place by importing the generated navigators directly. `BridgeProcessor` and
+`FromMapProcessor` defer only the targets carrying a Lombok trigger, to `processingOver()`. **Any future processor
+reading synthesised members of Lombok-annotated types must do one or the other; reading them in round one gets an
+un-patched view.**
 
 The in-memory `ProcessorHarness` (`:codegen` testFixtures) can't reproduce this — Lombok's javac hooks don't install in
 the in-process `JavaCompiler.CompilationTask` flow. Lombok integration tests must use Gradle's standard

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -340,10 +340,12 @@ member list (no synthesised getters / setters / builder) → "no readable proper
 
 Two shapes handle it, and which one a processor needs depends on whether its output has to be resolvable from
 same-module main code. `LombokFocusProcessor` retries every round and emits as soon as the bean surface reads complete
-(`emitBeanNavigatorIfReady`), using `processingOver()` only as a last-resort drain: a navigator emitted only in the
-final round does not exist yet when same-module main code is resolved. `BridgeProcessor` and `FromMapProcessor` defer
-only the targets carrying a Lombok trigger, to `processingOver()`. **Any future processor reading synthesised members of
-Lombok-annotated types must do one or the other; reading them in round one gets an un-patched view.**
+(`emitBeanNavigatorIfReady`), using `processingOver()` only to turn a target that never became readable into a
+diagnostic rather than silence — nothing is emitted there. Deferring emission itself to that round is what breaks: a
+navigator emitted only then does not exist yet when same-module main code is resolved, which `examples/library`'s
+`LombokDemo` holds in place by importing the generated navigators directly. `BridgeProcessor` and `FromMapProcessor`
+defer only the targets carrying a Lombok trigger, to `processingOver()`. **Any future processor reading synthesised
+members of Lombok-annotated types must do one or the other; reading them in round one gets an un-patched view.**
 
 The in-memory `ProcessorHarness` (`:codegen` testFixtures) can't reproduce this — Lombok's javac hooks don't install in
 the in-process `JavaCompiler.CompilationTask` flow. Lombok integration tests must use Gradle's standard

--- a/examples/library/src/main/java/io/github/eschizoid/telescope/examples/LombokDemo.java
+++ b/examples/library/src/main/java/io/github/eschizoid/telescope/examples/LombokDemo.java
@@ -1,21 +1,20 @@
 package io.github.eschizoid.telescope.examples;
 
-import io.github.eschizoid.telescope.Telescope;
 import io.github.eschizoid.telescope.examples.lombok.LombokBuilderUser;
+import io.github.eschizoid.telescope.examples.lombok.LombokBuilderUserTelescope;
 import io.github.eschizoid.telescope.examples.lombok.LombokDataUser;
+import io.github.eschizoid.telescope.examples.lombok.LombokDataUserTelescope;
 
 /**
  * Exercises the {@code telescope-lombok} integration. The {@code LombokFocusProcessor} runs over
  * the {@code @Data} and {@code @Builder} fixtures during {@code compileJava} and emits the same
- * {@code <X>Path<R>} navigator shape that {@code @BeanFocus} produces — but consuming Lombok's
+ * {@code <X>Telescope<R>} navigator shape that {@code @BeanFocus} produces — but consuming Lombok's
  * synthesised getters / setters / builder.
  *
- * <p>The Lombok processor emits on {@code processingOver()} (the last round) so its outputs are
- * <em>not</em> available to subsequent rounds of processing in the same task. Direct {@code import}
- * lines for {@code *Path} types therefore can't resolve. The integration test in {@code :lombok}
- * uses {@link Class#forName} for the same reason — that's the supported access path. Here we mirror
- * it: load the generated class by name, invoke its {@code start()} and per-property methods
- * reflectively, then exercise the resulting {@code Telescope} via its normal typed surface.
+ * <p>The navigators are referenced here by direct {@code import}, from main sources in the module
+ * whose compilation generates them. That resolving at all is the property the processor's emission
+ * order exists to provide: a navigator emitted only in the final processing round would not exist
+ * yet when these references are bound, so this class fails to compile if that order regresses.
  */
 final class LombokDemo {
 
@@ -30,38 +29,17 @@ final class LombokDemo {
     builderLombok();
   }
 
-  // @Data: synthesised getId / setId / getEmail / setEmail. The generated Path uses the no-arg ctor
-  // + setters rebuild path.
+  // @Data: synthesised getters and setters. The generated navigator rebuilds through the setters.
   private static void dataLombok() {
     final var user = new LombokDataUser("ABC", "FOO@BAR.COM");
-    final Telescope<LombokDataUser, String> emailPath = generatedEmailPath(
-      "io.github.eschizoid.telescope.examples.lombok.LombokDataUserPath"
-    );
-    final var lowered = emailPath.update(user, String::toLowerCase);
+    final var lowered = LombokDataUserTelescope.of().email().update(user, String::toLowerCase);
     System.out.println("[@Data] email update          : " + lowered);
   }
 
-  // @Builder + @Getter: synthesised builder(). The generated Path rebuilds via builder().
+  // @Builder + @Getter: synthesised builder(). The generated navigator rebuilds via builder().
   private static void builderLombok() {
     final var user = LombokBuilderUser.builder().id("ABC").email("FOO@BAR.COM").build();
-    final Telescope<LombokBuilderUser, String> emailPath = generatedEmailPath(
-      "io.github.eschizoid.telescope.examples.lombok.LombokBuilderUserPath"
-    );
-    final var lowered = emailPath.update(user, String::toLowerCase);
+    final var lowered = LombokBuilderUserTelescope.of().email().update(user, String::toLowerCase);
     System.out.println("[@Builder] email update       : id=" + lowered.getId() + ", email=" + lowered.getEmail());
-  }
-
-  // Load a generated <X>Path class by FQN, call its static start(), then call email() on the result
-  // to get the leaf Telescope. The reflective glue lives only here — every actual Telescope op runs
-  // through the normal typed API.
-  @SuppressWarnings("unchecked")
-  private static <S> Telescope<S, String> generatedEmailPath(final String pathClassFqn) {
-    try {
-      final var pathClass = Class.forName(pathClassFqn);
-      final var start = pathClass.getDeclaredMethod("start").invoke(null);
-      return (Telescope<S, String>) pathClass.getDeclaredMethod("email").invoke(start);
-    } catch (final ReflectiveOperationException e) {
-      throw new IllegalStateException("could not load generated path " + pathClassFqn, e);
-    }
   }
 }

--- a/lombok/src/main/java/io/github/eschizoid/telescope/codegen/lombok/LombokFocusProcessor.java
+++ b/lombok/src/main/java/io/github/eschizoid/telescope/codegen/lombok/LombokFocusProcessor.java
@@ -35,8 +35,7 @@ import javax.lang.model.element.TypeElement;
  * processing ends is run through the emit path on {@link RoundEnvironment#processingOver} anyway,
  * where the empty property list surfaces as a <em>no readable properties</em> diagnostic rather
  * than as silence. Deferring every target to that final round would be simpler and is wrong: a
- * navigator emitted only then does not exist yet when same-module main code is resolved, which
- * {@code examples/library}'s direct references to the generated navigators hold in place.
+ * navigator emitted only then does not exist yet when same-module main code is resolved.
  */
 @SupportedAnnotationTypes({ "lombok.Data", "lombok.Value", "lombok.Builder" })
 @SupportedSourceVersion(SourceVersion.RELEASE_21)
@@ -73,8 +72,7 @@ public final class LombokFocusProcessor extends AbstractTelescopeProcessor {
     // *generated* sources are themselves compiled, by which point Lombok has long finished. A
     // round where Lombok has not yet run emits nothing useful and a later round retries: the
     // `beanProperties()` query on an un-patched @Data returns empty, which
-    // `emitBeanNavigatorIfReady`
-    // treats as not-ready.
+    // `emitBeanNavigatorIfReady` treats as not-ready.
     for (final var pojo : List.copyOf(pending)) {
       if (emitBeanNavigatorIfReady(pojo)) pending.remove(pojo);
     }

--- a/lombok/src/main/java/io/github/eschizoid/telescope/codegen/lombok/LombokFocusProcessor.java
+++ b/lombok/src/main/java/io/github/eschizoid/telescope/codegen/lombok/LombokFocusProcessor.java
@@ -32,10 +32,11 @@ import javax.lang.model.element.TypeElement;
  *
  * <p>This processor therefore collects targets every round and emits each one as soon as its bean
  * surface reads complete, retrying the rest on later rounds. A target still unreadable when
- * processing ends is emitted on {@link RoundEnvironment#processingOver} as a last resort, so its
- * real problem surfaces as a diagnostic rather than as silence. Deferring every target to that
- * final round would be simpler and is wrong: a navigator emitted only then does not exist yet when
- * same-module main code is resolved.
+ * processing ends is run through the emit path on {@link RoundEnvironment#processingOver} anyway,
+ * where the empty property list surfaces as a <em>no readable properties</em> diagnostic rather
+ * than as silence. Deferring every target to that final round would be simpler and is wrong: a
+ * navigator emitted only then does not exist yet when same-module main code is resolved, which
+ * {@code examples/library}'s direct references to the generated navigators hold in place.
  */
 @SupportedAnnotationTypes({ "lombok.Data", "lombok.Value", "lombok.Builder" })
 @SupportedSourceVersion(SourceVersion.RELEASE_21)
@@ -59,7 +60,7 @@ public final class LombokFocusProcessor extends AbstractTelescopeProcessor {
       for (final var element : roundEnv.getElementsAnnotatedWith(anno)) {
         if (element.getKind() != ElementKind.CLASS) continue;
         // Nested static classes are supported: emitBeanNavigator flattens the enclosing hierarchy
-        // into the emitted <X>Telescope / <X><Cap>Step class names (e.g. an inner
+        // into the emitted <X>Telescope / <X><Cap>Step / <X>FieldOptics class names (e.g. an inner
         // `Outer.Inner` produces `OuterInnerTelescope`) and uses the dotted form for in-source type
         // references. Non-static inner classes (those whose enclosing element is a class but not
         // static) would still trip the no-no-arg-ctor or no-public-builder check in
@@ -67,22 +68,20 @@ public final class LombokFocusProcessor extends AbstractTelescopeProcessor {
         pending.add((TypeElement) element);
       }
     }
-    // Emit on EVERY round that has fresh @Data/@Value/@Builder targets. We previously deferred to
-    // `processingOver()` to ensure Lombok's lazy AST visitors had finished patching the host class
-    // — but that delay meant the emitted navigator didn't exist when same-module main code was
-    // resolved by the compiler. By emitting eagerly we make the Telescope and Step classes
-    // visible in time for main-source binding; Lombok's patches resolve later when the *generated*
-    // sources are themselves compiled, by which point Lombok has long finished. If Lombok hasn't
-    // run yet in a given round we emit nothing useful and let a later round retry — the
-    // `beanProperties()` query on an un-patched @Data returns empty, which `emitBeanNavigator`
-    // already handles as a "no readable properties" no-op.
+    // Emit on EVERY round that has fresh @Data/@Value/@Builder targets, so the navigator exists in
+    // time for same-module main code to bind against it. Lombok's patches resolve later, when the
+    // *generated* sources are themselves compiled, by which point Lombok has long finished. A
+    // round where Lombok has not yet run emits nothing useful and a later round retries: the
+    // `beanProperties()` query on an un-patched @Data returns empty, which
+    // `emitBeanNavigatorIfReady`
+    // treats as not-ready.
     for (final var pojo : List.copyOf(pending)) {
       if (emitBeanNavigatorIfReady(pojo)) pending.remove(pojo);
     }
     if (roundEnv.processingOver() && !pending.isEmpty()) {
-      // Last-resort emit on processingOver(): any target whose host class never became readable
-      // by the time annotation processing ends, still gets a navigator (the existing
-      // "no readable properties" error from emitBeanNavigator surfaces the real problem then).
+      // Last-resort pass on processingOver(): a target whose host class never became readable goes
+      // through emitBeanNavigator anyway, which finds no properties and reports the "no readable
+      // properties" error — so an unreadable target ends as a diagnostic rather than as silence.
       for (final var pojo : pending) emitBeanNavigator(pojo, "@Data/@Value/@Builder", LOMBOK_BEAN_ANNOTATIONS);
       pending.clear();
     }

--- a/lombok/src/main/java/io/github/eschizoid/telescope/codegen/lombok/LombokFocusProcessor.java
+++ b/lombok/src/main/java/io/github/eschizoid/telescope/codegen/lombok/LombokFocusProcessor.java
@@ -12,7 +12,7 @@ import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.TypeElement;
 
 /**
- * Annotation processor that emits {@code <Pojo>Path<R>} navigators for classes carrying any of
+ * Annotation processor that emits {@code <Pojo>Telescope<R>} navigators for classes carrying any of
  * {@code @lombok.Data} / {@code @lombok.Value} / {@code @lombok.Builder}. The class itself never
  * depends on Lombok at compile time — annotation triggers are looked up by string FQN, and the
  * processor is a graceful no-op when Lombok isn't on the consumer's processor path.
@@ -22,16 +22,20 @@ import javax.lang.model.element.TypeElement;
  * {@code Telescope<R, T>} methods; container properties (List/Set/Iterable, Map values, Optional)
  * yield container steps with the matching {@code each} / {@code eachValue} / {@code whenPresent}
  * method; sub-properties whose class also carries a Lombok bean annotation descend into their own
- * generated Path.
+ * generated navigator.
  *
- * <p><b>Round-deferred emission.</b> Lombok installs lazy AST visitors during processor init that
- * patch class declarations on traversal. In a non-trivial annotation-processor pipeline those
- * visitors haven't necessarily fired by the time round 1 starts, so a processor that queries {@link
+ * <p><b>Round ordering.</b> Lombok installs lazy AST visitors during processor init that patch
+ * class declarations on traversal. In a non-trivial annotation-processor pipeline those visitors
+ * haven't necessarily fired by the time round 1 starts, so a processor that queries {@link
  * javax.lang.model.util.Elements#getAllMembers} for a {@code @Data} class in round 1 may see the
- * un-patched member list (no getters / setters / builder). To stay correct regardless of round
- * ordering, this processor <em>collects</em> Lombok-annotated targets every round and only
- * <em>emits</em> when {@link RoundEnvironment#processingOver} is true — by then Lombok is
- * guaranteed done patching.
+ * un-patched member list (no getters / setters / builder).
+ *
+ * <p>This processor therefore collects targets every round and emits each one as soon as its bean
+ * surface reads complete, retrying the rest on later rounds. A target still unreadable when
+ * processing ends is emitted on {@link RoundEnvironment#processingOver} as a last resort, so its
+ * real problem surfaces as a diagnostic rather than as silence. Deferring every target to that
+ * final round would be simpler and is wrong: a navigator emitted only then does not exist yet when
+ * same-module main code is resolved.
  */
 @SupportedAnnotationTypes({ "lombok.Data", "lombok.Value", "lombok.Builder" })
 @SupportedSourceVersion(SourceVersion.RELEASE_21)
@@ -55,8 +59,8 @@ public final class LombokFocusProcessor extends AbstractTelescopeProcessor {
       for (final var element : roundEnv.getElementsAnnotatedWith(anno)) {
         if (element.getKind() != ElementKind.CLASS) continue;
         // Nested static classes are supported: emitBeanNavigator flattens the enclosing hierarchy
-        // into the emitted Path / Step / <X>Telescope holder class names (e.g. an inner
-        // `Outer.Inner` produces `OuterInnerPath`) and uses the dotted form for in-source type
+        // into the emitted <X>Telescope / <X><Cap>Step class names (e.g. an inner
+        // `Outer.Inner` produces `OuterInnerTelescope`) and uses the dotted form for in-source type
         // references. Non-static inner classes (those whose enclosing element is a class but not
         // static) would still trip the no-no-arg-ctor or no-public-builder check in
         // emitBeanNavigator, so we don't have to reject them up-front.
@@ -65,8 +69,8 @@ public final class LombokFocusProcessor extends AbstractTelescopeProcessor {
     }
     // Emit on EVERY round that has fresh @Data/@Value/@Builder targets. We previously deferred to
     // `processingOver()` to ensure Lombok's lazy AST visitors had finished patching the host class
-    // — but that delay meant the emitted Path symbol didn't exist when same-module main code was
-    // resolved by the compiler. By emitting eagerly we make Path / Telescope / Step classes
+    // — but that delay meant the emitted navigator didn't exist when same-module main code was
+    // resolved by the compiler. By emitting eagerly we make the Telescope and Step classes
     // visible in time for main-source binding; Lombok's patches resolve later when the *generated*
     // sources are themselves compiled, by which point Lombok has long finished. If Lombok hasn't
     // run yet in a given round we emit nothing useful and let a later round retry — the

--- a/lombok/src/test/java/io/github/eschizoid/telescope/codegen/lombok/LombokFocusProcessorTest.java
+++ b/lombok/src/test/java/io/github/eschizoid/telescope/codegen/lombok/LombokFocusProcessorTest.java
@@ -75,16 +75,18 @@ class LombokFocusProcessorTest {
     }
 
     @Test
-    @DisplayName("Lombok-emitted <X>Telescope is visible to same-module same-round consumers (no round-deferred limit)")
+    @DisplayName("a same-module consumer can reference the emitted <X>Telescope by direct import")
     void sameRoundConsumerCanReferenceEmittedPath() {
-      // SameRoundConsumer is in src/test/java alongside DataUser. Both go through the same javac
-      // compilation pass with LombokFocusProcessor on the annotation-processor classpath. The
-      // consumer references DataUserTelescope directly — if this class were loaded at all (it is,
-      // by
-      // this test), the consumer compiled, meaning the navigator symbol resolved during the
-      // consumer's
-      // own binding phase. That's the regression guard against re-introducing the
-      // processingOver()-only emission pattern.
+      // SameRoundConsumer is in src/test/java alongside DataUser, both compiled in one javac pass
+      // with LombokFocusProcessor on the annotation-processor classpath, and it references
+      // DataUserTelescope by direct import rather than by name. Loading this class at all proves
+      // the consumer compiled, so the navigator symbol resolved during its binding phase and the
+      // generated surface is usable through the typed API rather than only reflectively.
+      //
+      // This does NOT gate emission order: a test-source consumer resolves a navigator emitted in
+      // the final round just as well, so deferring every target to processingOver() leaves this
+      // green. Only a MAIN-source consumer distinguishes them, which is what the direct
+      // references in examples/library's LombokDemo hold in place.
       final var result = SameRoundConsumer.shoutEmail(new DataUser("u-1", "alice@example.com"));
       assertEquals("u-1", result.getId());
       assertEquals("ALICE@EXAMPLE.COM", result.getEmail());


### PR DESCRIPTION
Closes #334.

`LombokFocusProcessor`'s class javadoc described emission behaviour the processor abandoned: it said targets are collected every round and emitted only when `processingOver` is true. The implementation emits every round through `emitBeanNavigatorIfReady` and uses `processingOver()` as a last-resort drain — and the inline comment twenty lines below already explains why, so the file held both the wrong description and its own refutation.

This is the API-doc surface for the one out-of-tree consumer of `AbstractTelescopeProcessor`, and the file a future processor author reads to copy the round-ordering pattern from. `AGENTS.md` tells them to do one of two things; this javadoc taught the one this processor gave up.

The rewritten paragraph states the constraint rather than the history: emit as soon as a target's bean surface reads complete, retry the rest, drain on `processingOver` so a still-unreadable target surfaces a diagnostic instead of silence — and deferring everything to that final round is wrong because a navigator emitted only then does not exist yet when same-module main code is resolved.

## Also: the Path naming

The javadoc named the emitted class `<Pojo>Path<R>`, and three comments referred to `Path` / `OuterInnerPath`. The emitters produce `<X>Telescope` (`AbstractTelescopeProcessor:751`) and `<X>FieldOptics` (`:845`). `Path` is the 1.0 name and nothing emits it — the same stale naming corrected in `annotations/package-info.java` on #329.

No behaviour change. `:lombok:test` and `:lombok:spotlessCheck` green.