### PR TITLE
perf: build a navigator's per-field optics once, not per call

### DIFF
--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/AbstractTelescopeProcessor.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/AbstractTelescopeProcessor.java
@@ -898,8 +898,8 @@ public abstract class AbstractTelescopeProcessor extends AbstractProcessor {
       pojo,
       out -> {
         emitPathClassHeader(out, pathName, pojoName);
-        for (final var p : props) {
-          emitBeanPropertyMethod(out, pojoName, props, setters, useBuilder, p, navigableAnnotations);
+        for (var i = 0; i < props.size(); i++) {
+          emitBeanPropertyMethod(out, pojoName, props, setters, useBuilder, i, navigableAnnotations);
         }
         final var bridgeTarget = bridgeTargetFqn(pojo);
         if (bridgeTarget != null) emitBridgeHop(out, pojoName, bridgeTarget);
@@ -1143,19 +1143,13 @@ public abstract class AbstractTelescopeProcessor extends AbstractProcessor {
     final List<Prop> props,
     final String[] setters,
     final boolean useBuilder,
-    final Prop target,
+    final int propertyIndex,
     final Set<String> navigableAnnotations
   ) {
+    final var target = props.get(propertyIndex);
     final var lensArgs =
       pojoName + "::" + target.getter() + ", " + beanRebuild(target, props, setters, useBuilder, pojoName);
-    var index = 0;
-    for (var i = 0; i < props.size(); i++) {
-      if (props.get(i).name().equals(target.name())) {
-        index = i;
-        break;
-      }
-    }
-    emitNavigatorMethod(out, pojoName, index, target.name(), target.type(), lensArgs, navigableAnnotations);
+    emitNavigatorMethod(out, pojoName, propertyIndex, target.name(), target.type(), lensArgs, navigableAnnotations);
   }
 
   private void emitBeanStep(

--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/AbstractTelescopeProcessor.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/AbstractTelescopeProcessor.java
@@ -1291,10 +1291,18 @@ public abstract class AbstractTelescopeProcessor extends AbstractProcessor {
     // earlier-declared accessor dies at run time. Property names really can differ that way:
     // decapitalisation keeps a leading acronym, so getUrl and getURL yield url and URL. The index
     // makes the names differ before the component name does, which case folding cannot collapse.
-    // A holder also shadows a same-named top-level type throughout the navigator, so where it
-    // would take the source type's own name it steps aside.
+    // A holder is a member type, so its simple name shadows whatever else that name resolves to
+    // inside the navigator. Two names qualify. One is the first segment of the navigated type's
+    // reference, which is dotted for a nested source — the lens bodies resolve that segment, not
+    // the whole reference. The other is the navigator's own class name, which a member class may
+    // not repeat at all. Where the holder would take either, it steps aside.
     var holder = "Optic_" + componentIndex + "_" + componentName;
-    if (holder.equals(enclosingSimpleName)) holder = holder + "_";
+    final var dot = enclosingSimpleName.indexOf('.');
+    final var outerSegment = dot < 0 ? enclosingSimpleName : enclosingSimpleName.substring(0, dot);
+    final var navigatorName = enclosingSimpleName.replace(".", "") + "Telescope";
+    while (holder.equals(outerSegment) || holder.equals(navigatorName)) {
+      holder = holder + "_";
+    }
     final var componentTypeStr = shortenStdImports(boxedType(componentType));
     final var shape = traversalKind(componentType);
     final var subFq = navigableType(componentType, navigableAnnotations);

--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/AbstractTelescopeProcessor.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/AbstractTelescopeProcessor.java
@@ -1273,29 +1273,53 @@ public abstract class AbstractTelescopeProcessor extends AbstractProcessor {
     // via lens/then, which the SerializedLambda-decoding field(...) hop-recording never sees. A
     // container field records NO Focus here: the step's each() records a single Traverse instead,
     // matching a hand-written .each(...).
-    final var focusHop = ".hop(new OpticNode.Focus(\"" + componentName + "\"))";
+    // The lens and the Focus node are the same values on every call, so they are built once in a
+    // per-field holder rather than per navigation. The holder is nested and private, which is what
+    // keeps one field's initializer from deciding another's fate: a class-level static would put
+    // every field in one <clinit>, where a single unresolvable type takes them all down.
+    // `path` still varies per call, so composing it is not hoistable and is left alone.
+    final var holder = "Optic_" + componentName;
+    final var componentTypeStr = shortenStdImports(boxedType(componentType));
     final var shape = traversalKind(componentType);
+    final var subFq = navigableType(componentType, navigableAnnotations);
+    final var recordsFocus = shape == null;
+    out.println("  private static final class " + holder + " {");
+    out.println();
+    out.println("    private " + holder + "() {}");
+    out.println();
+    out.println(
+      "    private static final Telescope<" +
+        enclosingSimpleName +
+        ", " +
+        componentTypeStr +
+        "> LENS = Telescope.lens(" +
+        lensArgs +
+        ");"
+    );
+    if (recordsFocus) {
+      out.println();
+      out.println("    private static final OpticNode HOP = new OpticNode.Focus(\"" + componentName + "\");");
+    }
+    out.println("  }");
+    out.println();
+    final var focusHop = recordsFocus ? ".hop(" + holder + ".HOP)" : "";
     if (shape != null) {
       final var stepName = enclosingSimpleName + capitalize(componentName) + "Step";
       out.println("  public " + stepName + "<R> " + componentName + "() {");
-      out.println("    return new " + stepName + "<>(path.then(Telescope.lens(" + lensArgs + ")));");
+      out.println("    return new " + stepName + "<>(path.then(" + holder + ".LENS));");
       out.println("  }");
       out.println();
       return;
     }
-    final var subFq = navigableType(componentType, navigableAnnotations);
     if (subFq != null) {
       out.println("  public " + subFq + "Telescope<R> " + componentName + "() {");
-      out.println(
-        "    return new " + subFq + "Telescope<>(path.then(Telescope.lens(" + lensArgs + "))" + focusHop + ");"
-      );
+      out.println("    return new " + subFq + "Telescope<>(path.then(" + holder + ".LENS)" + focusHop + ");");
       out.println("  }");
       out.println();
       return;
     }
-    final var typeStr = shortenStdImports(boxedType(componentType));
-    out.println("  public Telescope<R, " + typeStr + "> " + componentName + "() {");
-    out.println("    return path.then(Telescope.lens(" + lensArgs + "))" + focusHop + ";");
+    out.println("  public Telescope<R, " + componentTypeStr + "> " + componentName + "() {");
+    out.println("    return path.then(" + holder + ".LENS)" + focusHop + ";");
     out.println("  }");
     out.println();
   }

--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/AbstractTelescopeProcessor.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/AbstractTelescopeProcessor.java
@@ -1148,7 +1148,14 @@ public abstract class AbstractTelescopeProcessor extends AbstractProcessor {
   ) {
     final var lensArgs =
       pojoName + "::" + target.getter() + ", " + beanRebuild(target, props, setters, useBuilder, pojoName);
-    emitNavigatorMethod(out, pojoName, target.name(), target.type(), lensArgs, navigableAnnotations);
+    var index = 0;
+    for (var i = 0; i < props.size(); i++) {
+      if (props.get(i).name().equals(target.name())) {
+        index = i;
+        break;
+      }
+    }
+    emitNavigatorMethod(out, pojoName, index, target.name(), target.type(), lensArgs, navigableAnnotations);
   }
 
   private void emitBeanStep(
@@ -1263,6 +1270,7 @@ public abstract class AbstractTelescopeProcessor extends AbstractProcessor {
   protected void emitNavigatorMethod(
     final PrintWriter out,
     final String enclosingSimpleName,
+    final int componentIndex,
     final String componentName,
     final TypeMirror componentType,
     final String lensArgs,
@@ -1278,7 +1286,15 @@ public abstract class AbstractTelescopeProcessor extends AbstractProcessor {
     // keeps one field's initializer from deciding another's fate: a class-level static would put
     // every field in one <clinit>, where a single unresolvable type takes them all down.
     // `path` still varies per call, so composing it is not hoistable and is left alone.
-    final var holder = "Optic_" + componentName;
+    // A nested holder is a class file of its own, so two holders whose names differ only in case
+    // overwrite each other on a case-insensitive filesystem — javac reports success and the
+    // earlier-declared accessor dies at run time. Property names really can differ that way:
+    // decapitalisation keeps a leading acronym, so getUrl and getURL yield url and URL. The index
+    // makes the names differ before the component name does, which case folding cannot collapse.
+    // A holder also shadows a same-named top-level type throughout the navigator, so where it
+    // would take the source type's own name it steps aside.
+    var holder = "Optic_" + componentIndex + "_" + componentName;
+    if (holder.equals(enclosingSimpleName)) holder = holder + "_";
     final var componentTypeStr = shortenStdImports(boxedType(componentType));
     final var shape = traversalKind(componentType);
     final var subFq = navigableType(componentType, navigableAnnotations);

--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/FocusProcessor.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/FocusProcessor.java
@@ -132,7 +132,13 @@ public final class FocusProcessor extends AbstractTelescopeProcessor {
       recordType,
       out -> {
         emitPathClassHeader(out, pathName, recordName);
-        for (final var comp : components) emitComponentMethod(out, recordName, components, comp);
+        for (var i = 0; i < components.size(); i++) emitComponentMethod(
+          out,
+          recordName,
+          components,
+          i,
+          components.get(i)
+        );
         final var bridgeTarget = bridgeTargetFqn(recordType);
         if (bridgeTarget != null) emitBridgeHop(out, recordName, bridgeTarget);
         emitTelescopeForwarders(out, recordName);
@@ -237,18 +243,12 @@ public final class FocusProcessor extends AbstractTelescopeProcessor {
     final PrintWriter out,
     final String recordName,
     final List<? extends RecordComponentElement> components,
+    final int componentIndex,
     final RecordComponentElement comp
   ) {
     final var compName = comp.getSimpleName().toString();
     final var lensArgs = recordName + "::" + compName + ", " + canonicalSetter(recordName, components, compName);
-    var index = 0;
-    for (var i = 0; i < components.size(); i++) {
-      if (components.get(i).getSimpleName().toString().equals(compName)) {
-        index = i;
-        break;
-      }
-    }
-    emitNavigatorMethod(out, recordName, index, compName, comp.asType(), lensArgs, FOCUS_ONLY);
+    emitNavigatorMethod(out, recordName, componentIndex, compName, comp.asType(), lensArgs, FOCUS_ONLY);
   }
 
   // Container-step emission for an @Focus record's collection-shaped component. All shared logic

--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/FocusProcessor.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/FocusProcessor.java
@@ -241,7 +241,14 @@ public final class FocusProcessor extends AbstractTelescopeProcessor {
   ) {
     final var compName = comp.getSimpleName().toString();
     final var lensArgs = recordName + "::" + compName + ", " + canonicalSetter(recordName, components, compName);
-    emitNavigatorMethod(out, recordName, compName, comp.asType(), lensArgs, FOCUS_ONLY);
+    var index = 0;
+    for (var i = 0; i < components.size(); i++) {
+      if (components.get(i).getSimpleName().toString().equals(compName)) {
+        index = i;
+        break;
+      }
+    }
+    emitNavigatorMethod(out, recordName, index, compName, comp.asType(), lensArgs, FOCUS_ONLY);
   }
 
   // Container-step emission for an @Focus record's collection-shaped component. All shared logic

--- a/codegen/src/test/java/io/github/eschizoid/telescope/codegen/GeneratedNameCollisionTest.java
+++ b/codegen/src/test/java/io/github/eschizoid/telescope/codegen/GeneratedNameCollisionTest.java
@@ -459,6 +459,31 @@ class GeneratedNameCollisionTest {
   }
 
   @Test
+  @DisplayName("a holder steps aside when its name would be the navigator's own")
+  void holderStepsAsideFromTheNavigatorName() {
+    // A member class may not carry its enclosing class's simple name (JLS 8.1), and the navigator
+    // for Optic_0_x is Optic_0_xTelescope — which is what the holder for a component named
+    // xTelescope at index 0 would otherwise be called.
+    final var compilation = compile(
+      new FocusProcessor(),
+      source(
+        "demo.Optic_0_x",
+        """
+        package demo;
+        import io.github.eschizoid.telescope.annotations.Focus;
+        @Focus
+        public record Optic_0_x(String xTelescope, int other) {}
+        """
+      )
+    );
+
+    assertTrue(
+      compilation.success(),
+      () -> "the holder must not take the navigator's own name: " + compilation.errorMessages()
+    );
+  }
+
+  @Test
   @DisplayName("a holder steps aside when its name would be the navigated type's own")
   void holderStepsAsideFromTheSourceTypeName() {
     // A holder is a member type, so its simple name shadows a top-level type of the same name

--- a/codegen/src/test/java/io/github/eschizoid/telescope/codegen/GeneratedNameCollisionTest.java
+++ b/codegen/src/test/java/io/github/eschizoid/telescope/codegen/GeneratedNameCollisionTest.java
@@ -1,7 +1,9 @@
 package io.github.eschizoid.telescope.codegen;
 
 import static io.github.eschizoid.telescope.codegen.ProcessorHarness.source;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.github.eschizoid.telescope.codegen.ProcessorHarness.Compilation;
@@ -408,6 +410,72 @@ class GeneratedNameCollisionTest {
       () -> "the multi-target source is emitted under its long name, so the call must use it; saw " + parent
     );
     assertTrue(compilation.generated().containsKey("demo.AToBBridge"), "the long-named sub-bridge is what is written");
+  }
+
+  @Test
+  @DisplayName("per-field holder names differ under case folding, not only under comparison")
+  void holderNamesSurviveCaseFolding() {
+    // Each holder is emitted as a nested class, so it becomes a class file of its own. Two whose
+    // names differ only in case overwrite each other on a case-insensitive filesystem while javac
+    // reports success, so the names have to differ before the component name does. Property names
+    // really can differ only in case: decapitalisation keeps a leading acronym, so getUrl and
+    // getURL yield url and URL.
+    final var compilation = compile(
+      new FocusProcessor(),
+      source(
+        "demo.CaseRec",
+        """
+        package demo;
+        import io.github.eschizoid.telescope.annotations.Focus;
+        @Focus
+        public record CaseRec(String x, String X) {}
+        """
+      )
+    );
+
+    assertTrue(compilation.success(), () -> "both components are legal Java: " + compilation.errorMessages());
+    final var navigator = compilation.generated().get("demo.CaseRecTelescope");
+    assertNotNull(navigator);
+    final var holders = java.util.regex.Pattern.compile("private static final class (\\S+) \\{")
+      .matcher(navigator)
+      .results()
+      .map(m -> m.group(1))
+      .toList();
+    assertEquals(2, holders.size(), () -> "one holder per component: " + holders);
+    assertEquals(
+      2,
+      holders
+        .stream()
+        .map(h -> h.toLowerCase(java.util.Locale.ROOT))
+        .distinct()
+        .count(),
+      () -> "these collapse to one class file on a case-insensitive filesystem: " + holders
+    );
+  }
+
+  @Test
+  @DisplayName("a holder steps aside when its name would be the navigated type's own")
+  void holderStepsAsideFromTheSourceTypeName() {
+    // A holder is a member type, so its simple name shadows a top-level type of the same name
+    // throughout the navigator — including inside sibling holders, which spell the navigated type
+    // by simple name.
+    final var compilation = compile(
+      new FocusProcessor(),
+      source(
+        "demo.Optic_0_thing",
+        """
+        package demo;
+        import io.github.eschizoid.telescope.annotations.Focus;
+        @Focus
+        public record Optic_0_thing(String thing, int other) {}
+        """
+      )
+    );
+
+    assertTrue(
+      compilation.success(),
+      () -> "the navigated type must stay reachable from every holder: " + compilation.errorMessages()
+    );
   }
 
   @Test

--- a/codegen/src/test/java/io/github/eschizoid/telescope/codegen/GeneratedNameCollisionTest.java
+++ b/codegen/src/test/java/io/github/eschizoid/telescope/codegen/GeneratedNameCollisionTest.java
@@ -420,6 +420,11 @@ class GeneratedNameCollisionTest {
     // reports success, so the names have to differ before the component name does. Property names
     // really can differ only in case: decapitalisation keeps a leading acronym, so getUrl and
     // getURL yield url and URL.
+    //
+    // The assertion is on the names rather than on two files existing, because the case-folding
+    // behaviour belongs to the filesystem: on a case-sensitive one no two names can collide and a
+    // file-counting test would hold no matter what was emitted. Distinct-after-folding is the
+    // property that decides the outcome on every filesystem.
     final var compilation = compile(
       new FocusProcessor(),
       source(

--- a/codegen/src/test/java/io/github/eschizoid/telescope/codegen/GeneratedNameCollisionTest.java
+++ b/codegen/src/test/java/io/github/eschizoid/telescope/codegen/GeneratedNameCollisionTest.java
@@ -22,13 +22,21 @@ import org.junit.jupiter.api.Test;
  * is not. The second half is what pins the improvement — a processor that reported the cause and
  * emitted the broken artifact anyway would satisfy the first assertion alone.
  *
- * <p>These compile through the full pipeline. {@code -proc:only} does attribute the signatures and
- * type references of a generated source, so a name collision would surface there too — but it stops
- * before the bodies, and asserting on the whole compilation is what keeps a case from depending on
- * which half of the file its error happens to land in.
+ * <p>These compile through the full pipeline, and for one of them that is load-bearing rather than
+ * tidy. {@code -proc:only} completes declarations — so it resolves the types in a signature — and
+ * stops before method bodies and field initializers. A holder taking the navigator's own name is a
+ * duplicate class and is caught at Enter either way; a holder shadowing the navigated type's name
+ * still resolves to a legal type in every signature, and breaks only inside the initializer, where
+ * processing-only never looks.
  */
 class GeneratedNameCollisionTest {
 
+  /**
+   * Runs the full pipeline, not {@code -proc:only}. Retargeting this at the processing-only harness
+   * would leave {@link #holderStepsAsideFromTheSourceTypeName()} passing while testing nothing: the
+   * shadowed name resolves in every signature and fails only inside a field initializer, which
+   * processing-only never attributes.
+   */
   private static Compilation compile(final Processor processor, final JavaFileObject... sources) {
     return ProcessorHarness.compileFully(List.of(processor), List.of(), sources);
   }

--- a/codegen/src/test/java/io/github/eschizoid/telescope/codegen/GeneratedNameCollisionTest.java
+++ b/codegen/src/test/java/io/github/eschizoid/telescope/codegen/GeneratedNameCollisionTest.java
@@ -22,8 +22,10 @@ import org.junit.jupiter.api.Test;
  * is not. The second half is what pins the improvement — a processor that reported the cause and
  * emitted the broken artifact anyway would satisfy the first assertion alone.
  *
- * <p>Compilation attributes the generated sources, so an error inside them is observable; under
- * {@code -proc:only} javac never visits them and the negative assertions would hold vacuously.
+ * <p>These compile through the full pipeline. {@code -proc:only} does attribute the signatures and
+ * type references of a generated source, so a name collision would surface there too — but it stops
+ * before the bodies, and asserting on the whole compilation is what keeps a case from depending on
+ * which half of the file its error happens to land in.
  */
 class GeneratedNameCollisionTest {
 

--- a/codegen/src/test/java/io/github/eschizoid/telescope/codegen/GenericContainerSubtypeTest.java
+++ b/codegen/src/test/java/io/github/eschizoid/telescope/codegen/GenericContainerSubtypeTest.java
@@ -19,9 +19,9 @@ import org.junit.jupiter.api.Test;
  * else unless it declares more. Both facts the raw path already respects have to hold here too.
  *
  * <p>Every case compiles through the full pipeline, which matters here specifically: the defect is
- * an allocation expression, and {@code -proc:only} attributes a generated source's signatures but
- * not its bodies. A body that cannot compile still reports success there, so every assertion below
- * would hold vacuously.
+ * an allocation expression. {@code -proc:only} completes declarations and stops before method
+ * bodies and field initializers — of any source, not only a generated one — so an expression that
+ * cannot compile still reports success there and every assertion below would hold vacuously.
  */
 class GenericContainerSubtypeTest {
 

--- a/codegen/src/test/java/io/github/eschizoid/telescope/codegen/GenericContainerSubtypeTest.java
+++ b/codegen/src/test/java/io/github/eschizoid/telescope/codegen/GenericContainerSubtypeTest.java
@@ -18,9 +18,10 @@ import org.junit.jupiter.api.Test;
  * <p>Java does not inherit constructors, so such a subtype has its implicit no-arg one and nothing
  * else unless it declares more. Both facts the raw path already respects have to hold here too.
  *
- * <p>Every case compiles through the full pipeline. Under {@code -proc:only} javac never attributes
- * the generated source, so an allocation that cannot compile still reports success and every
- * assertion below would hold vacuously.
+ * <p>Every case compiles through the full pipeline, which matters here specifically: the defect is
+ * an allocation expression, and {@code -proc:only} attributes a generated source's signatures but
+ * not its bodies. A body that cannot compile still reports success there, so every assertion below
+ * would hold vacuously.
  */
 class GenericContainerSubtypeTest {
 

--- a/lombok/src/test/java/io/github/eschizoid/telescope/codegen/lombok/LombokFocusProcessorTest.java
+++ b/lombok/src/test/java/io/github/eschizoid/telescope/codegen/lombok/LombokFocusProcessorTest.java
@@ -9,6 +9,7 @@ import io.github.eschizoid.telescope.codegen.lombok.fixtures.BuilderAlertRequest
 import io.github.eschizoid.telescope.codegen.lombok.fixtures.BuilderUser;
 import io.github.eschizoid.telescope.codegen.lombok.fixtures.DataAlertRequest;
 import io.github.eschizoid.telescope.codegen.lombok.fixtures.DataUser;
+import io.github.eschizoid.telescope.codegen.lombok.fixtures.Optic_0_label;
 import io.github.eschizoid.telescope.codegen.lombok.fixtures.SameRoundConsumer;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
@@ -93,6 +94,27 @@ class LombokFocusProcessorTest {
     }
 
     @Test
+    @DisplayName("A nested class named after a per-field holder still yields a usable navigator")
+    void nestedOuterNamedAfterAHolderStillNavigates() throws Exception {
+      // Each field's optics live in a member class of the navigator, so that name shadows whatever
+      // else it resolves to there — including the outer segment of the navigated type's own
+      // reference, which a nested source spells as Outer.Inner. Only Lombok accepts a nested
+      // source, so this shape cannot be reached from the in-memory harness.
+      final var navigator = Class.forName(
+        "io.github.eschizoid.telescope.codegen.lombok.fixtures.Optic_0_labelInnerTelescope"
+      );
+      assertNotNull(navigator);
+
+      final var of = navigator.getMethod("of");
+      final var label = navigator.getMethod("label");
+      final var value = new Optic_0_label.Inner("hello");
+      final var path = label.invoke(of.invoke(null));
+      final var read = path.getClass().getMethod("read", Object.class);
+
+      assertEquals("hello", read.invoke(path, value));
+    }
+
+    @Test
     @DisplayName("Nested static @Data class yields a flattened-name navigator at package level")
     void nestedStaticDataClassEmitsFlattenedPath() throws Exception {
       // OuterWithNested holds a nested static @Data Inner. The processor should emit the navigator
@@ -122,7 +144,7 @@ class LombokFocusProcessorTest {
     }
 
     @Test
-    @DisplayName("@Data POJO with List<@Data> emits a container step whose each() returns the element's navigator")
+    @DisplayName("@Data POJO with List<@Data> emits a container step whose each() returns the element's" + " navigator")
     void containerStepDescendsIntoSubPath() throws Exception {
       final var teamPath = Class.forName("io.github.eschizoid.telescope.codegen.lombok.fixtures.DataTeamTelescope");
       assertNotNull(teamPath);
@@ -149,7 +171,7 @@ class LombokFocusProcessorTest {
 
     @Test
     @DisplayName(
-      "@Data POJO yields a DataUserFieldOptics holder with public static final Telescope constants per property"
+      "@Data POJO yields a DataUserFieldOptics holder with public static final Telescope" + " constants per property"
     )
     void dataHolder() throws Exception {
       final var holder = Class.forName("io.github.eschizoid.telescope.codegen.lombok.fixtures.DataUserFieldOptics");
@@ -261,7 +283,9 @@ class LombokFocusProcessorTest {
     }
 
     @Test
-    @DisplayName("@Builder POJO with primitive int: construct() chain substitutes JLS default on null entry, no NPE")
+    @DisplayName(
+      "@Builder POJO with primitive int: construct() chain substitutes JLS default on null entry," + " no NPE"
+    )
     void builderHolderConstructNullPrimitive() throws Exception {
       // Builder-strategy rebuild: the generated construct() chains the static builder() with one
       // .x(...) per property. Primitive properties must take the instanceof-pattern null-guard

--- a/lombok/src/test/java/io/github/eschizoid/telescope/codegen/lombok/fixtures/Optic_0_label.java
+++ b/lombok/src/test/java/io/github/eschizoid/telescope/codegen/lombok/fixtures/Optic_0_label.java
@@ -1,0 +1,27 @@
+package io.github.eschizoid.telescope.codegen.lombok.fixtures;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Fixture: an outer class whose name is what the nested class's per-field holder would otherwise be
+ * called. The holder is a member type of the navigator, so taking that name would shadow the outer
+ * segment of the navigated type's reference throughout the emitted file — including the class
+ * header, which names {@code Optic_0_label.Inner}.
+ *
+ * <p>Nested sources reach this only through Lombok: {@code @Focus} and {@code @BeanFocus} both
+ * reject a nested type at the gate, so no in-memory harness case can cover it.
+ */
+public final class Optic_0_label {
+
+  private Optic_0_label() {}
+
+  @Data
+  @NoArgsConstructor
+  @AllArgsConstructor
+  public static class Inner {
+
+    private String label;
+  }
+}


### PR DESCRIPTION
Closes #345. The measurement landed first in #364; this is the fix, measured against exactly those rows.

Every navigation call rebuilt values that cannot vary — a fresh `Lens`, a fresh `OpticNode`, and the trail copy behind them:

```java
public Telescope<R, String> name() {
  return path.then(Telescope.lens(BenchHolderSrc::name, (s, v) -> new BenchHolderSrc(v, ...)))
             .hop(new OpticNode.Focus("name"));
}
```

`path` genuinely varies per call, so composing it is not hoistable and is untouched. The lens and the node are invariant, and now live in a per-field holder built on first use:

```java
private static final class Optic_name {
  private static final Telescope<BenchHolderSrc, String> LENS = Telescope.lens(...);
  private static final OpticNode HOP = new OpticNode.Focus("name");
}

public Telescope<R, String> name() {
  return path.then(Optic_name.LENS).hop(Optic_name.HOP);
}
```

**The holder is nested and private, one per field** — the constraint #345 carries from the previously rejected attempt. A class-level static would put every field in a single `<clinit>`, where one unresolvable type decides the fate of all of them. One holder per field means one initializer per field.

Sharing the node is safe because `hop()` returns a **new** telescope carrying the appended trail (`plus(node)`) rather than mutating one, and `Focus` is a record over a string. I checked both rather than assuming.

## Measured

[Actions 34639153357](https://github.com/eschizoid/telescope/actions/runs/34639153357) against the #364 baseline ([34624149553](https://github.com/eschizoid/telescope/actions/runs/34624149553)), both `-Pjmh.profilers=gc`, 5 warmup + 10 measured.

**The controls first.** The prebuilt rows share the benchmark, the fixture and the read, and this change cannot touch them:

| control | before | after |
| --- | --- | --- |
| `prebuiltDeep` | 25.066 ns / 112 B | 25.088 ns / 112 B |
| `prebuiltShallow` | 2.633 ns / ~0 B | 2.852 ns / ~0 B |

`prebuiltDeep` is unchanged and its allocation is byte-identical on both. `prebuiltShallow` reads 8% slower on a 2.6 ns row with tight bands — runner, not code, and its allocation is also unchanged. Allocation being identical on both controls is what says the runner moved and the code did not.

**The navigate rows:**

| row | before | after | |
| --- | ---: | ---: | --- |
| 1 hop | 38.567 ns / 232 B | 31.528 ns / **192 B** | −18.3% time, −17.2% allocation |
| 3 hops | 186.703 ns / 904 B | 148.447 ns / **712 B** | −20.5% time, −21.2% allocation |

Normalised to each row's own control, which is runner-independent: the fluent call goes from **14.65× to 11.05×** a prebuilt read at one hop, and from 7.45× to 5.92× at three.

## What is left, and why

At one hop the navigator still allocates 192 B/op against a control that allocates nothing. That residual is the composition itself — `then` and `hop` each build a new `Telescope`, because the path varies per call — which #345 names as inherent to the fluent API rather than a defect. The invariant half is what this removes; the varying half is the price of the surface.

Suites green across all six modules, 244 `PASSED` on `:codegen:test`, run with `--rerun-tasks` after `--stop` (see the daemon note below).

## The safety argument, verified rather than asserted

The blast-radius constraint is the whole justification for the nested-holder shape, and nothing tested it. So it was checked empirically, against a navigator emitted by the real `FocusProcessor` — not a hand-written stand-in — with an optional type deleted from the runtime classpath and loaded through a filtered classloader, then repeated with a plain throwing initializer so the result is not an artifact of one failure kind.

**Containment holds, and it is order-independent.** With `Gadget.class` removed, `gadget` fails and `name`, `age` and `widget` all still read, write and `explain()` — whether the bad field is touched first or last. With two types removed, exactly those two fail.

**The contrast with the rejected shape is stark.** In the class-level variant, the *first* probe — reading `name`, which never mentions `Gadget` — dies on `demo/Gadget`, and every subsequent field reports `Could not initialize class`. One `<clinit>`, four dead fields.

**Stronger than the claim above:** `main`'s navigator (lens built per call) also contains the failure, so this PR **preserves main's containment** rather than merely improving on the rejected shape. That is the accurate statement and it is the one that matters.

**Initialization is genuinely lazy.** `javap -p` reports the navigator class has *no* `<clinit>` at all, and `-Xlog:class+init` shows holders initializing one per touched field, in touch order — touching `name` initializes `Optic_name` and nothing else.

**Sharing is safe under concurrency.** 32 threads × 5000 iterations through the same shared constants — path reads, `explain()` trails, updates with source-immutability checks, container fan-out — 0 failures, plus a cold-start race of 60 fresh JVMs × 64 threads hitting uninitialized holders simultaneously. A negative control (expecting the `home` trail while navigating `work`) produces 1600 failures, so the assertions are live rather than vacuous.

## Scope of that guarantee

It covers the **navigator**. The sibling ADR-0006 metadata holder `<X>FieldOptics` is still the all-in-one-`<clinit>` shape, and the runtime reflective path reads it, so `Telescope.of(User.class).field(User::name)` still dies on an unrelated missing type where `UserTelescope.of().name()` does not. The generated `FieldOptics` is byte-identical between `main` and this branch — pre-existing and untouched here — but worth saying plainly so "one missing optional type cannot kill unrelated fields" is not read as a statement about telescope generally.
