### PR TITLE
fix: report generated-name collisions instead of emitting the broken artifact

### DIFF
--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/AbstractTelescopeProcessor.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/AbstractTelescopeProcessor.java
@@ -91,10 +91,15 @@ public abstract class AbstractTelescopeProcessor extends AbstractProcessor {
   }
 
   /**
-   * The zero-argument methods every generated navigator declares for itself. A property of the same
-   * name emits a second method with the same erasure, so the generated file does not compile — and
-   * javac reports it against the generated source, which the author never wrote. A property
-   * matching a forwarder that takes arguments is fine: those overload cleanly.
+   * The zero-argument methods every generated navigator declares for itself, whatever type it
+   * navigates. A property of the same name emits a second method with the same erasure, so the
+   * generated file does not compile — and javac reports it against the generated source, which the
+   * author never wrote. A property matching a forwarder that takes arguments is fine: those
+   * overload cleanly.
+   *
+   * <p>A navigator for a type that also carries {@code @Bridge} declares one more zero-argument
+   * method, {@code as<Target>()}, whose name depends on that target. It cannot live in this set, so
+   * callers pass it through {@code alsoReserved}.
    */
   private static final Set<String> RESERVED_NAVIGATOR_METHODS = Set.of("of", "get", "explain");
 
@@ -102,15 +107,16 @@ public abstract class AbstractTelescopeProcessor extends AbstractProcessor {
    * Reports any property whose name would collide with a method the navigator declares for itself,
    * and answers whether emission should be abandoned for this type. Callers check before writing
    * the navigator: emitting it anyway leaves the author with a javac error inside a file they
-   * cannot edit.
+   * cannot edit. {@code alsoReserved} carries the names that depend on the type being emitted.
    */
   protected boolean hasReservedPropertyName(
     final Element site,
     final String triggerLabel,
-    final List<String> propertyNames
+    final List<String> propertyNames,
+    final Set<String> alsoReserved
   ) {
     for (final var name : propertyNames) {
-      if (RESERVED_NAVIGATOR_METHODS.contains(name)) {
+      if (RESERVED_NAVIGATOR_METHODS.contains(name) || alsoReserved.contains(name)) {
         error(
           site,
           triggerLabel +
@@ -793,7 +799,28 @@ public abstract class AbstractTelescopeProcessor extends AbstractProcessor {
       error(pojo, triggerLabel + ": " + pojo.getQualifiedName() + " has no readable properties (getX()/isX())");
       return;
     }
-    if (hasReservedPropertyName(pojo, triggerLabel, props.stream().map(Prop::name).toList())) return;
+    final var hopTarget = bridgeTargetFqn(pojo);
+    final var reservedHop = hopTarget == null ? Set.<String>of() : Set.of("as" + simpleNameOf(hopTarget));
+    if (hasReservedPropertyName(pojo, triggerLabel, props.stream().map(Prop::name).toList(), reservedHop)) return;
+    // Both artifacts are rejected together, before either is written: a property that cannot be
+    // emitted as a typed constant also cannot be named in the navigator's type parameters, so
+    // emitting the navigator anyway hands the author a javac error inside a file they never wrote.
+    for (final var p : props) {
+      if (!isEmittableAsTypedConstant(p.type())) {
+        error(
+          pojo,
+          triggerLabel +
+            ": cannot emit metadata constant for property '" +
+            p.name() +
+            "' of type '" +
+            p.type() +
+            "' — generics with wildcard or self-referential bounds are not supported. Remove " +
+            triggerLabel +
+            " from this class to use the runtime path."
+        );
+        return;
+      }
+    }
 
     final var builder = staticBuilderMethod(pojo);
     final var builderType =
@@ -883,9 +910,9 @@ public abstract class AbstractTelescopeProcessor extends AbstractProcessor {
     final var holderName = pojoBaseName + "FieldOptics";
     final var qualifiedHolder = pkg.isEmpty() ? holderName : pkg + "." + holderName;
 
-    // Reject up-front: any un-emittable property type kills the whole holder for this POJO
-    // (the per-POJO holder is the unit of regeneration, mixed-quality holders would mask the
-    // gap). The Path navigator is unaffected — it has its own type handling.
+    // The caller has already rejected any POJO carrying an un-emittable property, before either
+    // artifact was written. This loop is the holder's own guard for callers that reach it by
+    // another route.
     for (final var p : props) {
       if (!isEmittableAsTypedConstant(p.type())) {
         error(

--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/AbstractTelescopeProcessor.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/AbstractTelescopeProcessor.java
@@ -90,6 +90,43 @@ public abstract class AbstractTelescopeProcessor extends AbstractProcessor {
     }
   }
 
+  /**
+   * The zero-argument methods every generated navigator declares for itself. A property of the same
+   * name emits a second method with the same erasure, so the generated file does not compile — and
+   * javac reports it against the generated source, which the author never wrote. A property
+   * matching a forwarder that takes arguments is fine: those overload cleanly.
+   */
+  private static final Set<String> RESERVED_NAVIGATOR_METHODS = Set.of("of", "get", "explain");
+
+  /**
+   * Reports any property whose name would collide with a method the navigator declares for itself,
+   * and answers whether emission should be abandoned for this type. Callers check before writing
+   * the navigator: emitting it anyway leaves the author with a javac error inside a file they
+   * cannot edit.
+   */
+  protected boolean hasReservedPropertyName(
+    final Element site,
+    final String triggerLabel,
+    final List<String> propertyNames
+  ) {
+    for (final var name : propertyNames) {
+      if (RESERVED_NAVIGATOR_METHODS.contains(name)) {
+        error(
+          site,
+          triggerLabel +
+            ": property '" +
+            name +
+            "' collides with the generated navigator's own " +
+            name +
+            "() method. Rename the property, or drop the annotation and use the runtime" +
+            " path."
+        );
+        return true;
+      }
+    }
+    return false;
+  }
+
   protected void error(final Element element, final String message) {
     processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR, message, element);
   }
@@ -756,6 +793,7 @@ public abstract class AbstractTelescopeProcessor extends AbstractProcessor {
       error(pojo, triggerLabel + ": " + pojo.getQualifiedName() + " has no readable properties (getX()/isX())");
       return;
     }
+    if (hasReservedPropertyName(pojo, triggerLabel, props.stream().map(Prop::name).toList())) return;
 
     final var builder = staticBuilderMethod(pojo);
     final var builderType =

--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
@@ -2958,20 +2958,6 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
     final var imports = new TreeSet<String>();
     for (final var entry : fieldPlans.entrySet()) {
       final var plan = entry.getValue();
-      // A field plan that references a sub-bridge by simple name resolves for free when the
-      // sub-bridge is emitted in this bridge's own package (the common single-package case). When
-      // it
-      // isn't — a cross-package sub-pair, e.g. a DB-entity field bridged to a same-simple-name BO
-      // type in another package — the simple name is unresolvable; import the sub-bridge's FQN.
-      // This
-      // applies to raw-container plans too (their helper also calls the sub-bridge by simple name),
-      // so it runs before the raw-container short-circuit below.
-      final var subImport = crossPackageSubBridgeImport(
-        plan,
-        fieldByName(sourceFields, entry.getKey()).type(),
-        parentPkg
-      );
-      if (subImport != null) imports.add(subImport);
       // Raw-container helpers render every container/element TYPE by fully-qualified name, so they
       // need no container-type imports (only the sub-bridge import handled above).
       if (plan.rawContainer()) continue;
@@ -2994,48 +2980,6 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
       }
     }
     return imports;
-  }
-
-  /**
-   * The FQN to import for {@code plan}'s sub-bridge when it lives in a different package than
-   * {@code parentPkg}, or {@code null} when the plan references no sub-bridge, the element passes
-   * through (identity), or the sub-bridge shares this bridge's package (simple name already
-   * resolves). The sub-bridge is emitted in the source sub-element's package, so that package plus
-   * the plan's simple sub-bridge name is the import.
-   */
-  private String crossPackageSubBridgeImport(
-    final FieldPlan plan,
-    final TypeMirror srcFieldType,
-    final String parentPkg
-  ) {
-    final var sub = plan.subBridgeName();
-    if (sub == null || IDENTITY_ELEMENT_SENTINEL.equals(sub)) return null;
-    // A @ViaMapper / qualifier sub-bridge name is already a fully-qualified user class (e.g.
-    // `mapper.AddressBridge`); the body emits it verbatim, so it resolves on its own and needs no
-    // import. Only auto-generated bridge names (a bare simple name, no dot) need the cross-package
-    // import — prepending a package to a name that already has one yields a bogus import.
-    if (sub.indexOf('.') >= 0) return null;
-    final var subElement = switch (plan.kind()) {
-      case RECURSE, NULLABLE_TO_OPTIONAL -> srcFieldType;
-      case LIST, SET, MAP_VALUES, OPTIONAL, OPTIONAL_TO_NULLABLE -> {
-        // A raw Collection/Map subtype field (`class CxDocs extends ArrayList<CxDoc>`) carries
-        // its
-        // element in the supertype, so containerShapeOf returns null — fall back to the raw
-        // shape,
-        // mirroring how planFields derives the element for the same field.
-        final var shape = containerShapeOf(srcFieldType);
-        yield shape != null
-          ? shape.elementType()
-          : rawContainerShapeOf(srcFieldType) != null
-            ? rawContainerShapeOf(srcFieldType).elementType()
-            : null;
-      }
-      default -> null;
-    };
-    if (!(subElement instanceof DeclaredType dt) || !(dt.asElement() instanceof TypeElement te)) return null;
-    final var subPkg = processingEnv.getElementUtils().getPackageOf(te).getQualifiedName().toString();
-    if (subPkg.isEmpty() || subPkg.equals(parentPkg)) return null;
-    return subPkg + "." + sub;
   }
 
   /**
@@ -3289,7 +3233,8 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
    * one — and a parent referencing both by simple name cannot resolve either, whichever package
    * each lives in. Qualifying every sub-bridge outside the parent's own package removes the
    * ambiguity at the reference rather than at the name: the emitted expression names exactly one
-   * class, and the file needs no import for it.
+   * class, and the file needs no import for it. This is the only mechanism — a name carrying a dot
+   * is emitted verbatim, so nothing downstream imports a sub-bridge.
    */
   private String subBridgeReference(
     final TypeElement subSource,
@@ -3297,8 +3242,18 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
     final boolean userDeclared,
     final String parentPkg
   ) {
-    final var simple = bridgeClassName(subSource, subTarget, userDeclared);
-    final var subPkg = processingEnv.getElementUtils().getPackageOf(subSource).getQualifiedName().toString();
+    // A carrier-form pair is emitted as <Carrier>Bridge in the carrier's package, so both halves
+    // of the reference differ from the source-anchored case and the carrier is what to ask.
+    final var subPair = new TypePair(subSource.getQualifiedName().toString(), subTarget.getQualifiedName().toString());
+    final var subCfg = configsByPair.get(subPair);
+    final var carrierEl =
+      subCfg == null || subCfg.carrierFq() == null
+        ? null
+        : processingEnv.getElementUtils().getTypeElement(subCfg.carrierFq());
+    final var simple =
+      carrierEl != null ? carrierEl.getSimpleName() + "Bridge" : bridgeClassName(subSource, subTarget, userDeclared);
+    final var owner = carrierEl != null ? carrierEl : subSource;
+    final var subPkg = processingEnv.getElementUtils().getPackageOf(owner).getQualifiedName().toString();
     if (subPkg.isEmpty() || subPkg.equals(parentPkg)) return simple;
     return subPkg + "." + simple;
   }

--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
@@ -189,6 +189,15 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
   // package-agnostic registry. Cleared after the write so a reused instance starts clean.
   private final Set<String> bridgeProviders = new LinkedHashSet<>();
 
+  /**
+   * Which pair claimed each generated bridge FQN. Auto-derived names are built from the two simple
+   * names, so two pairs whose types share simple names across different packages flatten to the
+   * same FQN — the second write is a FilerException reported against whichever file the Filer was
+   * given, which need not be one the author annotated. Holding the first claimant lets the clash be
+   * reported against the pair that caused it.
+   */
+  private final Map<String, TypePair> bridgeNameOwner = new HashMap<>();
+
   @Override
   public boolean process(final Set<? extends TypeElement> annotations, final RoundEnvironment roundEnv) {
     final var anno = processingEnv.getElementUtils().getTypeElement(ANNOTATION);
@@ -1139,6 +1148,27 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
     final var bridgeName =
       carrierEl != null ? carrierEl.getSimpleName() + "Bridge" : bridgeClassName(source, target, useShortName);
     final var qualifiedBridge = pkg.isEmpty() ? bridgeName : pkg + "." + bridgeName;
+
+    final var nameOwner = bridgeNameOwner.putIfAbsent(qualifiedBridge, thisPair);
+    if (nameOwner != null && !nameOwner.equals(thisPair)) {
+      error(
+        source,
+        "@Bridge: the generated bridge name " +
+          qualifiedBridge +
+          " is claimed by two different type pairs — " +
+          nameOwner.sourceFq() +
+          " -> " +
+          nameOwner.targetFq() +
+          " and " +
+          sourceFq +
+          " -> " +
+          targetFq +
+          ". Auto-derived names use the simple names, so types sharing a simple name across" +
+          " packages collide. Declare an explicit @Bridge on one of the pairs, or rename a" +
+          " type."
+      );
+      return;
+    }
 
     final var sourceFields = fieldsOf(source);
     final var targetFields = fieldsOf(target);

--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
@@ -191,10 +191,14 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
 
   /**
    * Which pair claimed each generated bridge FQN. Auto-derived names are built from the two simple
-   * names, so two pairs whose types share simple names across different packages flatten to the
-   * same FQN — the second write is a FilerException reported against whichever file the Filer was
-   * given, which need not be one the author annotated. Holding the first claimant lets the clash be
+   * names, so two pairs emitting into the same package from same-simple-named types land on one FQN
+   * — the second write is a FilerException reported against whichever file the Filer was given,
+   * which need not be one the author annotated. Holding the first claimant lets the clash be
    * reported against the pair that caused it.
+   *
+   * <p>The sibling case — pairs in different packages deriving the same simple name — yields
+   * distinct FQNs, so nothing collides here; it is resolved where the parent references them, in
+   * {@link #subBridgeReference}.
    */
   private final Map<String, TypePair> bridgeNameOwner = new HashMap<>();
 
@@ -1660,7 +1664,8 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
       pending,
       seen,
       userDeclared,
-      lenient
+      lenient,
+      pkg
     );
     if (fieldPlans == null) return;
 
@@ -2483,7 +2488,8 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
     final Deque<TypePair> pending,
     final Set<TypePair> seen,
     final Set<TypePair> userDeclared,
-    final boolean lenient
+    final boolean lenient,
+    final String parentPkg
   ) {
     final var plans = new LinkedHashMap<String, FieldPlan>();
     for (final var sf : sourceFields) {
@@ -2561,7 +2567,8 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
           pending,
           seen,
           userDeclared,
-          lenient
+          lenient,
+          parentPkg
         );
         if (subPlan == null) return null;
         // Attach the concrete-impl class the inline identity-element copy allocates: the target's
@@ -2636,7 +2643,8 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
           pending,
           seen,
           userDeclared,
-          lenient
+          lenient,
+          parentPkg
         );
         if (subPlan == null) return null;
         plans.put(sf.name(), FieldPlan.rawContainer(subPlan.kind(), subPlan.subBridgeName()));
@@ -2655,7 +2663,8 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
           pending,
           seen,
           userDeclared,
-          lenient
+          lenient,
+          parentPkg
         );
         if (subPlan == null) return null;
         plans.put(sf.name(), subPlan);
@@ -2672,7 +2681,8 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
           pending,
           seen,
           userDeclared,
-          lenient
+          lenient,
+          parentPkg
         );
         if (subPlan == null) return null;
         plans.put(sf.name(), subPlan);
@@ -2701,7 +2711,12 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
         // Leniency propagates: a lenient parent's nested sub-pair is itself lenient, so its
         // bijection check is skipped and unmatched nested-target fields take JLS defaults.
         if (lenient) lenientPairs.add(subPair);
-        final var subBridgeName = bridgeClassName(subSourceEl, subTargetEl, userDeclared.contains(subPair));
+        final var subBridgeName = subBridgeReference(
+          subSourceEl,
+          subTargetEl,
+          userDeclared.contains(subPair),
+          parentPkg
+        );
         plans.put(sf.name(), FieldPlan.recurse(subBridgeName));
         continue;
       }
@@ -2741,7 +2756,8 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
     final Deque<TypePair> pending,
     final Set<TypePair> seen,
     final Set<TypePair> userDeclared,
-    final boolean lenient
+    final boolean lenient,
+    final String parentPkg
   ) {
     if (isSameType(srcElement, tgtElement)) {
       // Container kind matters (lift), but no sub-bridge — the element passes through. Use a
@@ -2767,7 +2783,7 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
       }
       // Leniency propagates into the element pair too, matching the scalar sub-pair path.
       if (lenient) lenientPairs.add(subPair);
-      final var subBridgeName = bridgeClassName(subSourceEl, subTargetEl, userDeclared.contains(subPair));
+      final var subBridgeName = subBridgeReference(subSourceEl, subTargetEl, userDeclared.contains(subPair), parentPkg);
       return FieldPlan.ofKind(kind, subBridgeName);
     }
     error(
@@ -3265,6 +3281,26 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
   ) {
     if (userDeclared) return source.getSimpleName() + "Bridge";
     return source.getSimpleName() + "To" + target.getSimpleName() + "Bridge";
+  }
+
+  /**
+   * The name a parent bridge should call a sub-bridge by. Auto-derived names are built from the two
+   * simple names, so two sub-pairs whose types share simple names across packages derive the same
+   * one — and a parent referencing both by simple name cannot resolve either, whichever package
+   * each lives in. Qualifying every sub-bridge outside the parent's own package removes the
+   * ambiguity at the reference rather than at the name: the emitted expression names exactly one
+   * class, and the file needs no import for it.
+   */
+  private String subBridgeReference(
+    final TypeElement subSource,
+    final TypeElement subTarget,
+    final boolean userDeclared,
+    final String parentPkg
+  ) {
+    final var simple = bridgeClassName(subSource, subTarget, userDeclared);
+    final var subPkg = processingEnv.getElementUtils().getPackageOf(subSource).getQualifiedName().toString();
+    if (subPkg.isEmpty() || subPkg.equals(parentPkg)) return simple;
+    return subPkg + "." + simple;
   }
 
   /**

--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
@@ -1803,7 +1803,7 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
     // target).
     if (carrierEl != null) emitBridgeProvider(source, target, bridgeName, pkg);
 
-    final var imports = new TreeSet<>(importsFor(fieldPlans, sourceFields, targetFields, renames, pkg));
+    final var imports = new TreeSet<>(importsFor(fieldPlans, sourceFields, targetFields, renames));
     imports.add("io.github.eschizoid.telescope.Telescope");
     imports.add("io.github.eschizoid.telescope.conversion.BridgeFn");
     writeClass(
@@ -2952,14 +2952,13 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
     final Map<String, FieldPlan> fieldPlans,
     final List<Field> sourceFields,
     final List<Field> targetFields,
-    final Map<String, String> renames,
-    final String parentPkg
+    final Map<String, String> renames
   ) {
     final var imports = new TreeSet<String>();
     for (final var entry : fieldPlans.entrySet()) {
       final var plan = entry.getValue();
       // Raw-container helpers render every container/element TYPE by fully-qualified name, so they
-      // need no container-type imports (only the sub-bridge import handled above).
+      // need no container-type imports.
       if (plan.rawContainer()) continue;
       switch (plan.kind()) {
         // A container field needs both the declared raw of each side (the helper return / param
@@ -3233,8 +3232,9 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
    * one — and a parent referencing both by simple name cannot resolve either, whichever package
    * each lives in. Qualifying every sub-bridge outside the parent's own package removes the
    * ambiguity at the reference rather than at the name: the emitted expression names exactly one
-   * class, and the file needs no import for it. This is the only mechanism — a name carrying a dot
-   * is emitted verbatim, so nothing downstream imports a sub-bridge.
+   * class, and the file needs no import for it. This is the mechanism for field and element
+   * sub-bridges; sealed per-case references are qualified at their own emission site. No generated
+   * file imports a generated bridge.
    */
   private String subBridgeReference(
     final TypeElement subSource,
@@ -3245,7 +3245,12 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
     // A carrier-form pair is emitted as <Carrier>Bridge in the carrier's package, so both halves
     // of the reference differ from the source-anchored case and the carrier is what to ask.
     final var subPair = new TypePair(subSource.getQualifiedName().toString(), subTarget.getQualifiedName().toString());
-    final var subCfg = configsByPair.get(subPair);
+    // A Lombok-deferred pair's config is held in deferredConfigs until the final round, while the
+    // parent's reference is written when the parent is planned — read both, or a deferred
+    // carrier's pair falls back to the source-anchored name and points at a class nothing emits.
+    // Both maps are filled in the same element loop, before any draining, so this adds no ordering
+    // assumption of its own.
+    final var subCfg = configsByPair.containsKey(subPair) ? configsByPair.get(subPair) : deferredConfigs.get(subPair);
     final var carrierEl =
       subCfg == null || subCfg.carrierFq() == null
         ? null

--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/FocusProcessor.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/FocusProcessor.java
@@ -83,6 +83,35 @@ public final class FocusProcessor extends AbstractTelescopeProcessor {
     final var qualifiedPath = pkg.isEmpty() ? pathName : pkg + "." + pathName;
     final List<? extends RecordComponentElement> components = recordType.getRecordComponents();
 
+    // Both artifacts are rejected together, before either is written. A component that cannot be
+    // emitted as a typed constant also cannot be named in the navigator's type parameters, and a
+    // component colliding with a navigator method makes the navigator uncompilable — emitting
+    // either artifact anyway hands the author a javac error inside a file they never wrote.
+    if (
+      hasReservedPropertyName(
+        recordType,
+        "@Focus",
+        components
+          .stream()
+          .map(c -> c.getSimpleName().toString())
+          .toList()
+      )
+    ) return;
+    for (final var comp : components) {
+      if (!isEmittableAsTypedConstant(comp.asType())) {
+        error(
+          recordType,
+          "@Focus: cannot emit metadata constant for component '" +
+            comp.getSimpleName() +
+            "' of type '" +
+            comp.asType() +
+            "' — generics with wildcard or self-referential bounds are not supported. Remove " +
+            "@Focus from this record to use the runtime path."
+        );
+        return;
+      }
+    }
+
     // First, emit one container-step class per collection-shaped component (each goes in its own
     // top-level source file because each is public and Java permits at most one public top-level
     // type per file).
@@ -124,24 +153,6 @@ public final class FocusProcessor extends AbstractTelescopeProcessor {
   ) {
     final var holderName = recordName + "FieldOptics";
     final var qualifiedHolder = pkg.isEmpty() ? holderName : pkg + "." + holderName;
-
-    // Reject up-front: any un-emittable component type kills the whole holder for this record
-    // (the per-record holder is the unit of regeneration, mixed-quality holders would mask the
-    // gap). The Path navigator is unaffected — it has its own type handling.
-    for (final var comp : components) {
-      if (!isEmittableAsTypedConstant(comp.asType())) {
-        error(
-          recordType,
-          "@Focus: cannot emit metadata constant for component '" +
-            comp.getSimpleName() +
-            "' of type '" +
-            comp.asType() +
-            "' — generics with wildcard or self-referential bounds are not supported. Remove " +
-            "@Focus from this record to use the runtime path."
-        );
-        return;
-      }
-    }
 
     final Set<String> extraImports = new LinkedHashSet<>();
     for (final var comp : components) collectStdImports(comp.asType(), extraImports);

--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/FocusProcessor.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/FocusProcessor.java
@@ -87,6 +87,8 @@ public final class FocusProcessor extends AbstractTelescopeProcessor {
     // emitted as a typed constant also cannot be named in the navigator's type parameters, and a
     // component colliding with a navigator method makes the navigator uncompilable — emitting
     // either artifact anyway hands the author a javac error inside a file they never wrote.
+    final var hopTarget = bridgeTargetFqn(recordType);
+    final var reservedHop = hopTarget == null ? Set.<String>of() : Set.of("as" + simpleNameOf(hopTarget));
     if (
       hasReservedPropertyName(
         recordType,
@@ -94,7 +96,8 @@ public final class FocusProcessor extends AbstractTelescopeProcessor {
         components
           .stream()
           .map(c -> c.getSimpleName().toString())
-          .toList()
+          .toList(),
+        reservedHop
       )
     ) return;
     for (final var comp : components) {

--- a/codegen/src/test/java/io/github/eschizoid/telescope/codegen/GeneratedNameCollisionTest.java
+++ b/codegen/src/test/java/io/github/eschizoid/telescope/codegen/GeneratedNameCollisionTest.java
@@ -213,6 +213,41 @@ class GeneratedNameCollisionTest {
   }
 
   @Test
+  @DisplayName("sub-bridges sharing a simple name across packages are referenced without ambiguity")
+  void subBridgesSharingASimpleNameAcrossPackagesResolve() {
+    // a.User -> a.UserDto and b.User -> b.UserDto each derive UserToUserDtoBridge, in their own
+    // packages. The FQNs differ, so this is not a name clash the emitter can refuse — the parent
+    // has to reference both, and referencing them by simple name would leave one unresolvable and
+    // hand the other's forward a value of the wrong type.
+    final var compilation = compile(
+      new BridgeProcessor(),
+      source("a.User", "package a; public record User(String name) {}"),
+      source("a.UserDto", "package a; public record UserDto(String name) {}"),
+      source("b.User", "package b; public record User(String name) {}"),
+      source("b.UserDto", "package b; public record UserDto(String name) {}"),
+      source(
+        "demo.Root",
+        """
+        package demo;
+        import io.github.eschizoid.telescope.annotations.Bridge;
+        @Bridge(demo.RootDto.class) public record Root(a.User user, b.User other) {}
+        """
+      ),
+      source("demo.RootDto", "package demo; public record RootDto(a.UserDto user, b.UserDto other) {}")
+    );
+
+    assertTrue(
+      compilation.success(),
+      () -> "both sub-bridges must be referenced unambiguously; saw " + compilation.errorMessages()
+    );
+    final var bridge = compilation.generated().get("demo.RootBridge");
+    assertTrue(
+      bridge != null && bridge.contains("a.UserToUserDtoBridge") && bridge.contains("b.UserToUserDtoBridge"),
+      () -> "each sub-bridge must be named by its own package; saw " + bridge
+    );
+  }
+
+  @Test
   @DisplayName("two pairs whose auto-derived bridge names collide are named at the declaration")
   void collidingAutoBridgeNamesAreReported() {
     // a.MoneyA -> b.MoneyB and a.MoneyA -> c.MoneyB both derive MoneyAToMoneyBBridge in package a,

--- a/codegen/src/test/java/io/github/eschizoid/telescope/codegen/GeneratedNameCollisionTest.java
+++ b/codegen/src/test/java/io/github/eschizoid/telescope/codegen/GeneratedNameCollisionTest.java
@@ -66,6 +66,123 @@ class GeneratedNameCollisionTest {
   }
 
   @Test
+  @DisplayName("a component named after the bridge hop is reported, on records and on beans alike")
+  void componentCollidingWithBridgeHopIsReported() {
+    // The hop is named for its target, so this one cannot live in a fixed set — it is passed in
+    // per type. A record and a bean carrying the same clash must behave the same way.
+    final var record = compile(
+      new FocusProcessor(),
+      source(
+        "demo.Src",
+        """
+        package demo;
+        import io.github.eschizoid.telescope.annotations.Bridge;
+        import io.github.eschizoid.telescope.annotations.Focus;
+        @Focus @Bridge(demo.Tgt.class) public record Src(String id, String asTgt) {}
+        """
+      ),
+      source("demo.Tgt", "package demo; public record Tgt(String id, String asTgt) {}")
+    );
+
+    assertFalse(record.success(), "a component named after the bridge hop must not compile");
+    assertTrue(
+      record.hasError("collides with the generated navigator's own asTgt() method"),
+      () -> "expected the hop collision named at the record; saw " + record.errorMessages()
+    );
+    assertFalse(
+      record.hasError("is already defined in class"),
+      () ->
+        "the duplicate-method error inside the generated file must not be what the author sees;" +
+        " saw " +
+        record.errorMessages()
+    );
+
+    final var bean = compile(
+      new BeanFocusProcessor(),
+      source(
+        "demo.SrcBean",
+        """
+        package demo;
+        import io.github.eschizoid.telescope.annotations.BeanFocus;
+        import io.github.eschizoid.telescope.annotations.Bridge;
+        @BeanFocus @Bridge(demo.TgtBean.class) public class SrcBean {
+          private String id;
+          private String asTgtBean;
+          public SrcBean() {}
+          public String getId() { return id; }
+          public void setId(final String id) { this.id = id; }
+          public String getAsTgtBean() { return asTgtBean; }
+          public void setAsTgtBean(final String v) { this.asTgtBean = v; }
+        }
+        """
+      ),
+      source(
+        "demo.TgtBean",
+        """
+        package demo;
+        public class TgtBean {
+          private String id;
+          private String asTgtBean;
+          public TgtBean() {}
+          public String getId() { return id; }
+          public void setId(final String id) { this.id = id; }
+          public String getAsTgtBean() { return asTgtBean; }
+          public void setAsTgtBean(final String v) { this.asTgtBean = v; }
+        }
+        """
+      )
+    );
+
+    assertFalse(bean.success(), "a property named after the bridge hop must not compile");
+    assertTrue(
+      bean.hasError("collides with the generated navigator's own asTgtBean() method"),
+      () -> "expected the hop collision named at the class; saw " + bean.errorMessages()
+    );
+    assertFalse(
+      bean.hasError("is already defined in class"),
+      () ->
+        "the duplicate-method error inside the generated file must not be what the author sees;" +
+        " saw " +
+        bean.errorMessages()
+    );
+  }
+
+  @Test
+  @DisplayName("a generic POJO is rejected before either artifact is written")
+  void genericPojoEmitsNeitherArtifact() {
+    final var compilation = compile(
+      new BeanFocusProcessor(),
+      source(
+        "demo.BoxBean",
+        """
+        package demo;
+        import io.github.eschizoid.telescope.annotations.BeanFocus;
+        @BeanFocus public class BoxBean<T> {
+          private T value;
+          public BoxBean() {}
+          public T getValue() { return value; }
+          public void setValue(final T value) { this.value = value; }
+        }
+        """
+      )
+    );
+
+    assertFalse(compilation.success(), "a generic @BeanFocus class must not compile");
+    assertTrue(
+      compilation.hasError("cannot emit metadata constant"),
+      () -> "expected the un-emittable-property diagnostic; saw " + compilation.errorMessages()
+    );
+    assertFalse(
+      compilation.hasError("cannot find symbol"),
+      () -> "the navigator referencing the type variable must not be emitted; saw " + compilation.errorMessages()
+    );
+    assertTrue(
+      compilation.generated().isEmpty(),
+      () -> "the holder is rejected and the navigator must go with it; saw " + compilation.generated().keySet()
+    );
+  }
+
+  @Test
   @DisplayName("a generic record is rejected before either artifact is written")
   void genericRecordEmitsNeitherArtifact() {
     final var compilation = compile(

--- a/codegen/src/test/java/io/github/eschizoid/telescope/codegen/GeneratedNameCollisionTest.java
+++ b/codegen/src/test/java/io/github/eschizoid/telescope/codegen/GeneratedNameCollisionTest.java
@@ -1,0 +1,140 @@
+package io.github.eschizoid.telescope.codegen;
+
+import static io.github.eschizoid.telescope.codegen.ProcessorHarness.source;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.github.eschizoid.telescope.codegen.ProcessorHarness.Compilation;
+import java.util.List;
+import javax.annotation.processing.Processor;
+import javax.tools.JavaFileObject;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Three shapes where a name chosen for a generated artifact clashes with something else, and the
+ * clash used to reach the author only as a javac error inside a file they never wrote — or, for the
+ * bridge case, as a Filer failure attributed to a file carrying no annotation at all.
+ *
+ * <p>Each case asserts two things: the targeted diagnostic is present, and the raw downstream error
+ * is not. The second half is what pins the improvement — a processor that reported the cause and
+ * emitted the broken artifact anyway would satisfy the first assertion alone.
+ *
+ * <p>Compilation attributes the generated sources, so an error inside them is observable; under
+ * {@code -proc:only} javac never visits them and the negative assertions would hold vacuously.
+ */
+class GeneratedNameCollisionTest {
+
+  private static Compilation compile(final Processor processor, final JavaFileObject... sources) {
+    return ProcessorHarness.compileFully(List.of(processor), List.of(), sources);
+  }
+
+  @Test
+  @DisplayName("a component named after a navigator method is reported, and no navigator is emitted")
+  void componentCollidingWithNavigatorMethodIsReported() {
+    final var compilation = compile(
+      new FocusProcessor(),
+      source(
+        "demo.F",
+        """
+        package demo;
+        import io.github.eschizoid.telescope.annotations.Focus;
+        @Focus public record F(String get, String of, String explain, String read) {}
+        """
+      )
+    );
+
+    assertFalse(compilation.success(), "a component named after a navigator method must not compile");
+    assertTrue(
+      compilation.hasError("collides with the generated navigator's own"),
+      () -> "expected the collision named at the record; saw " + compilation.errorMessages()
+    );
+    assertFalse(
+      compilation.hasError("is already defined in class"),
+      () ->
+        "the duplicate-method error inside the generated file must not be what the author sees;" +
+        " saw " +
+        compilation.errorMessages()
+    );
+    assertTrue(
+      compilation.generated().isEmpty(),
+      () -> "no artifact should be emitted for a rejected record; saw " + compilation.generated().keySet()
+    );
+    // `read` takes a source argument on the navigator, so it overloads rather than clashing and is
+    // absent from the reserved set.
+    assertFalse(compilation.errorMessages().contains("'read'"), compilation::errorMessages);
+  }
+
+  @Test
+  @DisplayName("a generic record is rejected before either artifact is written")
+  void genericRecordEmitsNeitherArtifact() {
+    final var compilation = compile(
+      new FocusProcessor(),
+      source(
+        "demo.Box",
+        """
+        package demo;
+        import io.github.eschizoid.telescope.annotations.Focus;
+        @Focus public record Box<T>(T item, String tag) {}
+        """
+      )
+    );
+
+    assertFalse(compilation.success(), "a generic @Focus record must not compile");
+    assertTrue(
+      compilation.hasError("cannot emit metadata constant"),
+      () -> "expected the un-emittable-component diagnostic; saw " + compilation.errorMessages()
+    );
+    assertFalse(
+      compilation.hasError("cannot find symbol"),
+      () -> "the navigator referencing the type variable must not be emitted; saw " + compilation.errorMessages()
+    );
+    assertTrue(
+      compilation.generated().isEmpty(),
+      () -> "the holder is rejected and the navigator must go with it; saw " + compilation.generated().keySet()
+    );
+  }
+
+  @Test
+  @DisplayName("two pairs whose auto-derived bridge names collide are named at the declaration")
+  void collidingAutoBridgeNamesAreReported() {
+    // a.MoneyA -> b.MoneyB and a.MoneyA -> c.MoneyB both derive MoneyAToMoneyBBridge in package a,
+    // because the name is built from the simple names alone.
+    final var compilation = compile(
+      new BridgeProcessor(),
+      source("a.MoneyA", "package a; public record MoneyA(long cents) {}"),
+      source("b.MoneyB", "package b; public record MoneyB(long cents) {}"),
+      source("c.MoneyB", "package c; public record MoneyB(long cents) {}"),
+      source(
+        "a.Src1",
+        """
+        package a;
+        import io.github.eschizoid.telescope.annotations.Bridge;
+        @Bridge(a.Dst1.class) public record Src1(a.MoneyA amount) {}
+        """
+      ),
+      source("a.Dst1", "package a; public record Dst1(b.MoneyB amount) {}"),
+      source(
+        "a.Src2",
+        """
+        package a;
+        import io.github.eschizoid.telescope.annotations.Bridge;
+        @Bridge(a.Dst2.class) public record Src2(a.MoneyA amount) {}
+        """
+      ),
+      source("a.Dst2", "package a; public record Dst2(c.MoneyB amount) {}")
+    );
+
+    assertFalse(compilation.success(), "colliding auto-bridge names must not compile");
+    assertTrue(
+      compilation.hasError("claimed by two different type pairs") &&
+        compilation.hasError("b.MoneyB") &&
+        compilation.hasError("c.MoneyB"),
+      () -> "expected both colliding pairs named in the diagnostic; saw " + compilation.errorMessages()
+    );
+    assertFalse(
+      compilation.hasError("Attempt to recreate a file"),
+      () -> "the Filer failure must not be what the author sees; saw " + compilation.errorMessages()
+    );
+  }
+}

--- a/codegen/src/test/java/io/github/eschizoid/telescope/codegen/GeneratedNameCollisionTest.java
+++ b/codegen/src/test/java/io/github/eschizoid/telescope/codegen/GeneratedNameCollisionTest.java
@@ -289,6 +289,86 @@ class GeneratedNameCollisionTest {
   }
 
   @Test
+  @DisplayName("a carrier-declared sub-pair held back for Lombok is still referenced by the carrier's name")
+  void deferredCarrierSubPairIsReferencedByTheCarrierBridge() {
+    // A pair whose types carry a Lombok trigger is held back until the final round, while the
+    // parent's reference is written when the parent is planned. The trigger is matched by
+    // annotation name, so a stub lombok.Data drives the real deferral without Lombok on the
+    // classpath — and the POJOs carry explicit accessors, so nothing here reads a synthesised
+    // member, which is the part an in-memory compilation genuinely cannot reproduce.
+    final var compilation = compile(
+      new BridgeProcessor(),
+      source(
+        "lombok.Data",
+        """
+        package lombok;
+        import java.lang.annotation.ElementType;
+        import java.lang.annotation.Retention;
+        import java.lang.annotation.RetentionPolicy;
+        import java.lang.annotation.Target;
+        @Retention(RetentionPolicy.SOURCE)
+        @Target(ElementType.TYPE)
+        public @interface Data {}
+        """
+      ),
+      source(
+        "q.Item",
+        """
+        package q;
+        @lombok.Data
+        public class Item {
+          private String id;
+          public Item() {}
+          public String getId() { return id; }
+          public void setId(final String v) { this.id = v; }
+        }
+        """
+      ),
+      source(
+        "q.ItemDto",
+        """
+        package q;
+        @lombok.Data
+        public class ItemDto {
+          private String id;
+          public ItemDto() {}
+          public String getId() { return id; }
+          public void setId(final String v) { this.id = v; }
+        }
+        """
+      ),
+      source(
+        "carrier.ItemCarrier",
+        """
+        package carrier;
+        import io.github.eschizoid.telescope.annotations.Bridge;
+        @Bridge(source = q.Item.class, target = q.ItemDto.class)
+        public final class ItemCarrier {}
+        """
+      ),
+      source(
+        "p.Root",
+        """
+        package p;
+        import io.github.eschizoid.telescope.annotations.Bridge;
+        @Bridge(p.RootDto.class) public record Root(q.Item item) {}
+        """
+      ),
+      source("p.RootDto", "package p; public record RootDto(q.ItemDto item) {}")
+    );
+
+    assertTrue(
+      compilation.success(),
+      () -> "a deferred carrier's pair must still resolve; saw " + compilation.errorMessages()
+    );
+    final var bridge = compilation.generated().get("p.RootBridge");
+    assertTrue(
+      bridge != null && bridge.contains("carrier.ItemCarrierBridge"),
+      () -> "the parent must call the carrier's bridge, not a source-anchored name; saw " + bridge
+    );
+  }
+
+  @Test
   @DisplayName("two pairs whose auto-derived bridge names collide are named at the declaration")
   void collidingAutoBridgeNamesAreReported() {
     // a.MoneyA -> b.MoneyB and a.MoneyA -> c.MoneyB both derive MoneyAToMoneyBBridge in package a,

--- a/codegen/src/test/java/io/github/eschizoid/telescope/codegen/GeneratedNameCollisionTest.java
+++ b/codegen/src/test/java/io/github/eschizoid/telescope/codegen/GeneratedNameCollisionTest.java
@@ -248,6 +248,47 @@ class GeneratedNameCollisionTest {
   }
 
   @Test
+  @DisplayName("a carrier-declared sub-bridge is referenced by its carrier's package and name")
+  void carrierDeclaredSubBridgeIsReferencedByItsCarrier() {
+    // A carrier-form pair is emitted as <Carrier>Bridge in the carrier's package, so a parent
+    // reaching it by recursion must name both halves from the carrier rather than from the pair's
+    // source — which is neither the class's package nor its name.
+    final var compilation = compile(
+      new BridgeProcessor(),
+      source("q.Item", "package q; public record Item(String sku) {}"),
+      source("q.ItemDto", "package q; public record ItemDto(String sku) {}"),
+      source(
+        "carrier.ItemCarrier",
+        """
+        package carrier;
+        import io.github.eschizoid.telescope.annotations.Bridge;
+        @Bridge(source = q.Item.class, target = q.ItemDto.class)
+        public final class ItemCarrier {}
+        """
+      ),
+      source(
+        "p.Root",
+        """
+        package p;
+        import io.github.eschizoid.telescope.annotations.Bridge;
+        @Bridge(p.RootDto.class) public record Root(q.Item item) {}
+        """
+      ),
+      source("p.RootDto", "package p; public record RootDto(q.ItemDto item) {}")
+    );
+
+    assertTrue(
+      compilation.success(),
+      () -> "the carrier's bridge must be referenced where it is emitted; saw " + compilation.errorMessages()
+    );
+    final var bridge = compilation.generated().get("p.RootBridge");
+    assertTrue(
+      bridge != null && bridge.contains("carrier.ItemCarrierBridge"),
+      () -> "expected the carrier's package and name in the reference; saw " + bridge
+    );
+  }
+
+  @Test
   @DisplayName("two pairs whose auto-derived bridge names collide are named at the declaration")
   void collidingAutoBridgeNamesAreReported() {
     // a.MoneyA -> b.MoneyB and a.MoneyA -> c.MoneyB both derive MoneyAToMoneyBBridge in package a,


### PR DESCRIPTION
Closes #343. Found by the codegen audit's front-end fuzz (#351).

Four shapes where a name chosen for a generated artifact was wrong, and the mistake reached the author only as a javac error **inside a file they never wrote** — or, for the auto-bridge case, as a Filer failure attributed to a file carrying no annotation at all.

## Names that collide

**Reserved navigator names.** `@Focus record F(String get, String of, String explain, String read)` emitted `get()`, `of()` and `explain()` twice — once as the component method, once as the navigator's own — so the generated file didn't compile. The reserved set is exactly the zero-argument methods; a component matching a forwarder that takes arguments overloads cleanly, which is why `read` was always fine and stays fine. Both navigator emitters check before writing, so `@Focus` records and `@BeanFocus`/Lombok beans behave identically.

**Generic record, half-rejected.** `@Focus record Box<T>(T item, String tag)` was correctly rejected for its `FieldOptics` holder — and had its navigator written anyway, referencing `T` in a class declaring only `<R>`: `cannot find symbol: class T`. The comment beside that guard claimed "The Path navigator is unaffected — it has its own type handling." It does not. Both artifacts are now rejected together, before either is written.

**Package-blind auto-bridge names.** Auto-derived names are `<Source>To<Target>Bridge` from the *simple* names, so `a.MoneyA → b.MoneyB` and `a.MoneyA → c.MoneyB` both flatten to `a.MoneyAToMoneyBBridge`. The second write failed as `Attempt to recreate a file`, reported against `a/MoneyA.java` — a record with no annotation on it and no way to tell which two pairs were involved. The processor now holds which pair claimed each generated FQN and reports the clash against the second pair's source, naming both pairs and both targets.

## Names that resolve to the wrong class

The fourth is the inverse: nothing collides, and the parent bridge names a sub-bridge that exists under a different name or in a different package. A parent referenced its sub-bridges by simple name, adding an import when the sub-bridge landed elsewhere — which covers one such sub-bridge and cannot express two.

`demo.Root(a.User, b.User) → demo.RootDto(a.UserDto, b.UserDto)` derives `UserToUserDtoBridge` in both `a` and `b`. The FQNs differ, so this is not a clash the emitter can refuse; the parent has to name both, and one import cannot serve them. Separately, a sub-pair whose bridge is declared on a carrier is emitted as `<Carrier>Bridge` in the **carrier's** package, which the source-anchored name never matches. The reference is now built from the pair's own config and qualified when the package differs, and the import path — dead once every cross-package reference carries its own qualifier — is gone.

The Lombok case rides on that: a pair whose types carry a Lombok trigger is deferred to the final round, so its config sits in the deferred map while the parent's reference is written at planning time. Reading only the eager map fell back silently to the source-anchored name.

## Verification

Each collision test asserts **two** things: the targeted diagnostic is present, and the raw downstream error is absent. The second half is what pins the improvement — a processor that reported the cause and emitted the broken artifact anyway would satisfy the first assertion alone. Two of the three also assert `generated()` is empty.

The tests compile through the **full pipeline** (`compileFully`), so errors inside generated sources are observable; under `-proc:only` javac never attributes them and every negative assertion would hold vacuously.

The Lombok fixture needs no Lombok: deferral is decided by annotation **name**, so a stub `lombok.Data` drives the real branch, and the fixtures declare their accessors explicitly. What an in-memory compilation cannot reproduce is member *synthesis*, which nothing here reads.

Revert-proven hunk by hunk, each probe leaving the other tests green:

| hunk removed | tests that fail |
| --- | --- |
| the three collision guards | the 3 collision tests |
| the package qualifier on a sub-bridge reference | 3 — the shared simple name, and both carrier cases |
| carrier-derived naming | 2 — both carrier cases |
| the deferred-map fallback | 1 — the deferred carrier |

`:codegen` 208, `:core` 756 and `:lombok` 30 green with everything restored.
