### PR TITLE
fix: point HolderDispatchBenchmark's setup at the FieldOptics holder

### DIFF
--- a/benchmarks/src/jmh/java/io/github/eschizoid/telescope/benchmarks/HolderDispatchBenchmark.java
+++ b/benchmarks/src/jmh/java/io/github/eschizoid/telescope/benchmarks/HolderDispatchBenchmark.java
@@ -104,10 +104,11 @@ public class HolderDispatchBenchmark {
     fieldLmf = Telescope.of(BenchPlainRec.class).field(BenchPlainRec::name);
 
     // Direct holder-constant baseline: read the generated `name` constant from
-    // `BenchHolderRecTelescope` via reflection. This is the same Telescope value `Telescope.of(X)
-    // .field(X::name)` resolves to via the holder probe — but accessed without the probe so the
-    // benchmark measures the dispatch primitive, not the probe overhead.
-    final var holderClass = Class.forName(BenchHolderRec.class.getName() + "Telescope");
+    // `BenchHolderRecFieldOptics` via reflection — the metadata holder carries the per-field
+    // constants; the `<X>Telescope` navigator has only methods. This is the same Telescope value
+    // `Telescope.of(X).field(X::name)` resolves to via the holder probe — but accessed without the
+    // probe so the benchmark measures the dispatch primitive, not the probe overhead.
+    final var holderClass = Class.forName(BenchHolderRec.class.getName() + "FieldOptics");
     @SuppressWarnings("unchecked")
     final var directConstant = (Telescope<BenchHolderRec, String>) holderClass.getField("name").get(null);
     fieldHolderConstant = directConstant;


### PR DESCRIPTION
Closes #342.

`HolderDispatchBenchmark`'s `@Setup` resolved the per-field constant via `Class.forName(... + "Telescope").getField("name")` — but the constants live on the `<X>FieldOptics` metadata holder. The `<X>Telescope` navigator has only methods, and the runtime probe itself resolves `+ "FieldOptics"` (`MetadataHolderProbe.java:89`). The lookup threw `NoSuchFieldException`, and a `@Setup` throw kills every row in the class — so the holder-probe tier in the benchmark table has silently produced nothing since the constants moved out of the navigator. Coverage decay in its purest form: the row existed, the suite was green, the measurement was absent.

## Verification

Both directions, against the real compiled jmh classes:

```
OLD lookup (+Telescope):   NoSuchFieldException — setup was dead, confirmed
NEW lookup (+FieldOptics): resolved Telescope constant — setup lives
```

`:benchmarks:compileJmhJava` green. The full gate is the benchmark itself producing rows again — worth a `Benchmarks` workflow dispatch with `HolderDispatchBenchmark` as the filter after merge, which also re-establishes the holder-probe baseline the audit needs.

Found by the codegen audit (#351).