### PR TITLE
fix: null-gate user @ViaMapper bridge calls in forward and backward

### DIFF
--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
@@ -1597,7 +1597,14 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
       final var read = parsedDefaults.containsKey(srcName)
         ? "(" + local + " == null ? " + parsedDefaults.get(srcName) + " : " + local + ")"
         : local;
-      return applyForward(srcName, fieldPlans.get(srcName), read);
+      final var plan = fieldPlans.get(srcName);
+      // A @ViaMapper bridge is user code with no guaranteed null tolerance — auto-derived
+      // sub-bridges open with their own null guard, a user class may not — so the call is
+      // null-gated here. Both mentions reference the hoisted local, so nothing is re-read.
+      if (plan.userSuppliedBridge()) {
+        return "(" + local + " == null ? null : " + applyForward(srcName, plan, read) + ")";
+      }
+      return applyForward(srcName, plan, read);
     };
     // readBackward is called with SOURCE field names. For drops AND forward-only transforms, emit
     // the type's zero value — both mechanisms have no defined backward and the source slot must be
@@ -1613,7 +1620,12 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
       final var tf = fieldByName(targetFields, tgtName);
       final var local = "__bt_" + sourceName;
       backwardLocals.putIfAbsent(local, tf.type() + " " + local + " = " + readExpr(target, "t", tf) + ";");
-      return applyBackward(sourceName, fieldPlans.get(sourceName), local);
+      final var plan = fieldPlans.get(sourceName);
+      // Same user-bridge null gate as readForward, for the same reason.
+      if (plan.userSuppliedBridge()) {
+        return "(" + local + " == null ? null : " + applyBackward(sourceName, plan, local) + ")";
+      }
+      return applyBackward(sourceName, plan, local);
     };
 
     // Pass `source` as the annotation site so write-strategy errors land at the user's @Bridge
@@ -2108,7 +2120,11 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
     // via its no-arg constructor (subclasses don't inherit the JDK copy ctor), so these route to
     // the
     // self-contained raw helpers instead of the generic copy-ctor inline path.
-    boolean rawContainer
+    boolean rawContainer,
+    // RECURSE only: true when subBridgeName is a user-supplied @ViaMapper class rather than an
+    // auto-derived sub-bridge. Auto-derived bridges open their forward/backward with a null
+    // guard; a user class carries no such guarantee, so the caller emits the guard.
+    boolean userSuppliedBridge
   ) {
     enum Kind {
       IDENTITY,
@@ -2124,7 +2140,7 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
     }
 
     static FieldPlan identity() {
-      return new FieldPlan(Kind.IDENTITY, null, null, null, null, null, null, false);
+      return new FieldPlan(Kind.IDENTITY, null, null, null, null, null, null, false, false);
     }
 
     // Attach the concrete-impl class names for a LIST/SET/MAP_VALUES plan — the classes the inline
@@ -2138,7 +2154,8 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
         bwdNullDefault,
         fwdImpl,
         bwdImpl,
-        false
+        false,
+        userSuppliedBridge
       );
     }
 
@@ -2146,7 +2163,7 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
     // applyForward/applyBackward route to the self-contained raw helpers (no-arg ctor + addAll /
     // element loop) rather than the generic copy-ctor inline path.
     static FieldPlan rawContainer(final Kind kind, final String subBridgeName) {
-      return new FieldPlan(kind, Objects.requireNonNull(subBridgeName), null, null, null, null, null, true);
+      return new FieldPlan(kind, Objects.requireNonNull(subBridgeName), null, null, null, null, null, true, false);
     }
 
     // Primitive ↔ boxed wrapper. The direction that writes the primitive side null-coalesces a null
@@ -2154,15 +2171,41 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
     // (null is a legal wrapper value). Exactly one of the two defaults is non-null for any given
     // pair. Matches the runtime DeepMap.primitiveWrapperIso.
     static FieldPlan primWrapper(final String fwdNullDefault, final String bwdNullDefault) {
-      return new FieldPlan(Kind.PRIM_WRAPPER, null, null, fwdNullDefault, bwdNullDefault, null, null, false);
+      return new FieldPlan(Kind.PRIM_WRAPPER, null, null, fwdNullDefault, bwdNullDefault, null, null, false, false);
     }
 
     static FieldPlan recurse(final String subBridgeName) {
-      return new FieldPlan(Kind.RECURSE, Objects.requireNonNull(subBridgeName), null, null, null, null, null, false);
+      return new FieldPlan(
+        Kind.RECURSE,
+        Objects.requireNonNull(subBridgeName),
+        null,
+        null,
+        null,
+        null,
+        null,
+        false,
+        false
+      );
+    }
+
+    // A RECURSE plan whose bridge is the user's @ViaMapper class rather than an auto-derived
+    // sub-bridge — the caller must null-guard the conversion call.
+    static FieldPlan viaBridge(final String subBridgeName) {
+      return new FieldPlan(
+        Kind.RECURSE,
+        Objects.requireNonNull(subBridgeName),
+        null,
+        null,
+        null,
+        null,
+        null,
+        false,
+        true
+      );
     }
 
     static FieldPlan ofKind(final Kind kind, final String subBridgeName) {
-      return new FieldPlan(kind, Objects.requireNonNull(subBridgeName), null, null, null, null, null, false);
+      return new FieldPlan(kind, Objects.requireNonNull(subBridgeName), null, null, null, null, null, false, false);
     }
 
     // Qualifier-dispatch TRANSFORM variant: the `using` class hosts a named static method, NOT a
@@ -2177,6 +2220,7 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
         null,
         null,
         null,
+        false,
         false
       );
     }
@@ -2367,7 +2411,7 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
       // applyBackward already emit `<class>.forward(...)` / `<class>.backward(...)` for RECURSE,
       // so no new dispatch arm is needed.
       if (viaMappers.containsKey(sf.name())) {
-        plans.put(sf.name(), FieldPlan.recurse(viaMappers.get(sf.name())));
+        plans.put(sf.name(), FieldPlan.viaBridge(viaMappers.get(sf.name())));
         continue;
       }
       final var tf = fieldByName(targetFields, renames.getOrDefault(sf.name(), sf.name()));

--- a/codegen/src/test/java/io/github/eschizoid/telescope/codegen/BridgeProcessorTest.java
+++ b/codegen/src/test/java/io/github/eschizoid/telescope/codegen/BridgeProcessorTest.java
@@ -3084,17 +3084,23 @@ class BridgeProcessorTest {
       final var bridge = compilation.generated().get("demo.OrderBridge");
       assertNotNull(bridge, () -> "OrderBridge missing; saw " + compilation.generated().keySet());
 
-      // Forward routes the hoisted single-read local through the user-named bridge.
+      // Forward routes the hoisted single-read local through the user-named bridge, null-gated:
+      // a user class carries no null-tolerance guarantee, unlike auto-derived sub-bridges whose
+      // generated forward opens with its own guard. Both mentions reference the local.
       assertTrue(bridge.contains("final demo.Address __fs_address = s.address();"), bridge);
       assertTrue(
-        bridge.contains("new demo.OrderDto(__fs_id, demo.AddressBridge.forward(__fs_address))"),
-        () -> "expected forward via AddressBridge, saw: " + bridge
+        bridge.contains(
+          "new demo.OrderDto(__fs_id, (__fs_address == null ? null :" + " demo.AddressBridge.forward(__fs_address)))"
+        ),
+        () -> "expected null-gated forward via AddressBridge, saw: " + bridge
       );
-      // Backward routes the hoisted target-read local through the user-named bridge.
+      // Backward routes the hoisted target-read local through the user-named bridge, same gate.
       assertTrue(bridge.contains("final demo.AddressDto __bt_address = t.address();"), bridge);
       assertTrue(
-        bridge.contains("new demo.Order(__bt_id, demo.AddressBridge.backward(__bt_address))"),
-        () -> "expected backward via AddressBridge, saw: " + bridge
+        bridge.contains(
+          "new demo.Order(__bt_id, (__bt_address == null ? null :" + " demo.AddressBridge.backward(__bt_address)))"
+        ),
+        () -> "expected null-gated backward via AddressBridge, saw: " + bridge
       );
       // No auto-sub-bridge AddressBridge2 / AddressToAddressDtoBridge was generated for this pair.
       assertNull(compilation.generated().get("demo.AddressToAddressDtoBridge"));
@@ -4096,7 +4102,7 @@ class BridgeProcessorTest {
           bridge.contains("final java.lang.String __fs_tag = s.tag();") &&
           bridge.contains("(__fs_tag == null ? \"X\" : __fs_tag)") &&
           bridge.contains("__tx_qty.forward(__fs_qty)") &&
-          bridge.contains("demo.AddressBridge.forward(__fs_addr)") &&
+          bridge.contains("(__fs_addr == null ? null : demo.AddressBridge.forward(__fs_addr))") &&
           bridge.contains("__cp_env.get()"),
         () -> "forward composition incomplete; saw: " + bridge
       );
@@ -4111,7 +4117,7 @@ class BridgeProcessorTest {
         bridge.contains("final java.lang.String __bt_name = t.renamed();") &&
           bridge.contains(
             "new demo.Order(null, __bt_name, __bt_tag, __tx_qty.backward(__bt_qty)," +
-              " demo.AddressBridge.backward(__bt_addr))"
+              " (__bt_addr == null ? null : demo.AddressBridge.backward(__bt_addr)))"
           ),
         () -> "backward composition off; saw: " + bridge
       );

--- a/core/src/test/java/io/github/eschizoid/telescope/bridgexpkg/ViaMapperNullGuardTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/bridgexpkg/ViaMapperNullGuardTest.java
@@ -1,0 +1,59 @@
+package io.github.eschizoid.telescope.bridgexpkg;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.github.eschizoid.telescope.Telescope;
+import io.github.eschizoid.telescope.bridgexpkg.vm.VmAddress;
+import io.github.eschizoid.telescope.bridgexpkg.vm.VmAddressDto;
+import io.github.eschizoid.telescope.mapping.Mapping;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * A {@code @ViaMapper} class is arbitrary user code: unlike the auto-derived sub-bridges, whose
+ * generated {@code forward}/{@code backward} open with a null guard, nothing guarantees the user's
+ * methods tolerate null — the fixture bridge dereferences its argument unconditionally. The
+ * generated parent bridge therefore null-gates the call, matching the runtime {@code via} row's
+ * null-in/null-out contract. Each test asserts the absolute expected value AND codegen/runtime
+ * equality, so two implementations agreeing on a wrong answer cannot pass.
+ */
+class ViaMapperNullGuardTest {
+
+  private static io.github.eschizoid.telescope.conversion.Mapper<VmSource, VmTarget> runtime() {
+    final var sub = Telescope.mapper(VmAddress.class, VmAddressDto.class);
+    return Telescope.mapper(VmSource.class, VmTarget.class, Mapping.via(VmSource::address, VmTarget::address, sub));
+  }
+
+  @Test
+  @DisplayName("forward null-propagates a null @ViaMapper field instead of handing null to user code")
+  void forwardNullPropagatesTheViaField() {
+    final var source = new VmSource("i", null);
+
+    final var codegen = VmSourceBridge.forward(source);
+
+    assertEquals(new VmTarget("i", null), codegen);
+    assertEquals(runtime().forward(source), codegen);
+  }
+
+  @Test
+  @DisplayName("backward null-propagates a null @ViaMapper field instead of handing null to user code")
+  void backwardNullPropagatesTheViaField() {
+    final var target = new VmTarget("i", null);
+
+    final var codegen = VmSourceBridge.backward(target);
+
+    assertEquals(new VmSource("i", null), codegen);
+    assertEquals(runtime().backward(target), codegen);
+  }
+
+  @Test
+  @DisplayName("a present @ViaMapper value still converts through the user bridge")
+  void presentValueStillConvertsThroughTheUserBridge() {
+    final var source = new VmSource("i", new VmAddress("l1"));
+
+    final var codegen = VmSourceBridge.forward(source);
+
+    assertEquals(new VmTarget("i", new VmAddressDto("l1")), codegen);
+    assertEquals(runtime().forward(source), codegen);
+  }
+}


### PR DESCRIPTION
Closes #341. Found by the codegen audit's differential hunt (#351).

The generated parent bridge invoked a user-supplied `@ViaMapper` class with the raw hoisted local — `VmAddressBridge.forward(__fs_address)` — which NPEs when the field is null. The runtime `via` row routes through `Mapper.forward`, whose contract is null-in/null-out, so the same input yields a null field. MapStruct emits the guard too (`source.getAddress() != null ? mapper.map(...) : null`), so the runtime side was the correct one.

**The asymmetry was precise:** auto-derived sub-bridges open their generated `forward`/`backward` with their own null guard — so among the whole-field conversion classes, user-written via bridges were the unguarded ones — exactly the code whose null tolerance nothing guarantees. (`@Transform` classes also receive raw values, by documented contract: a transform handles null internally.)

## The fix

Via plans were indistinguishable from auto RECURSE plans at emission (`FieldPlan.recurse(userFqn)`). `FieldPlan` now carries a `userSuppliedBridge` marker set by the `@ViaMapper` construction path, and `readForward`/`readBackward` emit the gate: `(__fs_address == null ? null : demo.AddressBridge.forward(__fs_address))`. Both mentions reference the hoisted local, so nothing is re-read — the read-once rule holds. **Patch is untouched**: its slots are already null-gated before any conversion call, so no double guard appears under any merge order with #353.

Auto sub-bridge calls stay unguarded at the call site — their callee-side guard already covers them, and adding caller-side guards would change the emitted-body parity with MapStruct that the audit just established.

## Verification

`ViaMapperNullGuardTest` (differential, using the existing cross-package `vm`/`vmapper` fixtures whose user bridge dereferences unconditionally): asserts absolute expected values AND codegen/runtime equality, forward and backward, plus a present-value control. Revert-proven: gate removed → both null cases fail with the NPE, control passes; restored → all three pass. Two processor tests pinning the unguarded emission text now pin the gated shape.
