### PR TITLE
fix(codegen): reject abstract sides, and call the sub-bridge name emitted

### DIFF
--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
@@ -355,6 +355,21 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
           error(element, "@Bridge source must be a top-level type");
           continue;
         }
+        // An abstract class reaches here as an ordinary CLASS, so the kind check above lets it
+        // through and the rebuild emits a constructor call javac refuses. Both sides rebuild — the
+        // target on forward, the source on backward — so both are checked.
+        final var abstractDeclared = firstAbstractSide(sourceEl, targetEl);
+        if (abstractDeclared != null) {
+          error(
+            element,
+            "@Bridge " +
+              (abstractDeclared == sourceEl ? "source " : "target ") +
+              abstractDeclared.getSimpleName() +
+              " is abstract, so the rebuild has no constructor to call. Name a concrete" +
+              " subtype, or seal it and give each permit its own @Bridge."
+          );
+          continue;
+        }
         final var pair = new TypePair(sourceFq, targetEl.getQualifiedName().toString());
         userDeclared.add(pair);
         final var drops = dropsFromMirror(bridgeAm);
@@ -450,6 +465,7 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
       configsByPair.clear();
       lenientPairs.clear();
       bridgeProviders.clear();
+      bridgeNameOwner.clear();
     }
     return true;
   }
@@ -2767,6 +2783,19 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
           subSourceEl.getQualifiedName().toString(),
           subTargetEl.getQualifiedName().toString()
         );
+        final var abstractSub = firstAbstractSide(subSourceEl, subTargetEl);
+        if (abstractSub != null) {
+          error(
+            source,
+            "@Bridge field \"" +
+              sf.name() +
+              "\" needs a sub-bridge for " +
+              abstractSub.getSimpleName() +
+              ", which is abstract and has no constructor to rebuild through. Name a concrete" +
+              " type for that field, or give it an explicit @ViaMapper."
+          );
+          return null;
+        }
         // Sub-pairs whose source or target carries a Lombok-synthesizing annotation must wait for
         // processingOver() — same rationale as the top-level deferral. shouldDeferSubPair returns
         // false while inDeferredDrain is true, so the deferred drain itself doesn't re-defer.
@@ -3130,7 +3159,8 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
   // The first of the two raw-container fields whose concrete allocation class lacks a public no-arg
   // constructor (the generated `new <impl>()` would not compile), or null when both are
   // allocatable.
-  // The JDK default impls (ArrayList / LinkedHashSet / HashMap) always qualify; only a user subtype
+  // The JDK default impls (ArrayList / LinkedHashSet / LinkedHashMap) always qualify; only a user
+  // subtype
   // can hide its no-arg ctor.
   private String firstNonAllocatableContainer(
     final TypeMirror srcContainer,
@@ -3288,6 +3318,19 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
    * <Source>Bridge}; auto-generated sub-pairs use {@code <Source>To<Target>Bridge} so they don't
    * collide with a user-declared {@code <Source>Bridge} that points at a different target.
    */
+  /**
+   * The first of the two sides that is an abstract class, or {@code null} when both can be
+   * constructed. A rebuild calls a constructor and an abstract class has none to call, so the pair
+   * is refused here rather than emitted and left for javac to reject inside a file the author never
+   * wrote. An interface is handled separately; this is the class case the kind check lets through.
+   */
+  private static TypeElement firstAbstractSide(final TypeElement source, final TypeElement target) {
+    for (final var el : List.of(source, target)) {
+      if (el.getKind() == ElementKind.CLASS && el.getModifiers().contains(Modifier.ABSTRACT)) return el;
+    }
+    return null;
+  }
+
   private static String bridgeClassName(
     final TypeElement source,
     final TypeElement target,
@@ -3326,8 +3369,12 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
       subCfg == null || subCfg.carrierFq() == null
         ? null
         : processingEnv.getElementUtils().getTypeElement(subCfg.carrierFq());
+    // A source carrying more than one @Bridge target is emitted under the long name for every one
+    // of them, because the short name can belong to only one pair. Both emission sites apply that
+    // term, so a reference that omits it names a class nothing writes.
+    final var shortName = userDeclared && !multiTargetSources.contains(subSource.getQualifiedName().toString());
     final var simple =
-      carrierEl != null ? carrierEl.getSimpleName() + "Bridge" : bridgeClassName(subSource, subTarget, userDeclared);
+      carrierEl != null ? carrierEl.getSimpleName() + "Bridge" : bridgeClassName(subSource, subTarget, shortName);
     final var owner = carrierEl != null ? carrierEl : subSource;
     final var subPkg = processingEnv.getElementUtils().getPackageOf(owner).getQualifiedName().toString();
     if (subPkg.isEmpty() || subPkg.equals(parentPkg)) return simple;

--- a/codegen/src/test/java/io/github/eschizoid/telescope/codegen/BridgeProcessorTest.java
+++ b/codegen/src/test/java/io/github/eschizoid/telescope/codegen/BridgeProcessorTest.java
@@ -661,7 +661,7 @@ class BridgeProcessorTest {
         " interface default"
     )
     void mixedGenericAndRawCollectionElementBridges() {
-      final var compilation = compile(
+      final var compilation = compileAttributed(
         source(
           "demo.MixOrder",
           """
@@ -708,7 +708,7 @@ class BridgeProcessorTest {
       "mixed generic↔raw Map: Map<K, V> ↔ raw HashMap subtype, backward allocates the two-arg" + " default impl"
     )
     void mixedGenericAndRawMapElementBridges() {
-      final var compilation = compile(
+      final var compilation = compileAttributed(
         source(
           "demo.MMixOrder",
           """

--- a/codegen/src/test/java/io/github/eschizoid/telescope/codegen/DiagnosticWordingTest.java
+++ b/codegen/src/test/java/io/github/eschizoid/telescope/codegen/DiagnosticWordingTest.java
@@ -191,6 +191,106 @@ class DiagnosticWordingTest {
   }
 
   @Test
+  @DisplayName("an abstract target is reported, and no bridge is emitted for it")
+  void abstractTargetIsReported() {
+    final var compilation = compile(
+      ProcessorHarness.source(
+        "demo.ASrc",
+        """
+        package demo;
+        import io.github.eschizoid.telescope.annotations.Bridge;
+        @Bridge(demo.ADst.class)
+        public record ASrc(String name) {}
+        """
+      ),
+      ProcessorHarness.source("demo.ADst", "package demo; public abstract class ADst { public String name; }")
+    );
+
+    assertFalse(compilation.success(), "an abstract target has no constructor to rebuild through");
+    assertTrue(
+      compilation.hasError("@Bridge target ADst is abstract"),
+      () -> "the cause should be named where the annotation is: " + compilation.errorMessages()
+    );
+    assertFalse(
+      compilation.errorMessages().contains("is abstract; cannot be instantiated"),
+      () -> "javac's error inside generated code is what this replaces: " + compilation.errorMessages()
+    );
+    assertTrue(
+      compilation.generated().isEmpty(),
+      () -> "nothing should be written: " + compilation.generated().keySet()
+    );
+  }
+
+  @Test
+  @DisplayName("an abstract source is reported too, since backward rebuilds it")
+  void abstractSourceIsReported() {
+    final var compilation = compile(
+      ProcessorHarness.source(
+        "demo.BSrc",
+        """
+        package demo;
+        import io.github.eschizoid.telescope.annotations.Bridge;
+        @Bridge(demo.BDst.class)
+        public abstract class BSrc { public String name; }
+        """
+      ),
+      ProcessorHarness.source("demo.BDst", "package demo; public record BDst(String name) {}")
+    );
+
+    assertFalse(compilation.success(), "an abstract source cannot be rebuilt on backward");
+    assertTrue(
+      compilation.hasError("@Bridge source BSrc is abstract"),
+      () -> "the source side needs its own diagnostic: " + compilation.errorMessages()
+    );
+    assertTrue(
+      compilation.generated().isEmpty(),
+      () -> "nothing should be written: " + compilation.generated().keySet()
+    );
+  }
+
+  @Test
+  @DisplayName("an abstract type reached as a nested sub-pair is reported, not emitted against")
+  void abstractNestedSubPairIsReported() {
+    // The declared pair is concrete on both sides; the abstract type is discovered while planning
+    // the nested field, which is a different code path from the annotation scan.
+    final var compilation = compile(
+      ProcessorHarness.source(
+        "demo.NRoot",
+        """
+        package demo;
+        import io.github.eschizoid.telescope.annotations.Bridge;
+        @Bridge(demo.NRootDto.class)
+        public record NRoot(demo.NLeaf leaf) {}
+        """
+      ),
+      ProcessorHarness.source("demo.NRootDto", "package demo; public record NRootDto(demo.NAbsLeaf leaf) {}"),
+      ProcessorHarness.source("demo.NLeaf", "package demo; public record NLeaf(String v) {}"),
+      ProcessorHarness.source(
+        "demo.NAbsLeaf",
+        """
+        package demo;
+        // Pairs cleanly by name, so the only thing wrong with it is that it cannot be constructed.
+        public abstract class NAbsLeaf {
+          private String v;
+          public String getV() { return v; }
+          public void setV(final String v) { this.v = v; }
+        }
+        """
+      )
+    );
+
+    assertFalse(compilation.success(), "an abstract nested target has no constructor to rebuild through");
+    assertTrue(
+      compilation.hasError("which is abstract and has no constructor to rebuild through"),
+      () -> "the nested path needs its own diagnostic, naming the field: " + compilation.errorMessages()
+    );
+    assertFalse(
+      compilation.errorMessages().contains("is abstract; cannot be instantiated"),
+      () -> "javac inside generated code is the failure mode being replaced: " + compilation.errorMessages()
+    );
+  }
+
+  @Test
   @DisplayName("a lenient bridge writes null into an unmatched collection slot, as the javadoc says")
   void lenientUnmatchedCollectionIsWrittenNull() {
     final var compilation = compile(

--- a/codegen/src/test/java/io/github/eschizoid/telescope/codegen/GeneratedNameCollisionTest.java
+++ b/codegen/src/test/java/io/github/eschizoid/telescope/codegen/GeneratedNameCollisionTest.java
@@ -369,6 +369,48 @@ class GeneratedNameCollisionTest {
   }
 
   @Test
+  @DisplayName("a multi-target source is referenced by the long name it is actually emitted under")
+  void multiTargetSubBridgeIsReferencedByItsEmittedName() {
+    // A source with two @Bridge targets cannot use the short name for either, because the short
+    // name can belong to only one pair. The parent has to call whichever name was written.
+    final var compilation = compile(
+      new BridgeProcessor(),
+      source(
+        "demo.A",
+        """
+        package demo;
+        import io.github.eschizoid.telescope.annotations.Bridge;
+        @Bridge(demo.B.class)
+        @Bridge(demo.C.class)
+        public record A(String v) {}
+        """
+      ),
+      source("demo.B", "package demo; public record B(String v) {}"),
+      source("demo.C", "package demo; public record C(String v) {}"),
+      source(
+        "demo.P",
+        """
+        package demo;
+        import io.github.eschizoid.telescope.annotations.Bridge;
+        @Bridge(demo.PDto.class) public record P(demo.A a) {}
+        """
+      ),
+      source("demo.PDto", "package demo; public record PDto(demo.B a) {}")
+    );
+
+    assertTrue(
+      compilation.success(),
+      () -> "the parent must call a sub-bridge that exists; saw " + compilation.errorMessages()
+    );
+    final var parent = compilation.generated().get("demo.PBridge");
+    assertTrue(
+      parent != null && parent.contains("AToBBridge"),
+      () -> "the multi-target source is emitted under its long name, so the call must use it; saw " + parent
+    );
+    assertTrue(compilation.generated().containsKey("demo.AToBBridge"), "the long-named sub-bridge is what is written");
+  }
+
+  @Test
   @DisplayName("two pairs whose auto-derived bridge names collide are named at the declaration")
   void collidingAutoBridgeNamesAreReported() {
     // a.MoneyA -> b.MoneyB and a.MoneyA -> c.MoneyB both derive MoneyAToMoneyBBridge in package a,


### PR DESCRIPTION
Three defects found by an adversarial review of yesterday's merges — none of which had any review, because Copilot never attached to a single PR.

## Abstract sides were never rejected

My interface guard from #363 checks `ElementKind.INTERFACE`. An abstract class is `ElementKind.CLASS`, so it sails through and the rebuild emits a constructor call javac refuses — `is abstract; cannot be instantiated`, inside a file the author never wrote. That is precisely the failure shape the guard exists to replace, so the fix was half a fix.

Three sites reach that emission and all three are now covered by one check: the declared **target** (rebuilt on forward), the declared **source** (rebuilt on backward, which the original guard never looked at), and a **nested sub-pair**, which is discovered while planning a field rather than at the annotation scan.

The nested case is worth a note on test design. My first fixture used an abstract class with a public *field*, and the test passed — but for the wrong reason: the class exposes no properties, so it failed the bijection check instead, and the test would have passed with no abstractness handling at all. Giving it real getters made it fail, which is what proved the gap was real.

## A parent could call a sub-bridge that is never written

A source carrying more than one `@Bridge` target is emitted under the **long** name for every one of them, since the short name can belong to only one pair. Both emission sites apply that term:

```java
final var useShortName = userDeclared.contains(thisPair) && !multiTargetSources.contains(sourceFq);
```

`subBridgeReference` — the function #358 documented as the authority on that name — applied only the first half, so a parent referencing a multi-target type as a nested field called `ABridge`, while `AToBBridge` is what got written. Three `cannot find symbol`. Pre-existing, but it lives in the function now claiming to be the single source of that decision, which makes it the right home for the fix.

## One map missing from the reset it belongs to

`bridgeNameOwner` is the cross-round accumulator #358 added, and the only one absent from the `processingOver()` reset — the block that exists so a reused processor instance starts clean. Left in, a second compilation could be refused for a collision with a pair not in its own sources. One line.

## Also

The two sized-allocation tests from #362 now compile through the full pipeline. Under `-proc:only` javac never attributes generated sources, so an allocation expression that does not compile still reports success and a string assertion about it holds either way — they were pinning text, not behaviour.

## Verification

| hunk reverted | fails |
| --- | --- |
| the abstract check | both abstract tests, and the nested one |
| the multi-target term | the multi-target test only |

Every new test asserts the telescope diagnostic is present **and** that javac's downstream error is absent, and the two declared-side tests also assert nothing was emitted. Suites green across all six modules.
