### PR TITLE
fix: null-gate the sealed umbrella bridge's forward and backward

### DIFF
--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
@@ -2062,10 +2062,17 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
         out.println("      .exhaustive();");
         out.println();
         out.println("  public static " + targetFq + " forward(final " + sourceFq + " s) {");
+        // Null in -> null out, the same contract the field-sequence bridges emit. Match
+        // dispatches
+        // on the runtime class, which a null does not have, so without this the umbrella reports
+        // an
+        // unmatched case for a value every other generated bridge passes straight through.
+        out.println("    if (s == null) return null;");
         out.println("    return FORWARD.apply(s);");
         out.println("  }");
         out.println();
         out.println("  public static " + sourceFq + " backward(final " + targetFq + " t) {");
+        out.println("    if (t == null) return null;");
         out.println("    return BACKWARD.apply(t);");
         out.println("  }");
         out.println();

--- a/core/src/test/java/io/github/eschizoid/telescope/bridgexpkg/sealednull/Circle.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/bridgexpkg/sealednull/Circle.java
@@ -1,0 +1,6 @@
+package io.github.eschizoid.telescope.bridgexpkg.sealednull;
+
+import io.github.eschizoid.telescope.annotations.Bridge;
+
+@Bridge(CircleDto.class)
+public record Circle(double radius) implements Shape {}

--- a/core/src/test/java/io/github/eschizoid/telescope/bridgexpkg/sealednull/CircleDto.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/bridgexpkg/sealednull/CircleDto.java
@@ -1,0 +1,3 @@
+package io.github.eschizoid.telescope.bridgexpkg.sealednull;
+
+public record CircleDto(double radius) implements ShapeDto {}

--- a/core/src/test/java/io/github/eschizoid/telescope/bridgexpkg/sealednull/Label.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/bridgexpkg/sealednull/Label.java
@@ -1,0 +1,7 @@
+package io.github.eschizoid.telescope.bridgexpkg.sealednull;
+
+import io.github.eschizoid.telescope.annotations.Bridge;
+
+/** The non-sealed control: a plain bridged record sitting in the same parent as {@link Shape}. */
+@Bridge(LabelDto.class)
+public record Label(String text) {}

--- a/core/src/test/java/io/github/eschizoid/telescope/bridgexpkg/sealednull/LabelDto.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/bridgexpkg/sealednull/LabelDto.java
@@ -1,0 +1,3 @@
+package io.github.eschizoid.telescope.bridgexpkg.sealednull;
+
+public record LabelDto(String text) {}

--- a/core/src/test/java/io/github/eschizoid/telescope/bridgexpkg/sealednull/SealedNullGuardTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/bridgexpkg/sealednull/SealedNullGuardTest.java
@@ -1,0 +1,44 @@
+package io.github.eschizoid.telescope.bridgexpkg.sealednull;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * A generated bridge's {@code forward}/{@code backward} are null-in/null-out. That contract is what
+ * lets a caller hand over a slot it has not inspected, and it is what the generated container
+ * helpers rely on when an element is null. A sealed umbrella reaches the same two methods through
+ * {@code Match} dispatch rather than a field sequence, so it arrives at that contract by its own
+ * emission path and has to arrive at the same place.
+ *
+ * <p>{@link Label} is the non-sealed control on every assertion below: an auto-derived bridge of
+ * the plainest possible shape, called identically. Without it a change that removed null handling
+ * from every generated bridge at once would still satisfy the sealed half.
+ */
+class SealedNullGuardTest {
+
+  @Test
+  @DisplayName("a sealed umbrella answers null for null on forward, as a non-sealed bridge does")
+  void sealedForwardIsNullInNullOut() {
+    assertNull(LabelBridge.forward(null), "the non-sealed control must be null-in/null-out");
+    assertNull(ShapeBridge.forward(null), "sealed forward must not dispatch on a null source");
+  }
+
+  @Test
+  @DisplayName("a sealed umbrella answers null for null on backward, as a non-sealed bridge does")
+  void sealedBackwardIsNullInNullOut() {
+    assertNull(LabelBridge.backward(null), "the non-sealed control must be null-in/null-out");
+    assertNull(ShapeBridge.backward(null), "sealed backward must not dispatch on a null target");
+  }
+
+  @Test
+  @DisplayName("a present value still dispatches to the permit's own bridge, in both directions")
+  void presentValueStillDispatchesPerPermit() {
+    assertEquals(new CircleDto(2.0), ShapeBridge.forward(new Circle(2.0)));
+    assertEquals(new SquareDto(3.0), ShapeBridge.forward(new Square(3.0)));
+    assertEquals(new Circle(2.0), ShapeBridge.backward(new CircleDto(2.0)));
+    assertEquals(new Square(3.0), ShapeBridge.backward(new SquareDto(3.0)));
+  }
+}

--- a/core/src/test/java/io/github/eschizoid/telescope/bridgexpkg/sealednull/Shape.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/bridgexpkg/sealednull/Shape.java
@@ -1,0 +1,7 @@
+package io.github.eschizoid.telescope.bridgexpkg.sealednull;
+
+import io.github.eschizoid.telescope.annotations.Bridge;
+
+/** Sealed source root whose umbrella bridge dispatches per permit through {@code Match}. */
+@Bridge(ShapeDto.class)
+public sealed interface Shape permits Circle, Square {}

--- a/core/src/test/java/io/github/eschizoid/telescope/bridgexpkg/sealednull/ShapeDto.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/bridgexpkg/sealednull/ShapeDto.java
@@ -1,0 +1,4 @@
+package io.github.eschizoid.telescope.bridgexpkg.sealednull;
+
+/** Sealed target root; each permit pairs with one permit of {@link Shape}. */
+public sealed interface ShapeDto permits CircleDto, SquareDto {}

--- a/core/src/test/java/io/github/eschizoid/telescope/bridgexpkg/sealednull/Square.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/bridgexpkg/sealednull/Square.java
@@ -1,0 +1,6 @@
+package io.github.eschizoid.telescope.bridgexpkg.sealednull;
+
+import io.github.eschizoid.telescope.annotations.Bridge;
+
+@Bridge(SquareDto.class)
+public record Square(double side) implements Shape {}

--- a/core/src/test/java/io/github/eschizoid/telescope/bridgexpkg/sealednull/SquareDto.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/bridgexpkg/sealednull/SquareDto.java
@@ -1,0 +1,3 @@
+package io.github.eschizoid.telescope.bridgexpkg.sealednull;
+
+public record SquareDto(double side) implements ShapeDto {}


### PR DESCRIPTION
Closes #355.

Every generated bridge's `forward`/`backward` is null-in/null-out. That contract is what lets a caller hand over a slot it has not inspected, and it is what the generated container helpers rely on when an element is null. A sealed umbrella reaches those same two methods through `Match` dispatch rather than a field sequence, and opened with the dispatch directly — `return FORWARD.apply(s);` with no guard.

`Match` resolves on the runtime class, which a null does not have, so the umbrella refuses the value instead of passing it through. The fix is the guard the field-sequence bridges already emit, on both directions.

## Two corrections to the issue

**It is not an NPE.** `Match` null-checks before dispatching and throws `IllegalStateException: Match: no handler matched runtime class null for sealed root Shape`. The contract break is real — it throws where every other generated bridge returns null — but the mechanism is a reported unmatched case, not a dereference. Worth knowing for anyone searching logs for this.

**The RECURSE framing does not hold.** The issue describes the umbrella "reached as a RECURSE sub-bridge from a parent bridge". A parent cannot auto-derive a sub-bridge for a sealed pair at all — it rejects the field outright:

```
@Bridge Drawing -> DrawingDto: field 'shape' has incompatible types (Shape vs ShapeDto)
and no auto-bridge could be derived.
```

Reaching a sealed bridge from a parent means naming it through `@ViaMapper`, and that call site has been null-gated since #341. So the live exposure is the umbrella's own two methods — direct calls, and anything holding `BRIDGE_FN`/`BRIDGE`, both of which delegate to the statics and inherit the fix.

I also checked the third method: the sealed `patch` already opens `if (base == null || partial == null) return base;`, so the gap really was these two alone.

## Verification

The three tests fail against the unfixed emitter and pass with it — I ran them in that order rather than after the fact:

| test | before | after |
| --- | --- | --- |
| sealed forward is null-in/null-out | FAILED (`IllegalStateException`) | PASSED |
| sealed backward is null-in/null-out | FAILED (`IllegalStateException`) | PASSED |
| a present value still dispatches per permit | PASSED | PASSED |

The third row is the control that stays green on both sides — it is what separates "the guard was added" from "dispatch was broken".

`Label` is a second control, on a different axis: an auto-derived non-sealed bridge asserted on the **same line** as the sealed one in both null tests. Without it, a change that removed null handling from every generated bridge at once would still leave the sealed assertions looking meaningful.

Suites: `:codegen` 208, `:core` 759 (+3), `:lombok` 30, all green.

## Note on the fixtures

They live in `:core`'s test tree rather than the in-memory harness because the contract is an execution property, and `-proc:only` never runs the generated code. The first draft tried to reach the sealed bridge from a parent via `@ViaMapper(using = ShapeBridge.class)`; that does not compile in the same module, since the annotation value is resolved before the bridge it names is generated — the same round-ordering constraint that keeps Lombok-emitted navigators out of same-module main code.
