### PR TITLE
perf: size the default impl a raw-container helper allocates

### DIFF
--- a/benchmarks/src/jmh/java/io/github/eschizoid/telescope/benchmarks/RawContainerBenchmark.java
+++ b/benchmarks/src/jmh/java/io/github/eschizoid/telescope/benchmarks/RawContainerBenchmark.java
@@ -1,0 +1,62 @@
+package io.github.eschizoid.telescope.benchmarks;
+
+import java.util.ArrayList;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+
+/**
+ * Generated conversion of raw container subtypes, across cardinality.
+ *
+ * <p>Cardinality is the dimension that makes an unsized rebuild visible: a container filled element
+ * by element from its default capacity grows a logarithmic number of times, and every abandoned
+ * table counts toward the allocation the {@code gc} profiler reports. At one element nothing grows,
+ * so the low rows are the control for the high ones — a change that shifted every row equally would
+ * be measuring something other than sizing.
+ *
+ * <p>Run with {@code -Pjmh.profilers=gc}: allocation is deterministic and survives a runner
+ * difference, where the timings do not.
+ */
+@State(Scope.Thread)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+public class RawContainerBenchmark {
+
+  @Param({ "1", "16", "256", "4096" })
+  public int size;
+
+  private RawHolderA source;
+  private RawHolderB target;
+
+  @Setup
+  public void setup() {
+    final var urls = new RawListA();
+    final var index = new RawMapA();
+    final var plain = new ArrayList<RawUrlA>(size);
+    for (int i = 0; i < size; i++) {
+      urls.add(new RawUrlA("u" + i));
+      index.put("k" + i, new RawUrlA("u" + i));
+      plain.add(new RawUrlA("u" + i));
+    }
+    source = new RawHolderA(urls, index, plain);
+    target = RawHolderABridge.forward(source);
+  }
+
+  /** Both raw-subtype sides plus the interface-to-subtype direction of the mixed field. */
+  @Benchmark
+  public RawHolderB forward() {
+    return RawHolderABridge.forward(source);
+  }
+
+  /** The reverse, where the mixed field's output is a JDK default impl that can be sized. */
+  @Benchmark
+  public RawHolderA backward() {
+    return RawHolderABridge.backward(target);
+  }
+}

--- a/benchmarks/src/jmh/java/io/github/eschizoid/telescope/benchmarks/RawContainerFixtures.java
+++ b/benchmarks/src/jmh/java/io/github/eschizoid/telescope/benchmarks/RawContainerFixtures.java
@@ -1,0 +1,27 @@
+package io.github.eschizoid.telescope.benchmarks;
+
+import io.github.eschizoid.telescope.annotations.Bridge;
+import java.util.List;
+
+/**
+ * Raw container subtypes — the adopter shape {@code class ImageUrls extends ArrayList<ImageUrl>} —
+ * which no other benchmark fixture has. A raw subtype declares only its implicit no-arg
+ * constructor, because Java does not inherit constructors, so the generated helper cannot size it
+ * from the source the way it sizes a JDK default impl.
+ *
+ * <p>The element types differ across the pair, which forces the element-bridging loop rather than
+ * the {@code addAll}/{@code putAll} copy: that loop is where a hash container grows its table
+ * repeatedly instead of once.
+ *
+ * <p>The {@code plain} field is the mixed shape — an interface on one side, a raw subtype on the
+ * other — so one direction allocates a default impl that can be sized and the other a subtype that
+ * cannot.
+ */
+record RawUrlA(String url) {}
+
+record RawUrlB(String url) {}
+
+@Bridge(RawHolderB.class)
+record RawHolderA(RawListA urls, RawMapA index, List<RawUrlA> plain) {}
+
+record RawHolderB(RawListB urls, RawMapB index, RawListB plain) {}

--- a/benchmarks/src/jmh/java/io/github/eschizoid/telescope/benchmarks/RawListA.java
+++ b/benchmarks/src/jmh/java/io/github/eschizoid/telescope/benchmarks/RawListA.java
@@ -1,0 +1,6 @@
+package io.github.eschizoid.telescope.benchmarks;
+
+import java.util.ArrayList;
+
+/** Raw container subtype — no sized constructor, because Java does not inherit constructors. */
+public class RawListA extends ArrayList<RawUrlA> {}

--- a/benchmarks/src/jmh/java/io/github/eschizoid/telescope/benchmarks/RawListB.java
+++ b/benchmarks/src/jmh/java/io/github/eschizoid/telescope/benchmarks/RawListB.java
@@ -1,0 +1,6 @@
+package io.github.eschizoid.telescope.benchmarks;
+
+import java.util.ArrayList;
+
+/** Raw container subtype — no sized constructor, because Java does not inherit constructors. */
+public class RawListB extends ArrayList<RawUrlB> {}

--- a/benchmarks/src/jmh/java/io/github/eschizoid/telescope/benchmarks/RawMapA.java
+++ b/benchmarks/src/jmh/java/io/github/eschizoid/telescope/benchmarks/RawMapA.java
@@ -1,0 +1,6 @@
+package io.github.eschizoid.telescope.benchmarks;
+
+import java.util.HashMap;
+
+/** Raw container subtype — no sized constructor, because Java does not inherit constructors. */
+public class RawMapA extends HashMap<String, RawUrlA> {}

--- a/benchmarks/src/jmh/java/io/github/eschizoid/telescope/benchmarks/RawMapB.java
+++ b/benchmarks/src/jmh/java/io/github/eschizoid/telescope/benchmarks/RawMapB.java
@@ -1,0 +1,6 @@
+package io.github.eschizoid.telescope.benchmarks;
+
+import java.util.HashMap;
+
+/** Raw container subtype — no sized constructor, because Java does not inherit constructors. */
+public class RawMapB extends HashMap<String, RawUrlB> {}

--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
@@ -2465,16 +2465,25 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
    * @param typeArgs the emitted type arguments, without angle brackets
    */
   private static String sizedAlloc(final String implFqn, final String typeArgs) {
-    final var simple = simpleName(implFqn);
+    return sizedAlloc(implFqn, typeArgs, simpleName(implFqn));
+  }
+
+  /**
+   * As above, naming the class as {@code rendered} at the call site: the simple name where the
+   * emitting helper's file imports it, the fully-qualified name where it does not. Only the JDK
+   * default impls can be sized — a user subtype declares no sized constructor (constructors are not
+   * inherited), and one it declares itself carries whatever meaning its author gave the argument.
+   */
+  private static String sizedAlloc(final String implFqn, final String typeArgs, final String rendered) {
     return switch (implFqn) {
-      case "java.util.HashSet", "java.util.LinkedHashSet", "java.util.HashMap", "java.util.LinkedHashMap" -> simple +
+      case "java.util.HashSet", "java.util.LinkedHashSet", "java.util.HashMap", "java.util.LinkedHashMap" -> rendered +
       ".<" +
       typeArgs +
       ">new" +
-      simple +
+      simpleName(implFqn) +
       "(src.size())";
-      case "java.util.ArrayList" -> "new " + simple + "<" + typeArgs + ">(src.size())";
-      default -> "new " + simple + "<" + typeArgs + ">()";
+      case "java.util.ArrayList" -> "new " + rendered + "<" + typeArgs + ">(src.size())";
+      default -> "new " + rendered + "<" + typeArgs + ">()";
     };
   }
 
@@ -3036,9 +3045,8 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
   }
 
   // Emit one direction of a raw Collection/Map subtype container helper. Every type is rendered
-  // fully-qualified (no imports needed). The output collection is allocated via its no-arg
-  // constructor (a Collection/Map subtype does not inherit the JDK copy constructor) and filled by
-  // addAll/putAll for an identity element or an element-bridging loop otherwise.
+  // fully-qualified (no imports needed). The output is filled by addAll/putAll for an identity
+  // element, or by an element-bridging loop otherwise.
   private void emitRawContainerHelper(
     final PrintWriter out,
     final String name,
@@ -3089,10 +3097,16 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
   }
 
   // Allocation expression for a raw-container output: the target's concrete class (the subtype
-  // itself
-  // when instantiable, else the interface's default impl), with a diamond only when that class is
-  // generic. A non-generic subtype (`class ImageUrls extends ArrayList<ImageUrl>`) takes no type
-  // arguments; the default impl for a generic interface field takes the field's element args.
+  // itself when instantiable, else the interface's default impl), with a diamond only when that
+  // class is generic. A non-generic subtype (`class ImageUrls extends ArrayList<ImageUrl>`) takes
+  // no type arguments; the default impl for a generic interface field takes the field's element
+  // args.
+  //
+  // Only the JDK default impls are sized from the source. Java does not inherit constructors, so a
+  // subtype declaring nothing but its implicit no-arg one has no sized constructor to call, and a
+  // subtype that declares an `(int)` constructor gives the argument whatever meaning it chose --
+  // a page number reads exactly like a capacity from here. Filling such a subtype through addAll
+  // or putAll still lets the JDK size it in one step where those methods presize.
   private String rawAllocExpr(final TypeMirror container, final FieldPlan.Kind kind) {
     final var implFqn = concreteImplFqn(container, kind);
     final var implEl = processingEnv.getElementUtils().getTypeElement(implFqn);
@@ -3100,10 +3114,10 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
     if (!generic) return "new " + implFqn + "()";
     if (kind == FieldPlan.Kind.MAP_VALUES) {
       final var args = containerViewArgs(container, "java.util.Map");
-      return "new " + implFqn + "<" + args.get(0) + ", " + args.get(1) + ">()";
+      return sizedAlloc(implFqn, args.get(0) + ", " + args.get(1), implFqn);
     }
     final var args = containerViewArgs(container, kind == FieldPlan.Kind.SET ? "java.util.Set" : "java.util.List");
-    return "new " + implFqn + "<" + args.getFirst() + ">()";
+    return sizedAlloc(implFqn, args.getFirst().toString(), implFqn);
   }
 
   private void emitListHelper(

--- a/codegen/src/test/java/io/github/eschizoid/telescope/codegen/BridgeProcessorTest.java
+++ b/codegen/src/test/java/io/github/eschizoid/telescope/codegen/BridgeProcessorTest.java
@@ -697,7 +697,10 @@ class BridgeProcessorTest {
       assertNotNull(compilation.generated().get("demo.MixSrcToMixDstBridge"));
       // forward allocates the concrete subtype; backward allocates the interface's default impl.
       assertTrue(bridge.contains("new demo.MixWrap()"), bridge);
-      assertTrue(bridge.contains("new java.util.ArrayList<demo.MixSrc>()"), bridge);
+      // The interface side is a JDK default impl, so it is allocated sized; the raw subtype on
+      // the other side cannot be, having no constructor that takes a size.
+      assertTrue(bridge.contains("new java.util.ArrayList<demo.MixSrc>(src.size())"), bridge);
+      assertFalse(bridge.contains("new java.util.ArrayList<demo.MixSrc>()"), bridge);
     }
 
     @Test
@@ -742,7 +745,11 @@ class BridgeProcessorTest {
       // forward allocates the concrete subtype; backward allocates the Map interface's two-arg
       // default.
       assertTrue(bridge.contains("new demo.MMixWrap()"), bridge);
-      assertTrue(bridge.contains("new java.util.LinkedHashMap<java.lang.String, demo.MMixSrc>()"), bridge);
+      assertTrue(
+        bridge.contains("java.util.LinkedHashMap.<java.lang.String," + " demo.MMixSrc>newLinkedHashMap(src.size())"),
+        bridge
+      );
+      assertFalse(bridge.contains("new java.util.LinkedHashMap<java.lang.String, demo.MMixSrc>()"), bridge);
     }
 
     @Test


### PR DESCRIPTION
Closes #346.

`sizedAlloc` reached the generic container helpers but not the raw one, so a field pairing an interface with a raw container subtype allocated its default impl from the default capacity and grew it while filling — where the generic path for the same interface sized it from the source. That half is fixed.

## The other half cannot be fixed, and the issue's premise is wrong about why

The issue proposes presizing a subtype "when the subtype declares **or inherits** the `(int)` constructor". **Java does not inherit constructors.** A trivial `class ImageUrls extends ArrayList<ImageUrl> {}` has its implicit no-arg constructor and nothing else — which I verified rather than argued:

```
Trivial    ctors: [[]]
TrivialMap ctors: [[]]
TrivialSet ctors: [[]]
```

So the `(int)` path does not exist for exactly the shape the issue names. And where a subtype *does* declare one, the processor cannot know what the argument means — `Page(int pageNumber)` is indistinguishable from a capacity from inside `javax.lang.model`, and calling it with `src.size()` would be a semantic bug, not an optimisation. So raw subtypes keep the no-arg allocation. That is not a deferral; it is the only correct emission.

The issue's fallback — a sized intermediate plus `addAll` — is also worth skipping, and measuring the JDK says why:

| fill | resulting table/array |
| --- | --- |
| `ArrayList` subtype, `addAll(1000)` | 1000 — exact, one grow |
| `HashMap` subtype, `putAll(1000)` | 2048 |
| `HashMap` subtype, 1000x `put()` | 2048 |

`addAll` already sizes the list exactly, and `putAll` presizes the map, so the identity copy paths were never the problem. The element-bridging loop reaches the same final table as `putAll` does — the cost is the abandoned intermediate tables, which is real but which an extra intermediate container would pay for twice rather than remove.

## What changed

`sizedAlloc` gained a rendered-name parameter so it can emit fully-qualified names for the raw helper, which imports nothing, and `rawAllocExpr` now routes through it. Only the five JDK default impls are sized; every other class falls through to the allocation it had before, so a generic user subtype is untouched.

The generated bridge for the new fixture shows both halves side by side:

```java
// interface side — sized
final var out = new java.util.ArrayList<...RawUrlA>(src.size());
// raw subtype — cannot be
final var out = new ...RawListB();
```

## Verification

Two existing tests failed the moment the fix landed, and they are precisely the two mixed generic-to-raw cases it targets — which is the evidence the defect was reachable rather than theoretical. Both now assert the sized form **and** assert the unsized form is absent, so a regression that emitted both would not pass.

## The benchmark

#346 requires the fixture to land with the fix, because no fixture had a raw-subtype container and the defect was invisible to the suite — the same green-while-wrong shape the container tier itself was added to catch.

`RawContainerBenchmark` varies cardinality, which is the dimension that exposes an unsized rebuild: a container filled element by element from its default capacity grows a logarithmic number of times, and every abandoned table counts toward allocation. At one element nothing grows, so the low rows are the control for the high ones — a change that moved every row equally would be measuring something other than sizing. The `plain` field is deliberately mixed, so one direction allocates a sizable default impl and the other a subtype that cannot be sized, and a single pair of rows carries both.

Runs dispatched on this branch and on a baseline branch carrying the fixture against an unfixed emitter, since a benchmark that exists on only one side has nothing to measure. Numbers to follow.
