### PR TITLE
docs: repair the retraction, and recompute the deep range from its table

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,8 +410,8 @@ performance class:
 | --------------------------- | ------------------------------------------------------------------- |
 | flat (5 scalars)            | ~1.07× — a fifth of a nanosecond                                    |
 | nested (one nested type)    | 1.04×–1.46× across runs — a microbenchmark, not a service shape     |
-| deep (3 levels + list hops) | 1.06×–1.19× across runs — 4 ns on a 62 ns conversion at the low end |
-| Set or Map field, 100 items | a tie on time, and the same allocation                              |
+| deep (3 levels + list hops) | 1.06×–1.18× across runs — 4 ns on a 62 ns conversion at the low end |
+| Set or Map field, 100 items | the same allocation; timings pending a re-run                       |
 
 No codegen? `Telescope.mapper(...)` composes each record/bean pair into a single MethodHandle: zero annotations, no
 build step, within ~1.04–3.3× of MapStruct in the same workloads (flat ~3.3×, nested ~2.7×, deep ~1.3×, container fields

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -105,8 +105,9 @@ across all rows per tier, so the engines time the SAME work — only the convers
 **How to read the rows:**
 
 - `_mapstruct_*` vs `_telescope_codegen_*` is the closest comparison — both bind at compile time and emit direct
-  bytecode. Any delta is the cost of telescope's lattice composition vs MapStruct's hand-templated method body. Usually
-  small and dominated by JIT inlining.
+  bytecode. On flat and nested any delta is the cost of telescope's lattice composition against MapStruct's
+  hand-templated method body; on deep the residual sits below the first dispatch hop and has no established mechanism.
+  Usually small and dominated by JIT inlining.
 - `_telescope_runtime_*` establishes the upper bound on telescope when the consumer opts out of codegen entirely. The
   gap to `_telescope_codegen_*` is what `@Bridge` buys.
 
@@ -256,8 +257,9 @@ refreshes on the next benchmark workflow run.
 Tight error bands on the codegen/MapStruct rows (±0.01–0.35 ns) — the dedicated CI runner with no competing workload
 gives cleaner data than a laptop. The `static` column calls the codegen-emitted `<Source>Bridge.forward(s)` directly,
 bypassing the `Telescope` lattice; it isolates the lattice-dispatch tax. A directly-callable `BRIDGE_FN` constant (one
-interface hop, omitted here for width) lands at the `static` floor — the full four-call-shape breakdown and the
-dispatch-tax decomposition live in [`docs/perf-mapstruct-comparison.md`](../docs/perf-mapstruct-comparison.md).
+interface hop, omitted here for width) lands at the `static` floor on flat and nested, and above it on deep — the full
+four-call-shape breakdown and the dispatch-tax decomposition live in
+[`docs/perf-mapstruct-comparison.md`](../docs/perf-mapstruct-comparison.md).
 
 #### How the runtime path stays fast
 
@@ -287,9 +289,9 @@ the fixed dispatch overhead; at the flat scale you're choosing on API and capabi
 The gap is not mostly dispatch. The `static` column (zero-dispatch `<Source>Bridge.forward(s)`) is the floor; the
 `BRIDGE.read` lattice path sits a sub-nanosecond wrapper tax above it (its size, and on one run its sign, move between
 runs — see the doc), and on deep the residual over MapStruct sits below that floor. What it _is_ has no established
-mechanism — the two generated bodies are equivalent in source and bytecode and allocate identically — and the doc's "So
-is there a real gap?" section is the one place that says so. The full decomposition, all four call shapes (`static` /
-`BRIDGE_FN` / `BRIDGE.read` / MapStruct) at each tier, plus the JMH-artifact history, lives in
+mechanism — the two generated bodies do the same work, with the same guards on the same paths and the same allocations —
+and the doc's "So is there a real gap?" section is where that is characterised. The full decomposition, all four call
+shapes (`static` / `BRIDGE_FN` / `BRIDGE.read` / MapStruct) at each tier, plus the JMH-artifact history, lives in
 [`docs/perf-mapstruct-comparison.md`](../docs/perf-mapstruct-comparison.md).
 
 Where the flat-tier gap comes from. MapStruct emits one hand-templated method body per pair, fully monomorphic, and the
@@ -299,8 +301,9 @@ costs a fraction of a nanosecond; on deep, where element-by-element list convers
 past 50 ns, it is the same sub-nanosecond tax against a far larger row. What remains of the deep gap over MapStruct is
 not composability, and not the emitted body doing more work either; the comparison doc carries the per-run ratio, the
 across-run range, and what the residual has been ruled down to. If you're in a tight inner loop that doesn't need
-composition, call `<Source>Bridge.forward(s)` — or the directly-callable `BRIDGE_FN` constant — and pay the
-zero-dispatch floor.
+composition, call `<Source>Bridge.forward(s)` and pay the zero-dispatch floor. The directly-callable `BRIDGE_FN`
+constant is the same floor on flat and nested, but the one run that resolves it on deep puts it about 7 ns above — so on
+the deep tier prefer the static call.
 
 Runtime conversion (`Telescope.mapper(...)`) composes each record/bean pair into a single MethodHandle (see above), so
 the hot path is one `invokeExact` through the fused handle rather than an `Object[]` gather with boxed per-field

--- a/core/src/main/java/io/github/eschizoid/telescope/ContainerLifts.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/ContainerLifts.java
@@ -197,7 +197,7 @@ final class ContainerLifts {
    * Map-level lift that writes into the target's concrete raw class. Mirror of {@link
    * #liftListIntoTargetRaw} for Maps. Preserves source keys verbatim (matches {@link
    * Iso#liftMapValues}); the calling site already ensured the key classes match. Falls back to
-   * {@link HashMap} when the raw class is the {@link Map} interface itself (see {@link
+   * {@link LinkedHashMap} when the raw class is the {@link Map} interface itself (see {@link
    * #mapAllocatorFor}).
    */
   @SuppressWarnings({ "unchecked", "rawtypes" })

--- a/docs/mapstruct-parity.md
+++ b/docs/mapstruct-parity.md
@@ -347,7 +347,7 @@ including nested containers like `List<Optional<X>>` and `Map<K,List<X>>`. Bidir
 honesty caveat: auto-lift requires SAME-kind containers on both sides (PairingRules.java:79 — srcView.kind() ==
 tgtView.kind()); MapStruct's List -> Set cross-kind copy needs an explicit to(src, tgt, fwd, bwd) row in telescope.
 Target concrete class (ArrayList/LinkedList/CopyOnWriteArrayList/...) is honored via listAllocatorFor
-(DeepMap.java:1441-1461).
+(`ContainerLifts.listAllocatorFor`).
 
 <sub>Evidence: core/src/main/java/io/github/eschizoid/telescope/DeepMap.java:65-73 (engine javadoc:
 List/Set/Map-values/Optional lift the element Iso, containers nest to any depth), DeepMap.java:1093-1124 (LiftContainer
@@ -385,12 +385,11 @@ transform over the entire Map. No per-key/per-value format sugar like @MapMappin
 hand-written stream/collect transform row. Target Map concrete type is honored; EnumMap targets are rejected with a
 precise error (needs an explicit row).
 
-<sub>Evidence: core/src/main/java/io/github/eschizoid/telescope/DeepMap.java:1116-1120 (MAP_VALUES lift), 1405-1434
-(liftMapIntoTargetRaw: 'Preserves source keys verbatim'), 1238-1246 (via(...) throws when Map key types differ: 'Key
-types must match exactly; auto-lifting preserves the source keys'), 1487-1508 (mapAllocatorFor:
-HashMap/LinkedHashMap/TreeMap/ConcurrentHashMap/...; EnumMap rejected at plan time);
-internal/src/main/java/io/github/eschizoid/telescope/internal/pairing/PairingRules.java:80-91 (mismatched key types ->
-Incompatible), 119-122 (non-class key type arg means the Map is not treated as liftable);
+<sub>Evidence: `DeepMap`'s MAP_VALUES lift; `ContainerLifts.liftMapIntoTargetRaw` ('Preserves source keys verbatim');
+`DeepMap`'s via(...) rejection when Map key types differ ('Key types must match exactly; auto-lifting preserves the
+source keys'); `ContainerLifts.mapAllocatorFor` (HashMap/LinkedHashMap/TreeMap/ConcurrentHashMap/...; EnumMap rejected
+at plan time); internal/src/main/java/io/github/eschizoid/telescope/internal/pairing/PairingRules.java:80-91 (mismatched
+key types -> Incompatible), 119-122 (non-class key type arg means the Map is not treated as liftable);
 core/src/test/java/io/github/eschizoid/telescope/DeepMappingTest.java:172-174 (Map values recursed, keys preserved),
 280-289 (`Map<K, List<Record>>` auto-lifts);
 core/src/test/java/io/github/eschizoid/telescope/DeepMapCoverageTest.java:77,152 (key-type mismatch rejection

--- a/docs/perf-mapstruct-comparison.md
+++ b/docs/perf-mapstruct-comparison.md
@@ -13,7 +13,7 @@ hence the two columns below, read as the caption describes.
 | ----------------------------------- | ---------------: | ---------------: | ----: | ---------------------- | ----------------- |
 | flat (5 scalars)                    | 3.155 ± 0.019 ns | 3.362 ± 0.011 ns | 1.07x | ~1.07x (one run 1.13x) | 32 B/op both      |
 | nested (one nested type)            | 4.361 ± 0.045 ns | 5.604 ± 0.033 ns | 1.29x | 1.04x–1.46x            | 48 B/op both      |
-| deep (3 levels + 2 list hops)       |  62.38 ± 0.18 ns |  66.57 ± 0.52 ns | 1.07x | 1.06x–1.19x            | 376 B/op both     |
+| deep (3 levels + 2 list hops)       |  62.38 ± 0.18 ns |  66.57 ± 0.52 ns | 1.07x | 1.06x–1.18x            | 376 B/op both     |
 | container, Map-valued (100 entries) |     1262 ± 11 ns |     1244 ± 10 ns |   tie | measured once          | 7,528 B/op both\* |
 | container, Set-valued (100 entries) |     1455 ± 21 ns |      1445 ± 9 ns |   tie | measured once          | 7,576 B/op both   |
 
@@ -23,26 +23,30 @@ context: only flat holds its value between runs, and the container tiers exist o
 
 Read the two container rows carefully — telescope's mean is marginally lower on both, and on neither does that mean it
 won. On Set the intervals overlap almost entirely (telescope's sits inside MapStruct's), which is a clean tie. On Map
-they overlap by under 3 ns, so call it a tie but not a settled one: tighter bands could separate them either way.
+they overlap by under 3 ns, so call it a tie but not a settled one: tighter bands could separate them either way. Both
+container rows' timings predate the Map-container change described in the footnote and are pending a re-run.
 
 \* The Map row once carried an allocation win — 6,712 against 7,528 bytes per operation — and it was not one. An
 interface-typed `Map` field rebuilt as a `HashMap` where MapStruct builds a `LinkedHashMap`, so the two sides were
 building different containers and the cheaper one was being read as the better result. Telescope now builds the same
-container, its allocation lands on MapStruct's figure exactly, and an ordered source keeps its order across the
-conversion. The timings in this row predate that change and need a re-run before they are quoted again; the allocation
-figure does not, because allocation is deterministic rather than hardware-dependent.
+container and an ordered source keeps its order across the conversion. The 7,528 figure for telescope is measured, but
+by a later run than the timings beside it — Actions 34611507811, which ran this filter against the changed code and
+reported both sides at 7,528 B/op. **The timings in this row predate the change and should not be quoted until a re-run
+replaces them**, which applies to the tie reading above and to the container line in `README.md` as much as to the table
+cell.
 
 The scalar tiers are unchanged in character: a 0.2 ns difference on flat, 4 ns on a 62 ns deep conversion, and both
 outside their error bars, so each ratio is real within its own run. Only flat is also stable across runs, clustering at
-~1.07x. Deep is not: this run's 1.07x sits near the low end of a 1.06x–1.19x spread — the four runs of this benchmark
-measured 1.06x, 1.07x, 1.14x and 1.19x — so read it as a range too, and read this run as near its optimistic edge.
-Nested is the widest of the three — 1.04x to 1.46x across CI runs of this benchmark (the 1.46x end from Actions run
-34148517680; this run is 34470676359), landing at 1.29x here. It is a framework-overhead microbenchmark rather than a
-service-shaped workload; treat flat as the publishable figure, and deep and nested as ranges.
+~1.07x. Deep is not: this run's 1.07x sits near the low end of a 1.06x–1.18x spread — the four tabulated runs measured
+1.06x, 1.07x, 1.14x and 1.18x — so read it as a range too, and read this run as near its optimistic edge. Nested is the
+widest of the three — 1.04x to 1.46x across CI runs of this benchmark (the 1.46x end from Actions run 34148517680; this
+run is 34470676359), landing at 1.29x here. It is a framework-overhead microbenchmark rather than a service-shaped
+workload; treat flat as the publishable figure, and deep and nested as ranges.
 
-Runtime tier, same run: flat 3.34x, nested 2.66x, deep 1.27x, and 1.04x–1.06x on the two container shapes. MapStruct has
-no equivalent to this tier — it is what you get with no annotations and no build step — so these ratios say what the
-convenience costs, not who wins.
+Runtime tier, same run: flat 3.34x, nested 2.66x, deep 1.27x, and 1.04x–1.06x on the two container shapes — the Map
+shape there predates the same change, since it moved the runtime allocator too. MapStruct has no equivalent to this tier
+— it is what you get with no annotations and no build step — so these ratios say what the convenience costs, not who
+wins.
 
 ### What the container tier is for
 
@@ -90,7 +94,7 @@ three tiers (earlier revisions measured it on flat only).
 | ------ | ------------: | ------------------------------: | --------------------------: | -------------------------------: | ----------------: |
 | flat   | 2.527 ± 0.159 |                   2.692 ± 0.099 |               2.629 ± 0.294 |                    2.544 ± 0.077 |            1.065× |
 | nested | 4.506 ± 0.366 |                   4.699 ± 0.146 |               4.722 ± 0.331 |                    4.503 ± 0.144 |            1.043× |
-| deep   | 40.29 ± 0.801 |                   47.72 ± 1.503 |               48.41 ± 4.023 |                    47.40 ± 3.153 |            1.185× |
+| deep   | 40.29 ± 0.801 |                   47.72 ± 1.503 |               48.41 ± 4.023 |                    47.40 ± 3.153 |            1.184× |
 
 **Forward — Run 2 (tighter error bands):**
 
@@ -109,17 +113,17 @@ three tiers (earlier revisions measured it on flat only).
 | deep   | 42.11 ± 1.575 |        49.54 ± 1.312 |             1.18× |
 
 **What reproduces, and what doesn't** — as read at the time, from these two runs alone. Flat (1.065× / 1.072×) and deep
-(1.185× / 1.137×) are stable across the pair. The headline run later measured deep at ~1.07× and run 4 at ~1.06×, so
-~1.15× is what these two runs supported and 1.06×–1.19× is the spread across all four — not a figure that has since been
-superseded by a single lower one. Nested swings 1.043× → 1.424×: the `nested_mapstruct_forward` baseline carries a wide
-±0.35 band both runs, so the nested ratio is a JMH-noisy figure, not a real regression or improvement — don't publish a
-single number for it. On the dispatch spread, both runs agree: `BRIDGE_FN` tracks `static forward` within error (run 2
-flat: identical at 3.183), while `BRIDGE.read` sits a wrapper tax above the floor that grows with depth — 0.14 → 0.31 →
-0.77 ns across flat/nested/deep on the tight-band run, each outside its error band. So `BRIDGE_FN` is the floor; the
-lattice wrapper is a small (≤0.8 ns) tax that scales with nesting depth; and on deep the residual over MapStruct sits
-below the first dispatch hop (`static forward` alone is ~1.12× on deep, ~5.6 ns of the ~6.3 ns gap). What that residual
-_is_ was read at the time as the emitted body doing more work; it is not — see
-[So is there a real gap?](#so-is-there-a-real-gap).
+(1.184× / 1.137×) are stable across the pair. The headline run later measured deep at ~1.07× and run 4 at ~1.06×, so
+~1.15× is what these two runs supported and 1.06×–1.18× is the spread across the four tabulated runs — not a figure that
+has since been superseded by a single lower one. Nested swings 1.043× → 1.424×: the `nested_mapstruct_forward` baseline
+carries a wide ±0.35 band both runs, so the nested ratio is a JMH-noisy figure, not a real regression or improvement —
+don't publish a single number for it. On the dispatch spread, both runs agree: `BRIDGE_FN` tracks `static forward`
+within error (run 2 flat: identical at 3.183), while `BRIDGE.read` sits a wrapper tax above the floor that grows with
+depth — 0.14 → 0.31 → 0.77 ns across flat/nested/deep on the tight-band run, each outside its error band. So `BRIDGE_FN`
+is the floor on these two runs — a reading deep later reversed, see the dispatch section; the lattice wrapper is a small
+(≤0.8 ns) tax that scales with nesting depth; and on deep the residual over MapStruct sits below the first dispatch hop
+(`static forward` alone is ~1.12× on deep, ~5.6 ns of the ~6.3 ns gap). What that residual _is_ was read at the time as
+the emitted body doing more work; it is not — see [So is there a real gap?](#so-is-there-a-real-gap).
 
 **The whole of the following paragraph is superseded** — the runtime tier now lands at ~3.3× / ~2.7× / ~1.3× and
 ~1.04–1.06× on containers, and backward no longer trails forward. It is kept because the dispatch analysis below was
@@ -156,18 +160,19 @@ the floor rather than at it, bands disjoint. See [Run 4](#run-4--the-deep-tier-w
 
 R1's bands are 2–27× wider than the others' and every one of its rows reads "no" — too wide to resolve any of these
 gaps. R2 resolves all three tiers; R3 resolves flat and nested but not deep. Where both resolve they agree on flat and
-disagree on nested, which is itself the finding. Two things hold:
+disagree on nested, which is itself the finding. Three things hold:
 
 First, **`BRIDGE_FN` tracks the `static forward` floor on flat and nested**: identical on R2 flat (both 3.183), tied on
 R2 nested (5.896 vs 5.902), and the same on R3. The one-interface-hop constant is monomorphic (one concrete `Fn` per
-bridge) and the JIT inlines it to the raw static call. On R1 and R2 nothing measures below it; R3 nested is the one row
-where the lattice value does.
+bridge) and the JIT inlines it to the raw static call. On R1 and R2 nothing measures below it; on R4 deep both the
+static floor and the full lattice do, with disjoint bands, which is the reversal the next paragraph is about; R3 nested
+is the one row where the lattice value does.
 
 **Deep is the exception, and it took four runs to see it.** No earlier run resolved that cell: R1's ±4.0 and R3's ±5.3
 bands are far too wide, and R2's ±0.675 merely overlaps static rather than matching it. R4 is the first deep measurement
 tight enough to separate them, and it puts `BRIDGE_FN` ~7 ns above both the static floor and the full lattice, bands
-disjoint. One resolving run is not a settled result, but it is the only evidence there is on this tier, and it points
-the opposite way to the claim.
+disjoint. One resolving run is not a settled result, but it is the only evidence that resolves on this tier, and it
+points the opposite way to the claim.
 
 Second, **the full-lattice `BRIDGE.read` sits a small wrapper tax above that floor** — on R2, 0.14 ns (flat) → 0.31 ns
 (nested) → 0.77 ns (deep), each outside the tight error bands, which read as the lattice composition depth showing
@@ -191,7 +196,7 @@ The lesson stands: **smoke runs lie, and one CI run can too.** Run 1's 1.04× ne
 returned 1.42× on the same branch — the nested MapStruct baseline is JMH-noisy (±0.35). Laptop smoke runs earlier
 produced a 2.9–3.6× "forward gap" that clean CI hardware dissolved, plus two claims that survived it — see
 [Superseded and retracted](#superseded-and-retracted). Trust the numbers that reproduce across runs: flat ~1.07×, deep
-1.06×–1.19×, and `BRIDGE_FN` at the floor on flat and nested.
+1.06×–1.18×, and `BRIDGE_FN` at the floor on flat and nested.
 
 ## Run 4 — the deep tier with allocation profiling
 
@@ -217,10 +222,10 @@ GitHub Actions run 34561782655, `ubuntu-latest`, main at `f2885c81`, 5 warmup + 
 
 Three things fall out, and two of them change what this document can claim.
 
-**Allocation is identical — 376 B/op on every row, to the profiler's last digit.** Not merely close: the same figure for
-MapStruct, for all three telescope codegen call shapes, and for the runtime path that builds its conversion
-reflectively. Allocation is deterministic rather than hardware-dependent, so unlike the timings this one figure is not a
-property of the runner. Whatever separates these rows, it is not that one of them allocates more.
+**Allocation is identical — 376 B/op on every row.** Not merely close: the same figure for MapStruct, for all three
+telescope codegen call shapes, and for the runtime path that builds its conversion reflectively. Allocation is
+deterministic rather than hardware-dependent, so unlike the timings this one figure is not a property of the runner.
+Whatever separates these rows, it is not that one of them allocates more.
 
 **Backward runs the other way on this run.** Telescope 67.298 against MapStruct 70.666, bands disjoint — 0.95×, a win —
 while forward on the same run is 1.06× the other way, also disjoint: the same generator, on the same shape, at identical
@@ -235,7 +240,7 @@ next to the claim.
 ## So is there a real gap?
 
 **A small one on deep forward, and nothing in the emitted code explains it.** The ratios are in the headline table; this
-section is the one place that says what the deep residual is and is not, so a correction here does not have to be chased
+section is where the deep residual is characterised; the Bottom line and Remediation 2 summarise it and should move with
 through the document.
 
 **It is not dispatch.** The zero-dispatch `static forward` floor is itself above MapStruct — 67.155 against 63.418 on
@@ -251,7 +256,7 @@ bytecode the smaller of the two; run 4 then measured allocation identical at 376
 asymmetry the sentence described is not there.
 
 **What is still open.** Deep forward's residual is real within a run and moves between them — 1.06×, 1.07×, 1.14× and
-1.19× across the four — and deep backward has been resolved twice in opposite directions, 1.18× on run 1 against 0.95×
+1.18× across the four — and deep backward has been resolved twice in opposite directions, 1.18× on run 1 against 0.95×
 on run 4. Code alignment, inlining decisions and profile pollution remain live candidates, and none of them is visible
 in source or in bytecode. Separating them needs a `perfasm` run. Until one names a mechanism, no deep-tier emitter
 change has a target, and the wrapper is not what an adopter would be paying for either way.
@@ -286,8 +291,8 @@ adopters who want the floor already have `BRIDGE_FN`, which sits there. Worse, o
 its largest, the residual below the floor led it about 7:1; on R3's and R4's deep tiers the tax does not separate from
 zero at all. Either way removing it barely moves the ratio. It would add ~100 LOC of `BridgeProcessor` complexity to
 shave a sub-nanosecond tax off one of two already-shipped call shapes. **Not building it.** What _would_ move the deep
-number is not known — the two generated bodies are equivalent in source and bytecode and identical in allocation, so
-there is no emitter change with a target until a `perfasm` run names a mechanism. See
+number is not known — the two generated bodies do the same work, with the same guards on the same paths and the same
+allocations, so there is no emitter change with a target until a `perfasm` run names a mechanism. See
 [So is there a real gap?](#so-is-there-a-real-gap).
 
 ### 3. The CI-reproducible matrix is the baseline
@@ -343,14 +348,14 @@ until run 4, which measured it ~7 ns _above_ the floor with disjoint bands — s
 that support it.
 
 **Deep was briefly published as ~1.07× flat-out.** The number is this run's measurement and still stands in the headline
-table; what was wrong was presenting it as deep's figure rather than as one end of a spread, now 1.06×–1.19× with run
+table; what was wrong was presenting it as deep's figure rather than as one end of a spread, now 1.06×–1.18× with run
 4's 1.059× at the bottom. The `across runs` column is the honest form.
 
 ## Bottom line
 
 Telescope codegen is in MapStruct's performance class. The headline table has the figures and says which of them are
 stable across runs and which are ranges; the short version is that flat is settled, deep and nested are ranges, and the
-two container shapes tie on time and allocate identically.
+two container shapes allocate identically, with their timings pending a re-run.
 
 On dispatch, one half is settled on two tiers of three. `BRIDGE_FN` is the floor on flat and nested — it tracks the
 zero-dispatch static call there on every run within error, because the JIT inlines the monomorphic hop. On deep the only
@@ -358,9 +363,9 @@ run whose bands resolve it puts it ~7 ns above the floor instead. The full-latti
 sub-nanosecond wrapper tax wherever it resolves at all, but its size and even its sign move between runs, so how it
 scales with depth is provisional and only the magnitude is durable. Both proposed remediations are settled either way:
 one shipped and reached the floor on flat and nested, and the other would remove only that tax, which is small against
-the deep residual — the one tier where the residual is big enough to be worth chasing.
+the deep residual.
 
-What remains over MapStruct on deep forward is not dispatch — the zero-dispatch floor is itself above parity — and it is
-the emitted bodies are not doing more work either: the two are equivalent in source and bytecode and allocate
-identically, and deep backward has been resolved in both directions across runs. No emitter change has a target until a
-`perfasm` run names a mechanism.
+What remains over MapStruct on deep forward is not dispatch: the zero-dispatch floor is itself above parity. Nor are the
+emitted bodies doing more work — they carry the same guards on the same paths and allocate the same objects, and run 4
+measured their allocation identical. Deep backward has been resolved in both directions across runs. So the residual is
+real and unexplained, and no emitter change has a target until a `perfasm` run names a mechanism.


### PR DESCRIPTION
An audit of yesterday's perf-doc rewrite (#359) against the tables in the same document. Every finding here is against my own prose.

## The one that should not have shipped

The Bottom line read:

> "…and it is the emitted bodies are not doing more work either"

A head-to-tail splice of two drafts, produced by patching a paragraph line by line instead of rewriting it whole — the exact failure `AGENTS.md` warns about, and it reached `main` because it is still valid markdown, so spotless and CI passed it. It is the last paragraph a reader sees. Rewritten whole.

## Claims that contradicted the same document

**"Equivalent in source and bytecode"** appeared in three places. Two hundred lines above, the evidence it rests on names two bytecode-level differences: telescope's per-element call is an `invokestatic` against MapStruct's `invokevirtual`, and telescope's total bytecode is the smaller of the two. Bytecode differing in dispatch opcode and in size is not equivalent bytecode. What the evidence supports — same guards on the same paths, same allocations of the same objects — is what all three copies now say.

**The deep range's top endpoint does not recompute.** R1's derived cell is `47.72 / 40.29 = 1.1844`, published as `1.185×`; every other cell in both tables rounds correctly. That single third decimal is what made the range end at 1.19 rather than 1.18. The four per-run ratios recompute as 1.06 / 1.07 / 1.14 / **1.18**. Corrected in the cell and in the eight sites carrying the range, including `README.md`.

The asymmetry is the tell: the bottom of the range was carried to three decimals and stated precisely ("run 4's 1.059× at the bottom"), while the top inherited a two-decimal rounding of a stale third decimal and was never recomputed.

## A measurement published as measured, on the wrong run

The Map row's `7,528 B/op both` is genuinely measured — but by Actions 34611507811, which ran that filter against the changed code, not by the run the table cites. The footnote licensed the carry-over by saying allocation "is deterministic rather than hardware-dependent", which is an argument about *runner* variation and says nothing about a *code* change. The reason the timings need a re-run — the code under measurement changed — applied identically to the allocation.

It now names the run that measured it. And the embargo it declares is now honoured: the row's timings were being quoted three lines above ("call it a tie"), in the Bottom line, and on the README front page. All three are marked pending a re-run, including the runtime container figures, since the change moved the runtime allocator too.

## Retracted attributions still living in the sibling README

`benchmarks/README.md` kept three statements yesterday's corrections falsified, including the "How to read the rows" instruction that frames every table below it (*"Any delta is the cost of telescope's lattice composition vs MapStruct's hand-templated method body"* — the two-way split the doc now says the deep delta is neither of), and two telling adopters to reach for `BRIDGE_FN` for the zero-dispatch floor, which is wrong on the one tier that resolves it.

## Over-strong quantifiers I added

- *"the one place that says so"* — falsified by its own neighbours, in three copies, one of which states the claim itself in the same clause in a different file.
- *"the only evidence there is on this tier"* — R1, R2 and R3 all measured that cell. "The only evidence that resolves" is what the tables support; the stronger form erases three runs to strengthen a reversal.
- *"to the profiler's last digit"* — the table prints `376 B/op` with no decimals and no band.
- *"Two things hold:"* introducing three blocks, and a roll call of rows written before run 4 existed.

## Dangling citations

Three in `docs/mapstruct-parity.md` pointed into `DeepMap.java` past its end, left behind by the `ContainerLifts` extraction. They name symbols now rather than line ranges, which is what the house rule asks for. `ContainerLifts`' own caller javadoc still promised a `HashMap` fallback while the method it points at returns `LinkedHashMap`.

## What held up

The entire Run 4 section recomputed correctly — every ratio, every band-disjointness claim, the ~7 ns, the wrapper tax, the 3.7–7.4 ns gap range. So did R2 and R3 in every cell, the 120-column rule, and the retraction of the container allocation win, whose only surviving mention is the footnote that retracts it.
