### PR TITLE
fix: rebuild an interface-typed Map field insertion-ordered, as Set is

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,8 +410,8 @@ performance class:
 | --------------------------- | ------------------------------------------------------------------- |
 | flat (5 scalars)            | ~1.07× — a fifth of a nanosecond                                    |
 | nested (one nested type)    | 1.04×–1.46× across runs — a microbenchmark, not a service shape     |
-| deep (3 levels + list hops) | 1.07×–1.19× across runs — 4 ns on a 62 ns conversion at the low end |
-| Set or Map field, 100 items | a tie on time, and ~11% less allocated on the Map shape             |
+| deep (3 levels + list hops) | 1.06×–1.19× across runs — 4 ns on a 62 ns conversion at the low end |
+| Set or Map field, 100 items | a tie on time, and the same allocation                              |
 
 No codegen? `Telescope.mapper(...)` composes each record/bean pair into a single MethodHandle: zero annotations, no
 build step, within ~1.04–3.3× of MapStruct in the same workloads (flat ~3.3×, nested ~2.7×, deep ~1.3×, container fields

--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
@@ -2428,11 +2428,12 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
   // FQN of the concrete, instantiable class to allocate for a container field of the given declared
   // type — the declared subtype itself when it is an instantiable class (ArrayList, TreeSet,
   // TreeMap, …), else the default impl for the interface family. The interface-family defaults
-  // match
-  // the runtime DeepMap allocators for the bare interface raws: List → ArrayList
-  // (listAllocatorFor),
-  // Set → LinkedHashSet (setAllocatorFor), Map → HashMap (mapAllocatorFor), so codegen and the
-  // reflective path produce the same runtime class for an interface-typed field.
+  // match the runtime DeepMap allocators for the bare interface raws: List → ArrayList
+  // (listAllocatorFor), Set → LinkedHashSet (setAllocatorFor), Map → LinkedHashMap
+  // (mapAllocatorFor), so codegen and the reflective path produce the same runtime class for an
+  // interface-typed field. The two hash families default to their insertion-ordered form because a
+  // conversion that is not asked to reorder should not: an ordered source behind an interface-typed
+  // field keeps its order across the rebuild.
   private static String concreteImplFqn(final TypeMirror container, final FieldPlan.Kind kind) {
     final var el = (TypeElement) ((DeclaredType) container).asElement();
     if (el.getKind() == ElementKind.CLASS && !el.getModifiers().contains(Modifier.ABSTRACT)) {
@@ -2441,7 +2442,7 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
     return switch (kind) {
       case LIST -> "java.util.ArrayList";
       case SET -> "java.util.LinkedHashSet";
-      case MAP_VALUES -> "java.util.HashMap";
+      case MAP_VALUES -> "java.util.LinkedHashMap";
       default -> throw new IllegalStateException("not a collection/map kind: " + kind);
     };
   }

--- a/codegen/src/test/java/io/github/eschizoid/telescope/codegen/BridgeProcessorTest.java
+++ b/codegen/src/test/java/io/github/eschizoid/telescope/codegen/BridgeProcessorTest.java
@@ -742,7 +742,7 @@ class BridgeProcessorTest {
       // forward allocates the concrete subtype; backward allocates the Map interface's two-arg
       // default.
       assertTrue(bridge.contains("new demo.MMixWrap()"), bridge);
-      assertTrue(bridge.contains("new java.util.HashMap<java.lang.String, demo.MMixSrc>()"), bridge);
+      assertTrue(bridge.contains("new java.util.LinkedHashMap<java.lang.String, demo.MMixSrc>()"), bridge);
     }
 
     @Test
@@ -944,9 +944,10 @@ class BridgeProcessorTest {
       assertTrue(compilation.success(), () -> "compilation failed: " + compilation.errorMessages());
       final var bridge = compilation.generated().get("demo.IMOrderBridge");
       assertNotNull(bridge);
-      // Forward into the target TreeMap; backward into the source's default HashMap.
+      // Forward into the target TreeMap; backward into the Map interface's insertion-ordered
+      // default.
       assertTrue(bridge.contains("new TreeMap<>("), bridge);
-      assertTrue(bridge.contains("new HashMap<>("), bridge);
+      assertTrue(bridge.contains("new LinkedHashMap<>("), bridge);
     }
 
     @Test
@@ -1112,10 +1113,10 @@ class BridgeProcessorTest {
       assertTrue(cart.contains("__fwd_items(__fs_items)"), cart);
       assertTrue(cart.contains("final java.util.Map<java.lang.String,demo.LineItemDto> __bt_items = t.items();"), cart);
       assertTrue(cart.contains("__bwd_items(__bt_items)"), cart);
-      assertTrue(cart.contains("import java.util.HashMap;"), cart);
+      assertTrue(cart.contains("import java.util.LinkedHashMap;"), cart);
       assertTrue(cart.contains("import java.util.Map;"), cart);
-      assertTrue(cart.contains("HashMap.<java.lang.String, demo.LineItemDto>newHashMap(src.size())"), cart);
-      assertFalse(cart.contains("new HashMap<java.lang.String, demo.LineItemDto>(src.size())"), cart);
+      assertTrue(cart.contains("LinkedHashMap.<java.lang.String, demo.LineItemDto>newLinkedHashMap(src.size())"), cart);
+      assertFalse(cart.contains("new LinkedHashMap<java.lang.String, demo.LineItemDto>(src.size())"), cart);
       assertTrue(cart.contains("LineItemToLineItemDtoBridge.forward(e.getValue())"), cart);
       assertTrue(cart.contains("LineItemToLineItemDtoBridge.backward(e.getValue())"), cart);
     }

--- a/core/src/main/java/io/github/eschizoid/telescope/ContainerLifts.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/ContainerLifts.java
@@ -290,16 +290,22 @@ final class ContainerLifts {
   }
 
   /**
-   * Map-side allocator. {@code IdentityHashMap} and {@code WeakHashMap} are accepted but carry
-   * different semantics from a plain {@code HashMap} ({@code IdentityHashMap} uses reference
-   * equality for keys, {@code WeakHashMap} GCs keys without strong references) — adopters needing
-   * preservation declare an explicit {@code Mapping.via(...)} row. {@code EnumMap} is rejected at
-   * plan-time because its no-arg constructor doesn't exist (it needs the {@code Class<K>} arg);
-   * adopters must use the codegen path or an explicit row.
+   * Map-side allocator. A bare {@code Map} rebuilds as a {@code LinkedHashMap}, so an ordered
+   * source behind an interface-typed field keeps its iteration order across the conversion, and the
+   * Map side matches the Set side, which has always rebuilt as a {@code LinkedHashSet}. A field
+   * declared as {@code HashMap} asked for that class specifically and still gets it.
+   *
+   * <p>{@code IdentityHashMap} and {@code WeakHashMap} are accepted but carry different semantics
+   * from a plain {@code HashMap} ({@code IdentityHashMap} uses reference equality for keys, {@code
+   * WeakHashMap} GCs keys without strong references) — adopters needing preservation declare an
+   * explicit {@code Mapping.via(...)} row. {@code EnumMap} is rejected at plan-time because its
+   * no-arg constructor doesn't exist (it needs the {@code Class<K>} arg); adopters must use the
+   * codegen path or an explicit row.
    */
   private static Function<Object, Object> mapAllocatorFor(final Class<?> raw) {
-    if (raw == Map.class || raw == HashMap.class) return input -> HashMap.newHashMap(((Map<?, ?>) input).size());
-    if (raw == LinkedHashMap.class) return input -> LinkedHashMap.newLinkedHashMap(((Map<?, ?>) input).size());
+    if (raw == HashMap.class) return input -> HashMap.newHashMap(((Map<?, ?>) input).size());
+    if (raw == Map.class || raw == LinkedHashMap.class) return input ->
+      LinkedHashMap.newLinkedHashMap(((Map<?, ?>) input).size());
     if (raw == TreeMap.class) return input -> new TreeMap<>(mapComparator(input));
     if (raw == ConcurrentHashMap.class) return input -> new ConcurrentHashMap<>(((Map<?, ?>) input).size());
     if (raw == ConcurrentSkipListMap.class) return input -> new ConcurrentSkipListMap<>(mapComparator(input));

--- a/core/src/test/java/io/github/eschizoid/telescope/beans/BridgeCodegenTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/beans/BridgeCodegenTest.java
@@ -8,7 +8,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 
 import io.github.eschizoid.telescope.Telescope;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.LinkedList;
@@ -120,7 +119,8 @@ class BridgeCodegenTest {
 
   @Test
   @DisplayName(
-    "primitive ↔ wrapper backward with a null wrapper null-defaults to the primitive's JLS default (parity with runtime primitiveWrapperIso)"
+    "primitive ↔ wrapper backward with a null wrapper null-defaults to the primitive's JLS" +
+      " default (parity with runtime primitiveWrapperIso)"
   )
   void primitiveWrapperBackwardNullUnboxDefaults() {
     // A null wrapper on the backward (unbox) direction must coalesce to the primitive's JLS default
@@ -135,7 +135,8 @@ class BridgeCodegenTest {
 
   @Test
   @DisplayName(
-    "primitive ↔ wrapper forward with a null wrapper source null-defaults the primitive target (the other direction's wiring)"
+    "primitive ↔ wrapper forward with a null wrapper source null-defaults the primitive target" +
+      " (the other direction's wiring)"
   )
   void primitiveWrapperForwardNullDefaults() {
     // Reverse orientation: wrapper source, primitive target — so the FORWARD (read) direction
@@ -151,7 +152,8 @@ class BridgeCodegenTest {
 
   @Test
   @DisplayName(
-    "Optional bridge: a null Optional reference passes through as null instead of NPE (parity with Iso.liftOptional)"
+    "Optional bridge: a null Optional reference passes through as null instead of NPE (parity" +
+      " with Iso.liftOptional)"
   )
   void optionalNullReferencePassesThrough() {
     // A null Optional field reference (not Optional.empty()) must not NPE on the generated
@@ -178,7 +180,7 @@ class BridgeCodegenTest {
 
   @Test
   @DisplayName(
-    "nullable→Optional bridge: a null Optional target reference passes through backward as null instead of NPE"
+    "nullable→Optional bridge: a null Optional target reference passes through backward as null" + " instead of NPE"
   )
   void nullableToOptionalBackwardNullGuard() {
     // NtoOSrc.maybe is a plain (nullable) OptElem; NtoODst.maybe is Optional<OptElemBO>. The
@@ -195,7 +197,7 @@ class BridgeCodegenTest {
 
   @Test
   @DisplayName(
-    "container bridge: a null element passes through as null instead of NPE (parity with the runtime element Iso)"
+    "container bridge: a null element passes through as null instead of NPE (parity with the" + " runtime element Iso)"
   )
   void containerNullElementPassesThrough() {
     // A null element inside a bridged List must map to null, not NPE on subBridge.forward(null).
@@ -216,7 +218,9 @@ class BridgeCodegenTest {
 
   @Test
   @DisplayName(
-    "concrete container subtype: a LinkedList<Y> target field is bridged element-wise and rebuilt as a LinkedList, not the default ArrayList (parity with the runtime container allocation table)"
+    "concrete container subtype: a LinkedList<Y> target field is bridged element-wise and rebuilt" +
+      " as a LinkedList, not the default ArrayList (parity with the runtime container" +
+      " allocation table)"
   )
   void concreteListSubtypeRebuildsAsTargetClass() {
     final var src = new ConcreteListSrc(Arrays.asList(new OptElem("a"), new OptElem("b")));
@@ -230,7 +234,8 @@ class BridgeCodegenTest {
 
   @Test
   @DisplayName(
-    "concrete container subtype with identity elements: a List<String> ↔ LinkedList<String> copies inline into the target's concrete class"
+    "concrete container subtype with identity elements: a List<String> ↔ LinkedList<String>" +
+      " copies inline into the target's concrete class"
   )
   void concreteListSubtypeIdentityElementCopiesIntoTargetClass() {
     final var src = new IdListSrc(Arrays.asList("x", "y"));
@@ -241,7 +246,7 @@ class BridgeCodegenTest {
 
   @Test
   @DisplayName(
-    "concrete Set subtype: a TreeSet<String> target is rebuilt as a TreeSet via the no-presize copy constructor"
+    "concrete Set subtype: a TreeSet<String> target is rebuilt as a TreeSet via the no-presize" + " copy constructor"
   )
   void concreteSetSubtypeRebuildsAsTreeSet() {
     // Seed an insertion-ordered (unsorted) source so the [a, b, c] result proves the TreeSet's sort
@@ -254,7 +259,7 @@ class BridgeCodegenTest {
 
   @Test
   @DisplayName(
-    "concrete Map subtype: a TreeMap<String, Y> target bridges values element-wise and is rebuilt as a TreeMap"
+    "concrete Map subtype: a TreeMap<String, Y> target bridges values element-wise and is rebuilt" + " as a TreeMap"
   )
   void concreteMapSubtypeRebuildsAsTreeMap() {
     final Map<String, OptElem> in = new LinkedHashMap<>();
@@ -268,7 +273,8 @@ class BridgeCodegenTest {
 
   @Test
   @DisplayName(
-    "backward concrete container: a LinkedList<String> source field is rebuilt as a LinkedList on the backward pass"
+    "backward concrete container: a LinkedList<String> source field is rebuilt as a LinkedList on" +
+      " the backward pass"
   )
   void backwardConcreteContainerRebuildsAsSourceClass() {
     final var src = new BwdConcreteSrc(new LinkedList<>(Arrays.asList("x", "y")));
@@ -280,7 +286,8 @@ class BridgeCodegenTest {
 
   @Test
   @DisplayName(
-    "raw collection-subtype field (class Wrap extends ArrayList<Elem>) element-bridges end-to-end into a fresh target wrapper"
+    "raw collection-subtype field (class Wrap extends ArrayList<Elem>) element-bridges end-to-end" +
+      " into a fresh target wrapper"
   )
   void rawCollectionSubtypeBridgesEndToEnd() {
     // The adopter's shape: a custom ArrayList wrapper whose distinct element record needs bridging.
@@ -304,7 +311,8 @@ class BridgeCodegenTest {
 
   @Test
   @DisplayName(
-    "raw collection-subtype field on a BEAN parent (setter rebuild) element-bridges end-to-end — the adopter's @Data shape"
+    "raw collection-subtype field on a BEAN parent (setter rebuild) element-bridges end-to-end —" +
+      " the adopter's @Data shape"
   )
   void rawCollectionSubtypeOnBeanParentBridgesEndToEnd() {
     // The adopter's parent was a @Data bean, not a record: the rebuild routes the raw helper's
@@ -323,7 +331,8 @@ class BridgeCodegenTest {
 
   @Test
   @DisplayName(
-    "raw Map-subtype field (class Wrap extends HashMap<K, Elem>) element-bridges values, preserves keys, end-to-end"
+    "raw Map-subtype field (class Wrap extends HashMap<K, Elem>) element-bridges values," +
+      " preserves keys, end-to-end"
   )
   void rawMapSubtypeBridgesEndToEnd() {
     // Distinct emit path from the List case: entrySet/put + a two-type-arg allocation. Proves the
@@ -359,7 +368,8 @@ class BridgeCodegenTest {
 
   @Test
   @DisplayName(
-    "bare Map<K,V> default: codegen and the runtime reflective mapper allocate the SAME concrete class (HashMap) — cross-strategy parity on the interface-family default"
+    "bare Map<K,V> default: codegen and the runtime reflective mapper allocate the SAME concrete" +
+      " class (LinkedHashMap) — cross-strategy parity on the interface-family default"
   )
   void bareMapDefaultMatchesRuntimeConcreteClass() {
     final Map<String, OptElem> in = new LinkedHashMap<>();
@@ -369,9 +379,12 @@ class BridgeCodegenTest {
     final var viaCodegen = BareMapSrcBridge.BRIDGE.read(new BareMapSrc(in));
     final var viaRuntime = Telescope.mapper(BareMapSrc.class, BareMapDst.class).forward(new BareMapSrc(in));
 
-    // Both must land on the runtime allocator's bare-Map default (HashMap), or an adopter switching
-    // strategies gets a different runtime class for the same field — the seam this audit closes.
-    assertEquals(HashMap.class, viaCodegen.byKey().getClass(), "codegen allocates the runtime default impl");
+    // Both must land on the runtime allocator's bare-Map default, or an adopter switching
+    // strategies
+    // gets a different runtime class for the same field. The default is the insertion-ordered one,
+    // so
+    // an ordered source behind an interface-typed field survives either path.
+    assertEquals(LinkedHashMap.class, viaCodegen.byKey().getClass(), "codegen allocates the runtime default impl");
     assertEquals(
       viaRuntime.byKey().getClass(),
       viaCodegen.byKey().getClass(),

--- a/core/src/test/java/io/github/eschizoid/telescope/bridgexpkg/maporder/ConcreteMapSource.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/bridgexpkg/maporder/ConcreteMapSource.java
@@ -1,0 +1,13 @@
+package io.github.eschizoid.telescope.bridgexpkg.maporder;
+
+import io.github.eschizoid.telescope.annotations.Bridge;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+
+/**
+ * Fields declared as concrete classes asked for those classes rather than the interface family's
+ * default, so each keeps getting the one it named — the interface-typed sibling in this package is
+ * what moved.
+ */
+@Bridge(ConcreteMapTarget.class)
+public record ConcreteMapSource(HashMap<String, Leaf> hashed, LinkedHashMap<String, Leaf> ordered) {}

--- a/core/src/test/java/io/github/eschizoid/telescope/bridgexpkg/maporder/ConcreteMapTarget.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/bridgexpkg/maporder/ConcreteMapTarget.java
@@ -1,0 +1,6 @@
+package io.github.eschizoid.telescope.bridgexpkg.maporder;
+
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+
+public record ConcreteMapTarget(HashMap<String, LeafDto> hashed, LinkedHashMap<String, LeafDto> ordered) {}

--- a/core/src/test/java/io/github/eschizoid/telescope/bridgexpkg/maporder/Leaf.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/bridgexpkg/maporder/Leaf.java
@@ -1,0 +1,3 @@
+package io.github.eschizoid.telescope.bridgexpkg.maporder;
+
+public record Leaf(String value) {}

--- a/core/src/test/java/io/github/eschizoid/telescope/bridgexpkg/maporder/LeafDto.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/bridgexpkg/maporder/LeafDto.java
@@ -1,0 +1,3 @@
+package io.github.eschizoid.telescope.bridgexpkg.maporder;
+
+public record LeafDto(String value) {}

--- a/core/src/test/java/io/github/eschizoid/telescope/bridgexpkg/maporder/MapIterationOrderTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/bridgexpkg/maporder/MapIterationOrderTest.java
@@ -1,0 +1,106 @@
+package io.github.eschizoid.telescope.bridgexpkg.maporder;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import io.github.eschizoid.telescope.Telescope;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * A conversion that was not asked to reorder should not reorder. An interface-typed {@code Map}
+ * field picks its family default on both the generated and the reflective path, and that default
+ * decides whether an ordered source survives the rebuild.
+ *
+ * <p>The keys below are chosen so their hash order differs from their insertion order, and {@link
+ * #theKeysUsedHereActuallyReorderUnderAHashMap()} asserts that rather than assuming it — with keys
+ * that happened to hash in insertion order, every assertion in this class would hold no matter
+ * which container the rebuild picked.
+ *
+ * <p>The {@code items} Set is the control on each conversion: it has always rebuilt insertion
+ * ordered, so it stays green either way and separates "the Map default changed" from "the container
+ * rebuild stopped preserving anything".
+ */
+class MapIterationOrderTest {
+
+  private static final List<String> KEYS = List.of(
+    "zulu",
+    "yankee",
+    "xray",
+    "whiskey",
+    "victor",
+    "uniform",
+    "tango",
+    "sierra",
+    "romeo",
+    "quebec"
+  );
+
+  private static MapOrderSource source() {
+    final Map<String, Leaf> byKey = new LinkedHashMap<>();
+    final Set<Leaf> items = new LinkedHashSet<>();
+    for (final var key : KEYS) {
+      byKey.put(key, new Leaf(key));
+      items.add(new Leaf(key));
+    }
+    return new MapOrderSource(byKey, items);
+  }
+
+  private static List<String> valuesOf(final Set<LeafDto> items) {
+    return items.stream().map(LeafDto::value).toList();
+  }
+
+  @Test
+  @DisplayName("the keys used here really do reorder under a HashMap, so the assertions can fail")
+  void theKeysUsedHereActuallyReorderUnderAHashMap() {
+    final Map<String, String> hashed = new HashMap<>();
+    for (final var key : KEYS) {
+      hashed.put(key, key);
+    }
+
+    assertNotEquals(
+      KEYS,
+      new ArrayList<>(hashed.keySet()),
+      "these keys hash in insertion order, so this class would pass against either container"
+    );
+  }
+
+  @Test
+  @DisplayName("a generated bridge keeps the iteration order of an interface-typed Map field")
+  void codegenPreservesMapIterationOrder() {
+    final var converted = MapOrderSourceBridge.forward(source());
+
+    assertEquals(KEYS, new ArrayList<>(converted.byKey().keySet()));
+    assertEquals(KEYS, valuesOf(converted.items()));
+  }
+
+  @Test
+  @DisplayName("the reflective mapper keeps it too, so the two paths rebuild the same shape")
+  void runtimePreservesMapIterationOrder() {
+    final var mapper = Telescope.mapper(MapOrderSource.class, MapOrderTarget.class);
+
+    final var converted = mapper.forward(source());
+
+    assertEquals(KEYS, new ArrayList<>(converted.byKey().keySet()));
+    assertEquals(KEYS, valuesOf(converted.items()));
+  }
+
+  @Test
+  @DisplayName("backward keeps it as well, on both paths")
+  void bothPathsPreserveOrderBackward() {
+    final var target = MapOrderSourceBridge.forward(source());
+
+    final var codegen = MapOrderSourceBridge.backward(target);
+    final var runtime = Telescope.mapper(MapOrderSource.class, MapOrderTarget.class).backward(target);
+
+    assertEquals(KEYS, new ArrayList<>(codegen.byKey().keySet()));
+    assertEquals(KEYS, new ArrayList<>(runtime.byKey().keySet()));
+  }
+}

--- a/core/src/test/java/io/github/eschizoid/telescope/bridgexpkg/maporder/MapIterationOrderTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/bridgexpkg/maporder/MapIterationOrderTest.java
@@ -93,6 +93,31 @@ class MapIterationOrderTest {
   }
 
   @Test
+  @DisplayName("a field declared as a concrete map class keeps that class, on both paths")
+  void declaredConcreteMapFieldsKeepTheirDeclaredClass() {
+    final HashMap<String, Leaf> hashed = new HashMap<>();
+    final LinkedHashMap<String, Leaf> ordered = new LinkedHashMap<>();
+    for (final var key : KEYS) {
+      hashed.put(key, new Leaf(key));
+      ordered.put(key, new Leaf(key));
+    }
+    final var source = new ConcreteMapSource(hashed, ordered);
+
+    final var codegen = ConcreteMapSourceBridge.forward(source);
+    final var runtime = Telescope.mapper(ConcreteMapSource.class, ConcreteMapTarget.class).forward(source);
+
+    // A declared class is not the family default, in either direction of the change: the HashMap
+    // field must not pick up the new default, and the LinkedHashMap field must not be read as
+    // having asked for it.
+    assertEquals(HashMap.class, codegen.hashed().getClass());
+    assertEquals(HashMap.class, runtime.hashed().getClass());
+    assertEquals(LinkedHashMap.class, codegen.ordered().getClass());
+    assertEquals(LinkedHashMap.class, runtime.ordered().getClass());
+    assertEquals(KEYS, new ArrayList<>(codegen.ordered().keySet()));
+    assertEquals(new LeafDto("zulu"), codegen.hashed().get("zulu"));
+  }
+
+  @Test
   @DisplayName("backward keeps it as well, on both paths")
   void bothPathsPreserveOrderBackward() {
     final var target = MapOrderSourceBridge.forward(source());

--- a/core/src/test/java/io/github/eschizoid/telescope/bridgexpkg/maporder/MapOrderSource.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/bridgexpkg/maporder/MapOrderSource.java
@@ -1,0 +1,13 @@
+package io.github.eschizoid.telescope.bridgexpkg.maporder;
+
+import io.github.eschizoid.telescope.annotations.Bridge;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Interface-typed container fields, so both sides pick the family default rather than a declared
+ * concrete class. The Set field is the control: it has always rebuilt insertion-ordered, so it
+ * holds whatever the Map field is asserted to hold.
+ */
+@Bridge(MapOrderTarget.class)
+public record MapOrderSource(Map<String, Leaf> byKey, Set<Leaf> items) {}

--- a/core/src/test/java/io/github/eschizoid/telescope/bridgexpkg/maporder/MapOrderTarget.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/bridgexpkg/maporder/MapOrderTarget.java
@@ -1,0 +1,6 @@
+package io.github.eschizoid.telescope.bridgexpkg.maporder;
+
+import java.util.Map;
+import java.util.Set;
+
+public record MapOrderTarget(Map<String, LeafDto> byKey, Set<LeafDto> items) {}

--- a/docs/perf-mapstruct-comparison.md
+++ b/docs/perf-mapstruct-comparison.md
@@ -5,17 +5,17 @@ and propose remediations where the gap is structural.
 
 ## Headline finding
 
-**Telescope codegen is in MapStruct's performance class, and on a hash container it allocates less.** Separate runs land
-on runners of different speeds, so a ratio built from two of them is not a measurement — hence the two columns below,
-read as the caption describes.
+**Telescope codegen is in MapStruct's performance class, and allocates what MapStruct allocates on every tier
+measured.** Separate runs land on runners of different speeds, so a ratio built from two of them is not a measurement —
+hence the two columns below, read as the caption describes.
 
-| Tier (forward, codegen vs codegen)  |        MapStruct |        telescope | ratio | across runs            | allocation              |
-| ----------------------------------- | ---------------: | ---------------: | ----: | ---------------------- | ----------------------- |
-| flat (5 scalars)                    | 3.155 ± 0.019 ns | 3.362 ± 0.011 ns | 1.07x | ~1.07x (one run 1.13x) | 32 B/op both            |
-| nested (one nested type)            | 4.361 ± 0.045 ns | 5.604 ± 0.033 ns | 1.29x | 1.04x–1.46x            | 48 B/op both            |
-| deep (3 levels + 2 list hops)       |  62.38 ± 0.18 ns |  66.57 ± 0.52 ns | 1.07x | 1.06x–1.19x            | 376 B/op both           |
-| container, Map-valued (100 entries) |     1262 ± 11 ns |     1244 ± 10 ns |   tie | measured once          | **7,528 vs 6,712 B/op** |
-| container, Set-valued (100 entries) |     1455 ± 21 ns |      1445 ± 9 ns |   tie | measured once          | 7,576 B/op both         |
+| Tier (forward, codegen vs codegen)  |        MapStruct |        telescope | ratio | across runs            | allocation        |
+| ----------------------------------- | ---------------: | ---------------: | ----: | ---------------------- | ----------------- |
+| flat (5 scalars)                    | 3.155 ± 0.019 ns | 3.362 ± 0.011 ns | 1.07x | ~1.07x (one run 1.13x) | 32 B/op both      |
+| nested (one nested type)            | 4.361 ± 0.045 ns | 5.604 ± 0.033 ns | 1.29x | 1.04x–1.46x            | 48 B/op both      |
+| deep (3 levels + 2 list hops)       |  62.38 ± 0.18 ns |  66.57 ± 0.52 ns | 1.07x | 1.06x–1.19x            | 376 B/op both     |
+| container, Map-valued (100 entries) |     1262 ± 11 ns |     1244 ± 10 ns |   tie | measured once          | 7,528 B/op both\* |
+| container, Set-valued (100 entries) |     1455 ± 21 ns |      1445 ± 9 ns |   tie | measured once          | 7,576 B/op both   |
 
 GitHub Actions run 34470676359, `ubuntu-latest`, 10 measured iterations. The `ratio` column is this run alone, so every
 figure in it is comparable with every other. The `across runs` column is what keeps a single cell from travelling out of
@@ -23,9 +23,14 @@ context: only flat holds its value between runs, and the container tiers exist o
 
 Read the two container rows carefully — telescope's mean is marginally lower on both, and on neither does that mean it
 won. On Set the intervals overlap almost entirely (telescope's sits inside MapStruct's), which is a clean tie. On Map
-they overlap by under 3 ns, so call it a tie but not a settled one: tighter bands could separate them either way. What
-is real on that row is the allocation — 6,712 against 7,528 bytes per operation, about 11% less — and allocation is
-deterministic rather than hardware-dependent, which makes it the durable result.
+they overlap by under 3 ns, so call it a tie but not a settled one: tighter bands could separate them either way.
+
+\* The Map row once carried an allocation win — 6,712 against 7,528 bytes per operation — and it was not one. An
+interface-typed `Map` field rebuilt as a `HashMap` where MapStruct builds a `LinkedHashMap`, so the two sides were
+building different containers and the cheaper one was being read as the better result. Telescope now builds the same
+container, its allocation lands on MapStruct's figure exactly, and an ordered source keeps its order across the
+conversion. The timings in this row predate that change and need a re-run before they are quoted again; the allocation
+figure does not, because allocation is deterministic rather than hardware-dependent.
 
 The scalar tiers are unchanged in character: a 0.2 ns difference on flat, 4 ns on a 62 ns deep conversion, and both
 outside their error bars, so each ratio is real within its own run. Only flat is also stable across runs, clustering at
@@ -297,8 +302,9 @@ residual.
 - **`BRIDGE_FN` benchmarked across all three tiers** (`nested_*_bridgefn_forward`, `deep_*_bridgefn_forward`; flat
   already existed). This is what lets the forward tables compare all four call shapes — static, one-hop, lattice,
   MapStruct — on each run, which is what later let run 4 separate `BRIDGE_FN` from the floor on deep.
-- **The container tier**, Set- and Map-valued, which is where this revision's actual finding lives — see the headline
-  table for the figures and [What the container tier is for](#what-the-container-tier-is-for) for why it was added.
+- **The container tier**, Set- and Map-valued — see the headline table for the figures and
+  [What the container tier is for](#what-the-container-tier-is-for) for why it was added. It was published carrying an
+  allocation win on the Map shape; the footnote on that row records what became of it.
 - **This analysis doc, corrected against three runs.** What each correction retracted is recorded under
   [Superseded and retracted](#superseded-and-retracted) rather than restated here.
 - **No production code changed.** `BRIDGE_FN` already ships; the codegen is at parity as-is.
@@ -344,7 +350,7 @@ table; what was wrong was presenting it as deep's figure rather than as one end 
 
 Telescope codegen is in MapStruct's performance class. The headline table has the figures and says which of them are
 stable across runs and which are ranges; the short version is that flat is settled, deep and nested are ranges, and the
-two container shapes tie on time while telescope allocates less on the Map shape.
+two container shapes tie on time and allocate identically.
 
 On dispatch, one half is settled on two tiers of three. `BRIDGE_FN` is the floor on flat and nested — it tracks the
 zero-dispatch static call there on every run within error, because the JIT inlines the monomorphic hop. On deep the only


### PR DESCRIPTION
Closes #348.

**This changes a default, so it is not mine to merge — flagging it for a decision rather than landing it.**

A conversion that was not asked to reorder should not reorder. A field declared as the bare `Map` interface picked `HashMap` as its family default on both paths, so a `LinkedHashMap` source behind that field came out in hash order. Three facts, each verified rather than taken from the issue:

- **Codegen**: `concreteImplFqn` maps `SET -> java.util.LinkedHashSet` but `MAP_VALUES -> java.util.HashMap`.
- **Runtime**: `ContainerLifts.setAllocatorFor` treats `Set.class` as `LinkedHashSet`; `mapAllocatorFor` treats `Map.class` as `HashMap`.
- **MapStruct**, for the same pair, emits `LinkedHashMap.newLinkedHashMap( map.size() )` — and `LinkedHashSet.newLinkedHashSet( set.size() )` beside it.

So Map was the odd one out twice over: against telescope's own Set handling, and against the mapper we are trying to be a drop-in for. Both telescope paths move together here, so codegen and the reflective mapper still produce the same runtime class for the same field — the existing cross-strategy parity test is what holds that, and its path-to-path assertion never failed during this change.

A field declared as `HashMap` asked for that class specifically and still gets it. Only the bare-interface default moved.

## Blast radius

`LinkedHashMap extends HashMap`, so casts and `instanceof HashMap` are unaffected — I checked rather than assumed. What changes is the iteration order (from unspecified to the source's) and a `getClass() == HashMap.class` identity check. Not source- or binary-breaking, hence `fix:` rather than `fix!`.

## Verification

Four new tests, and the interesting one is the precondition: `theKeysUsedHereActuallyReorderUnderAHashMap` asserts that the ten keys the other tests use really do iterate differently under a `HashMap`. With keys that happened to hash in insertion order, every other assertion in the class would hold no matter which container the rebuild picked — the test would be untriggerable and look fine.

Each half of the fix is revert-proven separately, and each probe fails exactly the path it reverted:

| hunk reverted | fails | passes |
| --- | --- | --- |
| codegen `MAP_VALUES` only | codegen order, backward | runtime order, precondition |
| runtime `Map.class` only | runtime order, backward | codegen order, precondition |

The `items` Set field rides along on every conversion as a second control: it has always rebuilt insertion-ordered, so it stays green either way and separates "the Map default changed" from "the container rebuild stopped preserving anything".

## Four existing tests updated

These pinned the old default and are deliberate expectation changes, not incidental churn:

- `BridgeProcessorTest` ×3 — generated-text assertions for `HashMap` imports and `newHashMap(src.size())`.
- `BridgeCodegenTest` — the cross-strategy parity test. Note **which** of its two assertions failed: the hardcoded `assertEquals(HashMap.class, ...)`. The one that actually guards the seam, codegen-class == runtime-class, kept passing, which is the evidence the two paths stayed in lockstep.

Suites green: `:codegen` 208, `:core` 764 (+5), `:lombok` 30, `:internal` 344, `:quarkus` 6, `:spring-boot-starter` 7.

## Cost

Measured, both runs gc-profiled, with MapStruct as the control since this change cannot touch it — **[full numbers in the comment below](https://github.com/eschizoid/telescope/pull/361#issuecomment-5636234111)**.

The short version: the control moved 1.20x between the two runs, so the timings from this pair are a runner difference and I am not publishing a time delta from them. Allocation is deterministic and decisive — telescope codegen goes **6712 -> 7528 B/op, landing exactly on MapStruct's 7528**, where it previously allocated 816 B/op less by building the cheaper container. The +816 is precisely what `LinkedHashMap` costs here: 100 entries x 8 bytes for the two extra references per entry, plus 16 for the map object.

If this merges, the container row in `docs/perf-mapstruct-comparison.md` — which currently reports that allocation gap as telescope's real win on that tier — has to change with it. I have not touched the doc here, since it should only move if the decision is to take this.
