### PR TITLE
docs: give each perf figure one home so a correction cannot miss a copy

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -277,8 +277,8 @@ cycle is possible; cyclic SCCs keep the full guard).
 
 #### What the numbers say
 
-**Codegen-for-codegen, telescope and MapStruct are the same performance class — a tie at realistic depth.** The current
-figures, with the per-tier ranges and which of them are stable across runs, live in the headline table of
+**Codegen-for-codegen, telescope and MapStruct are the same performance class.** The current figures, with the per-tier
+ranges and which of them are stable across runs, live in the headline table of
 [`docs/perf-mapstruct-comparison.md`](../docs/perf-mapstruct-comparison.md); this section explains the shape rather than
 restating them. Flat is settled and close. Deep and nested are ranges, and nested's MapStruct baseline is JMH-noisy
 enough that no single figure is worth publishing. The deeper the tree, the more the per-level conversion work dominates
@@ -295,9 +295,9 @@ Where the flat-tier gap comes from. MapStruct emits one hand-templated method bo
 JIT inlines the whole conversion into a single basic block. Telescope's `@Bridge` codegen emits the same shape — a
 direct constructor call — wrapped in a `Telescope` for composability. On a flat ~3 ns conversion that composability
 costs a fraction of a nanosecond; on deep, where element-by-element list conversion dominates and the workload climbs
-past 50 ns, it is a tie within the range the comparison doc's headline table records. If you're in a tight inner loop
-that doesn't need composition, call `<Source>Bridge.forward(s)` — or the directly-callable `BRIDGE_FN` constant — and
-pay the zero-dispatch floor.
+past 50 ns, it is a few percent — the comparison doc's headline table carries the per-run ratio and the across-run
+range. If you're in a tight inner loop that doesn't need composition, call `<Source>Bridge.forward(s)` — or the
+directly-callable `BRIDGE_FN` constant — and pay the zero-dispatch floor.
 
 Runtime conversion (`Telescope.mapper(...)`) composes each record/bean pair into a single MethodHandle (see above), so
 the hot path is one `invokeExact` through the fused handle rather than an `Object[]` gather with boxed per-field
@@ -315,8 +315,9 @@ of MapStruct with **no annotations and no build step** — closest where the per
 the deep tier and the hash-container fields — close enough for most service code, and `@Bridge` codegen is there when a
 loop turns hot.
 
-All four columns in that table are from the same run; the codegen/MapStruct ratios reproduce across confirming runs
-within error (the runtime rows carry wider bands but the same magnitude).
+The codegen columns in that table are from one run, and its footnote marks the runtime cells that are not; the
+codegen/MapStruct ratios reproduce across confirming runs within error (the runtime rows carry wider bands but the same
+magnitude).
 
 A quick decision guide. If the problem is "convert this entity to this DTO and back, both directions known at build
 time, no nested-list iteration, only scalars," MapStruct's bytecode is marginally faster on the row — a fraction of a

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -241,9 +241,9 @@ difference between same-tier rows is the dispatch path. Reproducible: re-run the
 | deep   | bean → record |     48.68 ± 0.106 |             55.04 ± 0.522 |                    54.71 ± 0.375 |              90.1 ± 2.5\* |
 | deep   | record → bean |     48.54 ± 0.273 |             54.81 ± 0.418 |                                — |              95.0 ± 2.5\* |
 
-> **This table predates the current figures and has no container tier.** Where it disagrees with the text below, the
-> text is the more recent measurement (Actions run 34470676359);
-> [`docs/perf-mapstruct-comparison.md`](../docs/perf-mapstruct-comparison.md) carries the full current set.
+> **This table predates the current figures and has no container tier.**
+> [`docs/perf-mapstruct-comparison.md`](../docs/perf-mapstruct-comparison.md) carries the current set, with the per-tier
+> ranges and which of them hold between runs.
 
 \* The nested and deep runtime cells were re-measured on a laptop after two lattice sharpenings landed. **Deep** — the
 container-element MethodHandle loop (a nested `List`/`Set`/`Map` element loops over the leaf's raw handle instead of
@@ -295,33 +295,33 @@ Where the flat-tier gap comes from. MapStruct emits one hand-templated method bo
 JIT inlines the whole conversion into a single basic block. Telescope's `@Bridge` codegen emits the same shape — a
 direct constructor call — wrapped in a `Telescope` for composability. On a flat ~3 ns conversion that composability
 costs a fraction of a nanosecond; on deep, where element-by-element list conversion dominates and the workload climbs
-past 50 ns, it is a tie within the range the table records. If you're in a tight inner loop that doesn't need
-composition, call `<Source>Bridge.forward(s)` — or the directly-callable `BRIDGE_FN` constant — and pay the
-zero-dispatch floor.
+past 50 ns, it is a tie within the range the comparison doc's headline table records. If you're in a tight inner loop
+that doesn't need composition, call `<Source>Bridge.forward(s)` — or the directly-callable `BRIDGE_FN` constant — and
+pay the zero-dispatch floor.
 
 Runtime conversion (`Telescope.mapper(...)`) composes each record/bean pair into a single MethodHandle (see above), so
 the hot path is one `invokeExact` through the fused handle rather than an `Object[]` gather with boxed per-field
-dispatch. That lands the forward direction at **~3.3× MapStruct on flat, ~2.7× on nested, ~1.3× on deep**, and
-~1.04–1.06× on hash-container fields. Nested and deep both used to trail far worse (~6.2× and ~4.4×); two lattice
-sharpenings closed them. The container-element MethodHandle loop (a nested `List`/`Set`/`Map` element loops over the
-leaf's raw handle instead of dispatching `Iso.to` → `Function.apply` per element, which also un-megamorphizes the shared
-lift call site) roughly halved deep — same-machine 205 → 90 ns. Full-tree fusion (a scalar nested-pair slot inlines the
-sub-leaf's raw handle directly into the parent's composed handle, so the whole acyclic subtree collapses to one
-`invokeExact`) did the same for nested — 25 → 15 ns. The backward (record → bean) direction — previously the
-pathological case (allocate a bean, then N boxed setter calls, ~48× MapStruct on flat) — is now **~3.5× on flat** via
-the unboxed setter-fold, matching forward instead of trailing it. Allocation drops to the result-object floor (flat 32
-B/op, the array + every primitive box gone). Sub-microsecond everywhere. Reach for codegen on the hottest paths; the
-runtime path is now within ~1.04–3.3× of MapStruct with **no annotations and no build step** — closest where the
-per-call conversion work is largest, which is the deep tier and the hash-container fields — close enough for most
-service code, and `@Bridge` codegen is there when a loop turns hot.
+dispatch. The resulting ratios against MapStruct are in the comparison doc's headline section; what matters here is that
+nested and deep both used to trail far worse (~6.2× and ~4.4×) and two lattice sharpenings closed them. The
+container-element MethodHandle loop (a nested `List`/`Set`/`Map` element loops over the leaf's raw handle instead of
+dispatching `Iso.to` → `Function.apply` per element, which also un-megamorphizes the shared lift call site) roughly
+halved deep — same-machine 205 → 90 ns. Full-tree fusion (a scalar nested-pair slot inlines the sub-leaf's raw handle
+directly into the parent's composed handle, so the whole acyclic subtree collapses to one `invokeExact`) did the same
+for nested — 25 → 15 ns. The backward (record → bean) direction — previously the pathological case (allocate a bean,
+then N boxed setter calls, ~48× MapStruct on flat) — is now **~3.5× on flat** via the unboxed setter-fold, matching
+forward instead of trailing it. Allocation drops to the result-object floor (flat 32 B/op, the array + every primitive
+box gone). Sub-microsecond everywhere. Reach for codegen on the hottest paths; the runtime path is now within ~1.04–3.3×
+of MapStruct with **no annotations and no build step** — closest where the per-call conversion work is largest, which is
+the deep tier and the hash-container fields — close enough for most service code, and `@Bridge` codegen is there when a
+loop turns hot.
 
 All four columns in that table are from the same run; the codegen/MapStruct ratios reproduce across confirming runs
 within error (the runtime rows carry wider bands but the same magnitude).
 
 A quick decision guide. If the problem is "convert this entity to this DTO and back, both directions known at build
 time, no nested-list iteration, only scalars," MapStruct's bytecode is marginally faster on the row — a fraction of a
-nanosecond; the comparison doc carries the figure. On realistic deep workloads — nested records with list-of-records
-inside — telescope codegen matches MapStruct.
+nanosecond; [the comparison doc](../docs/perf-mapstruct-comparison.md) carries the figure. On realistic deep workloads —
+nested records with list-of-records inside — telescope codegen matches MapStruct.
 
 Where MapStruct stops being an option entirely: sealed-narrow paradigm hop, effectful update (`updateAsync`,
 `updateValidated`), JPA cycle handling, Hibernate `LAZY` proxy unwrap, deep navigation as a primitive. These are out of

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -277,12 +277,12 @@ cycle is possible; cyclic SCCs keep the full guard).
 
 #### What the numbers say
 
-**Codegen-for-codegen, telescope and MapStruct are the same performance class — a tie at realistic depth.** On flat
-(3.155 vs 3.362 ns) telescope is **~1.07×**, ~0.2 ns absolute; on deep (62.38 vs 66.57 ns) **~1.07× — ~4 ns on a ~62 ns
-op** on the most recent run, 1.07×–1.19× across runs. The nested single-hop tier swings 1.04×–1.46× run-to-run — its
-MapStruct baseline is JMH-noisy (±0.35) — so it's a framework-overhead microbench, not a number to publish. The deeper
-the tree, the more the per-level conversion work dominates the fixed dispatch overhead; at the flat scale you're
-choosing on API and capability, not nanoseconds.
+**Codegen-for-codegen, telescope and MapStruct are the same performance class — a tie at realistic depth.** The current
+figures, with the per-tier ranges and which of them are stable across runs, live in the headline table of
+[`docs/perf-mapstruct-comparison.md`](../docs/perf-mapstruct-comparison.md); this section explains the shape rather than
+restating them. Flat is settled and close. Deep and nested are ranges, and nested's MapStruct baseline is JMH-noisy
+enough that no single figure is worth publishing. The deeper the tree, the more the per-level conversion work dominates
+the fixed dispatch overhead; at the flat scale you're choosing on API and capability, not nanoseconds.
 
 The gap decomposes into a tiny dispatch tax plus the generated body. The `static` column (zero-dispatch
 `<Source>Bridge.forward(s)`) is the floor; the `BRIDGE.read` lattice path sits a sub-nanosecond wrapper tax above it
@@ -294,8 +294,8 @@ shapes (`static` / `BRIDGE_FN` / `BRIDGE.read` / MapStruct) at each tier, plus t
 Where the flat-tier gap comes from. MapStruct emits one hand-templated method body per pair, fully monomorphic, and the
 JIT inlines the whole conversion into a single basic block. Telescope's `@Bridge` codegen emits the same shape — a
 direct constructor call — wrapped in a `Telescope` for composability. On a flat ~3 ns conversion that composability
-costs ~0.2 ns total; on deep, where element-by-element list conversion dominates and the workload climbs past 50 ns, it
-is a ~1.07× tie on the most recent run, 1.07×–1.19× across runs. If you're in a tight inner loop that doesn't need
+costs a fraction of a nanosecond; on deep, where element-by-element list conversion dominates and the workload climbs
+past 50 ns, it is a tie within the range the table records. If you're in a tight inner loop that doesn't need
 composition, call `<Source>Bridge.forward(s)` — or the directly-callable `BRIDGE_FN` constant — and pay the
 zero-dispatch floor.
 
@@ -319,9 +319,9 @@ All four columns in that table are from the same run; the codegen/MapStruct rati
 within error (the runtime rows carry wider bands but the same magnitude).
 
 A quick decision guide. If the problem is "convert this entity to this DTO and back, both directions known at build
-time, no nested-list iteration, only scalars," MapStruct's bytecode is ~1.07× faster on the row (3.155 vs 3.362 ns, ~0.2
-ns absolute). On realistic deep workloads — nested records with list-of-records inside — telescope codegen matches
-MapStruct.
+time, no nested-list iteration, only scalars," MapStruct's bytecode is marginally faster on the row — a fraction of a
+nanosecond; the comparison doc carries the figure. On realistic deep workloads — nested records with list-of-records
+inside — telescope codegen matches MapStruct.
 
 Where MapStruct stops being an option entirely: sealed-narrow paradigm hop, effectful update (`updateAsync`,
 `updateValidated`), JPA cycle handling, Hibernate `LAZY` proxy unwrap, deep navigation as a primitive. These are out of

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -295,9 +295,10 @@ Where the flat-tier gap comes from. MapStruct emits one hand-templated method bo
 JIT inlines the whole conversion into a single basic block. Telescope's `@Bridge` codegen emits the same shape — a
 direct constructor call — wrapped in a `Telescope` for composability. On a flat ~3 ns conversion that composability
 costs a fraction of a nanosecond; on deep, where element-by-element list conversion dominates and the workload climbs
-past 50 ns, it is a few percent — the comparison doc's headline table carries the per-run ratio and the across-run
-range. If you're in a tight inner loop that doesn't need composition, call `<Source>Bridge.forward(s)` — or the
-directly-callable `BRIDGE_FN` constant — and pay the zero-dispatch floor.
+past 50 ns, it is the same sub-nanosecond tax against a far larger row. What remains of the deep gap over MapStruct is
+generated-body work rather than composability; the comparison doc's headline table carries the per-run ratio and the
+across-run range. If you're in a tight inner loop that doesn't need composition, call `<Source>Bridge.forward(s)` — or
+the directly-callable `BRIDGE_FN` constant — and pay the zero-dispatch floor.
 
 Runtime conversion (`Telescope.mapper(...)`) composes each record/bean pair into a single MethodHandle (see above), so
 the hot path is one `invokeExact` through the fused handle rather than an `Object[]` gather with boxed per-field
@@ -315,9 +316,8 @@ of MapStruct with **no annotations and no build step** — closest where the per
 the deep tier and the hash-container fields — close enough for most service code, and `@Bridge` codegen is there when a
 loop turns hot.
 
-The codegen columns in that table are from one run, and its footnote marks the runtime cells that are not; the
-codegen/MapStruct ratios reproduce across confirming runs within error (the runtime rows carry wider bands but the same
-magnitude).
+Every cell in that table but the four footnote-marked runtime ones is from a single CI run; the codegen/MapStruct ratios
+reproduce across confirming runs within error (the runtime rows carry wider bands but the same magnitude).
 
 A quick decision guide. If the problem is "convert this entity to this DTO and back, both directions known at build
 time, no nested-list iteration, only scalars," MapStruct's bytecode is marginally faster on the row — a fraction of a

--- a/docs/perf-mapstruct-comparison.md
+++ b/docs/perf-mapstruct-comparison.md
@@ -142,8 +142,7 @@ The `*_codegen_static_forward` (zero dispatch), `*_bridgefn_forward` (one interf
 | R3 deep   |                    66.27 |             69.22\* |                   66.57 |     0.30 ns | no (±0.27–0.52)  |
 
 \* R3 deep's `BRIDGE_FN` carries a ±5.3 ns band against `static forward`'s ±0.27 — about twenty times wider — so that
-one cell neither confirms nor contradicts the floor claim below. Every other `BRIDGE_FN` cell sits within a band
-comparable to its row's.
+one cell neither confirms nor contradicts the floor claim below.
 
 R1's bands are 2–27× wider than the others' and every one of its rows reads "no" — too wide to resolve any of these
 gaps. R2 resolves all three tiers; R3 resolves flat and nested but not deep. Where both resolve they agree on flat and
@@ -272,11 +271,12 @@ stable across runs and which are ranges; the short version is that flat is settl
 two container shapes tie on time while telescope allocates less on the Map shape.
 
 On dispatch, one half is settled and one is not. `BRIDGE_FN` is the floor — it tracks the zero-dispatch static call on
-every tier and every run bar one cell whose band is too wide to say, because the JIT inlines the monomorphic hop. The
-full-lattice `BRIDGE.read` carries a sub-nanosecond wrapper tax wherever it resolves at all, but its size and even its
-sign move between runs, so how it scales with depth is provisional and only the magnitude is durable. Both proposed
-remediations are settled either way: one shipped and reached the floor, and the other would remove only that tax, which
-the generated body dwarfs on deep — the one tier where the residual is big enough to be worth chasing.
+every tier and every run within error, because the JIT inlines the monomorphic hop — though on R3 deep only on a band
+too wide to say much. The full-lattice `BRIDGE.read` carries a sub-nanosecond wrapper tax wherever it resolves at all,
+but its size and even its sign move between runs, so how it scales with depth is provisional and only the magnitude is
+durable. Both proposed remediations are settled either way: one shipped and reached the floor, and the other would
+remove only that tax, which the generated body dwarfs on deep — the one tier where the residual is big enough to be
+worth chasing.
 
 What remains over MapStruct on deep is generated-body work rather than dispatch — the zero-dispatch floor is itself
 above parity — and closing it means matching MapStruct's inlined body. That stays adopter-gated on a real deep-tier hot

--- a/docs/perf-mapstruct-comparison.md
+++ b/docs/perf-mapstruct-comparison.md
@@ -176,18 +176,23 @@ floor.
 
 ## So is there a real gap?
 
-**A small one on deep, and it is mostly not dispatch.** On the headline run deep measured ~1.07× forward — a 4.19 ns gap
-on a 62 ns conversion, the low end of the 1.07×–1.19× spread. The split is the durable part: the zero-dispatch
-`static forward` floor is _already_ ~1.06× on deep (3.90 ns of the 4.19, the generated **body** — six leaf conversions,
-two list allocations, and per-field null-guards vs MapStruct's directly-inlined field sequence), with the lattice
-wrapper adding the remainder. That remainder is 0.30 ns and sits inside the error bands, so on this run it cannot be
-separated from zero and the body is effectively the whole gap; on R2, where the wrapper did resolve, the body led it
-about 7:1. Either way the wrapper is not what an adopter would be paying for. Whether it matters at all:
+**A small one on deep, and it is mostly not dispatch.** The ratios are in the headline table; what that table does not
+show is how the deep gap splits, which is the part that decides whether anything is worth doing about it.
+
+Almost all of it is the generated **body** — six leaf conversions, two list allocations and per-field null-guards
+against MapStruct's directly-inlined field sequence. The zero-dispatch `static forward` floor already carries that cost,
+so it sits above MapStruct before any lattice hop is involved. What the lattice wrapper adds on top is the tax measured
+in the dispatch table above: on the run where it resolved at all, the body led it about 7:1; on the headline run the
+remainder is inside the error bands and cannot be separated from zero. Either way the wrapper is not what an adopter
+would be paying for.
+
+Whether the gap matters at all:
 
 - At <10M ops/sec on a hot mapper: invisible against application work.
-- At >100M ops/sec on the deep tier: a ~4 ns per-call structural cost — measurable on a flame graph, rarely dominant.
-- On flat: no gap to speak of (~1.07×). On nested the ratio is JMH-noisy run-to-run (1.04×–1.46×) — near-parity, but the
-  noisy MapStruct baseline means no single figure is trustworthy.
+- At >100M ops/sec on the deep tier: a few nanoseconds of per-call structural cost — measurable on a flame graph, rarely
+  dominant.
+- On flat there is no gap to speak of. On nested the MapStruct baseline is JMH-noisy run-to-run, so no single figure is
+  trustworthy — read the range in the table, not a number.
 
 ## Remediations — status
 
@@ -195,12 +200,12 @@ about 7:1. Either way the wrapper is not what an adopter would be paying for. Wh
 
 `public static final BridgeFn<S, T> BRIDGE_FN = new Fn();` ships per generated bridge (asserted in
 `BridgeProcessorTest`). It gives adopters a passable one-hop mapper value instead of a static method. The benchmark
-tables above show it measures **at the `static forward` floor** on every run (run 2 flat: identical at 3.183; on R3 deep
-only within a ±5.3 ns band, so that cell settles little either way) — the JIT inlines the monomorphic hop to the raw
-static call, so it is the fastest passable value there is. Against `BRIDGE.read` it is usually the faster of the two by
-the sub-nanosecond lattice-wrapper tax, though not always: on R3 nested the lattice value measured below it with
-disjoint bands. So it is the ergonomic value (a `BridgeFn` you can pass around) and, on most rows, marginally the fast
-one.
+tables above show it measures **at the `static forward` floor** on every run (with the caveat the dispatch table records
+for R3 deep, where the band is wide enough that the cell settles little either way) — the JIT inlines the monomorphic
+hop to the raw static call, so it is the fastest passable value there is. Against `BRIDGE.read` it is usually the faster
+of the two by the sub-nanosecond lattice-wrapper tax, though not always: on R3 nested the lattice value measured below
+it with disjoint bands. So it is the ergonomic value (a `BridgeFn` you can pass around) and, on most rows, marginally
+the fast one.
 
 ### 2. Type-specialized bridge subclass whose `read(S)` is the inlined body — **measured and declined**
 
@@ -208,11 +213,11 @@ The idea was to emit a `Telescope`/bridge subclass that removes the `BridgeFn` f
 so `read(S)` _is_ the generated body. The data shrinks the premise to nothing worth building: the wrapper tax it would
 remove is sub-nanosecond wherever it resolves at all, and it applies **only to the composable `BRIDGE.read` value** —
 adopters who want the floor already have `BRIDGE_FN`, which sits there. Worse, on R2's deep tier, where the tax was at
-its largest (~0.8 ns), the generated-body gap (~5.6 ns) led it about 7:1; on R3's deep tier the tax does not separate
-from zero at all. Either way removing it barely moves the ratio. It would add ~100 LOC of `BridgeProcessor` complexity
-to shave a sub-nanosecond tax off one of two already-shipped call shapes. **Not building it.** The only thing that would
-move the deep number vs MapStruct is matching its generated _body_ (fewer null-guards, inlined leaf conversions) — a
-separate, finer optimization, adopter-gated on someone actually hitting the deep tier above 100M ops/sec.
+its largest, the generated-body gap led it about 7:1; on R3's deep tier the tax does not separate from zero at all.
+Either way removing it barely moves the ratio. It would add ~100 LOC of `BridgeProcessor` complexity to shave a
+sub-nanosecond tax off one of two already-shipped call shapes. **Not building it.** The only thing that would move the
+deep number vs MapStruct is matching its generated _body_ (fewer null-guards, inlined leaf conversions) — a separate,
+finer optimization, adopter-gated on someone actually hitting the deep tier above 100M ops/sec.
 
 ### 3. The CI-reproducible matrix is the baseline
 
@@ -226,42 +231,48 @@ residual.
 - **`BRIDGE_FN` benchmarked across all three tiers** (`nested_*_bridgefn_forward`, `deep_*_bridgefn_forward`; flat
   already existed). This is what lets the forward tables compare all four call shapes — static, one-hop, lattice,
   MapStruct — on each run and pin `BRIDGE_FN` to the floor.
-- **The container tier**, Set- and Map-valued, which is where this revision's actual finding lives: a tie on time and
-  about 11% less allocated on the Map shape. Every tier before it was List-only, which is how a sizing defect in the
-  container emitter shipped green.
-- **This analysis doc, corrected against three runs.** Prior revisions claimed a ~0.3–0.7 ns lattice slice and proposed
-  two remediations to close it; a first fresh run then over-corrected to "dispatch is free everywhere". What is settled
-  now is one half of that: `BRIDGE_FN` is the floor on every run, and the nested ratio is JMH-noisy. The lattice
-  wrapper's tax is sub-nanosecond wherever it resolves, but its depth-scaling did not survive the third run and is
-  marked provisional. The doc records the parity result, the ranges, and the measured-and-declined subclass decision.
+- **The container tier**, Set- and Map-valued, which is where this revision's actual finding lives — see the headline
+  table and the note under it on why that tier was added.
+- **This analysis doc, corrected against three runs.** What each correction retracted is recorded under
+  [Superseded and retracted](#superseded-and-retracted) rather than restated here.
 - **No production code changed.** `BRIDGE_FN` already ships; the codegen is at parity as-is.
+
+## Superseded and retracted
+
+Kept so a reader who finds an old figure elsewhere can tell what happened to it. Nothing here is a current measurement.
+
+**Three claims came out of laptop smoke runs.** Only one dissolved on clean CI hardware: the 2.9–3.6x forward gap. The
+other two survived. The static-slower-than-lattice inversion was reproduced on nested with disjoint bands in the
+headline run's dispatch table. And telescope codegen does measure faster than MapStruct on nested backward — 5.355
+against 5.983 ns, disjoint, on the `benchmarks/README` run — while this document's Run 1 backward table shows the same
+direction at 0.99× without resolving it. Flat and deep backward go the other way, which is what made the blanket "all
+wrong" wording fail rather than the claim itself.
+
+**The wrapper tax was once reported as growing monotonically with depth**, at 0.14 → 0.31 → 0.77 ns across flat, nested
+and deep. That ordering did not survive the third run, which measured +0.20, −0.31 and an unresolvable +0.30 on the same
+tiers. The magnitude — under a nanosecond wherever it resolves — is what reproduces; the ordering is not, and the
+dispatch table above carries both runs so the disagreement stays visible.
+
+**An earlier revision proposed closing a ~0.3–0.7 ns "lattice slice"** by emitting a directly-callable constant.
+`BRIDGE_FN` shipped and lands at the floor, so that half is done; the remediation table above records why the second
+proposal was declined.
+
+**Deep was briefly published at ~1.07×** on the strength of the headline run alone. That is the low end of its spread,
+not its centre — the table's `across runs` column is the honest form.
 
 ## Bottom line
 
-Telescope codegen is in MapStruct's performance class: 1.07x flat, 1.07x deep on this run against a 1.07x–1.19x spread
-across runs, a tie on the Set container and a near-tie on Map, where it also allocates about 11% less. Nested stays the
-unstable measurement — across CI runs of this benchmark it has ranged from 1.04x to 1.46x — so it is reported as a range
-rather than a figure.
+Telescope codegen is in MapStruct's performance class. The headline table has the figures and says which of them are
+stable across runs and which are ranges; the short version is that flat is settled, deep and nested are ranges, and the
+two container shapes tie on time while telescope allocates less on the Map shape.
 
-On dispatch, one half is settled and one is not. `BRIDGE_FN` is the floor: it tracks the zero-dispatch `static forward`
-within error on every tier and on every run, because the JIT inlines the monomorphic hop — though on R3 deep it clears
-that bar only on a ±5.3 ns band, some twenty times wider than `static forward`'s, so that one cell proves little. The
-full-lattice `BRIDGE.read` carries a wrapper tax under a nanosecond wherever it resolves at all — but its size and even
-its sign move between runs (R2 read 0.14 → 0.31 → 0.77 ns with depth; R3 read +0.20, −0.31, and an unresolvable +0.30),
-so the depth-scaling story is provisional and the magnitude is the only durable part. Either way both proposed
-remediations are settled: `BRIDGE_FN` shipped and lands at the floor, and the type-specialized subclass would remove
-only that sub-nanosecond tax, swamped several-fold by the body gap on deep — about 7:1 on R2, and on R3 not separable
-from zero at all. Declined.
+On dispatch, one half is settled and one is not. `BRIDGE_FN` is the floor — it tracks the zero-dispatch static call on
+every tier and every run, because the JIT inlines the monomorphic hop. The full-lattice `BRIDGE.read` carries a
+sub-nanosecond wrapper tax wherever it resolves at all, but its size and even its sign move between runs, so how it
+scales with depth is provisional and only the magnitude is durable. Both proposed remediations are settled either way:
+one shipped and reached the floor, and the other would remove only that tax, which the generated body dwarfs on the one
+tier where the gap is real.
 
-What remains over MapStruct on the deep tier is a few nanoseconds of generated-body work rather than dispatch —
-`static forward` alone is above parity — and closing it means matching MapStruct's inlined body. That stays
-adopter-gated on a real deep-tier hot loop that measures it.
-
-Two things in this document's history are worth keeping visible. Of the three claims a laptop produced, only the
-2.9-3.6x forward gap dissolved on clean CI hardware. The other two survived it: R3 measured the
-static-slower-than-lattice inversion on nested with disjoint bands, and telescope codegen measures faster than MapStruct
-on nested backward on the `benchmarks/README` run — 5.355 against 5.983 ns, disjoint — where this document's Run 1 table
-shows the same direction at 0.99× without resolving it. Flat and deep backward go the other way, which is what makes the
-blanket wording fail rather than the claim. And every tier here was List-only until recently, which let a sizing defect
-in the container emitter ship green — the container rows exist so that class of defect fails a measurement rather than
-passing one.
+What remains over MapStruct on deep is generated-body work rather than dispatch — the zero-dispatch floor is itself
+above parity — and closing it means matching MapStruct's inlined body. That stays adopter-gated on a real deep-tier hot
+loop that measures it.

--- a/docs/perf-mapstruct-comparison.md
+++ b/docs/perf-mapstruct-comparison.md
@@ -139,7 +139,11 @@ The `*_codegen_static_forward` (zero dispatch), `*_bridgefn_forward` (one interf
 | R2 deep   |                    51.92 |               52.59 |                   52.68 |     0.77 ns | yes (±0.12–0.16) |
 | R3 flat   |                    3.161 |               3.162 |                   3.362 |     0.20 ns | yes (±0.01–0.03) |
 | R3 nested |                    5.913 |               5.908 |                   5.604 |    −0.31 ns | yes (±0.03)      |
-| R3 deep   |                    66.27 |               69.22 |                   66.57 |     0.30 ns | no (±0.27–0.52)  |
+| R3 deep   |                    66.27 |             69.22\* |                   66.57 |     0.30 ns | no (±0.27–0.52)  |
+
+\* R3 deep's `BRIDGE_FN` carries a ±5.3 ns band against `static forward`'s ±0.27 — about twenty times wider — so that
+one cell neither confirms nor contradicts the floor claim below. Every other `BRIDGE_FN` cell sits within a band
+comparable to its row's.
 
 R1's bands are 2–27× wider than the others' and every one of its rows reads "no" — too wide to resolve any of these
 gaps. R2 resolves all three tiers; R3 resolves flat and nested but not deep. Where both resolve they agree on flat and
@@ -170,9 +174,9 @@ would remove only that, for only the narrow case of hot-looping the composable v
 
 The lesson stands: **smoke runs lie, and one CI run can too.** Run 1's 1.04× nested looked like a headline until run 2
 returned 1.42× on the same branch — the nested MapStruct baseline is JMH-noisy (±0.35). Laptop smoke runs earlier
-produced a 2.9–3.6× "forward gap" that clean CI hardware dissolved, plus two claims that survived it — see the bottom
-line for which. Trust the numbers that reproduce across runs: flat ~1.07×, deep 1.07×–1.19×, and `BRIDGE_FN` at the
-floor.
+produced a 2.9–3.6× "forward gap" that clean CI hardware dissolved, plus two claims that survived it — see
+[Superseded and retracted](#superseded-and-retracted). Trust the numbers that reproduce across runs: flat ~1.07×, deep
+1.07×–1.19×, and `BRIDGE_FN` at the floor.
 
 ## So is there a real gap?
 
@@ -182,9 +186,9 @@ show is how the deep gap splits, which is the part that decides whether anything
 Almost all of it is the generated **body** — six leaf conversions, two list allocations and per-field null-guards
 against MapStruct's directly-inlined field sequence. The zero-dispatch `static forward` floor already carries that cost,
 so it sits above MapStruct before any lattice hop is involved. What the lattice wrapper adds on top is the tax measured
-in the dispatch table above: on the run where it resolved at all, the body led it about 7:1; on the headline run the
-remainder is inside the error bands and cannot be separated from zero. Either way the wrapper is not what an adopter
-would be paying for.
+in the dispatch table above: on R2, the one run where the deep tax resolved, the body led it about 7:1; on the headline
+run the remainder is inside the error bands and cannot be separated from zero. Either way the wrapper is not what an
+adopter would be paying for.
 
 Whether the gap matters at all:
 
@@ -192,7 +196,7 @@ Whether the gap matters at all:
 - At >100M ops/sec on the deep tier: a few nanoseconds of per-call structural cost — measurable on a flame graph, rarely
   dominant.
 - On flat there is no gap to speak of. On nested the MapStruct baseline is JMH-noisy run-to-run, so no single figure is
-  trustworthy — read the range in the table, not a number.
+  trustworthy — read the range in the headline table, not a number.
 
 ## Remediations — status
 
@@ -200,12 +204,11 @@ Whether the gap matters at all:
 
 `public static final BridgeFn<S, T> BRIDGE_FN = new Fn();` ships per generated bridge (asserted in
 `BridgeProcessorTest`). It gives adopters a passable one-hop mapper value instead of a static method. The benchmark
-tables above show it measures **at the `static forward` floor** on every run (with the caveat the dispatch table records
-for R3 deep, where the band is wide enough that the cell settles little either way) — the JIT inlines the monomorphic
-hop to the raw static call, so it is the fastest passable value there is. Against `BRIDGE.read` it is usually the faster
-of the two by the sub-nanosecond lattice-wrapper tax, though not always: on R3 nested the lattice value measured below
-it with disjoint bands. So it is the ergonomic value (a `BridgeFn` you can pass around) and, on most rows, marginally
-the fast one.
+tables above show it measures **at the `static forward` floor** on every run (with the one weak cell the dispatch table
+footnotes: R3 deep's ±5.3 ns band settles little either way) — the JIT inlines the monomorphic hop to the raw static
+call, so it is the fastest passable value there is. Against `BRIDGE.read` it is usually the faster of the two by the
+sub-nanosecond lattice-wrapper tax, though not always: on R3 nested the lattice value measured below it with disjoint
+bands. So it is the ergonomic value (a `BridgeFn` you can pass around) and, on most rows, marginally the fast one.
 
 ### 2. Type-specialized bridge subclass whose `read(S)` is the inlined body — **measured and declined**
 
@@ -232,33 +235,35 @@ residual.
   already existed). This is what lets the forward tables compare all four call shapes — static, one-hop, lattice,
   MapStruct — on each run and pin `BRIDGE_FN` to the floor.
 - **The container tier**, Set- and Map-valued, which is where this revision's actual finding lives — see the headline
-  table and the note under it on why that tier was added.
+  table for the figures and [What the container tier is for](#what-the-container-tier-is-for) for why it was added.
 - **This analysis doc, corrected against three runs.** What each correction retracted is recorded under
   [Superseded and retracted](#superseded-and-retracted) rather than restated here.
 - **No production code changed.** `BRIDGE_FN` already ships; the codegen is at parity as-is.
 
 ## Superseded and retracted
 
-Kept so a reader who finds an old figure elsewhere can tell what happened to it. Nothing here is a current measurement.
+Claims and figures an earlier revision of this document got wrong or overstated, kept so a reader who meets one
+elsewhere can tell what happened to it. Where a number here is still live, it says so.
 
 **Three claims came out of laptop smoke runs.** Only one dissolved on clean CI hardware: the 2.9–3.6x forward gap. The
 other two survived. The static-slower-than-lattice inversion was reproduced on nested with disjoint bands in the
 headline run's dispatch table. And telescope codegen does measure faster than MapStruct on nested backward — 5.355
 against 5.983 ns, disjoint, on the `benchmarks/README` run — while this document's Run 1 backward table shows the same
-direction at 0.99× without resolving it. Flat and deep backward go the other way, which is what made the blanket "all
-wrong" wording fail rather than the claim itself.
+direction at 0.99× without resolving it. On that same README run flat and deep backward go the other way, which is what
+made the blanket "all wrong" wording fail rather than the claim itself.
 
 **The wrapper tax was once reported as growing monotonically with depth**, at 0.14 → 0.31 → 0.77 ns across flat, nested
 and deep. That ordering did not survive the third run, which measured +0.20, −0.31 and an unresolvable +0.30 on the same
 tiers. The magnitude — under a nanosecond wherever it resolves — is what reproduces; the ordering is not, and the
 dispatch table above carries both runs so the disagreement stays visible.
 
-**An earlier revision proposed closing a ~0.3–0.7 ns "lattice slice"** by emitting a directly-callable constant.
-`BRIDGE_FN` shipped and lands at the floor, so that half is done; the remediation table above records why the second
-proposal was declined.
+**An earlier revision proposed closing a ~0.3–0.7 ns "lattice slice"** by emitting a directly-callable constant, and a
+first fresh run then over-corrected the other way to "dispatch is free everywhere". `BRIDGE_FN` shipped and lands at the
+floor, so that half is done; the Remediations section above records why the second proposal was declined.
 
-**Deep was briefly published at ~1.07×** on the strength of the headline run alone. That is the low end of its spread,
-not its centre — the table's `across runs` column is the honest form.
+**Deep was briefly published as ~1.07× flat-out.** The number is this run's measurement and still stands in the headline
+table; what was wrong was presenting it as deep's figure rather than as the low end of a 1.07×–1.19× spread. The
+`across runs` column is the honest form.
 
 ## Bottom line
 
@@ -267,11 +272,11 @@ stable across runs and which are ranges; the short version is that flat is settl
 two container shapes tie on time while telescope allocates less on the Map shape.
 
 On dispatch, one half is settled and one is not. `BRIDGE_FN` is the floor — it tracks the zero-dispatch static call on
-every tier and every run, because the JIT inlines the monomorphic hop. The full-lattice `BRIDGE.read` carries a
-sub-nanosecond wrapper tax wherever it resolves at all, but its size and even its sign move between runs, so how it
-scales with depth is provisional and only the magnitude is durable. Both proposed remediations are settled either way:
-one shipped and reached the floor, and the other would remove only that tax, which the generated body dwarfs on the one
-tier where the gap is real.
+every tier and every run bar one cell whose band is too wide to say, because the JIT inlines the monomorphic hop. The
+full-lattice `BRIDGE.read` carries a sub-nanosecond wrapper tax wherever it resolves at all, but its size and even its
+sign move between runs, so how it scales with depth is provisional and only the magnitude is durable. Both proposed
+remediations are settled either way: one shipped and reached the floor, and the other would remove only that tax, which
+the generated body dwarfs on deep — the one tier where the residual is big enough to be worth chasing.
 
 What remains over MapStruct on deep is generated-body work rather than dispatch — the zero-dispatch floor is itself
 above parity — and closing it means matching MapStruct's inlined body. That stays adopter-gated on a real deep-tier hot


### PR DESCRIPTION
Closes #333.

Seven review rounds on the figure refresh (#328) found about twenty defects. After round two almost none were arithmetic — the numbers were right every time. They were all one shape: **a fact stated in N places and corrected in N−1.**

| fact | sites before |
| --- | --- |
| deep tier ratio | ~8 |
| lattice wrapper tax | 6 |
| "`BRIDGE_FN` is the floor" | 5 |
| three-claim laptop adjudication | 2 |

The clearest case was that last one: the same three claims were settled in both the dispatch lesson and the bottom line, and the rounds alternated between the copies. One round fixed the inversion in the lesson, the next fixed it in the bottom line, the next fixed the backward claim in the bottom line — and the lesson's backward verdict was still wrong two rounds later. Every fix was correct. The document stayed inconsistent because correcting one copy is not correcting the fact.

## What changed

**The tables are the single source.** Prose now references them instead of restating. Figure counts per section after this change:

| section | figures |
| --- | --- |
| Results — earlier CI runs | 20 (a table) |
| Dispatch | 17 (a table) |
| Headline finding | 8 (a table) |
| Superseded and retracted | 6 (the fenced register) |
| So is there a real gap? | 0 |
| Remediations | 0 |
| What this revision ships | 0 |
| Bottom line | 0 |

`So is there a real gap?` kept its whole argument — the deep gap is generated body rather than dispatch — and lost only the re-quoted ratios, which were its least durable part. The `Bottom line` was the single largest liability: it restated every conclusion in compressed form, so every correction anywhere had to be mirrored into it, and four of the seven rounds found a defect there. It is now prose.

**One fenced historical register.** Superseded figures, retracted claims and current measurements were interleaved, which is why later rounds kept bolting scoping prefixes onto individual paragraphs. `Superseded and retracted` now says up front that nothing in it is current, and holds the laptop claims and which survived, the monotonic wrapper tax that did not reproduce, the closed lattice-slice proposal, and the deep figure that was briefly published as settled.

**The container-tier defect was told twice** — its own subsection and again in the bottom line. It keeps the subsection.

**Cross-file.** `benchmarks/README.md` carried a third number set beside a stale table and a decision guide with a fourth; that is why it needed a reconciliation blockquote in one round and still produced findings in the two after. Its prose now explains the shape and links for figures. `README.md` is unchanged — its table is the deliberate front-door summary, it carries the across-runs ranges so a cell cannot travel out of context, and a README that links without saying anything is worse.

No figure changed value. This is purely about where each one lives.