### PR TITLE
bench: measure navigating a generated navigator per call

### DIFF
--- a/benchmarks/src/jmh/java/io/github/eschizoid/telescope/benchmarks/NavigatorFluencyBenchmark.java
+++ b/benchmarks/src/jmh/java/io/github/eschizoid/telescope/benchmarks/NavigatorFluencyBenchmark.java
@@ -1,0 +1,70 @@
+package io.github.eschizoid.telescope.benchmarks;
+
+import io.github.eschizoid.telescope.Telescope;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+
+/**
+ * Navigating a generated navigator inside the measured loop, which no other benchmark does: every
+ * existing row builds its path once in {@code @Setup}, so the cost of the fluent call itself is
+ * invisible to the whole suite.
+ *
+ * <p>Each navigator row has a prebuilt-path row beside it reading the same field of the same value.
+ * The pair is what separates the two costs: the read is common to both, so the difference is what
+ * the fluent call adds, and a change that moved both equally would be measuring the read.
+ *
+ * <p>Depth is the dimension. A one-hop path and a three-hop path do the same amount of reading per
+ * element but build a different number of intermediate optics, so a per-call construction cost
+ * shows up as a gap that widens with depth while the prebuilt rows stay flat relative to each
+ * other. Run with {@code -Pjmh.profilers=gc}: allocation is deterministic and survives a runner
+ * difference.
+ */
+@State(Scope.Thread)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+public class NavigatorFluencyBenchmark {
+
+  private BenchHolderSrc source;
+  private Telescope<BenchHolderSrc, String> shallowPath;
+  private Telescope<BenchHolderSrc, String> deepPath;
+
+  @Setup
+  public void setup() {
+    source = new BenchHolderSrc(
+      "acme",
+      new BenchHolderDeptSrc("platform", 8, new BenchHolderAddressSrc("berlin", "10115"))
+    );
+    shallowPath = BenchHolderSrcTelescope.of().name();
+    deepPath = BenchHolderSrcTelescope.of().department().address().city();
+  }
+
+  /** One hop, navigated per call. */
+  @Benchmark
+  public String navigateShallow() {
+    return BenchHolderSrcTelescope.of().name().read(source);
+  }
+
+  /** The same one-hop read against a path built once — the control for the row above. */
+  @Benchmark
+  public String prebuiltShallow() {
+    return shallowPath.read(source);
+  }
+
+  /** Three hops, navigated per call. */
+  @Benchmark
+  public String navigateDeep() {
+    return BenchHolderSrcTelescope.of().department().address().city().read(source);
+  }
+
+  /** The same three-hop read against a path built once. */
+  @Benchmark
+  public String prebuiltDeep() {
+    return deepPath.read(source);
+  }
+}


### PR DESCRIPTION
Groundwork for #345, which does not close here.

#345 asks for the measurement to land before the emitter change, because every existing benchmark builds its path in `@Setup` — so what a fluent navigation call costs is invisible to the entire suite. That is the same green-while-wrong shape that let the last three perf defects ship, and it means neither a win nor a regression from changing the navigator emission would be observable today.

## What it measures

The generated navigator rebuilds its optics on every call. From the emitted `BenchHolderSrcTelescope`:

```java
public Telescope<R, String> name() {
  return path.then(Telescope.lens(BenchHolderSrc::name, (s, v) -> new BenchHolderSrc(v, ...)))
             .hop(new OpticNode.Focus("name"));
}
```

A fresh `Lens`, a fresh composed `Telescope`, a fresh `OpticNode`, and `hop`'s trail copy — per invocation — although a byte-identical lens already exists as a constant on the sibling `BenchHolderSrcFieldOptics`.

## Design

Each navigator row has a **prebuilt-path row beside it** reading the same field of the same value. The read is common to both, so the difference is what the fluent call adds; a change that moved both rows equally would be measuring the read rather than the construction.

**Depth is the dimension**, and it is the one that discriminates. One hop and three hops do the same amount of reading but build a different number of intermediate optics, so a per-call construction cost appears as a gap that widens with depth, where a read cost would not. The chain is `department().address().city()` against `name()`.

No production code. Numbers to follow once the run lands; the fix is a separate PR so it has a before side to be measured against.
