### PR TITLE
docs: name the release notes AGENTS.md was calling a CHANGELOG

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,11 +47,12 @@ verifies mapper pairings at compile time. Read the mantras before the module map
   opposite: one line per paragraph, because GitHub's comment renderer turns a single newline into a line break. Commit
   messages wrap at ~72 columns, since they are read in terminals.
 - **No bug or issue numbers in source comments.** Describe the behaviour in its own terms; cross-references live in the
-  PR body and the release notes. There is no `CHANGELOG.md` — JReleaser builds the notes for each release from
-  conventional-commit subjects (`changelog { preset = "conventional-commits" }` in the root `build.gradle.kts`), which
-  is why the **subject** of a squash merge is load-bearing and the body is not. A breaking change needs a `!` in the
-  subject and a `BREAKING CHANGE:` footer, and the release has to be dispatched as `minor` or `major` — nothing infers
-  the bump from the commits.
+  PR body and the release notes. There is no `CHANGELOG.md` — JReleaser generates the notes for each release
+  (`preset.set("conventional-commits")` in the root `build.gradle.kts`). The preset categorises on the **subject**
+  alone, so the subject of a squash merge decides whether a change appears in the notes at all and what text they show;
+  the body is read only for a `BREAKING CHANGE:` footer and `Co-authored-by:` trailers. Mark a breaking change both ways
+  — the `!` in the subject flags it, the footer supplies the text the notes render — and dispatch the release as `minor`
+  or `major`, because nothing infers the bump from the commits.
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,7 +47,11 @@ verifies mapper pairings at compile time. Read the mantras before the module map
   opposite: one line per paragraph, because GitHub's comment renderer turns a single newline into a line break. Commit
   messages wrap at ~72 columns, since they are read in terminals.
 - **No bug or issue numbers in source comments.** Describe the behaviour in its own terms; cross-references live in the
-  PR and the CHANGELOG.
+  PR body and the release notes. There is no `CHANGELOG.md` — JReleaser builds the notes for each release from
+  conventional-commit subjects (`changelog { preset = "conventional-commits" }` in the root `build.gradle.kts`), which
+  is why the **subject** of a squash merge is load-bearing and the body is not. A breaking change needs a `!` in the
+  subject and a `BREAKING CHANGE:` footer, and the release has to be dispatched as `minor` or `major` — nothing infers
+  the bump from the commits.
 
 ---
 
@@ -617,9 +621,9 @@ burying the rationale in a code comment.
 
 ## Roadmap and open work
 
-Shipped work is recorded in `git log`, the CHANGELOG, and the ADR index above; it is not duplicated here. Open work
-lives in the issue tracker, labelled `performance`. Those issues each carry a mechanism, a measurement, and a proposed
-verification, which makes them the easiest ones to pick up cold.
+Shipped work is recorded in `git log`, the generated release notes, and the ADR index above; it is not duplicated here.
+Open work lives in the issue tracker, labelled `performance`. Those issues each carry a mechanism, a measurement, and a
+proposed verification, which makes them the easiest ones to pick up cold.
 
 Whatever you pick up, the two things a reviewer will ask for are the ones the mantras name: a measurement with a
 control, and a test that fails on the unfixed code.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,10 +49,13 @@ verifies mapper pairings at compile time. Read the mantras before the module map
 - **No bug or issue numbers in source comments.** Describe the behaviour in its own terms; cross-references live in the
   PR body and the release notes. There is no `CHANGELOG.md` — JReleaser generates the notes for each release
   (`preset.set("conventional-commits")` in the root `build.gradle.kts`). The preset categorises on the **subject**
-  alone, so the subject of a squash merge decides whether a change appears in the notes at all and what text they show;
-  the body is read only for a `BREAKING CHANGE:` footer and `Co-authored-by:` trailers. Mark a breaking change both ways
-  — the `!` in the subject flags it, the footer supplies the text the notes render — and dispatch the release as `minor`
-  or `major`, because nothing infers the bump from the commits.
+  alone, so the subject of a squash merge decides which section a change lands under and how it reads; a subject
+  matching no `type:` prefix still appears, unheaded below a rule, as its raw title. The body is read too — for a
+  `BREAKING CHANGE:` footer, for issue references (any ` #123`, which the entry renders as `, closes #123`), and for
+  `Co-authored-by:` lines, which feed the Contributors block. The issue reference is how a cross-reference kept out of a
+  source comment reaches the notes. Mark a breaking change both ways — the `!` in the subject flags it, the footer
+  supplies the text the notes render — and dispatch the release as `minor` or `major`, because nothing infers the bump
+  from the commits.
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,13 +49,15 @@ verifies mapper pairings at compile time. Read the mantras before the module map
 - **No bug or issue numbers in source comments.** Describe the behaviour in its own terms; cross-references live in the
   PR body and the release notes. There is no `CHANGELOG.md` — JReleaser generates the notes for each release
   (`preset.set("conventional-commits")` in the root `build.gradle.kts`). The preset categorises on the **subject**
-  alone, so the subject of a squash merge decides which section a change lands under and how it reads; a subject
-  matching no `type:` prefix still appears, unheaded below a rule, as its raw title. The body is read too — for a
-  `BREAKING CHANGE:` footer, for issue references (any ` #123`, which the entry renders as `, closes #123`), and for
-  `Co-authored-by:` lines, which feed the Contributors block. The issue reference is how a cross-reference kept out of a
-  source comment reaches the notes. Mark a breaking change both ways — the `!` in the subject flags it, the footer
-  supplies the text the notes render — and dispatch the release as `minor` or `major`, because nothing infers the bump
-  from the commits.
+  alone, so the subject of a squash merge decides which section a change lands under and how it reads. A subject whose
+  `type:` is not one the preset names still parses as conventional and renders its description, but lands below a rule
+  with no heading; a subject with no `type:` prefix at all lands there as its raw title. The body is read too — for a
+  `BREAKING CHANGE:` footer and for `Co-authored-by:` lines, which feed the Contributors block. Issue references are
+  picked up from the whole message, subject included: any `#123` preceded by a non-alphanumeric character renders as
+  `, closes #123` on the entry, so the `(#N)` GitHub appends to a squash subject already carries the cross-reference a
+  source comment must not. Mark a breaking change both ways — the `!` in the subject flags it, the footer supplies the
+  text the notes render — and dispatch the release as `minor` or `major`, because nothing infers the bump from the
+  commits.
 
 ---
 

--- a/examples/springboot/order-jpa/src/main/java/io/github/eschizoid/telescope/demo/spring/mapping/OrderMappers.java
+++ b/examples/springboot/order-jpa/src/main/java/io/github/eschizoid/telescope/demo/spring/mapping/OrderMappers.java
@@ -188,12 +188,12 @@ public class OrderMappers {
    *       should not) carry. Without this row the strict deep-mapper rejects the unmapped source.
    *   <li>{@code writeBeans(SETTERS)} — Lombok's {@code @Data}-synthesised setters are the right
    *       construction strategy for every nested bean target ({@code PartnerShippingLabel}, {@code
-   *       Customer}, {@code Address}). Telescope-lombok's emitted Path is used implicitly via the
-   *       holder-probe fast path; no explicit Path navigation needed at this call site.
+   *       Customer}, {@code Address}). Telescope-lombok's emitted navigator is used implicitly via
+   *       the holder-probe fast path; no explicit navigation needed at this call site.
    *   <li>Same-name {@code Order.customer ↔ PartnerShippingLabel.customer}, {@code
    *       shippingAddress}, {@code billingAddress}, and {@code giftWrap} all auto-recurse. The
    *       {@code Optional<Address> ↔ nullable PartnerShippingLabel.Address} bridge fires for {@code
-   *       giftWrap} (see v0.4.1 CHANGELOG — {@code Iso.liftOptionalToNullable}).
+   *       giftWrap}, via {@code Iso.liftOptionalToNullable}.
    * </ul>
    */
   @Bean

--- a/examples/springboot/order-jpa/src/main/java/io/github/eschizoid/telescope/demo/spring/partner/PartnerShippingLabel.java
+++ b/examples/springboot/order-jpa/src/main/java/io/github/eschizoid/telescope/demo/spring/partner/PartnerShippingLabel.java
@@ -77,7 +77,7 @@ public class PartnerShippingLabel {
   /**
    * Optional gift-wrap address; mirrors {@code Order.giftWrap} ({@code Optional<Address>} on the
    * record side). The {@code Optional} ↔ nullable bridge in {@code DeepMap.autoIso} handles the
-   * cross-paradigm conversion (see v0.4.1 CHANGELOG).
+   * cross-paradigm conversion.
    */
   @JsonProperty("gift_wrap")
   private PartnerAddress giftWrap;


### PR DESCRIPTION
Closes #331.

`AGENTS.md` referred to "the CHANGELOG" twice — as the venue for cross-references that must not go in source comments, and as part of the record of shipped work. No such file exists and none ever has. The guidance named something a contributor cannot edit, in the one place it matters most: the rule that tells them where a cross-reference goes *instead* of into a comment.

## Reword rather than adopt

Release notes already come from JReleaser's `conventional-commits` preset (`build.gradle.kts`), which reads commit subjects. That channel works — a `fix!` subject with a `BREAKING CHANGE:` footer reaches the published notes today. Creating a `CHANGELOG.md` would add a second, hand-maintained copy of the same information, and would need either a back-fill of v1.1.0 through v1.6.0 or a stub that says less than `git log` already does.

So the file now names the real channel.

## Two facts that were only tribal knowledge

Writing it down let two things land that had been passed around verbally and cost real mistakes:

- **The subject of a squash merge is load-bearing; the body is not.** A prose PR title files the change under the wrong section of the generated notes, and the carefully written conventional message in the commit body does nothing.
- **The release type is a `workflow_dispatch` input.** There is no release-please in this repo; axion takes the bump from what you type. A breaking change needs the `!` in the subject, the `BREAKING CHANGE:` footer, *and* a deliberate `minor` or `major` dispatch — nothing promotes it for you.

Surfaced independently by the review rounds on #329 and #330, both while deciding how to communicate a breaking or removing change.