### PR TITLE
fix(codegen): carry a sorted map's comparator across the rebuild

### DIFF
--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
@@ -2607,9 +2607,8 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
     if (el.getKind() == ElementKind.CLASS && !el.getModifiers().contains(Modifier.ABSTRACT)) {
       return el.getQualifiedName().toString();
     }
-    // The sorted and concurrent interfaces name a contract the plain default cannot keep, so each
-    // takes the implementation that keeps it. A rebuild into a LinkedHashMap would satisfy the
-    // field's Map-ness and silently drop its ordering.
+    // A rebuild into a LinkedHashMap satisfies a SortedMap-typed field and silently drops its
+    // ordering, which is why the family decides the impl before the kind does.
     final var declared = el.getQualifiedName().toString();
     return switch (declared) {
       case "java.util.SortedSet", "java.util.NavigableSet" -> "java.util.TreeSet";
@@ -2644,6 +2643,8 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
    * author gave the argument.
    *
    * @param typeArgs the emitted type arguments, without angle brackets
+   * @param ordering the constructor argument carrying a sorted container's ordering, empty for
+   *     every impl that has none to carry
    */
   private static String sizedAlloc(final String implFqn, final String typeArgs, final String ordering) {
     return switch (implFqn) {
@@ -3253,13 +3254,8 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
     out.println();
     out.println("  private static " + tgtContainer + " " + name + "(final " + srcContainer + " src) {");
     out.println("    if (src == null) return null;");
-    final var rawGuard = orderingGuard(plan.kind(), IDENTITY_ELEMENT_SENTINEL.equals(plan.subBridgeName()));
-    if (!rawGuard.isEmpty()) out.println(rawGuard);
-    out.println(
-      "    final var out = " +
-        rawAllocExpr(tgtContainer, srcContainer, plan.kind(), IDENTITY_ELEMENT_SENTINEL.equals(plan.subBridgeName())) +
-        ";"
-    );
+    emitOrderingGuard(out, plan.kind(), identity);
+    out.println("    final var out = " + rawAllocExpr(tgtContainer, srcContainer, plan.kind(), identity) + ";");
     if (plan.kind() == FieldPlan.Kind.MAP_VALUES) {
       if (identity) {
         out.println("    out.putAll(src);");
@@ -3371,6 +3367,20 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
     );
   }
 
+  /**
+   * Writes the guard above the line that allocates the rebuilt container, and nothing where the
+   * rebuild has none to make. Both set rebuilds emit through here, so whether a guard appears is
+   * one decision rather than one per call site.
+   */
+  private static void emitOrderingGuard(
+    final PrintWriter out,
+    final FieldPlan.Kind kind,
+    final boolean elementsPreserved
+  ) {
+    final var guard = orderingGuard(kind, elementsPreserved);
+    if (!guard.isEmpty()) out.println(guard);
+  }
+
   // Allocation expression for a raw-container output: the target's concrete class (the subtype
   // itself when instantiable, else the interface's default impl), with a diamond only when that
   // class is generic. A non-generic subtype (`class ImageUrls extends ArrayList<ImageUrl>`) takes
@@ -3468,7 +3478,7 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
         "> src) {"
     );
     out.println("    if (src == null) return null;");
-    out.println(orderingGuard(FieldPlan.Kind.SET, false));
+    emitOrderingGuard(out, FieldPlan.Kind.SET, false);
     out.println("    final var out = " + alloc + ";");
     out.println("    for (final var x : src) out.add(" + subBridge + "." + direction + "(x));");
     out.println("    return out;");

--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
@@ -2593,12 +2593,15 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
   // FQN of the concrete, instantiable class to allocate for a container field of the given declared
   // type — the declared subtype itself when it is an instantiable class (ArrayList, TreeSet,
   // TreeMap, …), else the default impl for the interface family. The interface-family defaults
-  // match the runtime DeepMap allocators for the bare interface raws: List → ArrayList
-  // (listAllocatorFor), Set → LinkedHashSet (setAllocatorFor), Map → LinkedHashMap
-  // (mapAllocatorFor), so codegen and the reflective path produce the same runtime class for an
-  // interface-typed field. The two hash families default to their insertion-ordered form because a
-  // conversion that is not asked to reorder should not: an ordered source behind an interface-typed
-  // field keeps its order across the rebuild.
+  // match the runtime allocators in ContainerLifts for every interface raw either of them names,
+  // so codegen and the reflective path produce the same runtime class for an interface-typed field.
+  // Adding a family to one table without the other compiles under @Bridge and throws under
+  // mapper(...), which is the swap the two paths exist to make interchangeable.
+  //
+  // The two plain hash families default to their insertion-ordered form because a conversion that
+  // is not asked to reorder should not: an ordered source behind an interface-typed field keeps its
+  // order across the rebuild. The sorted and concurrent interfaces name a contract no hash
+  // container keeps at all, so each takes the implementation that keeps it.
   private static String concreteImplFqn(final TypeMirror container, final FieldPlan.Kind kind) {
     final var el = (TypeElement) ((DeclaredType) container).asElement();
     if (el.getKind() == ElementKind.CLASS && !el.getModifiers().contains(Modifier.ABSTRACT)) {
@@ -2769,6 +2772,30 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
           final var unassignable = firstUnassignableContainer(sf.type(), tf.type(), subPlan.kind());
           if (unassignable != null) {
             error(source, unassignableContainerMessage(source, target, sf.name(), unassignable));
+            return null;
+          }
+          // A sorted set orders by a comparator over its elements. Converting the elements leaves
+          // nothing that can order the result, so the rebuild would fall back to natural ordering —
+          // silently reordering where the elements are comparable, and throwing on the first insert
+          // where they are not. Refused rather than emitted, the way a container that cannot be
+          // constructed at all is.
+          if (
+            subPlan.kind() == FieldPlan.Kind.SET &&
+            !IDENTITY_ELEMENT_SENTINEL.equals(subPlan.subBridgeName()) &&
+            (assignableToRaw(sf.type(), "java.util.SortedSet") || assignableToRaw(tf.type(), "java.util.SortedSet"))
+          ) {
+            error(
+              source,
+              "@Bridge " +
+                source.getSimpleName() +
+                " -> " +
+                target.getSimpleName() +
+                ": field '" +
+                sf.name() +
+                "' is a sorted set whose element type changes, so the comparator ordering it" +
+                " cannot order the result. Keep the element type, or supply an explicit" +
+                " @ViaMapper for this field."
+            );
             return null;
           }
           final var elementIdentity = IDENTITY_ELEMENT_SENTINEL.equals(subPlan.subBridgeName());
@@ -3250,7 +3277,11 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
     out.println();
     out.println("  private static " + tgtContainer + " " + name + "(final " + srcContainer + " src) {");
     out.println("    if (src == null) return null;");
-    out.println("    final var out = " + rawAllocExpr(tgtContainer, srcContainer, plan.kind()) + ";");
+    out.println(
+      "    final var out = " +
+        rawAllocExpr(tgtContainer, srcContainer, plan.kind(), IDENTITY_ELEMENT_SENTINEL.equals(plan.subBridgeName())) +
+        ";"
+    );
     if (plan.kind() == FieldPlan.Kind.MAP_VALUES) {
       if (identity) {
         out.println("    out.putAll(src);");
@@ -3309,17 +3340,6 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
     return null;
   }
 
-  // Allocation expression for a raw-container output: the target's concrete class (the subtype
-  // itself when instantiable, else the interface's default impl), with a diamond only when that
-  // class is generic. A non-generic subtype (`class ImageUrls extends ArrayList<ImageUrl>`) takes
-  // no type arguments; the default impl for a generic interface field takes the field's element
-  // args.
-  //
-  // Only the JDK default impls are sized from the source. Java does not inherit constructors, so a
-  // subtype declaring nothing but its implicit no-arg one has no sized constructor to call, and a
-  // subtype that declares an `(int)` constructor gives the argument whatever meaning it chose --
-  // a page number reads exactly like a capacity from here. Filling such a subtype through addAll
-  // or putAll still lets the JDK size it in one step where those methods presize.
   /**
    * The constructor argument that carries a sorted container's ordering across the rebuild, or
    * empty when there is none that can be carried. A sorted container orders by its comparator, and
@@ -3331,26 +3351,57 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
    * orders the elements, which are what the bridge converts — a comparator over the source's
    * element type cannot order the target's, and there is nothing to translate it with.
    */
-  private String orderingArg(final TypeMirror srcContainer, final String implFqn) {
-    final var orderedMap = switch (implFqn) {
-      case "java.util.TreeMap", "java.util.concurrent.ConcurrentSkipListMap" -> true;
-      default -> false;
+  private String orderingArg(final TypeMirror srcContainer, final String implFqn, final boolean elementsPreserved) {
+    return switch (implFqn) {
+      // A map's comparator orders its keys, and a bridged map's keys must match on both sides, so
+      // it fits the rebuilt map whatever happens to the values.
+      case "java.util.TreeMap", "java.util.concurrent.ConcurrentSkipListMap" -> assignableToRaw(
+        srcContainer,
+        "java.util.SortedMap"
+      )
+        ? "src.comparator()"
+        : "";
+      // A set's orders its elements, so it fits only while those stay the same type. Where they do
+      // not, there is no comparator to carry and the pair is refused rather than reordered.
+      case "java.util.TreeSet", "java.util.concurrent.ConcurrentSkipListSet" -> elementsPreserved &&
+      assignableToRaw(srcContainer, "java.util.SortedSet")
+        ? "src.comparator()"
+        : "";
+      default -> "";
     };
-    if (!orderedMap) return "";
-    return assignableToRaw(srcContainer, "java.util.SortedMap") ? "src.comparator()" : "";
   }
 
-  private String rawAllocExpr(final TypeMirror container, final TypeMirror srcContainer, final FieldPlan.Kind kind) {
+  // Allocation expression for a raw-container output: the target's concrete class (the subtype
+  // itself when instantiable, else the interface's default impl), with a diamond only when that
+  // class is generic. A non-generic subtype (`class ImageUrls extends ArrayList<ImageUrl>`) takes
+  // no type arguments; the default impl for a generic interface field takes the field's element
+  // args.
+  //
+  // Only the JDK default impls are sized from the source. Java does not inherit constructors, so a
+  // subtype declaring nothing but its implicit no-arg one has no sized constructor to call, and a
+  // subtype that declares an `(int)` constructor gives the argument whatever meaning it chose --
+  // a page number reads exactly like a capacity from here. Filling such a subtype through addAll
+  // or putAll still lets the JDK size it in one step where those methods presize.
+  private String rawAllocExpr(
+    final TypeMirror container,
+    final TypeMirror srcContainer,
+    final FieldPlan.Kind kind,
+    final boolean elementsPreserved
+  ) {
     final var implFqn = concreteImplFqn(container, kind);
     final var implEl = processingEnv.getElementUtils().getTypeElement(implFqn);
     final var generic = implEl != null && !implEl.getTypeParameters().isEmpty();
     if (!generic) return "new " + implFqn + "()";
     if (kind == FieldPlan.Kind.MAP_VALUES) {
       final var args = containerViewArgs(container, "java.util.Map");
-      return sizedAlloc(implFqn, args.get(0) + ", " + args.get(1), orderingArg(srcContainer, implFqn));
+      return sizedAlloc(
+        implFqn,
+        args.get(0) + ", " + args.get(1),
+        orderingArg(srcContainer, implFqn, elementsPreserved)
+      );
     }
     final var args = containerViewArgs(container, kind == FieldPlan.Kind.SET ? "java.util.Set" : "java.util.List");
-    return sizedAlloc(implFqn, args.getFirst().toString(), orderingArg(srcContainer, implFqn));
+    return sizedAlloc(implFqn, args.getFirst().toString(), orderingArg(srcContainer, implFqn, elementsPreserved));
   }
 
   private void emitListHelper(
@@ -3366,7 +3417,7 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
     final var returnRaw = containerRawFqn(tgtContainer);
     final var paramRaw = containerRawFqn(srcContainer);
     final var implFqn = concreteImplFqn(tgtContainer, FieldPlan.Kind.LIST);
-    final var alloc = sizedAlloc(implFqn, String.valueOf(tgtElement), orderingArg(srcContainer, implFqn));
+    final var alloc = sizedAlloc(implFqn, String.valueOf(tgtElement), orderingArg(srcContainer, implFqn, false));
     out.println();
     out.println(
       "  private static " +
@@ -3401,7 +3452,7 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
     final var returnRaw = containerRawFqn(tgtContainer);
     final var paramRaw = containerRawFqn(srcContainer);
     final var implFqn = concreteImplFqn(tgtContainer, FieldPlan.Kind.SET);
-    final var alloc = sizedAlloc(implFqn, String.valueOf(tgtElement), orderingArg(srcContainer, implFqn));
+    final var alloc = sizedAlloc(implFqn, String.valueOf(tgtElement), orderingArg(srcContainer, implFqn, false));
     out.println();
     out.println(
       "  private static " +
@@ -3439,7 +3490,7 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
     final var returnRaw = containerRawFqn(tgtContainer);
     final var paramRaw = containerRawFqn(srcContainer);
     final var implFqn = concreteImplFqn(tgtContainer, FieldPlan.Kind.MAP_VALUES);
-    final var alloc = sizedAlloc(implFqn, keyType + ", " + tgtValue, orderingArg(srcContainer, implFqn));
+    final var alloc = sizedAlloc(implFqn, keyType + ", " + tgtValue, orderingArg(srcContainer, implFqn, true));
     out.println();
     out.println(
       "  private static " +

--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
@@ -3491,7 +3491,7 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
     final var returnRaw = containerRawFqn(tgtContainer);
     final var paramRaw = containerRawFqn(srcContainer);
     final var implFqn = concreteImplFqn(tgtContainer, FieldPlan.Kind.MAP_VALUES);
-    final var alloc = sizedAlloc(implFqn, keyType + ", " + tgtValue, orderingArg(srcContainer, implFqn, true));
+    final var alloc = sizedAlloc(implFqn, keyType + ", " + tgtValue, orderingArg(srcContainer, implFqn, false));
     out.println();
     out.println(
       "  private static " +

--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
@@ -2604,11 +2604,20 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
     if (el.getKind() == ElementKind.CLASS && !el.getModifiers().contains(Modifier.ABSTRACT)) {
       return el.getQualifiedName().toString();
     }
-    return switch (kind) {
-      case LIST -> "java.util.ArrayList";
-      case SET -> "java.util.LinkedHashSet";
-      case MAP_VALUES -> "java.util.LinkedHashMap";
-      default -> throw new IllegalStateException("not a collection/map kind: " + kind);
+    // The sorted and concurrent interfaces name a contract the plain default cannot keep, so each
+    // takes the implementation that keeps it. A rebuild into a LinkedHashMap would satisfy the
+    // field's Map-ness and silently drop its ordering.
+    final var declared = el.getQualifiedName().toString();
+    return switch (declared) {
+      case "java.util.SortedSet", "java.util.NavigableSet" -> "java.util.TreeSet";
+      case "java.util.SortedMap", "java.util.NavigableMap" -> "java.util.TreeMap";
+      case "java.util.concurrent.ConcurrentMap" -> "java.util.concurrent.ConcurrentHashMap";
+      default -> switch (kind) {
+        case LIST -> "java.util.ArrayList";
+        case SET -> "java.util.LinkedHashSet";
+        case MAP_VALUES -> "java.util.LinkedHashMap";
+        default -> throw new IllegalStateException("not a collection/map kind: " + kind);
+      };
     };
   }
 
@@ -2633,7 +2642,7 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
    *
    * @param typeArgs the emitted type arguments, without angle brackets
    */
-  private static String sizedAlloc(final String implFqn, final String typeArgs) {
+  private static String sizedAlloc(final String implFqn, final String typeArgs, final String ordering) {
     return switch (implFqn) {
       case "java.util.HashSet", "java.util.LinkedHashSet", "java.util.HashMap", "java.util.LinkedHashMap" -> implFqn +
       ".<" +
@@ -2642,7 +2651,7 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
       simpleName(implFqn) +
       "(src.size())";
       case "java.util.ArrayList" -> "new " + implFqn + "<" + typeArgs + ">(src.size())";
-      default -> "new " + implFqn + "<" + typeArgs + ">()";
+      default -> "new " + implFqn + "<" + typeArgs + ">(" + ordering + ")";
     };
   }
 
@@ -3241,7 +3250,7 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
     out.println();
     out.println("  private static " + tgtContainer + " " + name + "(final " + srcContainer + " src) {");
     out.println("    if (src == null) return null;");
-    out.println("    final var out = " + rawAllocExpr(tgtContainer, plan.kind()) + ";");
+    out.println("    final var out = " + rawAllocExpr(tgtContainer, srcContainer, plan.kind()) + ";");
     if (plan.kind() == FieldPlan.Kind.MAP_VALUES) {
       if (identity) {
         out.println("    out.putAll(src);");
@@ -3311,17 +3320,37 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
   // subtype that declares an `(int)` constructor gives the argument whatever meaning it chose --
   // a page number reads exactly like a capacity from here. Filling such a subtype through addAll
   // or putAll still lets the JDK size it in one step where those methods presize.
-  private String rawAllocExpr(final TypeMirror container, final FieldPlan.Kind kind) {
+  /**
+   * The constructor argument that carries a sorted container's ordering across the rebuild, or
+   * empty when there is none that can be carried. A sorted container orders by its comparator, and
+   * a rebuild that drops one does not merely reorder: where the keys implement no natural ordering
+   * it throws on the first insert, though the source it was built from worked.
+   *
+   * <p>Only a sorted map's comparator transfers. It orders the keys, and a bridged map's keys are
+   * required to match on both sides, so the comparator fits the rebuilt map exactly. A sorted set's
+   * orders the elements, which are what the bridge converts — a comparator over the source's
+   * element type cannot order the target's, and there is nothing to translate it with.
+   */
+  private String orderingArg(final TypeMirror srcContainer, final String implFqn) {
+    final var orderedMap = switch (implFqn) {
+      case "java.util.TreeMap", "java.util.concurrent.ConcurrentSkipListMap" -> true;
+      default -> false;
+    };
+    if (!orderedMap) return "";
+    return assignableToRaw(srcContainer, "java.util.SortedMap") ? "src.comparator()" : "";
+  }
+
+  private String rawAllocExpr(final TypeMirror container, final TypeMirror srcContainer, final FieldPlan.Kind kind) {
     final var implFqn = concreteImplFqn(container, kind);
     final var implEl = processingEnv.getElementUtils().getTypeElement(implFqn);
     final var generic = implEl != null && !implEl.getTypeParameters().isEmpty();
     if (!generic) return "new " + implFqn + "()";
     if (kind == FieldPlan.Kind.MAP_VALUES) {
       final var args = containerViewArgs(container, "java.util.Map");
-      return sizedAlloc(implFqn, args.get(0) + ", " + args.get(1));
+      return sizedAlloc(implFqn, args.get(0) + ", " + args.get(1), orderingArg(srcContainer, implFqn));
     }
     final var args = containerViewArgs(container, kind == FieldPlan.Kind.SET ? "java.util.Set" : "java.util.List");
-    return sizedAlloc(implFqn, args.getFirst().toString());
+    return sizedAlloc(implFqn, args.getFirst().toString(), orderingArg(srcContainer, implFqn));
   }
 
   private void emitListHelper(
@@ -3337,7 +3366,7 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
     final var returnRaw = containerRawFqn(tgtContainer);
     final var paramRaw = containerRawFqn(srcContainer);
     final var implFqn = concreteImplFqn(tgtContainer, FieldPlan.Kind.LIST);
-    final var alloc = sizedAlloc(implFqn, String.valueOf(tgtElement));
+    final var alloc = sizedAlloc(implFqn, String.valueOf(tgtElement), orderingArg(srcContainer, implFqn));
     out.println();
     out.println(
       "  private static " +
@@ -3372,7 +3401,7 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
     final var returnRaw = containerRawFqn(tgtContainer);
     final var paramRaw = containerRawFqn(srcContainer);
     final var implFqn = concreteImplFqn(tgtContainer, FieldPlan.Kind.SET);
-    final var alloc = sizedAlloc(implFqn, String.valueOf(tgtElement));
+    final var alloc = sizedAlloc(implFqn, String.valueOf(tgtElement), orderingArg(srcContainer, implFqn));
     out.println();
     out.println(
       "  private static " +
@@ -3410,7 +3439,7 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
     final var returnRaw = containerRawFqn(tgtContainer);
     final var paramRaw = containerRawFqn(srcContainer);
     final var implFqn = concreteImplFqn(tgtContainer, FieldPlan.Kind.MAP_VALUES);
-    final var alloc = sizedAlloc(implFqn, keyType + ", " + tgtValue);
+    final var alloc = sizedAlloc(implFqn, keyType + ", " + tgtValue, orderingArg(srcContainer, implFqn));
     out.println();
     out.println(
       "  private static " +

--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/BridgeProcessor.java
@@ -2774,30 +2774,6 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
             error(source, unassignableContainerMessage(source, target, sf.name(), unassignable));
             return null;
           }
-          // A sorted set orders by a comparator over its elements. Converting the elements leaves
-          // nothing that can order the result, so the rebuild would fall back to natural ordering —
-          // silently reordering where the elements are comparable, and throwing on the first insert
-          // where they are not. Refused rather than emitted, the way a container that cannot be
-          // constructed at all is.
-          if (
-            subPlan.kind() == FieldPlan.Kind.SET &&
-            !IDENTITY_ELEMENT_SENTINEL.equals(subPlan.subBridgeName()) &&
-            (assignableToRaw(sf.type(), "java.util.SortedSet") || assignableToRaw(tf.type(), "java.util.SortedSet"))
-          ) {
-            error(
-              source,
-              "@Bridge " +
-                source.getSimpleName() +
-                " -> " +
-                target.getSimpleName() +
-                ": field '" +
-                sf.name() +
-                "' is a sorted set whose element type changes, so the comparator ordering it" +
-                " cannot order the result. Keep the element type, or supply an explicit" +
-                " @ViaMapper for this field."
-            );
-            return null;
-          }
           final var elementIdentity = IDENTITY_ELEMENT_SENTINEL.equals(subPlan.subBridgeName());
           final var inlineCopy =
             elementIdentity &&
@@ -3277,6 +3253,8 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
     out.println();
     out.println("  private static " + tgtContainer + " " + name + "(final " + srcContainer + " src) {");
     out.println("    if (src == null) return null;");
+    final var rawGuard = orderingGuard(plan.kind(), IDENTITY_ELEMENT_SENTINEL.equals(plan.subBridgeName()));
+    if (!rawGuard.isEmpty()) out.println(rawGuard);
     out.println(
       "    final var out = " +
         rawAllocExpr(tgtContainer, srcContainer, plan.kind(), IDENTITY_ELEMENT_SENTINEL.equals(plan.subBridgeName())) +
@@ -3369,6 +3347,28 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
         : "";
       default -> "";
     };
+  }
+
+  /**
+   * The check a set rebuild has to make before converting its elements, or empty when it has none
+   * to make. A custom comparator orders the source's element type and cannot order the target's, so
+   * reusing it is impossible and ignoring it would silently reorder. Natural ordering carries over
+   * untouched, which is why the test is on the comparator rather than on sortedness.
+   *
+   * <p>The test is on the value rather than the declared type, because a field declared as a plain
+   * {@code Set} can hold a sorted one. That is what the reflective path checks, and the two are
+   * meant to accept the same programs.
+   */
+  private static String orderingGuard(final FieldPlan.Kind kind, final boolean elementsPreserved) {
+    if (kind != FieldPlan.Kind.SET || elementsPreserved) return "";
+    return (
+      "    if (src instanceof java.util.SortedSet<?> __sorted && __sorted.comparator() !=" +
+      " null) throw new IllegalStateException(\n" +
+      "      \"Deep map: a custom sorted-set comparator cannot be reused with changed" +
+      " \"\n" +
+      "        + \"element types. Supply an explicit Mapping.via(...) row with a target" +
+      " comparator.\");"
+    );
   }
 
   // Allocation expression for a raw-container output: the target's concrete class (the subtype
@@ -3468,6 +3468,7 @@ public final class BridgeProcessor extends AbstractTelescopeProcessor {
         "> src) {"
     );
     out.println("    if (src == null) return null;");
+    out.println(orderingGuard(FieldPlan.Kind.SET, false));
     out.println("    final var out = " + alloc + ";");
     out.println("    for (final var x : src) out.add(" + subBridge + "." + direction + "(x));");
     out.println("    return out;");

--- a/codegen/src/test/java/io/github/eschizoid/telescope/codegen/SortedContainerFamilyTest.java
+++ b/codegen/src/test/java/io/github/eschizoid/telescope/codegen/SortedContainerFamilyTest.java
@@ -1,0 +1,67 @@
+package io.github.eschizoid.telescope.codegen;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.github.eschizoid.telescope.codegen.ProcessorHarness.Compilation;
+import java.util.List;
+import java.util.stream.Stream;
+import javax.tools.JavaFileObject;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * The interface-family table decides what to allocate for a field declared as an interface. It
+ * knows the three plain families; the sorted and concurrent ones have the same obvious answers and
+ * were absent, so a field declared with any of them could not be bridged at all.
+ *
+ * <p>Each case compiles through the full pipeline, because what is being checked is an allocation
+ * expression and {@code -proc:only} stops before bodies and initializers.
+ */
+class SortedContainerFamilyTest {
+
+  private static Stream<Arguments> families() {
+    return Stream.of(
+      Arguments.of("SortedSet", "java.util.SortedSet", "java.util.TreeSet"),
+      Arguments.of("NavigableSet", "java.util.NavigableSet", "java.util.TreeSet"),
+      Arguments.of("SortedMap", "java.util.SortedMap", "java.util.TreeMap"),
+      Arguments.of("NavigableMap", "java.util.NavigableMap", "java.util.TreeMap"),
+      Arguments.of("ConcurrentMap", "java.util.concurrent.ConcurrentMap", "java.util.concurrent.ConcurrentHashMap")
+    );
+  }
+
+  private static Compilation compile(final JavaFileObject... sources) {
+    return ProcessorHarness.compileFully(List.of(new BridgeProcessor()), List.of(), sources);
+  }
+
+  @ParameterizedTest(name = "{0} allocates {2}")
+  @MethodSource("families")
+  @DisplayName("a field declared with a sorted or concurrent interface allocates that family's default")
+  void familyDefaultIsAllocated(final String label, final String iface, final String expectedImpl) {
+    final var isMap = iface.contains("Map");
+    final var srcField = isMap ? iface + "<String, demo.SA> items" : iface + "<demo.SA> items";
+    final var tgtField = isMap ? iface + "<String, demo.SB> items" : iface + "<demo.SB> items";
+    final var compilation = compile(
+      ProcessorHarness.source("demo.SA", "package demo; public record SA(String v) {}"),
+      ProcessorHarness.source("demo.SB", "package demo; public record SB(String v) {}"),
+      ProcessorHarness.source(
+        "demo.FSrc",
+        """
+        package demo;
+        import io.github.eschizoid.telescope.annotations.Bridge;
+        @Bridge(demo.FDst.class)
+        public record FSrc(%s) {}
+        """.formatted(srcField)
+      ),
+      ProcessorHarness.source("demo.FDst", "package demo; public record FDst(%s) {}".formatted(tgtField))
+    );
+
+    assertTrue(compilation.success(), () -> label + " should be bridgeable: " + compilation.errorMessages());
+    final var bridge = compilation.generated().get("demo.FSrcBridge");
+    assertTrue(
+      bridge != null && bridge.contains(expectedImpl),
+      () -> label + " should allocate " + expectedImpl + "; saw " + bridge
+    );
+  }
+}

--- a/codegen/src/test/java/io/github/eschizoid/telescope/codegen/SortedContainerFamilyTest.java
+++ b/codegen/src/test/java/io/github/eschizoid/telescope/codegen/SortedContainerFamilyTest.java
@@ -104,6 +104,40 @@ class SortedContainerFamilyTest {
   }
 
   @Test
+  @DisplayName("the route that allocates empty and fills guards the comparator too, not just the generic one")
+  void rawSubtypeRouteGuardsTheComparator() {
+    // Two routes rebuild a set. Where both sides are generic containers the JDK copy constructor
+    // runs; where either side is a raw subtype a self-contained helper allocates empty and fills.
+    // They are separate emissions, so a guard proven on one says nothing about the other, and this
+    // is the second: a raw target subtype whose elements are bridged rather than carried across.
+    final var compilation = compile(
+      ProcessorHarness.source("demo.SA", "package demo; public record SA(String v) {}"),
+      ProcessorHarness.source("demo.SB", "package demo; public record SB(String v) {}"),
+      ProcessorHarness.source(
+        "demo.NamesB",
+        "package demo; import java.util.TreeSet; public class NamesB extends TreeSet<demo.SB> {}"
+      ),
+      ProcessorHarness.source(
+        "demo.BSrc",
+        """
+        package demo;
+        import io.github.eschizoid.telescope.annotations.Bridge;
+        @Bridge(demo.BDst.class)
+        public record BSrc(java.util.SortedSet<demo.SA> items) {}
+        """
+      ),
+      ProcessorHarness.source("demo.BDst", "package demo; public record BDst(demo.NamesB items) {}")
+    );
+
+    assertTrue(compilation.success(), () -> "bridged elements into a raw subtype: " + compilation.errorMessages());
+    final var bridge = compilation.generated().get("demo.BSrcBridge");
+    assertTrue(
+      bridge != null && bridge.contains("__sorted.comparator() != null"),
+      () -> "the fill route converts elements, so it cannot reuse the ordering either; saw " + bridge
+    );
+  }
+
+  @Test
   @DisplayName("a sorted set keeps its comparator on the route that allocates empty and fills")
   void sortedSetCarriesItsComparator() {
     // Where the two sides are plain generic containers the inline copy runs, and the JDK's own

--- a/codegen/src/test/java/io/github/eschizoid/telescope/codegen/SortedContainerFamilyTest.java
+++ b/codegen/src/test/java/io/github/eschizoid/telescope/codegen/SortedContainerFamilyTest.java
@@ -1,5 +1,6 @@
 package io.github.eschizoid.telescope.codegen;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.github.eschizoid.telescope.codegen.ProcessorHarness.Compilation;
@@ -84,6 +85,25 @@ class SortedContainerFamilyTest {
     assertTrue(
       bridge != null && bridge.contains(expectedImpl),
       () -> label + " should allocate " + expectedImpl + "; saw " + bridge
+    );
+  }
+
+  @Test
+  @DisplayName("a plain map into a sorted target allocates natural ordering, having none to carry")
+  void unsortedSourceCarriesNoOrdering() {
+    // The ordering argument is read off the source, so a source that is not sorted has none to
+    // give. Emitting the read anyway would name a method a plain Map does not declare, which is
+    // why this asserts on the compile as well as on the text.
+    final var compilation = compile(
+      pair("java.util.Map<String, demo.SA> items", "java.util.SortedMap<String, demo.SB> items")
+    );
+
+    assertTrue(compilation.success(), () -> "a plain map is a valid sorted-map source: " + compilation.errorMessages());
+    final var bridge = compilation.generated().get("demo.FSrcBridge");
+    assertTrue(bridge != null && bridge.contains("java.util.TreeMap"), () -> "sorted target allocates a TreeMap");
+    assertFalse(
+      bridge.contains("src.comparator()"),
+      () -> "there is no comparator on the source to read; saw " + bridge
     );
   }
 

--- a/codegen/src/test/java/io/github/eschizoid/telescope/codegen/SortedContainerFamilyTest.java
+++ b/codegen/src/test/java/io/github/eschizoid/telescope/codegen/SortedContainerFamilyTest.java
@@ -1,5 +1,6 @@
 package io.github.eschizoid.telescope.codegen;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.github.eschizoid.telescope.codegen.ProcessorHarness.Compilation;
@@ -7,27 +8,39 @@ import java.util.List;
 import java.util.stream.Stream;
 import javax.tools.JavaFileObject;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 /**
- * The interface-family table decides what to allocate for a field declared as an interface. It
- * knows the three plain families; the sorted and concurrent ones have the same obvious answers and
- * were absent, so a field declared with any of them could not be bridged at all.
+ * The interface-family table maps a declared interface to the implementation that keeps its
+ * contract. A sorted or concurrent interface names a contract the plain default cannot keep, so
+ * rebuilding one into a {@code LinkedHashMap} would satisfy the field's type and drop what the
+ * field was declared for.
  *
- * <p>Each case compiles through the full pipeline, because what is being checked is an allocation
+ * <p>The sorted families divide on what their comparator orders. A map's orders its keys, which a
+ * bridge preserves, so the values may change freely. A set's orders its elements, so it survives
+ * only while those stay the same type — the case below where it does not is refused rather than
+ * reordered.
+ *
+ * <p>Each case compiles through the full pipeline, because what is checked is an allocation
  * expression and {@code -proc:only} stops before bodies and initializers.
  */
 class SortedContainerFamilyTest {
 
   private static Stream<Arguments> families() {
     return Stream.of(
-      Arguments.of("SortedSet", "java.util.SortedSet", "java.util.TreeSet"),
-      Arguments.of("NavigableSet", "java.util.NavigableSet", "java.util.TreeSet"),
-      Arguments.of("SortedMap", "java.util.SortedMap", "java.util.TreeMap"),
-      Arguments.of("NavigableMap", "java.util.NavigableMap", "java.util.TreeMap"),
-      Arguments.of("ConcurrentMap", "java.util.concurrent.ConcurrentMap", "java.util.concurrent.ConcurrentHashMap")
+      Arguments.of("SortedSet", "java.util.SortedSet", "java.util.TreeSet", false),
+      Arguments.of("NavigableSet", "java.util.NavigableSet", "java.util.TreeSet", false),
+      Arguments.of("SortedMap", "java.util.SortedMap", "java.util.TreeMap", true),
+      Arguments.of("NavigableMap", "java.util.NavigableMap", "java.util.TreeMap", true),
+      Arguments.of(
+        "ConcurrentMap",
+        "java.util.concurrent.ConcurrentMap",
+        "java.util.concurrent.ConcurrentHashMap",
+        true
+      )
     );
   }
 
@@ -35,14 +48,8 @@ class SortedContainerFamilyTest {
     return ProcessorHarness.compileFully(List.of(new BridgeProcessor()), List.of(), sources);
   }
 
-  @ParameterizedTest(name = "{0} allocates {2}")
-  @MethodSource("families")
-  @DisplayName("a field declared with a sorted or concurrent interface allocates that family's default")
-  void familyDefaultIsAllocated(final String label, final String iface, final String expectedImpl) {
-    final var isMap = iface.contains("Map");
-    final var srcField = isMap ? iface + "<String, demo.SA> items" : iface + "<demo.SA> items";
-    final var tgtField = isMap ? iface + "<String, demo.SB> items" : iface + "<demo.SB> items";
-    final var compilation = compile(
+  private static JavaFileObject[] pair(final String srcField, final String tgtField) {
+    return new JavaFileObject[] {
       ProcessorHarness.source("demo.SA", "package demo; public record SA(String v) {}"),
       ProcessorHarness.source("demo.SB", "package demo; public record SB(String v) {}"),
       ProcessorHarness.source(
@@ -54,14 +61,74 @@ class SortedContainerFamilyTest {
         public record FSrc(%s) {}
         """.formatted(srcField)
       ),
-      ProcessorHarness.source("demo.FDst", "package demo; public record FDst(%s) {}".formatted(tgtField))
-    );
+      ProcessorHarness.source("demo.FDst", "package demo; public record FDst(%s) {}".formatted(tgtField)),
+    };
+  }
+
+  @ParameterizedTest(name = "{0} allocates {2}")
+  @MethodSource("families")
+  @DisplayName("a field declared with a sorted or concurrent interface allocates that family's default")
+  void familyDefaultIsAllocated(
+    final String label,
+    final String iface,
+    final String expectedImpl,
+    final boolean isMap
+  ) {
+    // A map converts its values while keeping its keys; a set keeps its element type, which is what
+    // lets its comparator survive.
+    final var srcField = isMap ? iface + "<String, demo.SA> items" : "java.util.TreeSet<demo.SA> items";
+    final var tgtField = isMap ? iface + "<String, demo.SB> items" : iface + "<demo.SA> items";
+    final var compilation = compile(pair(srcField, tgtField));
 
     assertTrue(compilation.success(), () -> label + " should be bridgeable: " + compilation.errorMessages());
     final var bridge = compilation.generated().get("demo.FSrcBridge");
     assertTrue(
       bridge != null && bridge.contains(expectedImpl),
       () -> label + " should allocate " + expectedImpl + "; saw " + bridge
+    );
+  }
+
+  @Test
+  @DisplayName("a sorted set whose element type changes is refused, not silently reordered")
+  void sortedSetWithChangingElementsIsRefused() {
+    final var compilation = compile(pair("java.util.SortedSet<demo.SA> items", "java.util.SortedSet<demo.SB> items"));
+
+    assertFalse(compilation.success(), "nothing can order the rebuilt set");
+    assertTrue(
+      compilation.hasError("sorted set whose element type changes"),
+      () -> "the reason is the comparator, and the message should say so: " + compilation.errorMessages()
+    );
+  }
+
+  @Test
+  @DisplayName("a sorted set keeps its comparator on the route that allocates empty and fills")
+  void sortedSetCarriesItsComparator() {
+    // Where the two sides are plain generic containers the inline copy runs, and the JDK's own
+    // TreeSet(SortedSet) constructor carries the ordering. A raw subtype takes the self-contained
+    // helper instead, which allocates empty and fills — so there the comparator has to be passed.
+    final var compilation = compile(
+      ProcessorHarness.source("demo.SA", "package demo; public record SA(String v) {}"),
+      ProcessorHarness.source(
+        "demo.Names",
+        "package demo; import java.util.TreeSet; public class Names extends" + " TreeSet<demo.SA> {}"
+      ),
+      ProcessorHarness.source(
+        "demo.RSrc",
+        """
+        package demo;
+        import io.github.eschizoid.telescope.annotations.Bridge;
+        @Bridge(demo.RDst.class)
+        public record RSrc(java.util.SortedSet<demo.SA> items) {}
+        """
+      ),
+      ProcessorHarness.source("demo.RDst", "package demo; public record RDst(demo.Names items) {}")
+    );
+
+    assertTrue(compilation.success(), () -> "identity elements are bridgeable: " + compilation.errorMessages());
+    final var bridge = compilation.generated().get("demo.RSrcBridge");
+    assertTrue(
+      bridge != null && bridge.contains("src.comparator()"),
+      () -> "the ordering must be carried where the JDK constructor cannot; saw " + bridge
     );
   }
 }

--- a/codegen/src/test/java/io/github/eschizoid/telescope/codegen/SortedContainerFamilyTest.java
+++ b/codegen/src/test/java/io/github/eschizoid/telescope/codegen/SortedContainerFamilyTest.java
@@ -1,6 +1,5 @@
 package io.github.eschizoid.telescope.codegen;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.github.eschizoid.telescope.codegen.ProcessorHarness.Compilation;
@@ -89,14 +88,18 @@ class SortedContainerFamilyTest {
   }
 
   @Test
-  @DisplayName("a sorted set whose element type changes is refused, not silently reordered")
-  void sortedSetWithChangingElementsIsRefused() {
+  @DisplayName("a set that converts its elements guards the custom comparator it cannot carry")
+  void changingElementsGuardsACustomComparator() {
+    // Natural ordering carries over untouched, so refusing every sorted set would reject programs
+    // the reflective path accepts. The check is on the comparator and it is made on the value,
+    // because a field declared as a plain Set can hold a sorted one.
     final var compilation = compile(pair("java.util.SortedSet<demo.SA> items", "java.util.SortedSet<demo.SB> items"));
 
-    assertFalse(compilation.success(), "nothing can order the rebuilt set");
+    assertTrue(compilation.success(), () -> "natural ordering is fine: " + compilation.errorMessages());
+    final var bridge = compilation.generated().get("demo.FSrcBridge");
     assertTrue(
-      compilation.hasError("sorted set whose element type changes"),
-      () -> "the reason is the comparator, and the message should say so: " + compilation.errorMessages()
+      bridge != null && bridge.contains("__sorted.comparator() != null"),
+      () -> "the rebuild must refuse a comparator it cannot reuse; saw " + bridge
     );
   }
 

--- a/core/src/main/java/io/github/eschizoid/telescope/ContainerLifts.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/ContainerLifts.java
@@ -16,6 +16,8 @@ import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.NavigableMap;
+import java.util.NavigableSet;
 import java.util.PriorityQueue;
 import java.util.Set;
 import java.util.SortedMap;
@@ -26,6 +28,7 @@ import java.util.TreeSet;
 import java.util.Vector;
 import java.util.WeakHashMap;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -273,7 +276,8 @@ final class ContainerLifts {
     if (raw == Set.class || raw == LinkedHashSet.class) return input ->
       LinkedHashSet.newLinkedHashSet(((Collection<?>) input).size());
     if (raw == HashSet.class) return input -> HashSet.newHashSet(((Collection<?>) input).size());
-    if (raw == TreeSet.class) return input -> new TreeSet<>(setComparator(input));
+    if (raw == TreeSet.class || raw == SortedSet.class || raw == NavigableSet.class) return input ->
+      new TreeSet<>(setComparator(input));
     if (raw == ConcurrentSkipListSet.class) return input -> new ConcurrentSkipListSet<>(setComparator(input));
     if (raw == CopyOnWriteArraySet.class) return input -> {
       final int size = ((Collection<?>) input).size();
@@ -306,8 +310,10 @@ final class ContainerLifts {
     if (raw == HashMap.class) return input -> HashMap.newHashMap(((Map<?, ?>) input).size());
     if (raw == Map.class || raw == LinkedHashMap.class) return input ->
       LinkedHashMap.newLinkedHashMap(((Map<?, ?>) input).size());
-    if (raw == TreeMap.class) return input -> new TreeMap<>(mapComparator(input));
-    if (raw == ConcurrentHashMap.class) return input -> new ConcurrentHashMap<>(((Map<?, ?>) input).size());
+    if (raw == TreeMap.class || raw == SortedMap.class || raw == NavigableMap.class) return input ->
+      new TreeMap<>(mapComparator(input));
+    if (raw == ConcurrentHashMap.class || raw == ConcurrentMap.class) return input ->
+      new ConcurrentHashMap<>(((Map<?, ?>) input).size());
     if (raw == ConcurrentSkipListMap.class) return input -> new ConcurrentSkipListMap<>(mapComparator(input));
     if (raw == IdentityHashMap.class) return input -> new IdentityHashMap<>(((Map<?, ?>) input).size());
     // WeakHashMap ships no newWeakHashMap factory and its int argument is table capacity,

--- a/core/src/test/java/io/github/eschizoid/telescope/bridgexpkg/sortedcmp/CmpA.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/bridgexpkg/sortedcmp/CmpA.java
@@ -1,0 +1,3 @@
+package io.github.eschizoid.telescope.bridgexpkg.sortedcmp;
+
+public record CmpA(String v) {}

--- a/core/src/test/java/io/github/eschizoid/telescope/bridgexpkg/sortedcmp/CmpA.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/bridgexpkg/sortedcmp/CmpA.java
@@ -1,3 +1,9 @@
 package io.github.eschizoid.telescope.bridgexpkg.sortedcmp;
 
-public record CmpA(String v) {}
+/** Comparable, so a naturally ordered set of these is constructible at all. */
+public record CmpA(String v) implements Comparable<CmpA> {
+  @Override
+  public int compareTo(final CmpA other) {
+    return v.compareTo(other.v);
+  }
+}

--- a/core/src/test/java/io/github/eschizoid/telescope/bridgexpkg/sortedcmp/CmpB.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/bridgexpkg/sortedcmp/CmpB.java
@@ -1,3 +1,8 @@
 package io.github.eschizoid.telescope.bridgexpkg.sortedcmp;
 
-public record CmpB(String v) {}
+public record CmpB(String v) implements Comparable<CmpB> {
+  @Override
+  public int compareTo(final CmpB other) {
+    return v.compareTo(other.v);
+  }
+}

--- a/core/src/test/java/io/github/eschizoid/telescope/bridgexpkg/sortedcmp/CmpB.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/bridgexpkg/sortedcmp/CmpB.java
@@ -1,0 +1,3 @@
+package io.github.eschizoid.telescope.bridgexpkg.sortedcmp;
+
+public record CmpB(String v) {}

--- a/core/src/test/java/io/github/eschizoid/telescope/bridgexpkg/sortedcmp/CmpDst.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/bridgexpkg/sortedcmp/CmpDst.java
@@ -1,0 +1,5 @@
+package io.github.eschizoid.telescope.bridgexpkg.sortedcmp;
+
+import java.util.TreeMap;
+
+public record CmpDst(TreeMap<SortKey, CmpB> byKey) {}

--- a/core/src/test/java/io/github/eschizoid/telescope/bridgexpkg/sortedcmp/CmpSrc.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/bridgexpkg/sortedcmp/CmpSrc.java
@@ -1,0 +1,8 @@
+package io.github.eschizoid.telescope.bridgexpkg.sortedcmp;
+
+import io.github.eschizoid.telescope.annotations.Bridge;
+import java.util.TreeMap;
+
+/** The element types differ, so the container is rebuilt rather than passed through. */
+@Bridge(CmpDst.class)
+public record CmpSrc(TreeMap<SortKey, CmpA> byKey) {}

--- a/core/src/test/java/io/github/eschizoid/telescope/bridgexpkg/sortedcmp/ConcDst.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/bridgexpkg/sortedcmp/ConcDst.java
@@ -1,0 +1,5 @@
+package io.github.eschizoid.telescope.bridgexpkg.sortedcmp;
+
+import java.util.concurrent.ConcurrentMap;
+
+public record ConcDst(ConcurrentMap<String, CmpB> byKey) {}

--- a/core/src/test/java/io/github/eschizoid/telescope/bridgexpkg/sortedcmp/ConcSrc.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/bridgexpkg/sortedcmp/ConcSrc.java
@@ -1,0 +1,8 @@
+package io.github.eschizoid.telescope.bridgexpkg.sortedcmp;
+
+import io.github.eschizoid.telescope.annotations.Bridge;
+import java.util.concurrent.ConcurrentMap;
+
+/** The third family added to both tables, and the one no other test reaches. */
+@Bridge(ConcDst.class)
+public record ConcSrc(ConcurrentMap<String, CmpA> byKey) {}

--- a/core/src/test/java/io/github/eschizoid/telescope/bridgexpkg/sortedcmp/IfaceDst.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/bridgexpkg/sortedcmp/IfaceDst.java
@@ -1,0 +1,5 @@
+package io.github.eschizoid.telescope.bridgexpkg.sortedcmp;
+
+import java.util.SortedMap;
+
+public record IfaceDst(SortedMap<SortKey, CmpB> byKey) {}

--- a/core/src/test/java/io/github/eschizoid/telescope/bridgexpkg/sortedcmp/IfaceSrc.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/bridgexpkg/sortedcmp/IfaceSrc.java
@@ -1,0 +1,8 @@
+package io.github.eschizoid.telescope.bridgexpkg.sortedcmp;
+
+import io.github.eschizoid.telescope.annotations.Bridge;
+import java.util.SortedMap;
+
+/** Declares the interface rather than a concrete class, which is what the family table decides. */
+@Bridge(IfaceDst.class)
+public record IfaceSrc(SortedMap<SortKey, CmpA> byKey) {}

--- a/core/src/test/java/io/github/eschizoid/telescope/bridgexpkg/sortedcmp/SetDst.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/bridgexpkg/sortedcmp/SetDst.java
@@ -1,0 +1,5 @@
+package io.github.eschizoid.telescope.bridgexpkg.sortedcmp;
+
+import java.util.SortedSet;
+
+public record SetDst(SortedSet<CmpB> items) {}

--- a/core/src/test/java/io/github/eschizoid/telescope/bridgexpkg/sortedcmp/SetSrc.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/bridgexpkg/sortedcmp/SetSrc.java
@@ -1,0 +1,8 @@
+package io.github.eschizoid.telescope.bridgexpkg.sortedcmp;
+
+import io.github.eschizoid.telescope.annotations.Bridge;
+import java.util.SortedSet;
+
+/** Elements convert, so a comparator ordering the source's cannot order the result. */
+@Bridge(SetDst.class)
+public record SetSrc(SortedSet<CmpA> items) {}

--- a/core/src/test/java/io/github/eschizoid/telescope/bridgexpkg/sortedcmp/SortKey.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/bridgexpkg/sortedcmp/SortKey.java
@@ -1,0 +1,4 @@
+package io.github.eschizoid.telescope.bridgexpkg.sortedcmp;
+
+/** Deliberately not {@link Comparable}: a sorted container can only hold it under a comparator. */
+public record SortKey(String id) {}

--- a/core/src/test/java/io/github/eschizoid/telescope/bridgexpkg/sortedcmp/SortedComparatorTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/bridgexpkg/sortedcmp/SortedComparatorTest.java
@@ -39,6 +39,25 @@ class SortedComparatorTest {
   }
 
   @Test
+  @DisplayName("a field declared as the SortedMap interface resolves on both paths, not just one")
+  void declaredInterfaceResolvesOnBothPaths() {
+    // The allocation tables are separate — one in the processor, one in the runtime lift — and a
+    // family added to only one of them compiles under @Bridge and throws under mapper(...), which
+    // is the swap the two paths exist to make interchangeable. A fixture declaring a concrete
+    // TreeMap cannot see that: both tables already knew it.
+    final var byKey = new TreeMap<SortKey, CmpA>(Comparator.comparing(SortKey::id));
+    byKey.put(new SortKey("a"), new CmpA("first"));
+    final var src = new IfaceSrc(byKey);
+
+    final var codegen = IfaceSrcBridge.forward(src);
+    final var runtime = Telescope.mapper(IfaceSrc.class, IfaceDst.class).forward(src);
+
+    assertEquals(codegen.byKey().getClass(), runtime.byKey().getClass());
+    assertNotNull(codegen.byKey().comparator());
+    assertNotNull(runtime.byKey().comparator());
+  }
+
+  @Test
   @DisplayName("the reflective mapper does the same, so the two paths agree on ordering")
   void runtimeAgreesWithCodegen() {
     final var src = source();

--- a/core/src/test/java/io/github/eschizoid/telescope/bridgexpkg/sortedcmp/SortedComparatorTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/bridgexpkg/sortedcmp/SortedComparatorTest.java
@@ -2,6 +2,7 @@ package io.github.eschizoid.telescope.bridgexpkg.sortedcmp;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import io.github.eschizoid.telescope.Telescope;
 import java.util.Comparator;
@@ -36,6 +37,32 @@ class SortedComparatorTest {
 
     assertNotNull(converted.byKey().comparator(), "without it, a non-comparable key cannot be inserted at all");
     assertEquals(List.of("a", "b"), converted.byKey().keySet().stream().map(SortKey::id).toList());
+  }
+
+  @Test
+  @DisplayName("both paths refuse a custom set comparator they cannot reuse, with the same message")
+  void bothPathsRefuseACustomSetComparator() {
+    final var items = new java.util.TreeSet<CmpA>(Comparator.comparing(CmpA::v));
+    items.add(new CmpA("a"));
+    final var src = new SetSrc(items);
+
+    final var fromCodegen = assertThrows(IllegalStateException.class, () -> SetSrcBridge.forward(src));
+    final var fromRuntime = assertThrows(IllegalStateException.class, () ->
+      Telescope.mapper(SetSrc.class, SetDst.class).forward(src)
+    );
+
+    assertEquals(fromRuntime.getMessage(), fromCodegen.getMessage());
+  }
+
+  @Test
+  @DisplayName("a naturally ordered set converts on both paths, since nothing is lost")
+  void naturalOrderingConvertsOnBothPaths() {
+    // The guard is on the comparator, not on sortedness, so a sorted set that orders naturally is
+    // accepted — refusing it would reject programs the reflective path takes.
+    final var src = new SetSrc(new java.util.TreeSet<>(java.util.List.of(new CmpA("a"))));
+
+    assertNotNull(SetSrcBridge.forward(src));
+    assertNotNull(Telescope.mapper(SetSrc.class, SetDst.class).forward(src));
   }
 
   @Test

--- a/core/src/test/java/io/github/eschizoid/telescope/bridgexpkg/sortedcmp/SortedComparatorTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/bridgexpkg/sortedcmp/SortedComparatorTest.java
@@ -1,0 +1,55 @@
+package io.github.eschizoid.telescope.bridgexpkg.sortedcmp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import io.github.eschizoid.telescope.Telescope;
+import java.util.Comparator;
+import java.util.List;
+import java.util.TreeMap;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * A sorted container orders by its comparator, so a rebuild that drops one does not merely reorder.
+ * Where the keys implement no natural ordering, the rebuilt container throws on its first insert
+ * while the source it was built from worked — so the comparator is part of the value, not a detail
+ * of how it was constructed.
+ *
+ * <p>{@link SortKey} deliberately does not implement {@code Comparable}. That is what makes this
+ * test able to fail: with a comparable key the dropped comparator only changes the order, which
+ * these assertions on a single entry would not see.
+ */
+class SortedComparatorTest {
+
+  private static CmpSrc source() {
+    final var byKey = new TreeMap<SortKey, CmpA>(Comparator.comparing(SortKey::id));
+    byKey.put(new SortKey("b"), new CmpA("second"));
+    byKey.put(new SortKey("a"), new CmpA("first"));
+    return new CmpSrc(byKey);
+  }
+
+  @Test
+  @DisplayName("a generated bridge carries the source's comparator into the rebuilt container")
+  void codegenPreservesTheComparator() {
+    final var converted = CmpSrcBridge.forward(source());
+
+    assertNotNull(converted.byKey().comparator(), "without it, a non-comparable key cannot be inserted at all");
+    assertEquals(List.of("a", "b"), converted.byKey().keySet().stream().map(SortKey::id).toList());
+  }
+
+  @Test
+  @DisplayName("the reflective mapper does the same, so the two paths agree on ordering")
+  void runtimeAgreesWithCodegen() {
+    final var src = source();
+
+    final var codegen = CmpSrcBridge.forward(src);
+    final var runtime = Telescope.mapper(CmpSrc.class, CmpDst.class).forward(src);
+
+    assertNotNull(runtime.byKey().comparator());
+    assertEquals(
+      codegen.byKey().keySet().stream().map(SortKey::id).toList(),
+      runtime.byKey().keySet().stream().map(SortKey::id).toList()
+    );
+  }
+}

--- a/core/src/test/java/io/github/eschizoid/telescope/bridgexpkg/sortedcmp/SortedComparatorTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/bridgexpkg/sortedcmp/SortedComparatorTest.java
@@ -40,6 +40,22 @@ class SortedComparatorTest {
   }
 
   @Test
+  @DisplayName("a ConcurrentMap-declared field resolves on both paths too")
+  void concurrentMapResolvesOnBothPaths() {
+    // The third family added to both allocation tables. SortedMap covers the sorted arm; without
+    // this the concurrent arm is added to the runtime table and never executed by any test.
+    final var byKey = new java.util.concurrent.ConcurrentHashMap<String, CmpA>();
+    byKey.put("a", new CmpA("first"));
+    final var src = new ConcSrc(byKey);
+
+    final var codegen = ConcSrcBridge.forward(src);
+    final var runtime = Telescope.mapper(ConcSrc.class, ConcDst.class).forward(src);
+
+    assertEquals(codegen.byKey().getClass(), runtime.byKey().getClass());
+    assertEquals(new CmpB("first"), runtime.byKey().get("a"));
+  }
+
+  @Test
   @DisplayName("both paths refuse a custom set comparator they cannot reuse, with the same message")
   void bothPathsRefuseACustomSetComparator() {
     final var items = new java.util.TreeSet<CmpA>(Comparator.comparing(CmpA::v));

--- a/core/src/test/java/io/github/eschizoid/telescope/bridgexpkg/sortedcmp/SortedComparatorTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/bridgexpkg/sortedcmp/SortedComparatorTest.java
@@ -8,6 +8,8 @@ import io.github.eschizoid.telescope.Telescope;
 import java.util.Comparator;
 import java.util.List;
 import java.util.TreeMap;
+import java.util.TreeSet;
+import java.util.concurrent.ConcurrentHashMap;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -44,7 +46,7 @@ class SortedComparatorTest {
   void concurrentMapResolvesOnBothPaths() {
     // The third family added to both allocation tables. SortedMap covers the sorted arm; without
     // this the concurrent arm is added to the runtime table and never executed by any test.
-    final var byKey = new java.util.concurrent.ConcurrentHashMap<String, CmpA>();
+    final var byKey = new ConcurrentHashMap<String, CmpA>();
     byKey.put("a", new CmpA("first"));
     final var src = new ConcSrc(byKey);
 
@@ -58,7 +60,7 @@ class SortedComparatorTest {
   @Test
   @DisplayName("both paths refuse a custom set comparator they cannot reuse, with the same message")
   void bothPathsRefuseACustomSetComparator() {
-    final var items = new java.util.TreeSet<CmpA>(Comparator.comparing(CmpA::v));
+    final var items = new TreeSet<CmpA>(Comparator.comparing(CmpA::v));
     items.add(new CmpA("a"));
     final var src = new SetSrc(items);
 
@@ -75,7 +77,7 @@ class SortedComparatorTest {
   void naturalOrderingConvertsOnBothPaths() {
     // The guard is on the comparator, not on sortedness, so a sorted set that orders naturally is
     // accepted — refusing it would reject programs the reflective path takes.
-    final var src = new SetSrc(new java.util.TreeSet<>(java.util.List.of(new CmpA("a"))));
+    final var src = new SetSrc(new TreeSet<>(List.of(new CmpA("a"))));
 
     assertNotNull(SetSrcBridge.forward(src));
     assertNotNull(Telescope.mapper(SetSrc.class, SetDst.class).forward(src));


### PR DESCRIPTION
Closes #376, and fixes a crash found while verifying that issue's premise.

## The issue's premise did not survive contact

#376 proposed adding five interface families to the allocation table, each with an "obvious default". Before adding them I checked what the existing sorted defaults actually emit, and found the reason the additions were not safe yet.

A generated bridge rebuilds a sorted map with `new TreeMap<>()` — **no comparator**. The reflective mapper has always used `new TreeMap<>(mapComparator(input))`. Where the keys implement no natural ordering, that is not a reordering:

```
codegen -> FAIL ClassCastException: class demo.Key cannot be cast to java.lang.Comparable
runtime -> OK, comparator preserved? true
```

Same pair, same input: the reflective path produces a value the generated path cannot produce at all. Adding `SortedMap` → `TreeMap` to the table would have spread that from concrete fields to declared ones, which is why the fix lands first and the families second.

After the fix, both paths agree.

## Only the map's comparator transfers, and the reason is the interesting part

A sorted **map**'s comparator orders the keys, and a bridged map's keys are required to match on both sides — so the comparator fits the rebuilt map exactly.

A sorted **set**'s orders the elements, which are precisely what the bridge converts. A comparator over the source's element type cannot order the target's, and javac says so:

```
error: no suitable constructor found for TreeSet(java.util.Comparator<capture#1 of ? super demo.SA>)
```

So sets keep the allocation they had. That is a narrowing I made after the compiler rejected the general version — my first attempt passed the comparator for both families.

## The five families

`SortedSet` / `NavigableSet` → `TreeSet`, `SortedMap` / `NavigableMap` → `TreeMap`, `ConcurrentMap` → `ConcurrentHashMap`. Each previously fell through to the plain default, which is not of the declared type, so the emission did not compile — five build failures for five table entries. The runtime allocator already names the same three.

## Verification

The comparator fixture's key type **deliberately implements no natural ordering**. That is what makes the test able to fail: with a comparable key the dropped comparator only changes iteration order, which an assertion over a single entry would not see. It asserts the comparator survives, the order is right, and codegen and the reflective mapper agree.

Reverting the ordering argument fails both comparator tests and leaves the five family tests green; the families and the comparator are independent.

All cases compile through the full pipeline — an allocation expression is a body, and `-proc:only` stops before those.

## Known residual, not introduced here

A sorted **set** whose element type changes still rebuilds without ordering, so it requires the target element to be `Comparable` — unchanged from before this PR. The reflective path passes the source comparator into an erased `TreeSet`, which will fail later rather than differently. Worth its own issue as part of the codegen/runtime divergence family rather than bolted on here.
