### PR TITLE
fix: validate @Transform's BridgeFn type arguments against the field pair

### DIFF
--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
@@ -76,6 +76,7 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
 
   private static final String ANNOTATION = "io.github.eschizoid.telescope.annotations.Bridge";
   private static final String BRIDGES_ANNOTATION = "io.github.eschizoid.telescope.annotations.Bridges";
+  private static final String BRIDGE_FN_FQN = "io.github.eschizoid.telescope.conversion.BridgeFn";
 
   // A named field on either side: a record component or a POJO getter-property, with its type.
   private record Field(String name, TypeMirror type) {}
@@ -1176,11 +1177,14 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
       }
       // BridgeFn-shape transforms (no `method` qualifier): the using class's BridgeFn type
       // arguments must fit the field pair, or the emitted __tx_ call sites reference javac
-      // errors inside a generated file the user never wrote. Only the forward direction is
-      // checked — it binds for every transform shape, forward-only included — and a raw
-      // BridgeFn supertype carries no arguments to check.
+      // errors inside a generated file the user never wrote. This catches the forward
+      // direction; a backward mismatch, a raw BridgeFn supertype (no arguments to compare)
+      // and a renamed field all still surface inside the generated file.
+      //
+      // Renamed fields are skipped because the target slot is looked up by the source name,
+      // which a rename has moved — and the pairing is rejected a few loops down anyway.
       final var txMethod = cfg.transformMethods().get(t);
-      if (txMethod == null || txMethod.isEmpty()) {
+      if ((txMethod == null || txMethod.isEmpty()) && !renames.containsKey(t)) {
         final var usingEl = processingEnv.getElementUtils().getTypeElement(transforms.get(t));
         final var fn = usingEl == null ? null : bridgeFnInstantiation(usingEl.asType());
         if (fn == null) {
@@ -1191,23 +1195,27 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
           return;
         }
         final var args = fn.getTypeArguments();
-        final var sfType = boxed(
-          sourceFields
-            .stream()
-            .filter(f -> f.name().equals(t))
-            .findFirst()
-            .orElseThrow()
-            .type()
-        );
+        final var sfType = sourceFields
+          .stream()
+          .filter(f -> f.name().equals(t))
+          .findFirst()
+          .orElseThrow()
+          .type();
         final var tfField = targetFields
           .stream()
           .filter(f -> f.name().equals(t))
           .findFirst()
           .orElse(null);
         if (args.size() == 2 && tfField != null) {
-          final var tfType = boxed(tfField.type());
+          final var tfType = tfField.type();
           final var types = processingEnv.getTypeUtils();
-          if (!types.isAssignable(sfType, args.get(0)) || !types.isAssignable(args.get(1), tfType)) {
+          // Assignability already models boxing and unboxing-plus-widening in both directions, so
+          // the raw field types are what to compare — boxing either side first would discard the
+          // conversions the emitted call relies on.
+          if (
+            !types.isAssignable(sfType, erasedBound(args.get(0))) ||
+            !types.isAssignable(erasedBound(args.get(1)), tfType)
+          ) {
             error(
               source,
               "@Transform field=\"" +
@@ -2768,9 +2776,7 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
   // how many levels up the hierarchy it sits.
   private DeclaredType bridgeFnInstantiation(final TypeMirror usingType) {
     final var types = processingEnv.getTypeUtils();
-    final var fnEl = processingEnv
-      .getElementUtils()
-      .getTypeElement("io.github.eschizoid.telescope.conversion.BridgeFn");
+    final var fnEl = processingEnv.getElementUtils().getTypeElement(BRIDGE_FN_FQN);
     if (fnEl == null) return null;
     final var erasedFn = types.erasure(fnEl.asType());
     final Deque<TypeMirror> work = new ArrayDeque<>();
@@ -2786,11 +2792,11 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
     return null;
   }
 
-  // A primitive boxed to its wrapper, so assignability against BridgeFn's reference-typed
-  // arguments compares like with like; reference types pass through.
-  private TypeMirror boxed(final TypeMirror t) {
-    if (!t.getKind().isPrimitive()) return t;
-    return processingEnv.getTypeUtils().boxedClass((PrimitiveType) t).asType();
+  // A type-variable argument stands for whatever the emitter's raw call site erases it to, so the
+  // fit test compares against that bound; every other type passes through unchanged.
+  private TypeMirror erasedBound(final TypeMirror t) {
+    if (t.getKind() != TypeKind.TYPEVAR) return t;
+    return processingEnv.getTypeUtils().erasure(t);
   }
 
   private String applyForward(final String fieldName, final FieldPlan plan, final String readExpr) {

--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
@@ -1174,6 +1174,60 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
         error(source, "@Bridge field \"" + t + "\" appears in both transforms and drops — pick one.");
         return;
       }
+      // BridgeFn-shape transforms (no `method` qualifier): the using class's BridgeFn type
+      // arguments must fit the field pair, or the emitted __tx_ call sites reference javac
+      // errors inside a generated file the user never wrote. Only the forward direction is
+      // checked — it binds for every transform shape, forward-only included — and a raw
+      // BridgeFn supertype carries no arguments to check.
+      final var txMethod = cfg.transformMethods().get(t);
+      if (txMethod == null || txMethod.isEmpty()) {
+        final var usingEl = processingEnv.getElementUtils().getTypeElement(transforms.get(t));
+        final var fn = usingEl == null ? null : bridgeFnInstantiation(usingEl.asType());
+        if (fn == null) {
+          error(
+            source,
+            "@Transform field=\"" + t + "\" `using` class " + transforms.get(t) + " does not implement BridgeFn"
+          );
+          return;
+        }
+        final var args = fn.getTypeArguments();
+        final var sfType = boxed(
+          sourceFields
+            .stream()
+            .filter(f -> f.name().equals(t))
+            .findFirst()
+            .orElseThrow()
+            .type()
+        );
+        final var tfField = targetFields
+          .stream()
+          .filter(f -> f.name().equals(t))
+          .findFirst()
+          .orElse(null);
+        if (args.size() == 2 && tfField != null) {
+          final var tfType = boxed(tfField.type());
+          final var types = processingEnv.getTypeUtils();
+          if (!types.isAssignable(sfType, args.get(0)) || !types.isAssignable(args.get(1), tfType)) {
+            error(
+              source,
+              "@Transform field=\"" +
+                t +
+                "\" does not fit: the field pair is " +
+                sfType +
+                " -> " +
+                tfType +
+                " but " +
+                transforms.get(t) +
+                " implements BridgeFn<" +
+                args.get(0) +
+                ", " +
+                args.get(1) +
+                ">"
+            );
+            return;
+          }
+        }
+      }
     }
 
     // Validate viaMappers fields exist and don't overlap with drops, transforms, renames, or
@@ -2707,6 +2761,36 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
   // than emitting `new null<>(...)`.
   private static String requireImpl(final String impl, final String fieldName) {
     return Objects.requireNonNull(impl, "container impl not attached for field '" + fieldName + "'");
+  }
+
+  // The BridgeFn<A, B> instantiation in `usingType`'s supertype closure, or null when the class
+  // does not implement BridgeFn at all. The erasure comparison finds the interface regardless of
+  // how many levels up the hierarchy it sits.
+  private DeclaredType bridgeFnInstantiation(final TypeMirror usingType) {
+    final var types = processingEnv.getTypeUtils();
+    final var fnEl = processingEnv
+      .getElementUtils()
+      .getTypeElement("io.github.eschizoid.telescope.conversion.BridgeFn");
+    if (fnEl == null) return null;
+    final var erasedFn = types.erasure(fnEl.asType());
+    final Deque<TypeMirror> work = new ArrayDeque<>();
+    work.add(usingType);
+    final var seen = new HashSet<String>();
+    while (!work.isEmpty()) {
+      final var t = work.poll();
+      if (t.getKind() != TypeKind.DECLARED) continue;
+      if (!seen.add(t.toString())) continue;
+      if (types.isSameType(types.erasure(t), erasedFn)) return (DeclaredType) t;
+      work.addAll(types.directSupertypes(t));
+    }
+    return null;
+  }
+
+  // A primitive boxed to its wrapper, so assignability against BridgeFn's reference-typed
+  // arguments compares like with like; reference types pass through.
+  private TypeMirror boxed(final TypeMirror t) {
+    if (!t.getKind().isPrimitive()) return t;
+    return processingEnv.getTypeUtils().boxedClass((PrimitiveType) t).asType();
   }
 
   private String applyForward(final String fieldName, final FieldPlan plan, final String readExpr) {

--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
@@ -1209,9 +1209,9 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
         if (args.size() == 2 && tfField != null) {
           final var tfType = tfField.type();
           final var types = processingEnv.getTypeUtils();
-          // Assignability already models boxing and unboxing-plus-widening in both directions, so
-          // the raw field types are what to compare — boxing either side first would discard the
-          // conversions the emitted call relies on.
+          // Assignability models the boxing the source read needs and the unboxing-plus-widening
+          // the target write needs, so the declared field types are what to compare — boxing
+          // either side first would discard the second.
           if (
             !types.isAssignable(sfType, erasedBound(args.get(0))) ||
             !types.isAssignable(erasedBound(args.get(1)), tfType)

--- a/codegen/src/test/java/io/github/eschizoid/telescope/codegen/BridgeProcessorTest.java
+++ b/codegen/src/test/java/io/github/eschizoid/telescope/codegen/BridgeProcessorTest.java
@@ -2137,9 +2137,9 @@ class BridgeProcessorTest {
     @DisplayName("@Transform on a raw generic BridgeFn is rejected by name instead of inside the generated" + " file")
     void transformWithRawGenericBridgeFnRejectedByName() {
       // An annotation can only carry a raw class literal, so a BridgeFn<T, T> implementor reaches
-      // the emitter with its variables unresolved and its forward returns Object. Before the
-      // check this surfaced as "incompatible types: Object cannot be converted to String" inside
-      // the generated file; it is now named at the @Bridge declaration, arguments and all.
+      // the emitter with its variables unresolved and its forward returns Object. Without the
+      // arguments named at the declaration, the mismatch is only visible as an incompatible-types
+      // error inside the generated file.
       final var compilation = compile(
         source(
           "demo.IdFn",

--- a/codegen/src/test/java/io/github/eschizoid/telescope/codegen/BridgeProcessorTest.java
+++ b/codegen/src/test/java/io/github/eschizoid/telescope/codegen/BridgeProcessorTest.java
@@ -2286,14 +2286,18 @@ class BridgeProcessorTest {
     }
 
     @Test
-    @DisplayName("@Transform accepts a widening BridgeFn and a boxed primitive pair")
+    @DisplayName(
+      "@Transform accepts the conversions the emitted call relies on — widening, boxing, and" +
+        " unboxing-plus-widening"
+    )
     void transformAcceptsWideningAndBoxedPairs() {
       // Assignability models the boxing the source read needs and the unboxing-plus-widening the
       // target write needs, so the declared field types are what to compare — boxing either side
       // first would discard the second. The two asymmetric rows are forward-only: widening and
       // unboxing-plus-widening run one way, so the emitted backward would not compile, and the
       // check must accept the direction that exists rather than the pair as a whole. The boxed
-      // int row is bidirectional because boxing reverses.
+      // int row is bidirectional because int boxes to Integer and Integer unboxes to int on both
+      // sides of the row, so both directions perform the same pair of conversions.
       final var compilation = compileAttributed(
         source(
           "demo.WideFn",

--- a/codegen/src/test/java/io/github/eschizoid/telescope/codegen/BridgeProcessorTest.java
+++ b/codegen/src/test/java/io/github/eschizoid/telescope/codegen/BridgeProcessorTest.java
@@ -2150,7 +2150,7 @@ class BridgeProcessorTest {
       // The emitter instantiates the fn raw, so a type-variable argument erases to its bound and
       // the call accepts anything assignable to that. Both shapes below compile, and the fit test
       // must not reject them for having a variable where a concrete type could stand.
-      final var compilation = compile(
+      final var compilation = compileAttributed(
         source(
           "demo.RenderFn",
           """
@@ -2288,12 +2288,13 @@ class BridgeProcessorTest {
     @Test
     @DisplayName("@Transform accepts a widening BridgeFn and a boxed primitive pair")
     void transformAcceptsWideningAndBoxedPairs() {
-      // Assignability already models the conversions the emitted call relies on: a
-      // BridgeFn<CharSequence, String> consumes a String field by widening, BridgeFn<Integer,
-      // Integer> reaches an int field by boxing and unboxing, and a BridgeFn returning Integer
-      // reaches a long field by unboxing plus a widening primitive conversion. Comparing boxed
-      // types instead of the declared ones would lose that last one.
-      final var compilation = compile(
+      // Assignability models the boxing the source read needs and the unboxing-plus-widening the
+      // target write needs, so the declared field types are what to compare — boxing either side
+      // first would discard the second. The two asymmetric rows are forward-only: widening and
+      // unboxing-plus-widening run one way, so the emitted backward would not compile, and the
+      // check must accept the direction that exists rather than the pair as a whole. The boxed
+      // int row is bidirectional because boxing reverses.
+      final var compilation = compileAttributed(
         source(
           "demo.WideFn",
           """
@@ -2337,9 +2338,9 @@ class BridgeProcessorTest {
           import io.github.eschizoid.telescope.annotations.Bridge;
           import io.github.eschizoid.telescope.annotations.Transform;
           @Bridge(value = demo.Tgt.class, transforms = {
-            @Transform(field = "label", using = demo.WideFn.class),
+            @Transform(field = "label", using = demo.WideFn.class, forwardOnly = true),
             @Transform(field = "count", using = demo.BoxFn.class),
-            @Transform(field = "size", using = demo.SizeFn.class)
+            @Transform(field = "size", using = demo.SizeFn.class, forwardOnly = true)
           })
           public record Src(String label, int count, String size) {}
           """

--- a/codegen/src/test/java/io/github/eschizoid/telescope/codegen/BridgeProcessorTest.java
+++ b/codegen/src/test/java/io/github/eschizoid/telescope/codegen/BridgeProcessorTest.java
@@ -2109,6 +2109,47 @@ class BridgeProcessorTest {
     }
 
     @Test
+    @DisplayName("@Transform with a BridgeFn whose type arguments do not fit the field pair is rejected at" + " build")
+    void transformWithMisfittingBridgeFnRejected() {
+      // Without the check, the bridge is emitted anyway and the mismatch surfaces as raw
+      // incompatible-types errors inside the generated file — code the user never wrote. The
+      // diagnostic must land on the @Bridge declaration and name the field pair and the
+      // BridgeFn's actual arguments.
+      final var compilation = compile(
+        source(
+          "demo.BadFn",
+          """
+          package demo;
+          import io.github.eschizoid.telescope.conversion.BridgeFn;
+          public final class BadFn implements BridgeFn<Integer, Long> {
+            public BadFn() {}
+            @Override public Long forward(Integer x) { return x.longValue(); }
+            @Override public Integer backward(Long c) { return c.intValue(); }
+          }
+          """
+        ),
+        source(
+          "demo.Src",
+          """
+          package demo;
+          import io.github.eschizoid.telescope.annotations.Bridge;
+          import io.github.eschizoid.telescope.annotations.Transform;
+          @Bridge(value = demo.Tgt.class, transforms = { @Transform(field = "label", using = demo.BadFn.class) })
+          public record Src(String id, String label) {}
+          """
+        ),
+        source("demo.Tgt", "package demo; public record Tgt(String id, String label) {}")
+      );
+
+      assertFalse(compilation.success(), "a misfitting BridgeFn must not compile");
+      assertTrue(
+        compilation.hasError("does not fit") && compilation.hasError("BridgeFn<java.lang.Integer, java.lang.Long>"),
+        () ->
+          "expected a diagnostic naming the field pair and the BridgeFn arguments; saw " + compilation.errorMessages()
+      );
+    }
+
+    @Test
     @DisplayName("@Transform per-field conversion routes through the BridgeFn class in both directions")
     void transformRoutesThroughBridgeFn() {
       final var compilation = compile(

--- a/codegen/src/test/java/io/github/eschizoid/telescope/codegen/BridgeProcessorTest.java
+++ b/codegen/src/test/java/io/github/eschizoid/telescope/codegen/BridgeProcessorTest.java
@@ -2109,6 +2109,170 @@ class BridgeProcessorTest {
     }
 
     @Test
+    @DisplayName("@Transform whose using class is not a BridgeFn at all is rejected with a targeted message")
+    void transformWithNonBridgeFnClassRejected() {
+      final var compilation = compile(
+        source("demo.NotAnFn", "package demo; public final class NotAnFn { public NotAnFn() {} }"),
+        source(
+          "demo.Src",
+          """
+          package demo;
+          import io.github.eschizoid.telescope.annotations.Bridge;
+          import io.github.eschizoid.telescope.annotations.Transform;
+          @Bridge(value = demo.Tgt.class, transforms = { @Transform(field = "label", using = demo.NotAnFn.class) })
+          public record Src(String id, String label) {}
+          """
+        ),
+        source("demo.Tgt", "package demo; public record Tgt(String id, String label) {}")
+      );
+
+      assertFalse(compilation.success(), "a non-BridgeFn using class must not compile");
+      assertTrue(
+        compilation.hasError("does not implement BridgeFn"),
+        () -> "expected a targeted non-BridgeFn diagnostic; saw " + compilation.errorMessages()
+      );
+    }
+
+    @Test
+    @DisplayName("@Transform on a raw generic BridgeFn is rejected by name instead of inside the generated" + " file")
+    void transformWithRawGenericBridgeFnRejectedByName() {
+      // An annotation can only carry a raw class literal, so a BridgeFn<T, T> implementor reaches
+      // the emitter with its variables unresolved and its forward returns Object. Before the
+      // check this surfaced as "incompatible types: Object cannot be converted to String" inside
+      // the generated file; it is now named at the @Bridge declaration, arguments and all.
+      final var compilation = compile(
+        source(
+          "demo.IdFn",
+          """
+          package demo;
+          import io.github.eschizoid.telescope.conversion.BridgeFn;
+          public final class IdFn<T> implements BridgeFn<T, T> {
+            public IdFn() {}
+            @Override public T forward(T t) { return t; }
+            @Override public T backward(T t) { return t; }
+          }
+          """
+        ),
+        source(
+          "demo.Src",
+          """
+          package demo;
+          import io.github.eschizoid.telescope.annotations.Bridge;
+          import io.github.eschizoid.telescope.annotations.Transform;
+          @Bridge(value = demo.Tgt.class, transforms = { @Transform(field = "label", using = demo.IdFn.class) })
+          public record Src(String label) {}
+          """
+        ),
+        source("demo.Tgt", "package demo; public record Tgt(String label) {}")
+      );
+
+      assertFalse(compilation.success(), "a raw generic BridgeFn must not compile");
+      assertTrue(
+        compilation.hasError("does not fit") && compilation.hasError("BridgeFn<T, T>"),
+        () -> "expected the diagnostic to name the unresolved arguments; saw " + compilation.errorMessages()
+      );
+      assertFalse(
+        compilation.hasError("cannot be converted to"),
+        () -> "the raw generated-code error must not be what the user sees; saw " + compilation.errorMessages()
+      );
+    }
+
+    @Test
+    @DisplayName("@Transform accepts a BridgeFn reached through an intermediate abstract class")
+    void transformAcceptsBridgeFnThroughIntermediateSupertype() {
+      // The validator walks the supertype closure rather than the direct interfaces, so an
+      // implementor several levels up still resolves its BridgeFn arguments.
+      final var compilation = compile(
+        source(
+          "demo.AbstractLen",
+          """
+          package demo;
+          import io.github.eschizoid.telescope.conversion.BridgeFn;
+          public abstract class AbstractLen implements BridgeFn<String, Integer> {}
+          """
+        ),
+        source(
+          "demo.LenFn",
+          """
+          package demo;
+          public final class LenFn extends AbstractLen {
+            public LenFn() {}
+            @Override public Integer forward(String s) { return s.length(); }
+            @Override public String backward(Integer n) { return "x".repeat(n); }
+          }
+          """
+        ),
+        source(
+          "demo.Src",
+          """
+          package demo;
+          import io.github.eschizoid.telescope.annotations.Bridge;
+          import io.github.eschizoid.telescope.annotations.Transform;
+          @Bridge(value = demo.Tgt.class, transforms = { @Transform(field = "label", using = demo.LenFn.class) })
+          public record Src(String id, String label) {}
+          """
+        ),
+        source("demo.Tgt", "package demo; public record Tgt(String id, Integer label) {}")
+      );
+
+      assertTrue(compilation.success(), () -> "inherited BridgeFn must be accepted: " + compilation.errorMessages());
+      assertNotNull(compilation.generated().get("demo.SrcBridge"));
+    }
+
+    @Test
+    @DisplayName("@Transform accepts a widening BridgeFn and a boxed primitive pair")
+    void transformAcceptsWideningAndBoxedPairs() {
+      // Assignability, not identity: a BridgeFn<CharSequence, String> consumes a String field, and
+      // an int field is boxed before comparison so BridgeFn<Integer, Integer> fits it.
+      final var compilation = compile(
+        source(
+          "demo.WideFn",
+          """
+          package demo;
+          import io.github.eschizoid.telescope.conversion.BridgeFn;
+          public final class WideFn implements BridgeFn<CharSequence, String> {
+            public WideFn() {}
+            @Override public String forward(CharSequence c) { return c.toString(); }
+            @Override public CharSequence backward(String s) { return s; }
+          }
+          """
+        ),
+        source(
+          "demo.BoxFn",
+          """
+          package demo;
+          import io.github.eschizoid.telescope.conversion.BridgeFn;
+          public final class BoxFn implements BridgeFn<Integer, Integer> {
+            public BoxFn() {}
+            @Override public Integer forward(Integer n) { return n + 1; }
+            @Override public Integer backward(Integer n) { return n - 1; }
+          }
+          """
+        ),
+        source(
+          "demo.Src",
+          """
+          package demo;
+          import io.github.eschizoid.telescope.annotations.Bridge;
+          import io.github.eschizoid.telescope.annotations.Transform;
+          @Bridge(value = demo.Tgt.class, transforms = {
+            @Transform(field = "label", using = demo.WideFn.class),
+            @Transform(field = "count", using = demo.BoxFn.class)
+          })
+          public record Src(String label, int count) {}
+          """
+        ),
+        source("demo.Tgt", "package demo; public record Tgt(String label, int count) {}")
+      );
+
+      assertTrue(
+        compilation.success(),
+        () -> "widening and boxed BridgeFn pairs must be accepted: " + compilation.errorMessages()
+      );
+      assertNotNull(compilation.generated().get("demo.SrcBridge"));
+    }
+
+    @Test
     @DisplayName("@Transform with a BridgeFn whose type arguments do not fit the field pair is rejected at" + " build")
     void transformWithMisfittingBridgeFnRejected() {
       // Without the check, the bridge is emitted anyway and the mismatch surfaces as raw

--- a/codegen/src/test/java/io/github/eschizoid/telescope/codegen/BridgeProcessorTest.java
+++ b/codegen/src/test/java/io/github/eschizoid/telescope/codegen/BridgeProcessorTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.github.eschizoid.telescope.codegen.ProcessorHarness.Compilation;
+import java.util.List;
 import javax.tools.JavaFileObject;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -22,6 +23,16 @@ class BridgeProcessorTest {
 
   private static Compilation compile(final JavaFileObject... sources) {
     return ProcessorHarness.compile(new BridgeProcessor(), sources);
+  }
+
+  /**
+   * Compiles through the full javac pipeline, so the generated source is attributed and an
+   * expression-level error inside it is observable. {@link #compile} runs {@code -proc:only}, where
+   * Attr never visits the generated file — an assertion about a generated-file type error holds
+   * vacuously there.
+   */
+  private static Compilation compileAttributed(final JavaFileObject... sources) {
+    return ProcessorHarness.compileFully(List.of(new BridgeProcessor()), List.of(), sources);
   }
 
   /**
@@ -2134,13 +2145,68 @@ class BridgeProcessorTest {
     }
 
     @Test
+    @DisplayName("@Transform accepts a type-variable BridgeFn whose erased bound fits the field pair")
+    void transformAcceptsTypeVariableBridgeFnThatFits() {
+      // The emitter instantiates the fn raw, so a type-variable argument erases to its bound and
+      // the call accepts anything assignable to that. Both shapes below compile, and the fit test
+      // must not reject them for having a variable where a concrete type could stand.
+      final var compilation = compile(
+        source(
+          "demo.RenderFn",
+          """
+          package demo;
+          import io.github.eschizoid.telescope.conversion.BridgeFn;
+          public final class RenderFn<T> implements BridgeFn<T, String> {
+            public RenderFn() {}
+            @Override public String forward(T t) { return String.valueOf(t); }
+            @Override public T backward(String s) { throw new UnsupportedOperationException(); }
+          }
+          """
+        ),
+        source(
+          "demo.IdFn2",
+          """
+          package demo;
+          import io.github.eschizoid.telescope.conversion.BridgeFn;
+          public final class IdFn2<T> implements BridgeFn<T, T> {
+            public IdFn2() {}
+            @Override public T forward(T t) { return t; }
+            @Override public T backward(T t) { return t; }
+          }
+          """
+        ),
+        source(
+          "demo.SrcG",
+          """
+          package demo;
+          import io.github.eschizoid.telescope.annotations.Bridge;
+          import io.github.eschizoid.telescope.annotations.Transform;
+          @Bridge(value = demo.TgtG.class, transforms = {
+            @Transform(field = "payload", using = demo.RenderFn.class, forwardOnly = true),
+            @Transform(field = "label", using = demo.IdFn2.class)
+          })
+          public record SrcG(Object payload, Object label) {}
+          """
+        ),
+        source("demo.TgtG", "package demo; public record TgtG(String payload, Object label) {}")
+      );
+
+      assertTrue(
+        compilation.success(),
+        () -> "a type-variable BridgeFn whose bound fits must be accepted: " + compilation.errorMessages()
+      );
+      assertNotNull(compilation.generated().get("demo.SrcGBridge"));
+    }
+
+    @Test
     @DisplayName("@Transform on a raw generic BridgeFn is rejected by name instead of inside the generated" + " file")
     void transformWithRawGenericBridgeFnRejectedByName() {
-      // An annotation can only carry a raw class literal, so a BridgeFn<T, T> implementor reaches
-      // the emitter with its variables unresolved and its forward returns Object. Without the
-      // arguments named at the declaration, the mismatch is only visible as an incompatible-types
-      // error inside the generated file.
-      final var compilation = compile(
+      // An annotation carries only a raw class literal, so the emitter instantiates the fn raw and
+      // its forward erases to the type variable's bound — Object here. That fits an Object-typed
+      // slot and not a String one, so this pair is named at the declaration; the sibling test
+      // covers the pairs it does fit. Attributed compilation, so the generated-file error this
+      // replaces would be observable if it were still what the user saw.
+      final var compilation = compileAttributed(
         source(
           "demo.IdFn",
           """
@@ -2222,8 +2288,11 @@ class BridgeProcessorTest {
     @Test
     @DisplayName("@Transform accepts a widening BridgeFn and a boxed primitive pair")
     void transformAcceptsWideningAndBoxedPairs() {
-      // Assignability, not identity: a BridgeFn<CharSequence, String> consumes a String field, and
-      // an int field is boxed before comparison so BridgeFn<Integer, Integer> fits it.
+      // Assignability already models the conversions the emitted call relies on: a
+      // BridgeFn<CharSequence, String> consumes a String field by widening, BridgeFn<Integer,
+      // Integer> reaches an int field by boxing and unboxing, and a BridgeFn returning Integer
+      // reaches a long field by unboxing plus a widening primitive conversion. Comparing boxed
+      // types instead of the declared ones would lose that last one.
       final var compilation = compile(
         source(
           "demo.WideFn",
@@ -2250,6 +2319,18 @@ class BridgeProcessorTest {
           """
         ),
         source(
+          "demo.SizeFn",
+          """
+          package demo;
+          import io.github.eschizoid.telescope.conversion.BridgeFn;
+          public final class SizeFn implements BridgeFn<String, Integer> {
+            public SizeFn() {}
+            @Override public Integer forward(String s) { return s.length(); }
+            @Override public String backward(Integer n) { return "x".repeat(n); }
+          }
+          """
+        ),
+        source(
           "demo.Src",
           """
           package demo;
@@ -2257,12 +2338,13 @@ class BridgeProcessorTest {
           import io.github.eschizoid.telescope.annotations.Transform;
           @Bridge(value = demo.Tgt.class, transforms = {
             @Transform(field = "label", using = demo.WideFn.class),
-            @Transform(field = "count", using = demo.BoxFn.class)
+            @Transform(field = "count", using = demo.BoxFn.class),
+            @Transform(field = "size", using = demo.SizeFn.class)
           })
-          public record Src(String label, int count) {}
+          public record Src(String label, int count, String size) {}
           """
         ),
-        source("demo.Tgt", "package demo; public record Tgt(String label, int count) {}")
+        source("demo.Tgt", "package demo; public record Tgt(String label, int count, long size) {}")
       );
 
       assertTrue(


### PR DESCRIPTION
Closes #344. Found by the codegen audit's front-end fuzz (#351).

A `@Transform` whose `using` class implements `BridgeFn` with arguments that don't fit the field (field `String`, `using = BadFn.class` where `BadFn implements BridgeFn<Integer, Long>`) emitted the bridge anyway — three raw `incompatible types` errors inside the generated file, no processor diagnostic, no pointer to the annotation.

## The fix

At the existing per-transform validation site (where the field pair is in scope), the processor now walks the `using` class's supertype closure to its `BridgeFn<A, B>` instantiation and checks the forward direction: the source field assignable to `A`, `B` assignable to the target field, primitives boxed so the comparison is like-with-like. Only forward is checked — it binds for every transform shape, forward-only included — and a raw `BridgeFn` supertype carries no arguments to check. A class that doesn't implement `BridgeFn` at all (with no `method` qualifier to excuse it) is now also a targeted error rather than emitted nonsense.

Diagnostic: `@Transform field="label" does not fit: the field pair is java.lang.String -> java.lang.String but demo.BadFn implements BridgeFn<java.lang.Integer, java.lang.Long>` — on the `@Bridge` declaration.

## Verification

New negative test asserts the diagnostic by content — the discriminator, since under full attribution the compile fails either way; what changes is *where* and *how usefully*. Revert-proven: exactly that one test fails without the check. The existing fitting-`BridgeFn` transform tests (`CentsConverter` `BigDecimal↔Long` and friends) are the control and stay green, so the check rejects the misfit without touching any valid shape.