### PR TITLE
fix: treat a holder that cannot initialize as one that is absent

### DIFF
--- a/internal/src/main/java/io/github/eschizoid/telescope/internal/MetadataHolderProbe.java
+++ b/internal/src/main/java/io/github/eschizoid/telescope/internal/MetadataHolderProbe.java
@@ -94,6 +94,13 @@ public final class MetadataHolderProbe {
       return Optional.of(new HolderRef(holder, constants, constructor));
     } catch (final ClassNotFoundException e) {
       return Optional.empty();
+    } catch (final LinkageError e) {
+      // The holder exists to skip the reflective build, so it is an optimization and not a
+      // dependency: one that cannot initialize is a reason to take the slower path, the same answer
+      // already given when no holder is on the classpath at all. A type present when the holder was
+      // compiled and absent at run time arrives here, and it carries every field of its owner with
+      // it, because the holder builds them all in one initializer.
+      return Optional.empty();
     } catch (final ReflectiveOperationException e) {
       throw new IllegalStateException("Failed to probe metadata holder " + holderName, e);
     }
@@ -124,8 +131,8 @@ public final class MetadataHolderProbe {
       throw new IllegalStateException(
         "Metadata holder " +
           holder.getName() +
-          " has a `constants()` method but its shape is wrong (must be `public static Map<...>`). " +
-          "Re-run the @Focus / @BeanFocus processor."
+          " has a `constants()` method but its shape is wrong (must be `public static" +
+          " Map<...>`). Re-run the @Focus / @BeanFocus processor."
       );
     }
     final var result = (Map<String, Object>) method.invoke(null);
@@ -157,7 +164,8 @@ public final class MetadataHolderProbe {
           holder.getName() +
           " is missing the required `public static " +
           target.getSimpleName() +
-          " construct(Function<String, Object>)` method. Re-run the @Focus / @BeanFocus processor.",
+          " construct(Function<String, Object>)` method. Re-run the @Focus / @BeanFocus" +
+          " processor.",
         e
       );
     }
@@ -169,9 +177,11 @@ public final class MetadataHolderProbe {
       throw new IllegalStateException(
         "Metadata holder " +
           holder.getName() +
-          " has a `construct(Function)` method but its shape is wrong (must be `public static " +
+          " has a `construct(Function)` method but its shape is wrong (must be `public static" +
+          " " +
           target.getSimpleName() +
-          " construct(Function<String, Object>)`). Re-run the @Focus / @BeanFocus processor."
+          " construct(Function<String, Object>)`). Re-run the @Focus / @BeanFocus" +
+          " processor."
       );
     }
     try {

--- a/internal/src/test/java/io/github/eschizoid/telescope/internal/HolderFailingInit.java
+++ b/internal/src/test/java/io/github/eschizoid/telescope/internal/HolderFailingInit.java
@@ -1,0 +1,8 @@
+package io.github.eschizoid.telescope.internal;
+
+/**
+ * Fixture pair for a holder whose class initializer cannot complete. Stands in for the shape that
+ * matters in practice: a type present when the holder was compiled and absent at run time, which
+ * arrives as a {@code NoClassDefFoundError} from the same initializer.
+ */
+public record HolderFailingInit(String name) {}

--- a/internal/src/test/java/io/github/eschizoid/telescope/internal/HolderFailingInitFieldOptics.java
+++ b/internal/src/test/java/io/github/eschizoid/telescope/internal/HolderFailingInitFieldOptics.java
@@ -1,0 +1,34 @@
+package io.github.eschizoid.telescope.internal;
+
+import java.util.Map;
+import java.util.function.Function;
+
+/**
+ * DELIBERATELY UNINITIALIZABLE holder fixture. Pair to {@link HolderFailingInit}. Its class
+ * initializer throws, so every access arrives as an {@link ExceptionInInitializerError} and then,
+ * on any later attempt, a {@code NoClassDefFoundError} naming the erroneous class.
+ *
+ * <p>The holder exists to skip the reflective build, so it is an optimization rather than a
+ * dependency: {@link MetadataHolderProbe#probeFor} must answer empty and let the caller take the
+ * slower path, which is the same answer it gives when no holder is present at all.
+ *
+ * <p>Hand-written (NOT codegen-emitted) so the shape is stable across processor regenerations.
+ */
+public final class HolderFailingInitFieldOptics {
+
+  static {
+    if (Boolean.parseBoolean("true")) {
+      throw new IllegalStateException("this holder cannot initialize");
+    }
+  }
+
+  private HolderFailingInitFieldOptics() {}
+
+  public static Map<String, Object> constants() {
+    return Map.of();
+  }
+
+  public static HolderFailingInit construct(final Function<String, Object> values) {
+    return new HolderFailingInit((String) values.apply("name"));
+  }
+}

--- a/internal/src/test/java/io/github/eschizoid/telescope/internal/MetadataHolderProbeShapeCheckTest.java
+++ b/internal/src/test/java/io/github/eschizoid/telescope/internal/MetadataHolderProbeShapeCheckTest.java
@@ -26,7 +26,7 @@ class MetadataHolderProbeShapeCheckTest {
 
     @Test
     @DisplayName(
-      "HolderRef.constructor() round-trips a sibling FieldOptics's construct(Function) via LambdaMetafactory"
+      "HolderRef.constructor() round-trips a sibling FieldOptics's construct(Function) via" + " LambdaMetafactory"
     )
     void constructorRoundTrip() {
       // The holder-probe contract: probeFor returns a HolderRef whose `constructor` is a cached
@@ -62,7 +62,28 @@ class MetadataHolderProbeShapeCheckTest {
   class ShapeCheck {
 
     @Test
-    @DisplayName("Missing constants() method throws IllegalStateException naming the missing method + re-run hint")
+    @DisplayName("A holder whose initializer cannot complete degrades to the reflective path")
+    void holderThatCannotInitializeDegrades() {
+      // The holder skips the reflective build; it is an optimization, not a dependency. A type
+      // present when the holder was compiled and absent at run time takes the initializer down,
+      // and because the holder builds every field's constant in that one initializer it takes
+      // every field of its owner with it. Answering empty is the same answer given when no holder
+      // is on the classpath, and it leaves the caller with a slower path rather than no path.
+      assertTrue(
+        MetadataHolderProbe.probeFor(HolderFailingInit.class).isEmpty(),
+        "an uninitializable holder must read as absent, not propagate"
+      );
+
+      // Cached, and the second read is the one that arrives as NoClassDefFoundError rather than
+      // ExceptionInInitializerError — the JVM marks the class erroneous after the first attempt.
+      assertTrue(
+        MetadataHolderProbe.probeFor(HolderFailingInit.class).isEmpty(),
+        "the answer must hold on a second read, where the error arrives in its other form"
+      );
+    }
+
+    @Test
+    @DisplayName("Missing constants() method throws IllegalStateException naming the missing method + re-run" + " hint")
     void missingConstantsMethod() {
       // Real scenario: adopter upgrades the runtime but their build cache still has an older holder
       // shape — FieldOptics from an older codegen that didn't emit constants(). The diagnostic must


### PR DESCRIPTION
Small, and deliberately **not** closing #371 — the measurement that came out of investigating it overturned that issue's diagnosis, and this is the part that survived.

## What changed

`MetadataHolderProbe` already answers `Optional.empty()` when no `<X>FieldOptics` is on the classpath, and the caller takes the reflective path. A holder that *is* present but whose class initializer cannot complete propagated the `LinkageError` instead and took the call down with it.

The holder exists to skip the reflective build. It is an optimization, not a dependency, so an unusable one should cost the fast path and nothing else. Both cases now answer the same way.

## What this does not do

I reached this from #371, which says `FieldOptics` building every field in one `<clinit>` is what disables the runtime path when one component type is missing. **That diagnosis is wrong.** With `Gadget` removed from the runtime classpath:

```
codegen  navigator name() -> OK
codegen  navigator age()  -> OK
runtime  field(User::name) -> FAIL NoClassDefFoundError
    at java.base/java.lang.Class.getRecordComponents0(Native Method)
    at io.github.eschizoid.telescope.internal.Records$RecordInfo.of(Records.java:331)
```

`Class.getRecordComponents()` resolves every component's type, so reflecting on the record requires the missing class regardless of what the holder does. The original report's trace stopped at the probe because the probe was the *first* thing to need the type — not the only one. With this change the probe steps aside and the reflective fallback fails two frames later, for a reason telescope does not own.

So splitting `FieldOptics` per field would change nothing observable, and I have said so on #371 rather than leave the issue pointing at work that would not help.

## Verification

A hand-written holder fixture whose initializer throws, alongside the existing malformed-holder fixtures — the established pattern in that suite, and stable across processor regenerations. It asserts the probe answers empty **twice**, because the second read is where the JVM reports the erroneous class as `NoClassDefFoundError` rather than `ExceptionInInitializerError`, and `LinkageError` has to cover both.

Revert-proven: narrowing the catch to `RuntimeException` fails that test alone.

`:internal` 345 PASSED, full suite green, run with `--rerun-tasks` after `--stop`.

One honest note on scope: for a *missing component type* specifically, this branch is unreachable in practice — the JDK fails first. What it does cover is a holder that cannot initialize for any other reason, which is the case the malformed-holder suite around it already exists to police.
