### PR TITLE
fix(codegen): allocate a generic container subtype the way a raw one is

### DIFF
--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
@@ -2506,19 +2506,28 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
   }
 
   /**
-   * Whether this side's container can be built by handing its constructor the source container,
-   * which is what the inline identity copy does. This is a property of the class, not of its
-   * package: most JDK containers offer such a constructor and {@code java.util.Stack} does not,
-   * while a subtype has one only where it declares one, because constructors are not inherited.
+   * Whether this side's container can be built by handing {@code argument} to its constructor,
+   * which is what the inline identity copy does. The test is directional: a constructor that takes
+   * a {@code Collection} accepts any of them, while one narrowed to {@code ArrayList} does not
+   * accept a {@code List}, and only the value actually being passed decides which. It is also a
+   * property of the class rather than of its package — most JDK containers offer such a constructor
+   * and {@code java.util.Stack} does not, while a subtype has one only where it declares one,
+   * because constructors are not inherited.
    */
-  private boolean hasCopyConstructor(final TypeMirror container, final FieldPlan.Kind kind) {
+  private boolean hasCopyConstructorAccepting(
+    final TypeMirror container,
+    final FieldPlan.Kind kind,
+    final TypeMirror argument
+  ) {
     final var implEl = processingEnv.getElementUtils().getTypeElement(concreteImplFqn(container, kind));
     if (implEl == null) return false;
-    final var accepts = kind == FieldPlan.Kind.MAP_VALUES ? "java.util.Map" : "java.util.Collection";
+    final var types = processingEnv.getTypeUtils();
     for (final var ctor : ElementFilter.constructorsIn(implEl.getEnclosedElements())) {
       if (!ctor.getModifiers().contains(Modifier.PUBLIC)) continue;
       final var params = ctor.getParameters();
-      if (params.size() == 1 && assignableToRaw(params.getFirst().asType(), accepts)) return true;
+      if (
+        params.size() == 1 && types.isAssignable(types.erasure(argument), types.erasure(params.getFirst().asType()))
+      ) return true;
     }
     return false;
   }
@@ -2692,8 +2701,11 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
         // Where either side cannot be built that way, route to the self-contained helper, which
         // allocates no-arg and fills — the treatment a raw subtype already gets.
         if (isContainerKind(subPlan.kind())) {
+          // Forward hands the source container to the target's constructor and backward does the
+          // reverse, so each side is asked about the value it will actually receive.
           final var needsHelper =
-            !hasCopyConstructor(sf.type(), subPlan.kind()) || !hasCopyConstructor(tf.type(), subPlan.kind());
+            !hasCopyConstructorAccepting(tf.type(), subPlan.kind(), sf.type()) ||
+            !hasCopyConstructorAccepting(sf.type(), subPlan.kind(), tf.type());
           if (needsHelper) {
             final var badAlloc = firstNonAllocatableContainer(sf.type(), tf.type(), subPlan.kind());
             if (badAlloc != null) {

--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
@@ -2501,6 +2501,35 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
     return ((TypeElement) ((DeclaredType) container).asElement()).getQualifiedName().toString();
   }
 
+  /**
+   * Why a container field cannot be emitted, and what the author can do about it. Every route but
+   * the inline identity copy allocates no-arg, so a class without that constructor cannot be built.
+   * The remedy depends on who owns the class: adding a constructor is only advice the author can
+   * act on for a type they wrote.
+   */
+  private static String unallocatableContainerMessage(
+    final TypeElement source,
+    final TypeElement target,
+    final String fieldName,
+    final String badAlloc
+  ) {
+    return (
+      "@Bridge " +
+      source.getSimpleName() +
+      " -> " +
+      target.getSimpleName() +
+      ": field '" +
+      fieldName +
+      "' container type '" +
+      badAlloc +
+      "' has no public no-arg constructor — codegen allocates it directly. " +
+      (badAlloc.startsWith("java.")
+        ? "Declare the field as a type that has one, or supply an explicit @ViaMapper"
+        : "Add a no-arg constructor, or use the runtime mapper with an explicit row") +
+      " for this field."
+    );
+  }
+
   private static boolean isContainerKind(final FieldPlan.Kind kind) {
     return kind == FieldPlan.Kind.LIST || kind == FieldPlan.Kind.SET || kind == FieldPlan.Kind.MAP_VALUES;
   }
@@ -2715,20 +2744,7 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
           if (!inlineCopy) {
             final var badAlloc = firstNonAllocatableContainer(sf.type(), tf.type(), subPlan.kind());
             if (badAlloc != null) {
-              error(
-                source,
-                "@Bridge " +
-                  source.getSimpleName() +
-                  " -> " +
-                  target.getSimpleName() +
-                  ": field '" +
-                  sf.name() +
-                  "' container type '" +
-                  badAlloc +
-                  "' has no public no-arg constructor — codegen allocates it directly. Add a" +
-                  " no-arg constructor, or use the runtime mapper with an explicit row for" +
-                  " this field."
-              );
+              error(source, unallocatableContainerMessage(source, target, sf.name(), badAlloc));
               return null;
             }
             // Identity elements have no helper of their own, so they take the self-contained one.
@@ -2786,20 +2802,7 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
         // here with a telescope-authored diagnostic instead.
         final var badAlloc = firstNonAllocatableContainer(sf.type(), tf.type(), srcRaw.kind());
         if (badAlloc != null) {
-          error(
-            source,
-            "@Bridge " +
-              source.getSimpleName() +
-              " -> " +
-              target.getSimpleName() +
-              ": field '" +
-              sf.name() +
-              "' container type '" +
-              badAlloc +
-              "' has no public no-arg constructor — codegen allocates it directly. Add a" +
-              " no-arg constructor, or use the runtime mapper with an explicit row for this" +
-              " field."
-          );
+          error(source, unallocatableContainerMessage(source, target, sf.name(), badAlloc));
           return null;
         }
         final var subPlan = planElementSubBridge(

--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
@@ -2513,6 +2513,10 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
    * property of the class rather than of its package — most JDK containers offer such a constructor
    * and {@code java.util.Stack} does not, while a subtype has one only where it declares one,
    * because constructors are not inherited.
+   *
+   * <p>The comparison is by erasure, which is what lets a parameter written {@code Collection<?
+   * extends T>} match at all: its type variable is unresolved here. A constructor sharing an
+   * erasure with the argument but not its type argument therefore reads as usable.
    */
   private boolean hasCopyConstructorAccepting(
     final TypeMirror container,
@@ -2695,18 +2699,20 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
           parentPkg
         );
         if (subPlan == null) return null;
-        // The inline identity copy hands the source container to the output's constructor, so it is
-        // available only where that constructor exists. A subtype has one where it declares one,
-        // constructors not being inherited, and a handful of JDK containers lack one outright.
-        // Where either side cannot be built that way, route to the self-contained helper, which
-        // allocates no-arg and fills — the treatment a raw subtype already gets.
+        // Only one of the container routes copy-constructs. The inline copy hands the source
+        // container to the output's constructor and is reachable solely when the element type is
+        // identity; every other route — the self-contained helper for identity elements, the
+        // element-bridging helpers for the rest — allocates no-arg and fills. So the constructor a
+        // container must offer depends on the route it takes, and the route depends on its
+        // elements. Forward hands the source to the target's constructor and backward does the
+        // reverse, so each side is asked about the value it will actually receive.
         if (isContainerKind(subPlan.kind())) {
-          // Forward hands the source container to the target's constructor and backward does the
-          // reverse, so each side is asked about the value it will actually receive.
-          final var needsHelper =
-            !hasCopyConstructorAccepting(tf.type(), subPlan.kind(), sf.type()) ||
-            !hasCopyConstructorAccepting(sf.type(), subPlan.kind(), tf.type());
-          if (needsHelper) {
+          final var elementIdentity = IDENTITY_ELEMENT_SENTINEL.equals(subPlan.subBridgeName());
+          final var inlineCopy =
+            elementIdentity &&
+            hasCopyConstructorAccepting(tf.type(), subPlan.kind(), sf.type()) &&
+            hasCopyConstructorAccepting(sf.type(), subPlan.kind(), tf.type());
+          if (!inlineCopy) {
             final var badAlloc = firstNonAllocatableContainer(sf.type(), tf.type(), subPlan.kind());
             if (badAlloc != null) {
               error(
@@ -2725,8 +2731,13 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
               );
               return null;
             }
-            plans.put(sf.name(), subPlan.asRawContainer());
-            continue;
+            // Identity elements have no helper of their own, so they take the self-contained one.
+            // Bridged elements already route to emitListHelper / emitSetHelper / emitMapHelper,
+            // which allocate the same way — they only needed the allocation checked first.
+            if (elementIdentity) {
+              plans.put(sf.name(), subPlan.asRawContainer());
+              continue;
+            }
           }
         }
         // Attach the concrete-impl class the inline identity-element copy allocates: the target's

--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
@@ -2501,6 +2501,28 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
     return ((TypeElement) ((DeclaredType) container).asElement()).getQualifiedName().toString();
   }
 
+  private static boolean isContainerKind(final FieldPlan.Kind kind) {
+    return kind == FieldPlan.Kind.LIST || kind == FieldPlan.Kind.SET || kind == FieldPlan.Kind.MAP_VALUES;
+  }
+
+  /**
+   * Whether this side's container can be built by handing its constructor the source container,
+   * which is what the inline identity copy does. This is a property of the class, not of its
+   * package: most JDK containers offer such a constructor and {@code java.util.Stack} does not,
+   * while a subtype has one only where it declares one, because constructors are not inherited.
+   */
+  private boolean hasCopyConstructor(final TypeMirror container, final FieldPlan.Kind kind) {
+    final var implEl = processingEnv.getElementUtils().getTypeElement(concreteImplFqn(container, kind));
+    if (implEl == null) return false;
+    final var accepts = kind == FieldPlan.Kind.MAP_VALUES ? "java.util.Map" : "java.util.Collection";
+    for (final var ctor : ElementFilter.constructorsIn(implEl.getEnclosedElements())) {
+      if (!ctor.getModifiers().contains(Modifier.PUBLIC)) continue;
+      final var params = ctor.getParameters();
+      if (params.size() == 1 && assignableToRaw(params.getFirst().asType(), accepts)) return true;
+    }
+    return false;
+  }
+
   // FQN of the concrete, instantiable class to allocate for a container field of the given declared
   // type — the declared subtype itself when it is an instantiable class (ArrayList, TreeSet,
   // TreeMap, …), else the default impl for the interface family. The interface-family defaults
@@ -2510,19 +2532,6 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
   // interface-typed field. The two hash families default to their insertion-ordered form because a
   // conversion that is not asked to reorder should not: an ordered source behind an interface-typed
   // field keeps its order across the rebuild.
-  private static boolean isContainerKind(final FieldPlan.Kind kind) {
-    return kind == FieldPlan.Kind.LIST || kind == FieldPlan.Kind.SET || kind == FieldPlan.Kind.MAP_VALUES;
-  }
-
-  /**
-   * Whether this side's container is allocated as a type the adopter wrote rather than a JDK class.
-   * A JDK container offers a copy constructor; a subtype of one does not inherit it, so the two are
-   * allocated differently and only the JDK side can be copy-constructed inline.
-   */
-  private static boolean isUserContainerImpl(final TypeMirror container, final FieldPlan.Kind kind) {
-    return !concreteImplFqn(container, kind).startsWith("java.");
-  }
-
   private static String concreteImplFqn(final TypeMirror container, final FieldPlan.Kind kind) {
     final var el = (TypeElement) ((DeclaredType) container).asElement();
     if (el.getKind() == ElementKind.CLASS && !el.getModifiers().contains(Modifier.ABSTRACT)) {
@@ -2677,17 +2686,15 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
           parentPkg
         );
         if (subPlan == null) return null;
-        // Attach the concrete-impl class the inline identity-element copy allocates: the target's
-        // class on forward, the source's on backward — so a field typed as a concrete subtype
-        // (LinkedList, TreeSet, …) is rebuilt as that class, not the default impl.
-        // A user subtype declares no copy constructor, because Java does not inherit them, so the
-        // inline identity copy is invalid for it whether or not it kept its own type parameter.
-        // Route it to the self-contained helper, which allocates no-arg and fills — the same
-        // treatment a raw subtype already gets, and for the same reason.
+        // The inline identity copy hands the source container to the output's constructor, so it is
+        // available only where that constructor exists. A subtype has one where it declares one,
+        // constructors not being inherited, and a handful of JDK containers lack one outright.
+        // Where either side cannot be built that way, route to the self-contained helper, which
+        // allocates no-arg and fills — the treatment a raw subtype already gets.
         if (isContainerKind(subPlan.kind())) {
-          final var userSubtype =
-            isUserContainerImpl(sf.type(), subPlan.kind()) || isUserContainerImpl(tf.type(), subPlan.kind());
-          if (userSubtype) {
+          final var needsHelper =
+            !hasCopyConstructor(sf.type(), subPlan.kind()) || !hasCopyConstructor(tf.type(), subPlan.kind());
+          if (needsHelper) {
             final var badAlloc = firstNonAllocatableContainer(sf.type(), tf.type(), subPlan.kind());
             if (badAlloc != null) {
               error(
@@ -2710,6 +2717,9 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
             continue;
           }
         }
+        // Attach the concrete-impl class the inline identity-element copy allocates: the target's
+        // class on forward, the source's on backward — so a field typed as a concrete subtype
+        // (LinkedList, TreeSet, …) is rebuilt as that class, not the default impl.
         final var withImpls = switch (subPlan.kind()) {
           case LIST, SET, MAP_VALUES -> subPlan.withContainerImpls(
             simpleName(concreteImplFqn(tf.type(), subPlan.kind())),

--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
@@ -2280,15 +2280,12 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
     // table.
     String fwdContainerImpl,
     String bwdContainerImpl,
-    // LIST/SET/MAP_VALUES only: true when the field is a raw (non-generic) Collection/Map subtype
-    // on
-    // at least one side (e.g. `class ImageUrls extends ArrayList<ImageUrl>`, or a generic
-    // interface
-    // paired with such a subtype). The element type lives in the supertype, the subtype is
-    // allocated
-    // via its no-arg constructor (subclasses don't inherit the JDK copy ctor), so these route to
-    // the
-    // self-contained raw helpers instead of the generic copy-ctor inline path.
+    // LIST/SET/MAP_VALUES only: true when at least one side is allocated as a Collection/Map type
+    // the adopter wrote rather than a JDK class — a raw subtype (`class ImageUrls extends
+    // ArrayList<ImageUrl>`, whose element type lives in the supertype) or a generic one (`class
+    // MyList<T> extends ArrayList<T>`). Either is allocated via its no-arg constructor, because
+    // subclasses do not inherit the JDK copy ctor, so both route to the self-contained helpers
+    // instead of the inline copy-ctor path.
     boolean rawContainer,
     // RECURSE only: true when subBridgeName is a user-supplied @ViaMapper class rather than an
     // auto-derived sub-bridge. Auto-derived bridges open their forward/backward with a null
@@ -2324,6 +2321,20 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
         fwdImpl,
         bwdImpl,
         false,
+        userSuppliedBridge
+      );
+    }
+
+    FieldPlan asRawContainer() {
+      return new FieldPlan(
+        kind,
+        subBridgeName,
+        qualifierMethod,
+        fwdNullDefault,
+        bwdNullDefault,
+        fwdContainerImpl,
+        bwdContainerImpl,
+        true,
         userSuppliedBridge
       );
     }
@@ -2499,6 +2510,19 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
   // interface-typed field. The two hash families default to their insertion-ordered form because a
   // conversion that is not asked to reorder should not: an ordered source behind an interface-typed
   // field keeps its order across the rebuild.
+  private static boolean isContainerKind(final FieldPlan.Kind kind) {
+    return kind == FieldPlan.Kind.LIST || kind == FieldPlan.Kind.SET || kind == FieldPlan.Kind.MAP_VALUES;
+  }
+
+  /**
+   * Whether this side's container is allocated as a type the adopter wrote rather than a JDK class.
+   * A JDK container offers a copy constructor; a subtype of one does not inherit it, so the two are
+   * allocated differently and only the JDK side can be copy-constructed inline.
+   */
+  private static boolean isUserContainerImpl(final TypeMirror container, final FieldPlan.Kind kind) {
+    return !concreteImplFqn(container, kind).startsWith("java.");
+  }
+
   private static String concreteImplFqn(final TypeMirror container, final FieldPlan.Kind kind) {
     final var el = (TypeElement) ((DeclaredType) container).asElement();
     if (el.getKind() == ElementKind.CLASS && !el.getModifiers().contains(Modifier.ABSTRACT)) {
@@ -2656,6 +2680,36 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
         // Attach the concrete-impl class the inline identity-element copy allocates: the target's
         // class on forward, the source's on backward — so a field typed as a concrete subtype
         // (LinkedList, TreeSet, …) is rebuilt as that class, not the default impl.
+        // A user subtype declares no copy constructor, because Java does not inherit them, so the
+        // inline identity copy is invalid for it whether or not it kept its own type parameter.
+        // Route it to the self-contained helper, which allocates no-arg and fills — the same
+        // treatment a raw subtype already gets, and for the same reason.
+        if (isContainerKind(subPlan.kind())) {
+          final var userSubtype =
+            isUserContainerImpl(sf.type(), subPlan.kind()) || isUserContainerImpl(tf.type(), subPlan.kind());
+          if (userSubtype) {
+            final var badAlloc = firstNonAllocatableContainer(sf.type(), tf.type(), subPlan.kind());
+            if (badAlloc != null) {
+              error(
+                source,
+                "@Bridge " +
+                  source.getSimpleName() +
+                  " -> " +
+                  target.getSimpleName() +
+                  ": field '" +
+                  sf.name() +
+                  "' container type '" +
+                  badAlloc +
+                  "' has no public no-arg constructor — codegen allocates it directly. Add a" +
+                  " no-arg constructor, or use the runtime mapper with an explicit row for" +
+                  " this field."
+              );
+              return null;
+            }
+            plans.put(sf.name(), subPlan.asRawContainer());
+            continue;
+          }
+        }
         final var withImpls = switch (subPlan.kind()) {
           case LIST, SET, MAP_VALUES -> subPlan.withContainerImpls(
             simpleName(concreteImplFqn(tf.type(), subPlan.kind())),
@@ -3095,8 +3149,9 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
       final var plan = entry.getValue();
       final var srcType = fieldByName(sourceFields, fieldName).type();
       final var tgtType = fieldByName(targetFields, renames.getOrDefault(fieldName, fieldName)).type();
-      // Raw Collection/Map subtype containers get the self-contained helper even for identity
-      // elements (the inline copy-ctor path is invalid for a non-generic subtype).
+      // A container allocated as a type the adopter wrote gets the self-contained helper even for
+      // identity elements: the inline copy-ctor path needs a copy constructor, and a subtype does
+      // not inherit one. Whether it kept its own type parameter makes no difference to that.
       if (plan.rawContainer()) {
         emitRawContainerHelper(out, "__fwd_" + fieldName, srcType, tgtType, plan, "forward");
         emitRawContainerHelper(out, "__bwd_" + fieldName, tgtType, srcType, plan, "backward");

--- a/codegen/src/test/java/io/github/eschizoid/telescope/codegen/GenericContainerSubtypeTest.java
+++ b/codegen/src/test/java/io/github/eschizoid/telescope/codegen/GenericContainerSubtypeTest.java
@@ -131,6 +131,49 @@ class GenericContainerSubtypeTest {
   }
 
   @Test
+  @DisplayName("a constructor narrower than the value being passed does not count as a copy constructor")
+  void narrowedCopyConstructorIsNotUsable() {
+    // Having a single-argument constructor that takes *a* collection is not the same as being able
+    // to take *this* collection: backward hands a List to the source's constructor, and one
+    // declared to take an ArrayList cannot accept it.
+    final var compilation = compile(
+      ProcessorHarness.source(
+        "demo.Narrow",
+        """
+        package demo;
+        import java.util.ArrayList;
+        public class Narrow<T> extends ArrayList<T> {
+          public Narrow(final ArrayList<T> c) { super(c); }
+        }
+        """
+      ),
+      ProcessorHarness.source(
+        "demo.NwSrc",
+        """
+        package demo;
+        import io.github.eschizoid.telescope.annotations.Bridge;
+        @Bridge(demo.NwDst.class)
+        public record NwSrc(demo.Narrow<String> items) {}
+        """
+      ),
+      ProcessorHarness.source(
+        "demo.NwDst",
+        "package demo; import java.util.List; public record NwDst(List<String> items) {}"
+      )
+    );
+
+    assertFalse(compilation.success(), "the narrowed constructor cannot take a List");
+    assertTrue(
+      compilation.hasError("no public no-arg constructor"),
+      () -> "it should be reported the way any unallocatable container is: " + compilation.errorMessages()
+    );
+    assertFalse(
+      compilation.errorMessages().contains("cannot infer type arguments"),
+      () -> "javac inside generated code is the failure mode being replaced: " + compilation.errorMessages()
+    );
+  }
+
+  @Test
   @DisplayName("a JDK container without a copy constructor is filled rather than copy-constructed")
   void jdkContainerLackingACopyConstructorIsFilled() {
     // java.util.Stack has no (Collection) constructor, so the package a class lives in does not

--- a/codegen/src/test/java/io/github/eschizoid/telescope/codegen/GenericContainerSubtypeTest.java
+++ b/codegen/src/test/java/io/github/eschizoid/telescope/codegen/GenericContainerSubtypeTest.java
@@ -131,6 +131,53 @@ class GenericContainerSubtypeTest {
   }
 
   @Test
+  @DisplayName("a copy constructor does not help when the elements need bridging")
+  void copyConstructorDoesNotCoverTheBridgedElementRoute() {
+    // The inline copy is reachable only for identity elements. Once the elements need converting
+    // the emission allocates no-arg and fills, so a class offering only a copy constructor cannot
+    // serve that route — and a wrapper holding convertible elements is the ordinary bridge case,
+    // not an exotic one.
+    final var compilation = compile(
+      ProcessorHarness.source(
+        "demo.CopyList2",
+        """
+        package demo;
+        import java.util.ArrayList;
+        import java.util.Collection;
+        public class CopyList2<T> extends ArrayList<T> {
+          public CopyList2(final Collection<? extends T> c) { super(c); }
+        }
+        """
+      ),
+      ProcessorHarness.source(
+        "demo.DSrc",
+        """
+        package demo;
+        import io.github.eschizoid.telescope.annotations.Bridge;
+        @Bridge(demo.DDst.class)
+        public record DSrc(demo.CopyList2<demo.DElem> items) {}
+        """
+      ),
+      ProcessorHarness.source(
+        "demo.DDst",
+        "package demo; import java.util.List; public record DDst(List<demo.DElemDto> items)" + " {}"
+      ),
+      ProcessorHarness.source("demo.DElem", "package demo; public record DElem(String v) {}"),
+      ProcessorHarness.source("demo.DElemDto", "package demo; public record DElemDto(String v) {}")
+    );
+
+    assertFalse(compilation.success(), "the bridged-element route cannot use a copy constructor");
+    assertTrue(
+      compilation.hasError("no public no-arg constructor"),
+      () -> "the allocation the route performs is what should be reported: " + compilation.errorMessages()
+    );
+    assertFalse(
+      compilation.errorMessages().contains("cannot be applied to given types"),
+      () -> "javac inside generated code is the failure mode being replaced: " + compilation.errorMessages()
+    );
+  }
+
+  @Test
   @DisplayName("a constructor narrower than the value being passed does not count as a copy constructor")
   void narrowedCopyConstructorIsNotUsable() {
     // Having a single-argument constructor that takes *a* collection is not the same as being able

--- a/codegen/src/test/java/io/github/eschizoid/telescope/codegen/GenericContainerSubtypeTest.java
+++ b/codegen/src/test/java/io/github/eschizoid/telescope/codegen/GenericContainerSubtypeTest.java
@@ -1,0 +1,136 @@
+package io.github.eschizoid.telescope.codegen;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.github.eschizoid.telescope.codegen.ProcessorHarness.Compilation;
+import java.util.List;
+import javax.tools.JavaFileObject;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * A container subtype that keeps its own type parameter — {@code class MyList<T> extends
+ * ArrayList<T> {}} — is an ordinary adopter shape, and the emitter has never been asked to allocate
+ * one: every container fixture elsewhere is raw ({@code class Wrap extends ArrayList<Elem> {}}),
+ * and the generic shapes exist only in suites that never emit a bridge.
+ *
+ * <p>Java does not inherit constructors, so such a subtype has its implicit no-arg one and nothing
+ * else unless it declares more. Both facts the raw path already respects have to hold here too.
+ *
+ * <p>Every case compiles through the full pipeline. Under {@code -proc:only} javac never attributes
+ * the generated source, so an allocation that cannot compile still reports success and every
+ * assertion below would hold vacuously.
+ */
+class GenericContainerSubtypeTest {
+
+  private static Compilation compile(final JavaFileObject... sources) {
+    return ProcessorHarness.compileFully(List.of(new BridgeProcessor()), List.of(), sources);
+  }
+
+  private static final JavaFileObject MY_LIST = ProcessorHarness.source(
+    "demo.MyList",
+    """
+    package demo;
+    import java.util.ArrayList;
+    public class MyList<T> extends ArrayList<T> {}
+    """
+  );
+
+  @Test
+  @DisplayName("a generic subtype holding identity elements is filled, not copy-constructed")
+  void genericSubtypeWithIdentityElementsCompiles() {
+    final var compilation = compile(
+      MY_LIST,
+      ProcessorHarness.source(
+        "demo.GSrc",
+        """
+        package demo;
+        import io.github.eschizoid.telescope.annotations.Bridge;
+        @Bridge(demo.GDst.class)
+        public record GSrc(demo.MyList<String> items) {}
+        """
+      ),
+      ProcessorHarness.source(
+        "demo.GDst",
+        "package demo; import java.util.List; public record GDst(List<String> items) {}"
+      )
+    );
+
+    assertTrue(compilation.success(), () -> "the generated source must compile: " + compilation.errorMessages());
+    final var bridge = compilation.generated().get("demo.GSrcBridge");
+    assertFalse(
+      bridge != null && bridge.contains("new demo.MyList<>("),
+      () -> "a subtype declares no copy constructor, so nothing may call one: " + bridge
+    );
+  }
+
+  @Test
+  @DisplayName("a generic subtype whose elements need bridging is allocated with a constructor it has")
+  void genericSubtypeWithBridgedElementsCompiles() {
+    final var compilation = compile(
+      MY_LIST,
+      ProcessorHarness.source(
+        "demo.HSrc",
+        """
+        package demo;
+        import io.github.eschizoid.telescope.annotations.Bridge;
+        @Bridge(demo.HDst.class)
+        public record HSrc(demo.MyList<demo.HElem> items) {}
+        """
+      ),
+      ProcessorHarness.source(
+        "demo.HDst",
+        "package demo; import java.util.List; public record HDst(List<demo.HElemDto> items)" + " {}"
+      ),
+      ProcessorHarness.source("demo.HElem", "package demo; public record HElem(String v) {}"),
+      ProcessorHarness.source("demo.HElemDto", "package demo; public record HElemDto(String v) {}")
+    );
+
+    assertTrue(compilation.success(), () -> "the generated source must compile: " + compilation.errorMessages());
+  }
+
+  @Test
+  @DisplayName("a generic subtype with no usable constructor is reported, not emitted against")
+  void genericSubtypeWithoutNoArgCtorIsReported() {
+    final var compilation = compile(
+      ProcessorHarness.source(
+        "demo.SizedList",
+        """
+        package demo;
+        import java.util.ArrayList;
+        // Declares a constructor, so it has no implicit no-arg one — and what the argument means
+        // is the author's business, not something the processor can read.
+        public class SizedList<T> extends ArrayList<T> {
+          public SizedList(final int pageNumber) { super(); }
+        }
+        """
+      ),
+      ProcessorHarness.source(
+        "demo.ISrc2",
+        """
+        package demo;
+        import io.github.eschizoid.telescope.annotations.Bridge;
+        @Bridge(demo.IDst2.class)
+        public record ISrc2(demo.SizedList<demo.HElem2> items) {}
+        """
+      ),
+      ProcessorHarness.source(
+        "demo.IDst2",
+        "package demo; import java.util.List; public record IDst2(List<demo.HElemDto2>" + " items) {}"
+      ),
+      ProcessorHarness.source("demo.HElem2", "package demo; public record HElem2(String v) {}"),
+      ProcessorHarness.source("demo.HElemDto2", "package demo; public record HElemDto2(String v) {}")
+    );
+
+    assertFalse(compilation.success(), "a container the processor cannot allocate must be refused");
+    assertTrue(
+      compilation.hasError("no public no-arg constructor"),
+      () -> "the raw path's diagnostic should cover this shape too: " + compilation.errorMessages()
+    );
+    assertFalse(
+      compilation.errorMessages().contains("cannot be applied to given types"),
+      () -> "javac inside generated code is the failure mode being replaced: " + compilation.errorMessages()
+    );
+  }
+}

--- a/codegen/src/test/java/io/github/eschizoid/telescope/codegen/GenericContainerSubtypeTest.java
+++ b/codegen/src/test/java/io/github/eschizoid/telescope/codegen/GenericContainerSubtypeTest.java
@@ -91,6 +91,106 @@ class GenericContainerSubtypeTest {
   }
 
   @Test
+  @DisplayName("a subtype that declares a copy constructor keeps the inline copy that uses it")
+  void subtypeDeclaringACopyConstructorStillCopies() {
+    // Constructors are not inherited, but they can be declared. A subtype offering the one the
+    // inline copy needs has no reason to be routed anywhere else — and no reason to be asked for a
+    // no-arg constructor it does not have.
+    final var compilation = compile(
+      ProcessorHarness.source(
+        "demo.CopyList",
+        """
+        package demo;
+        import java.util.ArrayList;
+        import java.util.Collection;
+        public class CopyList<T> extends ArrayList<T> {
+          public CopyList(final Collection<? extends T> c) { super(c); }
+        }
+        """
+      ),
+      ProcessorHarness.source(
+        "demo.CSrc",
+        """
+        package demo;
+        import io.github.eschizoid.telescope.annotations.Bridge;
+        @Bridge(demo.CDst.class)
+        public record CSrc(demo.CopyList<String> items) {}
+        """
+      ),
+      ProcessorHarness.source(
+        "demo.CDst",
+        "package demo; import java.util.List; public record CDst(List<String> items) {}"
+      )
+    );
+
+    assertTrue(compilation.success(), () -> "a declared copy constructor is usable: " + compilation.errorMessages());
+    assertFalse(
+      compilation.errorMessages().contains("no public no-arg constructor"),
+      () -> "it was never asked for a no-arg constructor: " + compilation.errorMessages()
+    );
+  }
+
+  @Test
+  @DisplayName("a JDK container without a copy constructor is filled rather than copy-constructed")
+  void jdkContainerLackingACopyConstructorIsFilled() {
+    // java.util.Stack has no (Collection) constructor, so the package a class lives in does not
+    // decide this; the constructor it declares does.
+    final var compilation = compile(
+      ProcessorHarness.source(
+        "demo.KSrc3",
+        """
+        package demo;
+        import io.github.eschizoid.telescope.annotations.Bridge;
+        import java.util.Stack;
+        @Bridge(demo.KDst3.class)
+        public record KSrc3(Stack<String> items) {}
+        """
+      ),
+      ProcessorHarness.source(
+        "demo.KDst3",
+        "package demo; import java.util.List; public record KDst3(List<String> items) {}"
+      )
+    );
+
+    assertTrue(compilation.success(), () -> "the generated source must compile: " + compilation.errorMessages());
+  }
+
+  @Test
+  @DisplayName("the Set and Map kinds are repaired too, not only List")
+  void genericSubtypeSetAndMapCompile() {
+    final var compilation = compile(
+      ProcessorHarness.source(
+        "demo.MySet",
+        "package demo; import java.util.HashSet; public class MySet<T> extends HashSet<T>" + " {}"
+      ),
+      ProcessorHarness.source(
+        "demo.MyMap",
+        "package demo; import java.util.HashMap; public class MyMap<K, V> extends" + " HashMap<K, V> {}"
+      ),
+      ProcessorHarness.source(
+        "demo.SMSrc",
+        """
+        package demo;
+        import io.github.eschizoid.telescope.annotations.Bridge;
+        @Bridge(demo.SMDst.class)
+        public record SMSrc(demo.MySet<String> tags, demo.MyMap<String, String> byKey) {}
+        """
+      ),
+      ProcessorHarness.source(
+        "demo.SMDst",
+        """
+        package demo;
+        import java.util.Map;
+        import java.util.Set;
+        public record SMDst(Set<String> tags, Map<String, String> byKey) {}
+        """
+      )
+    );
+
+    assertTrue(compilation.success(), () -> "the generated source must compile: " + compilation.errorMessages());
+  }
+
+  @Test
   @DisplayName("a generic subtype with no usable constructor is reported, not emitted against")
   void genericSubtypeWithoutNoArgCtorIsReported() {
     final var compilation = compile(


### PR DESCRIPTION
Closes #365, found by the adversarial review of #362's premise.

A container subtype that keeps its own type parameter — `class MyList<T> extends ArrayList<T> {}` — is an ordinary adopter shape, and it made `@Bridge` emit code that does not compile.

## One decision, two failures

Java does not inherit constructors, so a subtype has only the one it declares. The raw-subtype path already turns on exactly that fact, and the flag carrying the decision says so in its own comment:

> "the subtype is allocated via its no-arg constructor (subclasses don't inherit the JDK copy ctor), so these route to the self-contained raw helpers instead of the generic copy-ctor inline path"

The reasoning is right; the scope was wrong. It was applied only to **raw** subtypes, and a generic one is just as much a subtype.

**Identity elements emitted a copy constructor that does not exist:**

```
ERROR: cannot infer type arguments for demo.MyList<>
  reason: cannot infer type-variable(s) T
    (actual and formal argument lists differ in length)
```

**The no-arg guard never ran.** The check that reports *"has no public no-arg constructor"* was called only from the raw branch, so a generic subtype declaring an `(int)` constructor was emitted against with no telescope diagnostic at all:

```
ERROR: constructor SizedList in class demo.SizedList<T> cannot be applied to given types;
  required: int
```

Both are the same question — is the allocation target a type the adopter wrote? — so both are answered in one place now. Where it is, the plan routes to the self-contained helper, which allocates no-arg and fills, and the guard runs first. Nothing changes for a JDK container, which does offer the copy constructor the inline path needs.

## Why it survived

**No `@Bridge` fixture has a generic container subtype.** Every container fixture in the codegen suite is raw (`class Wrap extends ArrayList<Elem> {}`); the generic shapes — `MyList<E>`, `MyMap<K,V>`, `TaggedList<Tag,E>` — exist only in the runtime mapper suites and in `MapperVerifierProcessorTest`, which never emits a bridge. The emitter had never been asked to allocate one.

## Verification

Written as repros first and watched to fail:

| test | before | after |
| --- | --- | --- |
| identity elements compile | FAILED — `cannot infer type arguments` | PASSED |
| no usable constructor is reported | FAILED — javac's `cannot be applied` | PASSED |
| bridged elements compile | PASSED | PASSED |

The third row is the control that was already green, since the element-bridging path allocates no-arg correctly — it separates "the new routing works" from "the container path was broken generally". Reverting the routing fails the first two and leaves it standing.

All cases compile through the **full pipeline**. Under `-proc:only` javac never attributes generated sources, so an allocation that cannot compile still reports success and every assertion here would hold vacuously — which is how the defect stayed invisible.

Suites green across all six modules.
