### PR TITLE
fix(codegen): say which annotation failed, and what the target is

### DIFF
--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/AbstractTelescopeProcessor.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/AbstractTelescopeProcessor.java
@@ -13,6 +13,7 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.function.Consumer;
 import javax.annotation.processing.AbstractProcessor;
+import javax.annotation.processing.FilerException;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.ExecutableElement;
@@ -86,8 +87,28 @@ public abstract class AbstractTelescopeProcessor extends AbstractProcessor {
         out.println("}");
       }
     } catch (final IOException e) {
-      error(origin, "Failed to write " + qualifiedName + ": " + e.getMessage());
+      error(origin, writeFailureMessage(qualifiedName, e));
     }
+  }
+
+  /**
+   * Phrase a failed emission. A {@link FilerException} for a name already taken is the one case
+   * with an action attached: some other type in the compilation already owns the name the processor
+   * derives, and the fix is to change a name rather than to read a stack trace. Every other {@code
+   * IOException} is a genuine write failure and is reported as it arrives.
+   */
+  private static String writeFailureMessage(final String qualifiedName, final IOException e) {
+    if (e instanceof FilerException) {
+      return (
+        "Cannot generate " +
+        qualifiedName +
+        " — that name is already taken in this compilation. Rename the existing type, or rename" +
+        " the source or target so the derived name differs. (" +
+        e.getMessage() +
+        ")"
+      );
+    }
+    return "Failed to write " + qualifiedName + ": " + e.getMessage();
   }
 
   /**
@@ -664,7 +685,7 @@ public abstract class AbstractTelescopeProcessor extends AbstractProcessor {
         out.println("}");
       }
     } catch (final IOException e) {
-      error(origin, "Failed to write " + qualifiedName + ": " + e.getMessage());
+      error(origin, writeFailureMessage(qualifiedName, e));
     }
   }
 
@@ -738,7 +759,7 @@ public abstract class AbstractTelescopeProcessor extends AbstractProcessor {
         out.println("}");
       }
     } catch (final IOException e) {
-      error(origin, "Failed to write " + qualifiedName + ": " + e.getMessage());
+      error(origin, writeFailureMessage(qualifiedName, e));
     }
   }
 

--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
@@ -333,6 +333,21 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
           error(element, "@Bridge target must be a top-level type");
           continue;
         }
+        // An interface is a declared type, so it reaches here like any other; without this it pairs
+        // against an empty component list and is reported as a bijection failure, which describes
+        // the symptom and not the cause. Only a sealed one is a target: it names its permits, and
+        // each permit is what carries components and a constructor.
+        if (targetEl.getKind() == ElementKind.INTERFACE && !targetEl.getModifiers().contains(Modifier.SEALED)) {
+          error(
+            element,
+            "@Bridge target " +
+              targetEl.getSimpleName() +
+              " is an interface with no permits. A plain interface has no components to pair" +
+              " and no constructor to rebuild — name the implementation type instead, or seal" +
+              " the interface and give each permit its own @Bridge."
+          );
+          continue;
+        }
         final TypeElement sourceEl = carrierForm
           ? (TypeElement) ((DeclaredType) sourceMirror).asElement()
           : (TypeElement) element;
@@ -932,11 +947,14 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
     return Map.of();
   }
 
-  // Parse a @Constant string value against the target field's declared type. Returns the
-  // Java-source literal expression to emit at the field's ctor-arg position, or null when the
-  // value can't be represented at that type (the caller already reported via error()).
+  // Parse an annotation's string value against a field's declared type. Returns the Java-source
+  // literal expression to emit at the field's ctor-arg position, or null when the value can't be
+  // represented at that type (the caller already reported via error()). Both @Constant and @Default
+  // carry a string value parsed this way, so the caller passes its own name for the diagnostic:
+  // naming the wrong one sends the reader to an annotation their source does not contain.
   private String parseConstantLiteral(
     final Element origin,
+    final String annotation,
     final String fieldName,
     final String value,
     final TypeMirror type
@@ -950,28 +968,28 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
           return "\"" + escapeJavaString(value) + "\"";
         }
         case "java.lang.Boolean" -> {
-          return parseBooleanOrError(origin, fieldName, value, "Boolean");
+          return parseBooleanOrError(origin, annotation, fieldName, value, "Boolean");
         }
         case "java.lang.Integer" -> {
-          return parseIntegralOrError(origin, fieldName, value, "Integer", "");
+          return parseIntegralOrError(origin, annotation, fieldName, value, "Integer", "");
         }
         case "java.lang.Long" -> {
-          return parseIntegralOrError(origin, fieldName, value, "Long", "L");
+          return parseIntegralOrError(origin, annotation, fieldName, value, "Long", "L");
         }
         case "java.lang.Short" -> {
-          return castIntegralOrError(origin, fieldName, value, "Short", "short");
+          return castIntegralOrError(origin, annotation, fieldName, value, "Short", "short");
         }
         case "java.lang.Byte" -> {
-          return castIntegralOrError(origin, fieldName, value, "Byte", "byte");
+          return castIntegralOrError(origin, annotation, fieldName, value, "Byte", "byte");
         }
         case "java.lang.Double" -> {
-          return parseFloatingOrError(origin, fieldName, value, "Double", "");
+          return parseFloatingOrError(origin, annotation, fieldName, value, "Double", "");
         }
         case "java.lang.Float" -> {
-          return parseFloatingOrError(origin, fieldName, value, "Float", "f");
+          return parseFloatingOrError(origin, annotation, fieldName, value, "Float", "f");
         }
         case "java.lang.Character" -> {
-          return parseCharOrError(origin, fieldName, value);
+          return parseCharOrError(origin, annotation, fieldName, value);
         }
         default -> {
         }
@@ -979,20 +997,21 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
     }
     if (kind.isPrimitive()) {
       return switch (kind) {
-        case BOOLEAN -> parseBooleanOrError(origin, fieldName, value, "boolean");
-        case INT -> parseIntegralOrError(origin, fieldName, value, "int", "");
-        case LONG -> parseIntegralOrError(origin, fieldName, value, "long", "L");
-        case SHORT -> castIntegralOrError(origin, fieldName, value, "short", "short");
-        case BYTE -> castIntegralOrError(origin, fieldName, value, "byte", "byte");
-        case DOUBLE -> parseFloatingOrError(origin, fieldName, value, "double", "");
-        case FLOAT -> parseFloatingOrError(origin, fieldName, value, "float", "f");
-        case CHAR -> parseCharOrError(origin, fieldName, value);
+        case BOOLEAN -> parseBooleanOrError(origin, annotation, fieldName, value, "boolean");
+        case INT -> parseIntegralOrError(origin, annotation, fieldName, value, "int", "");
+        case LONG -> parseIntegralOrError(origin, annotation, fieldName, value, "long", "L");
+        case SHORT -> castIntegralOrError(origin, annotation, fieldName, value, "short", "short");
+        case BYTE -> castIntegralOrError(origin, annotation, fieldName, value, "byte", "byte");
+        case DOUBLE -> parseFloatingOrError(origin, annotation, fieldName, value, "double", "");
+        case FLOAT -> parseFloatingOrError(origin, annotation, fieldName, value, "float", "f");
+        case CHAR -> parseCharOrError(origin, annotation, fieldName, value);
         default -> null;
       };
     }
     error(
       origin,
-      "@Constant value cannot be parsed at the target field \"" +
+      annotation +
+        " value cannot be parsed at the target field \"" +
         fieldName +
         "\" of type " +
         type +
@@ -1004,6 +1023,7 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
 
   private String parseBooleanOrError(
     final Element origin,
+    final String annotation,
     final String fieldName,
     final String value,
     final String displayType
@@ -1012,13 +1032,14 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
     if ("false".equals(value)) return "false";
     error(
       origin,
-      "@Constant value=\"" + value + "\" is not a valid " + displayType + " literal at field \"" + fieldName + "\""
+      annotation + " value=\"" + value + "\" is not a valid " + displayType + " literal at field \"" + fieldName + "\""
     );
     return null;
   }
 
   private String parseIntegralOrError(
     final Element origin,
+    final String annotation,
     final String fieldName,
     final String value,
     final String displayType,
@@ -1030,7 +1051,14 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
     } catch (final NumberFormatException e) {
       error(
         origin,
-        "@Constant value=\"" + value + "\" is not a valid " + displayType + " literal at field \"" + fieldName + "\""
+        annotation +
+          " value=\"" +
+          value +
+          "\" is not a valid " +
+          displayType +
+          " literal at field \"" +
+          fieldName +
+          "\""
       );
       return null;
     }
@@ -1039,6 +1067,7 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
 
   private String castIntegralOrError(
     final Element origin,
+    final String annotation,
     final String fieldName,
     final String value,
     final String displayType,
@@ -1050,7 +1079,14 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
     } catch (final NumberFormatException e) {
       error(
         origin,
-        "@Constant value=\"" + value + "\" is not a valid " + displayType + " literal at field \"" + fieldName + "\""
+        annotation +
+          " value=\"" +
+          value +
+          "\" is not a valid " +
+          displayType +
+          " literal at field \"" +
+          fieldName +
+          "\""
       );
       return null;
     }
@@ -1059,6 +1095,7 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
 
   private String parseFloatingOrError(
     final Element origin,
+    final String annotation,
     final String fieldName,
     final String value,
     final String displayType,
@@ -1070,16 +1107,28 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
     } catch (final NumberFormatException e) {
       error(
         origin,
-        "@Constant value=\"" + value + "\" is not a valid " + displayType + " literal at field \"" + fieldName + "\""
+        annotation +
+          " value=\"" +
+          value +
+          "\" is not a valid " +
+          displayType +
+          " literal at field \"" +
+          fieldName +
+          "\""
       );
       return null;
     }
     return value + suffix;
   }
 
-  private String parseCharOrError(final Element origin, final String fieldName, final String value) {
+  private String parseCharOrError(
+    final Element origin,
+    final String annotation,
+    final String fieldName,
+    final String value
+  ) {
     if (value.length() != 1) {
-      error(origin, "@Constant value=\"" + value + "\" must be a single character at field \"" + fieldName + "\"");
+      error(origin, annotation + " value=\"" + value + "\" must be a single character at field \"" + fieldName + "\"");
       return null;
     }
     final var c = value.charAt(0);
@@ -1492,7 +1541,7 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
         );
         return;
       }
-      final var lit = parseConstantLiteral(source, fieldName, e.getValue(), sf.type());
+      final var lit = parseConstantLiteral(source, "@Default", fieldName, e.getValue(), sf.type());
       if (lit == null) return;
       parsedDefaults.put(fieldName, lit);
     }
@@ -1525,7 +1574,7 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
         );
         return;
       }
-      final var lit = parseConstantLiteral(source, fieldName, e.getValue(), tf.type());
+      final var lit = parseConstantLiteral(source, "@Constant", fieldName, e.getValue(), tf.type());
       if (lit == null) return;
       parsedConstants.put(fieldName, lit);
       injectedTargetFields.add(fieldName);

--- a/codegen/src/test/java/io/github/eschizoid/telescope/codegen/ConstantLiteralEmissionTest.java
+++ b/codegen/src/test/java/io/github/eschizoid/telescope/codegen/ConstantLiteralEmissionTest.java
@@ -1,0 +1,82 @@
+package io.github.eschizoid.telescope.codegen;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.github.eschizoid.telescope.codegen.ProcessorHarness.Compilation;
+import java.util.List;
+import java.util.stream.Stream;
+import javax.tools.JavaFileObject;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * An annotation carries its value as a string, and the processor has to turn that string into a
+ * Java literal valid at the field's declared type. The suffix and the cast are the part that can go
+ * wrong silently: {@code 42} assigned to a {@code long} field compiles either way, but {@code 1.5}
+ * without the {@code f} does not compile at a {@code float}, and {@code 7} without the cast does
+ * not compile at a {@code short}.
+ *
+ * <p>These compile through the full pipeline, so a literal that is wrong for its type fails here
+ * rather than being asserted as a string and never attributed.
+ */
+class ConstantLiteralEmissionTest {
+
+  private static Stream<Arguments> types() {
+    return Stream.of(
+      Arguments.of("boolean", "true", "true"),
+      Arguments.of("Boolean", "true", "true"),
+      Arguments.of("int", "42", "42"),
+      Arguments.of("Integer", "42", "42"),
+      Arguments.of("long", "42", "42L"),
+      Arguments.of("Long", "42", "42L"),
+      Arguments.of("short", "7", "(short) 7"),
+      Arguments.of("Short", "7", "(short) 7"),
+      Arguments.of("byte", "7", "(byte) 7"),
+      Arguments.of("Byte", "7", "(byte) 7"),
+      Arguments.of("double", "1.5", "1.5"),
+      Arguments.of("Double", "1.5", "1.5"),
+      Arguments.of("float", "1.5", "1.5f"),
+      Arguments.of("Float", "1.5", "1.5f"),
+      Arguments.of("char", "x", "'x'"),
+      Arguments.of("Character", "x", "'x'"),
+      Arguments.of("String", "hi", "\"hi\"")
+    );
+  }
+
+  private static Compilation compile(final JavaFileObject... sources) {
+    return ProcessorHarness.compileFully(List.of(new BridgeProcessor()), List.of(), sources);
+  }
+
+  @ParameterizedTest(name = "{0} <- \"{1}\" emits {2}")
+  @MethodSource("types")
+  @DisplayName("a @Constant string becomes the literal its target field's type requires")
+  void constantBecomesATypedLiteral(final String type, final String value, final String literal) {
+    final var compilation = compile(
+      ProcessorHarness.source(
+        "demo.KSrc",
+        """
+        package demo;
+        import io.github.eschizoid.telescope.annotations.Bridge;
+        import io.github.eschizoid.telescope.annotations.Constant;
+        @Bridge(value = demo.KDst.class, constants = @Constant(field = "v", value = "%s"))
+        public record KSrc(String name) {}
+        """.formatted(value)
+      ),
+      ProcessorHarness.source("demo.KDst", "package demo; public record KDst(String name, %s v) {}".formatted(type))
+    );
+
+    assertTrue(
+      compilation.success(),
+      () -> "a valid " + type + " constant must compile: " + compilation.errorMessages()
+    );
+    final var bridge = compilation.generated().get("demo.KSrcBridge");
+    assertNotNull(bridge);
+    assertTrue(
+      bridge.contains("new demo.KDst(__fs_name, " + literal + ")"),
+      () -> "expected the " + type + " slot to take " + literal + ": " + bridge
+    );
+  }
+}

--- a/codegen/src/test/java/io/github/eschizoid/telescope/codegen/DiagnosticWordingTest.java
+++ b/codegen/src/test/java/io/github/eschizoid/telescope/codegen/DiagnosticWordingTest.java
@@ -1,0 +1,171 @@
+package io.github.eschizoid.telescope.codegen;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.github.eschizoid.telescope.codegen.ProcessorHarness.Compilation;
+import java.util.List;
+import javax.tools.JavaFileObject;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * A diagnostic is read by someone who cannot see the code that produced it, so naming the wrong
+ * annotation or describing a symptom instead of a cause sends them somewhere their source does not
+ * go. Each test below asserts the message that should appear <em>and</em> that the misleading one
+ * does not, because a processor that emitted both would satisfy the first assertion alone.
+ */
+class DiagnosticWordingTest {
+
+  private static Compilation compile(final JavaFileObject... sources) {
+    return ProcessorHarness.compileFully(List.of(new BridgeProcessor()), List.of(), sources);
+  }
+
+  @Test
+  @DisplayName("an unparseable @Default value is reported against @Default, not @Constant")
+  void unparseableDefaultNamesDefault() {
+    final var compilation = compile(
+      ProcessorHarness.source(
+        "demo.Src",
+        """
+        package demo;
+        import io.github.eschizoid.telescope.annotations.Bridge;
+        import io.github.eschizoid.telescope.annotations.Default;
+        @Bridge(value = demo.Dst.class, defaults = @Default(field = "count", value = "not-a-number"))
+        public record Src(String name, Integer count) {}
+        """
+      ),
+      ProcessorHarness.source("demo.Dst", "package demo; public record Dst(String name, Integer count) {}")
+    );
+
+    assertFalse(compilation.success(), "an unparseable default must not compile");
+    assertTrue(
+      compilation.hasError("@Default value=\"not-a-number\""),
+      () -> "the diagnostic must name the annotation the source carries: " + compilation.errorMessages()
+    );
+    assertFalse(
+      compilation.errorMessages().contains("@Constant"),
+      () -> "there is no @Constant in this source: " + compilation.errorMessages()
+    );
+  }
+
+  @Test
+  @DisplayName("an unparseable @Constant value still names @Constant")
+  void unparseableConstantStillNamesConstant() {
+    // The control for the test above: the shared parser takes the name from its caller, so the
+    // other caller has to keep reporting its own.
+    final var compilation = compile(
+      ProcessorHarness.source(
+        "demo.CSrc",
+        """
+        package demo;
+        import io.github.eschizoid.telescope.annotations.Bridge;
+        import io.github.eschizoid.telescope.annotations.Constant;
+        @Bridge(value = demo.CDst.class, constants = @Constant(field = "count", value = "not-a-number"))
+        public record CSrc(String name) {}
+        """
+      ),
+      ProcessorHarness.source("demo.CDst", "package demo; public record CDst(String name, Integer count) {}")
+    );
+
+    assertFalse(compilation.success(), "an unparseable constant must not compile");
+    assertTrue(
+      compilation.hasError("@Constant value=\"not-a-number\""),
+      () -> "the constant path must keep naming @Constant: " + compilation.errorMessages()
+    );
+    assertFalse(
+      compilation.errorMessages().contains("@Default"),
+      () -> "there is no @Default in this source: " + compilation.errorMessages()
+    );
+  }
+
+  @Test
+  @DisplayName("a plain interface target is reported as an interface, not as a bijection failure")
+  void plainInterfaceTargetIsNamedAsSuch() {
+    final var compilation = compile(
+      ProcessorHarness.source(
+        "demo.ISrc",
+        """
+        package demo;
+        import io.github.eschizoid.telescope.annotations.Bridge;
+        @Bridge(demo.IDst.class)
+        public record ISrc(String name) {}
+        """
+      ),
+      ProcessorHarness.source("demo.IDst", "package demo; public interface IDst { String name(); }")
+    );
+
+    assertFalse(compilation.success(), "an interface target must not compile");
+    assertTrue(
+      compilation.hasError("is an interface with no permits"),
+      () -> "the cause is the target's kind, which the message should say: " + compilation.errorMessages()
+    );
+    assertFalse(
+      compilation.errorMessages().contains("has []"),
+      () -> "the empty-component-set wording describes the symptom: " + compilation.errorMessages()
+    );
+  }
+
+  @Test
+  @DisplayName("a name already taken by a hand-written type says what to rename")
+  void takenBridgeNameSaysWhatToRename() {
+    final var compilation = compile(
+      ProcessorHarness.source(
+        "demo.NSrc",
+        """
+        package demo;
+        import io.github.eschizoid.telescope.annotations.Bridge;
+        @Bridge(demo.NDst.class)
+        public record NSrc(String name) {}
+        """
+      ),
+      ProcessorHarness.source("demo.NDst", "package demo; public record NDst(String name) {}"),
+      // The adopter already owns the name the processor derives for this pair.
+      ProcessorHarness.source("demo.NSrcBridge", "package demo; public final class NSrcBridge {}")
+    );
+
+    assertFalse(compilation.success(), "the processor cannot write over a hand-written type");
+    assertTrue(
+      compilation.hasError("that name is already taken"),
+      () -> "the message should name the collision and an action: " + compilation.errorMessages()
+    );
+    assertFalse(
+      compilation.errorMessages().contains("Failed to write"),
+      () -> "the generic write-failure wording gives the reader nothing to do: " + compilation.errorMessages()
+    );
+  }
+
+  @Test
+  @DisplayName("a lenient bridge writes null into an unmatched collection slot, as the javadoc says")
+  void lenientUnmatchedCollectionIsWrittenNull() {
+    final var compilation = compile(
+      ProcessorHarness.source(
+        "demo.LSrc",
+        """
+        package demo;
+        import io.github.eschizoid.telescope.annotations.Bridge;
+        @Bridge(value = demo.LDst.class, lenient = true)
+        public record LSrc(String name) {}
+        """
+      ),
+      ProcessorHarness.source(
+        "demo.LDst",
+        "package demo; import java.util.List; public record LDst(String name, List<String>" + " tags, int count) {}"
+      )
+    );
+
+    assertTrue(compilation.success(), () -> "lenient should compile: " + compilation.errorMessages());
+    final var bridge = compilation.generated().get("demo.LSrcBridge");
+    assertNotNull(bridge);
+    // The unmatched slots take the JLS default for their declared type, which for a collection is
+    // null rather than an empty container. Asserting the whole constructor call is what makes this
+    // fail if the collection slot changes: every generated bridge contains the word "null" in its
+    // guards, so a substring test for it alone would hold no matter what was written here. The
+    // primitive slot beside it is the control — it shows the two are decided by type, not by name.
+    assertTrue(
+      bridge.contains("new demo.LDst(__fs_name, null, 0)"),
+      () -> "the collection slot takes null and the primitive takes zero, in one constructor call: " + bridge
+    );
+  }
+}

--- a/codegen/src/test/java/io/github/eschizoid/telescope/codegen/DiagnosticWordingTest.java
+++ b/codegen/src/test/java/io/github/eschizoid/telescope/codegen/DiagnosticWordingTest.java
@@ -137,6 +137,60 @@ class DiagnosticWordingTest {
   }
 
   @Test
+  @DisplayName("a multi-character value for a char field says so, naming its annotation")
+  void multiCharConstantIsRejected() {
+    final var compilation = compile(
+      ProcessorHarness.source(
+        "demo.MSrc",
+        """
+        package demo;
+        import io.github.eschizoid.telescope.annotations.Bridge;
+        import io.github.eschizoid.telescope.annotations.Constant;
+        @Bridge(value = demo.MDst.class, constants = @Constant(field = "initial", value = "xy"))
+        public record MSrc(String name) {}
+        """
+      ),
+      ProcessorHarness.source("demo.MDst", "package demo; public record MDst(String name, char initial) {}")
+    );
+
+    assertFalse(compilation.success(), "two characters do not fit a char");
+    assertTrue(
+      compilation.hasError("@Constant value=\"xy\" must be a single character"),
+      () -> "the char arm reports through the same caller-supplied name: " + compilation.errorMessages()
+    );
+  }
+
+  @Test
+  @DisplayName("a taken navigator name reports the same way a taken bridge name does")
+  void takenNavigatorNameSaysWhatToRename() {
+    // The navigator and the metadata holder are written by different emitters than the bridge, so
+    // each carries its own copy of the failure path.
+    final var compilation = ProcessorHarness.compileFully(
+      List.of(new FocusProcessor()),
+      List.of(),
+      ProcessorHarness.source(
+        "demo.FSrc",
+        """
+        package demo;
+        import io.github.eschizoid.telescope.annotations.Focus;
+        @Focus
+        public record FSrc(String name) {}
+        """
+      ),
+      ProcessorHarness.source("demo.FSrcTelescope", "package demo; public final class FSrcTelescope {}"),
+      // The metadata holder is written by the utility-class emitter, a third copy of the
+      // path.
+      ProcessorHarness.source("demo.FSrcFieldOptics", "package demo; public final class FSrcFieldOptics {}")
+    );
+
+    assertFalse(compilation.success(), "the processor cannot write over a hand-written navigator");
+    assertTrue(
+      compilation.hasError("that name is already taken"),
+      () -> "every emitter should phrase this the same way: " + compilation.errorMessages()
+    );
+  }
+
+  @Test
   @DisplayName("a lenient bridge writes null into an unmatched collection slot, as the javadoc says")
   void lenientUnmatchedCollectionIsWrittenNull() {
     final var compilation = compile(

--- a/core/src/main/java/io/github/eschizoid/telescope/annotations/Bridge.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/annotations/Bridge.java
@@ -235,7 +235,7 @@ public @interface Bridge {
    * Skip the strict-bijection check. When {@code lenient = true}, the processor emits writes only
    * for the components named in {@link #renames()} / {@link #transforms()} plus same-name
    * auto-matches that exist on both sides; unmatched target components take their JLS default (zero
-   * for primitives, empty for collections, {@code null} for references); unmatched source
+   * for primitives, {@code null} for every reference type, collections included); unmatched source
    * components are silently ignored.
    *
    * <p>Designed for the small-DTO → large-entity pattern (e.g. mapping a 7-field DTO into a
@@ -247,11 +247,11 @@ public @interface Bridge {
    * <em>partial-Iso</em>. The forward direction {@code BRIDGE.read(source)} is fine — unmatched
    * Target fields take JLS defaults, which is the whole point. The backward direction {@code
    * BRIDGE.set(source, target)} is the lossy one: every {@code Source}-side field that has no
-   * {@code Target} counterpart comes back populated at the JLS default ({@code null} for
-   * references, zero / empty for primitives and collections), regardless of what the original
-   * Source held. Adopters who rely on backward round-trip safety must NOT set {@code lenient}. The
-   * generated {@code <X>Bridge} class javadoc carries a matching warning so the asymmetry is
-   * unambiguous in IDE auto-complete.
+   * {@code Target} counterpart comes back populated at the JLS default ({@code null} for every
+   * reference type, zero for primitives), regardless of what the original Source held. A collection
+   * slot comes back {@code null}, not empty. Adopters who rely on backward round-trip safety must
+   * NOT set {@code lenient}. The generated {@code <X>Bridge} class javadoc carries a matching
+   * warning so the asymmetry is unambiguous in IDE auto-complete.
    *
    * <p>Same-name auto-matches and declared renames still go through their normal type-safety
    * pipeline — {@code lenient} only removes the bijection-completeness check, never the per-pair


### PR DESCRIPTION
Closes #350. All four items, each with a test that fails against the unfixed processor.

A diagnostic is read by someone who cannot see the code that produced it, so naming the wrong annotation or describing a symptom instead of a cause sends them somewhere their source does not go.

## The four

**The shared literal parser named the wrong annotation.** `parseConstantLiteral` serves both `@Constant` and `@Default` and hardcoded `@Constant` in all six of its messages, so an unparseable `@Default` was reported against an annotation the file does not contain. The caller now passes its own name. The `@Constant` path has its own test as the control — the fix is a parameter, so the other caller has to keep reporting its own name.

**A plain interface target was reported as a bijection failure.** An interface is a declared type, so it passed the kind check, paired against an empty component list, and came back as `Tgt has []` — the symptom. It is now named as what it is, with the two ways out (name the implementation, or seal it and give each permit its own `@Bridge`).

**A name already owned by a hand-written type surfaced the raw Filer text** under a generic `Failed to write` prefix. It now says the name is taken and what to rename. Other `IOException`s keep the old wording, being genuine write failures with nothing to act on.

**The `lenient` javadoc contradicted itself.** It promised unmatched target components take *"their JLS default (zero for primitives, empty for collections, `null` for references)"*. A collection **is** a reference type, so its JLS default is null — the sentence disagreed with its own opening clause. Both implementations fill null and agree with each other, which makes the javadoc the wrong party, exactly as the issue reasoned.

## On that last test

My first version asserted `bridge.contains("null")`. That passes against any generated bridge ever emitted, because every one of them opens with a null guard — a test that could not fail. I dumped the actual emission instead:

```java
return new demo.LDst(__fs_name, null, 0);
```

and now assert that whole constructor call. The `int` slot beside the collection is the control: it shows the two are decided by declared type, not by name.

## Verification

| hunk reverted | fails |
| --- | --- |
| parser takes its name from the caller | the `@Default` test only — the `@Constant` control stays green |
| interface-target guard | the interface test only |

Each probe failed exactly its own test and left the other four passing. Every test also asserts the *misleading* message is absent, not just that the right one is present, since a processor emitting both would satisfy a one-sided assertion.

Suites green across all six modules.
