### PR TITLE
fix(codegen): allocate a container the declared type can hold, and name it

### DIFF
--- a/codegen/build.gradle.kts
+++ b/codegen/build.gradle.kts
@@ -27,7 +27,10 @@ java {
 tasks.withType<JavaCompile>().configureEach {
     options.release = 21
     options.encoding = "UTF-8"
-    options.compilerArgs.addAll(listOf("-Xlint:all,-processing", "-parameters"))
+    // -Werror because one of these warnings earns its keep here: a javadoc block left above the
+    // wrong member after an insertion is reported as dangling, and that is the only automatic
+    // signal for a comment that has drifted off the thing it documents. Advisory, it scrolls past.
+    options.compilerArgs.addAll(listOf("-Xlint:all,-processing", "-parameters", "-Werror"))
 }
 
 tasks.withType<Test>().configureEach {

--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
@@ -2502,6 +2502,31 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
   }
 
   /**
+   * Why a container field cannot be emitted when nothing telescope can construct is of its declared
+   * type. Naming a concrete type is the only fix the author can apply, since the type itself is
+   * what rules out every candidate.
+   */
+  private static String unassignableContainerMessage(
+    final TypeElement source,
+    final TypeElement target,
+    final String fieldName,
+    final String container
+  ) {
+    return (
+      "@Bridge " +
+      source.getSimpleName() +
+      " -> " +
+      target.getSimpleName() +
+      ": field '" +
+      fieldName +
+      "' is declared as '" +
+      container +
+      "', which telescope cannot construct — the class it would allocate is not of that type." +
+      " Declare the field as a concrete container, or supply an explicit @ViaMapper for it."
+    );
+  }
+
+  /**
    * Why a container field cannot be emitted, and what the author can do about it. Every route but
    * the inline identity copy allocates no-arg, so a class without that constructor cannot be built.
    * The remedy depends on who owns the class: adding a constructor is only advice the author can
@@ -2736,6 +2761,13 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
         // elements. Forward hands the source to the target's constructor and backward does the
         // reverse, so each side is asked about the value it will actually receive.
         if (isContainerKind(subPlan.kind())) {
+          // Whatever route the container takes, it allocates a class that has to BE the declared
+          // type. That is decided before the route is, so it is asked first.
+          final var unassignable = firstUnassignableContainer(sf.type(), tf.type(), subPlan.kind());
+          if (unassignable != null) {
+            error(source, unassignableContainerMessage(source, target, sf.name(), unassignable));
+            return null;
+          }
           final var elementIdentity = IDENTITY_ELEMENT_SENTINEL.equals(subPlan.subBridgeName());
           final var inlineCopy =
             elementIdentity &&
@@ -2761,8 +2793,8 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
         // (LinkedList, TreeSet, …) is rebuilt as that class, not the default impl.
         final var withImpls = switch (subPlan.kind()) {
           case LIST, SET, MAP_VALUES -> subPlan.withContainerImpls(
-            simpleName(concreteImplFqn(tf.type(), subPlan.kind())),
-            simpleName(concreteImplFqn(sf.type(), subPlan.kind()))
+            concreteImplFqn(tf.type(), subPlan.kind()),
+            concreteImplFqn(sf.type(), subPlan.kind())
           );
           default -> subPlan;
         };
@@ -2800,6 +2832,11 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
         // subtype that hides it (`class Wrap extends ArrayList<X> { Wrap(int cap) {} }`) would make
         // the generated `new Wrap()` fail in the consumer's build with a raw javac error; reject it
         // here with a telescope-authored diagnostic instead.
+        final var unassignableRaw = firstUnassignableContainer(sf.type(), tf.type(), srcRaw.kind());
+        if (unassignableRaw != null) {
+          error(source, unassignableContainerMessage(source, target, sf.name(), unassignableRaw));
+          return null;
+        }
         final var badAlloc = firstNonAllocatableContainer(sf.type(), tf.type(), srcRaw.kind());
         if (badAlloc != null) {
           error(source, unallocatableContainerMessage(source, target, sf.name(), badAlloc));
@@ -3150,13 +3187,10 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
         // types and the inline copy) and the concrete impl each side allocates. For the common
         // interface-typed field this is {List, ArrayList} etc., unchanged; a concrete subtype adds
         // its own class (LinkedList, TreeSet, …).
+        // A container's raw type and its allocation class are rendered fully qualified, so they
+        // need no import — and importing them would reintroduce the collision two subtypes of the
+        // same simple name in different packages otherwise cause.
         case LIST, SET, MAP_VALUES -> {
-          final var srcType = fieldByName(sourceFields, entry.getKey()).type();
-          final var tgtType = fieldByName(targetFields, renames.getOrDefault(entry.getKey(), entry.getKey())).type();
-          for (final var t : List.of(srcType, tgtType)) {
-            imports.add(containerRawFqn(t));
-            imports.add(concreteImplFqn(t, plan.kind()));
-          }
         }
         case OPTIONAL_TO_NULLABLE, NULLABLE_TO_OPTIONAL -> imports.add("java.util.Optional");
         default -> {
@@ -3253,6 +3287,28 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
   // The JDK default impls (ArrayList / LinkedHashSet / LinkedHashMap) always qualify; only a user
   // subtype
   // can hide its no-arg ctor.
+  /**
+   * The first of the two container types whose chosen allocation class cannot be assigned to it, or
+   * null when both fit. Picking a class and being able to name it are separate obligations from
+   * being able to assign it: an interface or abstract type the adopter wrote falls through to the
+   * family default, which is instantiable and has the right shape and is still not that type.
+   */
+  private String firstUnassignableContainer(
+    final TypeMirror srcContainer,
+    final TypeMirror tgtContainer,
+    final FieldPlan.Kind kind
+  ) {
+    final var types = processingEnv.getTypeUtils();
+    for (final var container : List.of(srcContainer, tgtContainer)) {
+      final var implEl = processingEnv.getElementUtils().getTypeElement(concreteImplFqn(container, kind));
+      if (implEl == null) continue;
+      if (!types.isAssignable(types.erasure(implEl.asType()), types.erasure(container))) {
+        return container.toString();
+      }
+    }
+    return null;
+  }
+
   private String firstNonAllocatableContainer(
     final TypeMirror srcContainer,
     final TypeMirror tgtContainer,
@@ -3300,10 +3356,10 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
   ) {
     final var srcElement = ((DeclaredType) srcContainer).getTypeArguments().getFirst();
     final var tgtElement = ((DeclaredType) tgtContainer).getTypeArguments().getFirst();
-    final var returnRaw = simpleName(containerRawFqn(tgtContainer));
-    final var paramRaw = simpleName(containerRawFqn(srcContainer));
+    final var returnRaw = containerRawFqn(tgtContainer);
+    final var paramRaw = containerRawFqn(srcContainer);
     final var implFqn = concreteImplFqn(tgtContainer, FieldPlan.Kind.LIST);
-    final var alloc = sizedAlloc(implFqn, String.valueOf(tgtElement));
+    final var alloc = sizedAlloc(implFqn, String.valueOf(tgtElement), implFqn);
     out.println();
     out.println(
       "  private static " +
@@ -3335,10 +3391,10 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
   ) {
     final var srcElement = ((DeclaredType) srcContainer).getTypeArguments().getFirst();
     final var tgtElement = ((DeclaredType) tgtContainer).getTypeArguments().getFirst();
-    final var returnRaw = simpleName(containerRawFqn(tgtContainer));
-    final var paramRaw = simpleName(containerRawFqn(srcContainer));
+    final var returnRaw = containerRawFqn(tgtContainer);
+    final var paramRaw = containerRawFqn(srcContainer);
     final var implFqn = concreteImplFqn(tgtContainer, FieldPlan.Kind.SET);
-    final var alloc = sizedAlloc(implFqn, String.valueOf(tgtElement));
+    final var alloc = sizedAlloc(implFqn, String.valueOf(tgtElement), implFqn);
     out.println();
     out.println(
       "  private static " +
@@ -3373,10 +3429,10 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
     final var keyType = srcArgs.get(0);
     final var srcValue = srcArgs.get(1);
     final var tgtValue = tgtArgs.get(1);
-    final var returnRaw = simpleName(containerRawFqn(tgtContainer));
-    final var paramRaw = simpleName(containerRawFqn(srcContainer));
+    final var returnRaw = containerRawFqn(tgtContainer);
+    final var paramRaw = containerRawFqn(srcContainer);
     final var implFqn = concreteImplFqn(tgtContainer, FieldPlan.Kind.MAP_VALUES);
-    final var alloc = sizedAlloc(implFqn, keyType + ", " + tgtValue);
+    final var alloc = sizedAlloc(implFqn, keyType + ", " + tgtValue, implFqn);
     out.println();
     out.println(
       "  private static " +
@@ -3405,11 +3461,6 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
   }
 
   /**
-   * Compute the bridge class name. User-declared pairs use the original convention {@code
-   * <Source>Bridge}; auto-generated sub-pairs use {@code <Source>To<Target>Bridge} so they don't
-   * collide with a user-declared {@code <Source>Bridge} that points at a different target.
-   */
-  /**
    * The first of the two sides that is an abstract class, or {@code null} when both can be
    * constructed. A rebuild calls a constructor and an abstract class has none to call, so the pair
    * is refused here rather than emitted and left for javac to reject inside a file the author never
@@ -3422,6 +3473,11 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
     return null;
   }
 
+  /**
+   * Compute the bridge class name. User-declared pairs use the original convention {@code
+   * <Source>Bridge}; auto-generated sub-pairs use {@code <Source>To<Target>Bridge} so they don't
+   * collide with a user-declared {@code <Source>Bridge} that points at a different target.
+   */
   private static String bridgeClassName(
     final TypeElement source,
     final TypeElement target,

--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
@@ -2270,8 +2270,8 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
     // primitiveWrapperIso's fwdDefault / bwdDefault.
     String fwdNullDefault,
     String bwdNullDefault,
-    // LIST/SET/MAP_VALUES only: the simple name of the concrete collection/map class to allocate
-    // for
+    // LIST/SET/MAP_VALUES only: the fully-qualified name of the concrete collection/map class to
+    // allocate for
     // the forward (target) and backward (source) outputs, used by the inline identity-element
     // copy
     // in applyForward/applyBackward. Null for non-container kinds (the element-bridging helper
@@ -2632,19 +2632,17 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
    * author gave the argument.
    *
    * @param typeArgs the emitted type arguments, without angle brackets
-   * @param rendered how the class is named at the call site — always fully qualified, because a
-   *     container helper imports nothing
    */
-  private static String sizedAlloc(final String implFqn, final String typeArgs, final String rendered) {
+  private static String sizedAlloc(final String implFqn, final String typeArgs) {
     return switch (implFqn) {
-      case "java.util.HashSet", "java.util.LinkedHashSet", "java.util.HashMap", "java.util.LinkedHashMap" -> rendered +
+      case "java.util.HashSet", "java.util.LinkedHashSet", "java.util.HashMap", "java.util.LinkedHashMap" -> implFqn +
       ".<" +
       typeArgs +
       ">new" +
       simpleName(implFqn) +
       "(src.size())";
-      case "java.util.ArrayList" -> "new " + rendered + "<" + typeArgs + ">(src.size())";
-      default -> "new " + rendered + "<" + typeArgs + ">()";
+      case "java.util.ArrayList" -> "new " + implFqn + "<" + typeArgs + ">(src.size())";
+      default -> "new " + implFqn + "<" + typeArgs + ">()";
     };
   }
 
@@ -3171,15 +3169,7 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
   private Set<String> importsFor(final Map<String, FieldPlan> fieldPlans) {
     final var imports = new TreeSet<String>();
     for (final var plan : fieldPlans.values()) {
-      // Raw-container helpers render every container/element TYPE by fully-qualified name, so they
-      // need no container-type imports.
-      if (plan.rawContainer()) continue;
       switch (plan.kind()) {
-        // A container's raw type and its allocation class are rendered fully qualified, so they
-        // need no import — and importing them would reintroduce the collision two subtypes of the
-        // same simple name in different packages otherwise cause.
-        case LIST, SET, MAP_VALUES -> {
-        }
         case OPTIONAL_TO_NULLABLE, NULLABLE_TO_OPTIONAL -> imports.add("java.util.Optional");
         default -> {
         }
@@ -3328,10 +3318,10 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
     if (!generic) return "new " + implFqn + "()";
     if (kind == FieldPlan.Kind.MAP_VALUES) {
       final var args = containerViewArgs(container, "java.util.Map");
-      return sizedAlloc(implFqn, args.get(0) + ", " + args.get(1), implFqn);
+      return sizedAlloc(implFqn, args.get(0) + ", " + args.get(1));
     }
     final var args = containerViewArgs(container, kind == FieldPlan.Kind.SET ? "java.util.Set" : "java.util.List");
-    return sizedAlloc(implFqn, args.getFirst().toString(), implFqn);
+    return sizedAlloc(implFqn, args.getFirst().toString());
   }
 
   private void emitListHelper(
@@ -3347,7 +3337,7 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
     final var returnRaw = containerRawFqn(tgtContainer);
     final var paramRaw = containerRawFqn(srcContainer);
     final var implFqn = concreteImplFqn(tgtContainer, FieldPlan.Kind.LIST);
-    final var alloc = sizedAlloc(implFqn, String.valueOf(tgtElement), implFqn);
+    final var alloc = sizedAlloc(implFqn, String.valueOf(tgtElement));
     out.println();
     out.println(
       "  private static " +
@@ -3382,7 +3372,7 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
     final var returnRaw = containerRawFqn(tgtContainer);
     final var paramRaw = containerRawFqn(srcContainer);
     final var implFqn = concreteImplFqn(tgtContainer, FieldPlan.Kind.SET);
-    final var alloc = sizedAlloc(implFqn, String.valueOf(tgtElement), implFqn);
+    final var alloc = sizedAlloc(implFqn, String.valueOf(tgtElement));
     out.println();
     out.println(
       "  private static " +
@@ -3420,7 +3410,7 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
     final var returnRaw = containerRawFqn(tgtContainer);
     final var paramRaw = containerRawFqn(srcContainer);
     final var implFqn = concreteImplFqn(tgtContainer, FieldPlan.Kind.MAP_VALUES);
-    final var alloc = sizedAlloc(implFqn, keyType + ", " + tgtValue, implFqn);
+    final var alloc = sizedAlloc(implFqn, keyType + ", " + tgtValue);
     out.println();
     out.println(
       "  private static " +

--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
@@ -1868,7 +1868,7 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
     // target).
     if (carrierEl != null) emitBridgeProvider(source, target, bridgeName, pkg);
 
-    final var imports = new TreeSet<>(importsFor(fieldPlans, sourceFields, targetFields, renames));
+    final var imports = new TreeSet<>(importsFor(fieldPlans));
     imports.add("io.github.eschizoid.telescope.Telescope");
     imports.add("io.github.eschizoid.telescope.conversion.BridgeFn");
     writeClass(
@@ -2503,8 +2503,8 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
 
   /**
    * Why a container field cannot be emitted when nothing telescope can construct is of its declared
-   * type. Naming a concrete type is the only fix the author can apply, since the type itself is
-   * what rules out every candidate.
+   * type. The declared type is what rules out every candidate, so the fix is to name one telescope
+   * can build or to convert the field explicitly.
    */
   private static String unassignableContainerMessage(
     final TypeElement source,
@@ -2627,17 +2627,13 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
    * factories, which apply the load factor for the caller. A container with neither is filled from
    * its default capacity.
    *
+   * <p>Only the JDK default impls can be sized at all: a user subtype declares no sized constructor
+   * (constructors are not inherited), and one it declares itself carries whatever meaning its
+   * author gave the argument.
+   *
    * @param typeArgs the emitted type arguments, without angle brackets
-   */
-  private static String sizedAlloc(final String implFqn, final String typeArgs) {
-    return sizedAlloc(implFqn, typeArgs, simpleName(implFqn));
-  }
-
-  /**
-   * As above, naming the class as {@code rendered} at the call site: the simple name where the
-   * emitting helper's file imports it, the fully-qualified name where it does not. Only the JDK
-   * default impls can be sized — a user subtype declares no sized constructor (constructors are not
-   * inherited), and one it declares itself carries whatever meaning its author gave the argument.
+   * @param rendered how the class is named at the call site — always fully qualified, because a
+   *     container helper imports nothing
    */
   private static String sizedAlloc(final String implFqn, final String typeArgs, final String rendered) {
     return switch (implFqn) {
@@ -3166,27 +3162,19 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
 
   /**
    * Compute the {@code java.util.*} imports a bridge needs based on the kinds of fields in its
-   * plan. Returned set is fed into {@link AbstractTelescopeProcessor#writeClass(String, String,
-   * Set, String, Element, java.util.function.Consumer)} so the emitted file has clean imports
-   * instead of FQNs in the body.
+   * plan. Container types are not among them: a container helper renders every type fully
+   * qualified, so importing them would only reintroduce a simple-name collision. Returned set is
+   * fed into {@link AbstractTelescopeProcessor#writeClass(String, String, Set, String, Element,
+   * java.util.function.Consumer)} so the emitted file has clean imports instead of FQNs in the
+   * body.
    */
-  private Set<String> importsFor(
-    final Map<String, FieldPlan> fieldPlans,
-    final List<Field> sourceFields,
-    final List<Field> targetFields,
-    final Map<String, String> renames
-  ) {
+  private Set<String> importsFor(final Map<String, FieldPlan> fieldPlans) {
     final var imports = new TreeSet<String>();
-    for (final var entry : fieldPlans.entrySet()) {
-      final var plan = entry.getValue();
+    for (final var plan : fieldPlans.values()) {
       // Raw-container helpers render every container/element TYPE by fully-qualified name, so they
       // need no container-type imports.
       if (plan.rawContainer()) continue;
       switch (plan.kind()) {
-        // A container field needs both the declared raw of each side (the helper return / param
-        // types and the inline copy) and the concrete impl each side allocates. For the common
-        // interface-typed field this is {List, ArrayList} etc., unchanged; a concrete subtype adds
-        // its own class (LinkedList, TreeSet, …).
         // A container's raw type and its allocation class are rendered fully qualified, so they
         // need no import — and importing them would reintroduce the collision two subtypes of the
         // same simple name in different packages otherwise cause.
@@ -3281,12 +3269,6 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
     out.println("  }");
   }
 
-  // The first of the two raw-container fields whose concrete allocation class lacks a public no-arg
-  // constructor (the generated `new <impl>()` would not compile), or null when both are
-  // allocatable.
-  // The JDK default impls (ArrayList / LinkedHashSet / LinkedHashMap) always qualify; only a user
-  // subtype
-  // can hide its no-arg ctor.
   /**
    * The first of the two container types whose chosen allocation class cannot be assigned to it, or
    * null when both fit. Picking a class and being able to name it are separate obligations from
@@ -3309,6 +3291,12 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
     return null;
   }
 
+  // The first of the two raw-container fields whose concrete allocation class lacks a public no-arg
+  // constructor (the generated `new <impl>()` would not compile), or null when both are
+  // allocatable.
+  // The JDK default impls (ArrayList / LinkedHashSet / LinkedHashMap) always qualify; only a user
+  // subtype
+  // can hide its no-arg ctor.
   private String firstNonAllocatableContainer(
     final TypeMirror srcContainer,
     final TypeMirror tgtContainer,

--- a/codegen/src/test/java/io/github/eschizoid/telescope/codegen/BridgeProcessorTest.java
+++ b/codegen/src/test/java/io/github/eschizoid/telescope/codegen/BridgeProcessorTest.java
@@ -321,8 +321,12 @@ class BridgeProcessorTest {
       assertTrue(orderBridge.contains("__fwd_items(__fs_items)"), orderBridge);
       assertTrue(orderBridge.contains("final java.util.List<demo.LineItemDto> __bt_items = t.items();"), orderBridge);
       assertTrue(orderBridge.contains("__bwd_items(__bt_items)"), orderBridge);
-      // A container helper renders every type fully qualified, so it imports none of them.
+      // A container helper renders every type fully qualified, so it imports none of them — not the
+      // allocation class and not the declared raw. Pinning the raw as well as the impl states the
+      // invariant directly; a colliding pair failing downstream only catches it once two of them
+      // exist in one bridge.
       assertFalse(orderBridge.contains("import java.util.ArrayList;"), orderBridge);
+      assertFalse(orderBridge.contains("import java.util.List;"), orderBridge);
       assertTrue(
         orderBridge.contains(
           "private static java.util.List<demo.LineItemDto> __fwd_items(final" + " java.util.List<demo.LineItem> src)"

--- a/codegen/src/test/java/io/github/eschizoid/telescope/codegen/BridgeProcessorTest.java
+++ b/codegen/src/test/java/io/github/eschizoid/telescope/codegen/BridgeProcessorTest.java
@@ -321,13 +321,15 @@ class BridgeProcessorTest {
       assertTrue(orderBridge.contains("__fwd_items(__fs_items)"), orderBridge);
       assertTrue(orderBridge.contains("final java.util.List<demo.LineItemDto> __bt_items = t.items();"), orderBridge);
       assertTrue(orderBridge.contains("__bwd_items(__bt_items)"), orderBridge);
-      assertTrue(orderBridge.contains("import java.util.ArrayList;"), orderBridge);
-      assertTrue(orderBridge.contains("import java.util.List;"), orderBridge);
+      // A container helper renders every type fully qualified, so it imports none of them.
+      assertFalse(orderBridge.contains("import java.util.ArrayList;"), orderBridge);
       assertTrue(
-        orderBridge.contains("private static List<demo.LineItemDto> __fwd_items(final List<demo.LineItem> src)"),
+        orderBridge.contains(
+          "private static java.util.List<demo.LineItemDto> __fwd_items(final" + " java.util.List<demo.LineItem> src)"
+        ),
         orderBridge
       );
-      assertTrue(orderBridge.contains("new ArrayList<demo.LineItemDto>(src.size())"), orderBridge);
+      assertTrue(orderBridge.contains("new java.util.ArrayList<demo.LineItemDto>(src.size())"), orderBridge);
       assertTrue(orderBridge.contains("LineItemToLineItemDtoBridge.forward(x)"), orderBridge);
       assertTrue(orderBridge.contains("LineItemToLineItemDtoBridge.backward(x)"), orderBridge);
     }
@@ -381,7 +383,7 @@ class BridgeProcessorTest {
       assertNotNull(bridge);
       // The forward helper writes the target's concrete class (LinkedList), not the default
       // ArrayList, and its return type is the target's declared concrete type.
-      assertTrue(bridge.contains("new LinkedList<demo.LLItemDto>"), bridge);
+      assertTrue(bridge.contains("new java.util.LinkedList<demo.LLItemDto>"), bridge);
     }
 
     @Test
@@ -883,8 +885,8 @@ class BridgeProcessorTest {
       assertNotNull(bridge);
       // Identity element → no helper; an inline copy into the target's LinkedList (forward) and the
       // source's default ArrayList (backward).
-      assertTrue(bridge.contains("new LinkedList<>("), bridge);
-      assertTrue(bridge.contains("new ArrayList<>("), bridge);
+      assertTrue(bridge.contains("new java.util.LinkedList<>("), bridge);
+      assertTrue(bridge.contains("new java.util.ArrayList<>("), bridge);
     }
 
     @Test
@@ -917,8 +919,8 @@ class BridgeProcessorTest {
       assertTrue(compilation.success(), () -> "compilation failed: " + compilation.errorMessages());
       final var bridge = compilation.generated().get("demo.ISOrderBridge");
       assertNotNull(bridge);
-      assertTrue(bridge.contains("new TreeSet<>("), bridge);
-      assertTrue(bridge.contains("new LinkedHashSet<>("), bridge);
+      assertTrue(bridge.contains("new java.util.TreeSet<>("), bridge);
+      assertTrue(bridge.contains("new java.util.LinkedHashSet<>("), bridge);
     }
 
     @Test
@@ -953,8 +955,8 @@ class BridgeProcessorTest {
       assertNotNull(bridge);
       // Forward into the target TreeMap; backward into the Map interface's insertion-ordered
       // default.
-      assertTrue(bridge.contains("new TreeMap<>("), bridge);
-      assertTrue(bridge.contains("new LinkedHashMap<>("), bridge);
+      assertTrue(bridge.contains("new java.util.TreeMap<>("), bridge);
+      assertTrue(bridge.contains("new java.util.LinkedHashMap<>("), bridge);
     }
 
     @Test
@@ -1003,13 +1005,12 @@ class BridgeProcessorTest {
       assertTrue(catalog.contains("__fwd_tags(__fs_tags)"), catalog);
       assertTrue(catalog.contains("final java.util.Set<demo.TagDto> __bt_tags = t.tags();"), catalog);
       assertTrue(catalog.contains("__bwd_tags(__bt_tags)"), catalog);
-      assertTrue(catalog.contains("import java.util.LinkedHashSet;"), catalog);
-      assertTrue(catalog.contains("import java.util.Set;"), catalog);
+      assertFalse(catalog.contains("import java.util.LinkedHashSet;"), catalog);
       // newLinkedHashSet, not the int constructor: that argument is a table capacity, and a table
       // built straight from an element count resizes once that count passes three quarters of the
       // next power of two.
-      assertTrue(catalog.contains("LinkedHashSet.<demo.TagDto>newLinkedHashSet(src.size())"), catalog);
-      assertFalse(catalog.contains("new LinkedHashSet<demo.TagDto>(src.size())"), catalog);
+      assertTrue(catalog.contains("java.util.LinkedHashSet.<demo.TagDto>newLinkedHashSet(src.size())"), catalog);
+      assertFalse(catalog.contains("new java.util.LinkedHashSet<demo.TagDto>(src.size())"), catalog);
       assertTrue(catalog.contains("TagToTagDtoBridge.forward(x)"), catalog);
       assertTrue(catalog.contains("TagToTagDtoBridge.backward(x)"), catalog);
     }
@@ -1120,10 +1121,12 @@ class BridgeProcessorTest {
       assertTrue(cart.contains("__fwd_items(__fs_items)"), cart);
       assertTrue(cart.contains("final java.util.Map<java.lang.String,demo.LineItemDto> __bt_items = t.items();"), cart);
       assertTrue(cart.contains("__bwd_items(__bt_items)"), cart);
-      assertTrue(cart.contains("import java.util.LinkedHashMap;"), cart);
-      assertTrue(cart.contains("import java.util.Map;"), cart);
-      assertTrue(cart.contains("LinkedHashMap.<java.lang.String, demo.LineItemDto>newLinkedHashMap(src.size())"), cart);
-      assertFalse(cart.contains("new LinkedHashMap<java.lang.String, demo.LineItemDto>(src.size())"), cart);
+      assertFalse(cart.contains("import java.util.LinkedHashMap;"), cart);
+      assertTrue(
+        cart.contains("java.util.LinkedHashMap.<java.lang.String," + " demo.LineItemDto>newLinkedHashMap(src.size())"),
+        cart
+      );
+      assertFalse(cart.contains("new java.util.LinkedHashMap<java.lang.String, demo.LineItemDto>(src.size())"), cart);
       assertTrue(cart.contains("LineItemToLineItemDtoBridge.forward(e.getValue())"), cart);
       assertTrue(cart.contains("LineItemToLineItemDtoBridge.backward(e.getValue())"), cart);
     }

--- a/codegen/src/test/java/io/github/eschizoid/telescope/codegen/ContainerImplSelectionTest.java
+++ b/codegen/src/test/java/io/github/eschizoid/telescope/codegen/ContainerImplSelectionTest.java
@@ -1,0 +1,100 @@
+package io.github.eschizoid.telescope.codegen;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.github.eschizoid.telescope.codegen.ProcessorHarness.Compilation;
+import java.util.List;
+import javax.tools.JavaFileObject;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Choosing the class to allocate for a container field has two obligations that are easy to treat
+ * as one: the class has to be assignable to the declared type, and it has to be nameable from the
+ * helper that allocates it. A choice can satisfy either and fail the other.
+ *
+ * <p>These compile through the full pipeline. The failures here land in method bodies and field
+ * initializers, which {@code -proc:only} does not attribute, so every assertion would hold
+ * vacuously under the processing-only harness.
+ */
+class ContainerImplSelectionTest {
+
+  private static Compilation compile(final JavaFileObject... sources) {
+    return ProcessorHarness.compileFully(List.of(new BridgeProcessor()), List.of(), sources);
+  }
+
+  @Test
+  @DisplayName("a field typed as an adopter's own interface is reported, not filled with a default impl")
+  void adopterInterfaceFieldIsReported() {
+    // concreteImplFqn falls through to the family default for anything it cannot instantiate, and
+    // ArrayList is not assignable to the declared type.
+    final var compilation = compile(
+      ProcessorHarness.source(
+        "demo.MyListIface",
+        "package demo; import java.util.List; public interface MyListIface<T> extends" + " List<T> {}"
+      ),
+      ProcessorHarness.source(
+        "demo.ISrc",
+        """
+        package demo;
+        import io.github.eschizoid.telescope.annotations.Bridge;
+        @Bridge(demo.IDst.class)
+        public record ISrc(demo.MyListIface<String> items) {}
+        """
+      ),
+      ProcessorHarness.source(
+        "demo.IDst",
+        "package demo; import java.util.List; public record IDst(List<String> items) {}"
+      )
+    );
+
+    assertFalse(compilation.success(), "telescope cannot construct an adopter's interface");
+    assertTrue(
+      compilation.hasError("which telescope cannot construct"),
+      () -> "the declared type is the cause and should be named: " + compilation.errorMessages()
+    );
+    assertFalse(
+      compilation.errorMessages().contains("conforms to"),
+      () -> "javac's assignability error inside generated code is what this replaces: " + compilation.errorMessages()
+    );
+  }
+
+  @Test
+  @DisplayName("two same-named container subtypes in different packages resolve when elements are bridged")
+  void sameNamedSubtypesWithBridgedElements() {
+    // The self-contained helper renders every type fully qualified, so the identity-element form of
+    // this already works. The element-bridging helpers name their types by simple name plus an
+    // import, and two imports of the same simple name cannot coexist.
+    final var compilation = compile(
+      ProcessorHarness.source(
+        "one.Wrap",
+        "package one; import java.util.ArrayList; public class Wrap<T> extends ArrayList<T>" + " {}"
+      ),
+      ProcessorHarness.source(
+        "two.Wrap",
+        "package two; import java.util.ArrayList; public class Wrap<T> extends ArrayList<T>" + " {}"
+      ),
+      ProcessorHarness.source("demo.EA", "package demo; public record EA(String v) {}"),
+      ProcessorHarness.source("demo.EB", "package demo; public record EB(String v) {}"),
+      ProcessorHarness.source(
+        "demo.WSrc",
+        """
+        package demo;
+        import io.github.eschizoid.telescope.annotations.Bridge;
+        @Bridge(demo.WDst.class)
+        public record WSrc(one.Wrap<demo.EA> left, two.Wrap<demo.EA> right) {}
+        """
+      ),
+      ProcessorHarness.source(
+        "demo.WDst",
+        "package demo; public record WDst(one.Wrap<demo.EB> left, two.Wrap<demo.EB> right)" + " {}"
+      )
+    );
+
+    assertTrue(
+      compilation.success(),
+      () -> "both subtypes must be nameable from the same bridge: " + compilation.errorMessages()
+    );
+  }
+}


### PR DESCRIPTION
Addresses two of the three gaps in #369. **Not closing it** — the third is still open, and is described at the end.

Choosing the class to allocate for a container field carries two obligations that the code treated as one. Both failures land as javac errors inside a file the author never wrote.

## It has to *be* the declared type

A field typed as an interface or abstract class the adopter wrote falls through to the family default. That default is instantiable and has the right shape, and it is still not that type:

```java
public interface MyListIface<T> extends List<T> {}
@Bridge(IDst.class) record ISrc(MyListIface<String> items) {}
```

```
error: incompatible types: bad type in conditional expression
  cannot infer type arguments for java.util.ArrayList<>
    reason: no instance(s) of type variable(s) E exist so that
            java.util.ArrayList<E> conforms to demo.MyListIface<java.lang.String>
```

The pair is now refused with the declared type named, the same treatment an abstract side already gets.

**The check runs before the route is chosen**, not inside one branch of it. My first attempt put it next to the allocatability guard, which sits inside the non-inline-copy branch — so the repro still failed, because this shape takes the inline copy. Every route allocates, and the choice is made once for all of them.

## It has to be *nameable* where it is allocated

The element-bridging helpers spelled container types by simple name plus an import. Two subtypes sharing a simple name in different packages therefore could not both be imported:

```
error: reference to Wrap is ambiguous          (x8)
error: a type with the same simple name is already defined by the single-type-import of one.Wrap
```

#368 fixed the identity-element half of this shape, because the self-contained helper renders everything fully qualified. The bridged-element half kept failing, so the two halves of one shape disagreed — worse to reason about than both being broken.

They now render fully qualified and import nothing, which is what `emitRawContainerHelper` has always done. The two helper families agree, and the collision cannot recur by construction rather than by detection.

## Verification

Each fix fails only its own test:

| hunk reverted | fails |
| --- | --- |
| the assignability guard | the adopter-interface test only |
| fully-qualified rendering in the three helpers | the same-simple-name test only |

Both compile through the full pipeline — these failures live in method bodies and field initializers, which `-proc:only` does not attribute, so both assertions would hold vacuously under the processing-only harness.

Eleven existing assertions in `BridgeProcessorTest` were updated: the generated helpers now spell container types fully qualified and import none of them, so the assertions that pinned the simple-name spelling pin the qualified one, and three that asserted an import now assert its absence. The properties they guard are unchanged.

I also reunited two javadoc blocks my own insertions had orphaned — `javac` flagged them as `dangling-doc-comments`, which is a warning worth having.

## Still open on #369

A constructor sharing an erasure with the argument but not its type argument still reads as usable (`TypedList<Integer>` whose constructor takes `List<String>`). That was blocked on the first gap: the principled cure is `Types.asMemberOf`, which needs the allocation class to be the declared one — and after this change that is true everywhere it is not rejected outright. So the blocker is gone, but the fix is not written, and it belongs in its own change rather than bolted onto this one.
