### PR TITLE
fix: reach the iterable traversal through a public factory

### DIFF
--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/AbstractTelescopeProcessor.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/AbstractTelescopeProcessor.java
@@ -1209,21 +1209,19 @@ public abstract class AbstractTelescopeProcessor extends AbstractProcessor {
       case "set" -> "Telescope.<R, " + elementType + ">asSet(path).each()";
       case "optional" -> "Telescope.<R, " + elementType + ">asOptional(path).present()";
       case "map" -> "Telescope.asMap(path).values()";
-      // Iterable case: declared leaf is some `? extends Iterable<E>` shape that isn't List,
-      // Set,
-      // Map, or Optional (e.g. bare `Iterable<E>` or `Collection<E>`). Pin both type arguments
-      // on `Telescope.wrap(...)` explicitly so the produced `Telescope<containerType,
-      // elementType>` matches the `path.then(...)` left side regardless of the exact declared
-      // container subtype. NOTE: `Traversals.eachIterable()` only safely rebuilds List and Set
-      // sources — other Iterable subtypes (Queue, Deque, custom iterables) trigger a runtime
-      // IllegalArgumentException at update time. The generated step still compiles; if your
-      // model uses Queue/Deque, re-declare the leaf as `List<E>` or `Set<E>` at the source so
-      // the codegen lands on the typed `list`/`set` branches above instead.
-      default -> "path.then(Telescope.<" +
-      containerType +
-      ", " +
-      elementType +
-      ">wrap(io.github.eschizoid.telescope.internal.optics.collections.Traversals.eachIterable()))";
+      // Every remaining `? extends Iterable<E>` leaf: a bare `Iterable<E>`, a
+      // `Collection<E>`, or any subtype that is not List, Set, Map or Optional. The
+      // container type is pinned alongside the element type because this branch stands
+      // for every remaining shape, so it has no single container to name.
+      //
+      // The step reaches the element traversal through a public factory. Generated code
+      // lands in the consumer's package, where a package-private member of Telescope and
+      // a qualified-exported internal package are both out of reach.
+      //
+      // `Traversals.eachIterable()` rebuilds a List or a Set source and rejects any other
+      // at update time, so a model using a Queue or a Deque should declare the leaf as
+      // `List<E>` or `Set<E>` and land on a typed branch above.
+      default -> "Telescope.<R, " + containerType + ", " + elementType + ">asIterable(path).each()";
     };
     // One Traverse per container step, mirroring a hand-written .each(), .eachValue(), or
     // .whenPresent(). The label names the runtime container family used by the hand-written hops.

--- a/codegen/src/main/java/io/github/eschizoid/telescope/codegen/AbstractTelescopeProcessor.java
+++ b/codegen/src/main/java/io/github/eschizoid/telescope/codegen/AbstractTelescopeProcessor.java
@@ -8,10 +8,12 @@ import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.function.Consumer;
+import java.util.stream.Stream;
 import javax.annotation.processing.AbstractProcessor;
 import javax.annotation.processing.FilerException;
 import javax.lang.model.element.Element;
@@ -222,8 +224,13 @@ public abstract class AbstractTelescopeProcessor extends AbstractProcessor {
    * {@code "iterable"}) used to pick which {@code Telescope.asX(...)} static factory the codegen
    * emits. Returned by {@link #traversalKind}; {@code null} when the type isn't a traversable
    * container.
+   *
+   * @param rebuildable whether a write through this step can succeed. The polymorphic iterable
+   *     traversal rebuilds a {@code List} or a {@code Set}, so a declared type that can hold
+   *     neither -- a {@code Deque}, a {@code Queue}, an adopter's own {@code Iterable} subtype --
+   *     reads correctly and throws on update. Always true for the four typed kinds.
    */
-  protected record TraversalShape(String elementType, String stepMethod, String containerKind) {}
+  protected record TraversalShape(String elementType, String stepMethod, String containerKind, boolean rebuildable) {}
 
   /**
    * The traversal shape of a collection-shaped {@code type}, or {@code null} if it isn't
@@ -244,31 +251,46 @@ public abstract class AbstractTelescopeProcessor extends AbstractProcessor {
     final var map = elements.getTypeElement("java.util.Map");
     if (map != null && types.isAssignable(erasure, types.erasure(map.asType()))) {
       final var elem = concreteArg(args, 1);
-      return elem == null ? null : new TraversalShape(elem, "eachValue", "map");
+      return elem == null ? null : new TraversalShape(elem, "eachValue", "map", true);
     }
     final var optional = elements.getTypeElement("java.util.Optional");
     if (optional != null && types.isSameType(erasure, types.erasure(optional.asType()))) {
       final var elem = concreteArg(args, 0);
-      return elem == null ? null : new TraversalShape(elem, "whenPresent", "optional");
+      return elem == null ? null : new TraversalShape(elem, "whenPresent", "optional", true);
     }
     // Differentiate List vs Set vs raw Iterable so the codegen can emit the right typed
     // Telescope.asList/asSet factory at the step (zero runtime container dispatch).
     final var list = elements.getTypeElement("java.util.List");
     if (list != null && types.isAssignable(erasure, types.erasure(list.asType()))) {
       final var elem = concreteArg(args, 0);
-      return elem == null ? null : new TraversalShape(elem, "each", "list");
+      return elem == null ? null : new TraversalShape(elem, "each", "list", true);
     }
     final var set = elements.getTypeElement("java.util.Set");
     if (set != null && types.isAssignable(erasure, types.erasure(set.asType()))) {
       final var elem = concreteArg(args, 0);
-      return elem == null ? null : new TraversalShape(elem, "each", "set");
+      return elem == null ? null : new TraversalShape(elem, "each", "set", true);
     }
     final var iterable = elements.getTypeElement("java.lang.Iterable");
     if (iterable != null && types.isAssignable(erasure, types.erasure(iterable.asType()))) {
       final var elem = concreteArg(args, 0);
-      return elem == null ? null : new TraversalShape(elem, "each", "iterable");
+      return elem == null ? null : new TraversalShape(elem, "each", "iterable", rebuildableIterable(erasure));
     }
     return null;
+  }
+
+  /**
+   * Whether a write through the polymorphic iterable step can succeed for this declared type. The
+   * traversal rebuilds its source as an {@code ArrayList} or a {@code LinkedHashSet}, so a declared
+   * type that can hold neither has no rebuild the write could store. Reads are unaffected: every
+   * {@code Iterable} enumerates.
+   */
+  private boolean rebuildableIterable(final TypeMirror erasure) {
+    final var types = processingEnv.getTypeUtils();
+    final var elements = processingEnv.getElementUtils();
+    return Stream.of("java.util.ArrayList", "java.util.LinkedHashSet")
+      .map(elements::getTypeElement)
+      .filter(Objects::nonNull)
+      .anyMatch(impl -> types.isAssignable(types.erasure(impl.asType()), erasure));
   }
 
   /**
@@ -1195,6 +1217,23 @@ public abstract class AbstractTelescopeProcessor extends AbstractProcessor {
     final Set<String> navigableAnnotations,
     final String javadoc
   ) {
+    if (!shape.rebuildable()) {
+      // Reads enumerate any Iterable, so the step is useful and still emitted. Only a write has no
+      // rebuild to store, and it fails at update time with the traversal's own message.
+      processingEnv
+        .getMessager()
+        .printMessage(
+          Diagnostic.Kind.WARNING,
+          "telescope: '" +
+            componentName +
+            "' is declared " +
+            containerType +
+            ", which can hold neither an ArrayList nor a LinkedHashSet. Reading through this step" +
+            " works; updating through it throws, because the rebuild has no container to produce." +
+            " Declare the component as List<E> or Set<E> to make writes work.",
+          origin
+        );
+    }
     final var stepName = enclosingSimpleName + capitalize(componentName) + "Step";
     final var qualifiedStep = pkg.isEmpty() ? stepName : pkg + "." + stepName;
     final var rawElementType = shape.elementType();

--- a/codegen/src/test/java/io/github/eschizoid/telescope/codegen/GeneratedCodeReachabilityTest.java
+++ b/codegen/src/test/java/io/github/eschizoid/telescope/codegen/GeneratedCodeReachabilityTest.java
@@ -1,0 +1,92 @@
+package io.github.eschizoid.telescope.codegen;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.github.eschizoid.telescope.codegen.ProcessorHarness.Compilation;
+import java.util.List;
+import java.util.stream.Stream;
+import javax.tools.JavaFileObject;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * Generated code lands in the consumer's own package, so everything it names has to be reachable
+ * from there: public, and in an exported package. Two things are not, and both are one import away
+ * from an emitter that means well — a package-private member of {@code Telescope}, and the {@code
+ * internal} packages, which {@code module-info} exports to {@code :core} alone.
+ *
+ * <p>Neither failure is visible to a processing-only compile, because both land in a method body.
+ * Both are invisible to a classpath consumer in one case and to a modular one in the other: a
+ * package-private member fails everywhere, while a non-exported package compiles on the classpath
+ * and fails only for a consumer that declares a module. These compile through the full pipeline,
+ * which catches the first, and assert on the emitted text, which catches the second.
+ */
+class GeneratedCodeReachabilityTest {
+
+  private static final String INTERNAL_PACKAGE = "io.github.eschizoid.telescope.internal";
+
+  private static Compilation compile(final JavaFileObject... sources) {
+    return ProcessorHarness.compileFully(List.of(new FocusProcessor()), List.of(), sources);
+  }
+
+  private static JavaFileObject record(final String leaf) {
+    return ProcessorHarness.source(
+      "demo.P",
+      "package demo; import io.github.eschizoid.telescope.annotations.Focus;\n@Focus public record P(" + leaf + ") {}"
+    );
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @ValueSource(
+    strings = {
+      "java.util.Collection<String> items",
+      "Iterable<String> items",
+      "java.util.List<String> items",
+      "java.util.Set<String> items",
+      "java.util.Map<String, String> items",
+      "java.util.Optional<String> items",
+      "String name",
+    }
+  )
+  @DisplayName("a navigator names nothing the consumer's package cannot reach")
+  void navigatorNamesOnlyReachableTypes(final String leaf) {
+    final var compilation = compile(record(leaf));
+
+    // The compile is the gate on access: a package-private member of Telescope fails here and
+    // nowhere earlier, since the reference sits in a step method's body.
+    assertTrue(compilation.success(), () -> leaf + " should compile for a consumer: " + compilation.errorMessages());
+
+    // The text is the gate on exports: a non-exported package compiles for a classpath consumer
+    // and fails only for one that declares a module, which no test here can be.
+    compilation
+      .generated()
+      .forEach((name, src) ->
+        assertFalse(
+          src.contains(INTERNAL_PACKAGE),
+          () -> name + " names a package exported to :core alone, so a modular consumer cannot compile it:\n" + src
+        )
+      );
+  }
+
+  @Test
+  @DisplayName("the container leaf with no fixed container reaches its elements through the public factory")
+  void iterableLeafUsesThePublicFactory() {
+    // List, Set, Map and Optional each have a companion that names their container. Everything
+    // else shares one, and it is the branch with no obvious public route to the element traversal.
+    final var steps = Stream.of("java.util.Collection<String> items", "Iterable<String> items")
+      .map(leaf -> compile(record(leaf)))
+      .peek(c -> assertTrue(c.success(), () -> "iterable leaf: " + c.errorMessages()))
+      .map(c -> c.generated().get("demo.PItemsStep"))
+      .toList();
+
+    steps.forEach(step ->
+      assertTrue(
+        step != null && step.contains("asIterable(path).each()"),
+        () -> "the step must descend through the public factory; saw " + step
+      )
+    );
+  }
+}

--- a/codegen/src/test/java/io/github/eschizoid/telescope/codegen/GeneratedCodeReachabilityTest.java
+++ b/codegen/src/test/java/io/github/eschizoid/telescope/codegen/GeneratedCodeReachabilityTest.java
@@ -71,6 +71,41 @@ class GeneratedCodeReachabilityTest {
       );
   }
 
+  @ParameterizedTest(name = "{0}")
+  @ValueSource(strings = { "java.util.Deque<String> items", "java.util.Queue<String> items" })
+  @DisplayName("a leaf no rebuild can produce is emitted with a warning rather than in silence")
+  void unwritableIterableLeafWarns(final String leaf) {
+    // The step still reads, so refusing to emit would take away a working capability. What it
+    // cannot do is write, and the one moment that is knowable is here rather than at update time.
+    final var compilation = compile(record(leaf));
+
+    assertTrue(compilation.success(), () -> leaf + " still reads, so it must still compile");
+    final var warned = compilation
+      .diagnostics()
+      .stream()
+      .anyMatch(d -> d.getMessage(null).contains("updating through it throws"));
+    assertTrue(warned, () -> "no warning for a leaf that cannot be written: " + compilation.diagnostics());
+  }
+
+  @Test
+  @DisplayName("a leaf a rebuild can produce is emitted without that warning")
+  void writableIterableLeafIsSilent() {
+    // The control. Collection and Iterable both admit an ArrayList, so a write through them lands
+    // somewhere -- without this, a warning emitted for every iterable leaf would pass the test
+    // above.
+    Stream.of("java.util.Collection<String> items", "Iterable<String> items")
+      .map(leaf -> compile(record(leaf)))
+      .forEach(c ->
+        assertFalse(
+          c
+            .diagnostics()
+            .stream()
+            .anyMatch(d -> d.getMessage(null).contains("updating through it throws")),
+          () -> "a writable leaf must not warn: " + c.diagnostics()
+        )
+      );
+  }
+
   @Test
   @DisplayName("the container leaf with no fixed container reaches its elements through the public factory")
   void iterableLeafUsesThePublicFactory() {

--- a/codegen/src/test/java/io/github/eschizoid/telescope/codegen/GeneratedCodeReachabilityTest.java
+++ b/codegen/src/test/java/io/github/eschizoid/telescope/codegen/GeneratedCodeReachabilityTest.java
@@ -35,7 +35,10 @@ class GeneratedCodeReachabilityTest {
   private static JavaFileObject record(final String leaf) {
     return ProcessorHarness.source(
       "demo.P",
-      "package demo; import io.github.eschizoid.telescope.annotations.Focus;\n@Focus public record P(" + leaf + ") {}"
+      "package demo; import io.github.eschizoid.telescope.annotations.Focus;\n" +
+        "@Focus public record P(" +
+        leaf +
+        ") {}"
     );
   }
 
@@ -66,7 +69,7 @@ class GeneratedCodeReachabilityTest {
       .forEach((name, src) ->
         assertFalse(
           src.contains(INTERNAL_PACKAGE),
-          () -> name + " names a package exported to :core alone, so a modular consumer cannot compile it:\n" + src
+          () -> name + " names a package exported to :core alone, so a modular consumer" + " cannot compile it:\n" + src
         )
       );
   }
@@ -85,6 +88,36 @@ class GeneratedCodeReachabilityTest {
       .stream()
       .anyMatch(d -> d.getMessage(null).contains("updating through it throws"));
     assertTrue(warned, () -> "no warning for a leaf that cannot be written: " + compilation.diagnostics());
+  }
+
+  @Test
+  @DisplayName("a generic record is rejected outright, rather than emitting a step over an erased element")
+  void genericRecordIsRejected() {
+    // A container component whose element is a type variable has nothing concrete for a step's
+    // signature to name. The processor declines the whole record rather than emitting a navigator
+    // with a hole in it, and says which component and which type made it decline.
+    final var compilation = ProcessorHarness.compileFully(
+      List.of(new FocusProcessor()),
+      List.of(),
+      ProcessorHarness.source(
+        "demo.Box",
+        """
+        package demo;
+        import io.github.eschizoid.telescope.annotations.Focus;
+        @Focus public record Box<T>(java.util.List<T> items, String label) {}
+        """
+      )
+    );
+
+    assertFalse(compilation.success(), "an erased element type cannot be navigated");
+    assertTrue(
+      compilation.hasError("generics with wildcard or self-referential bounds are not supported"),
+      () -> "the refusal should name the limitation: " + compilation.errorMessages()
+    );
+    assertTrue(
+      compilation.errorMessages().contains("items"),
+      () -> "and the component that triggered it: " + compilation.errorMessages()
+    );
   }
 
   @Test

--- a/core/src/main/java/io/github/eschizoid/telescope/Telescope.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/Telescope.java
@@ -389,10 +389,18 @@ public sealed class Telescope<
    * {@code Iterable&lt;X&gt;}. The container type stays on the type parameter, because unlike the
    * four fixed-container companions this one has no single container to name.
    *
-   * <p>The element traversal rebuilds a {@code List} or a {@code Set} source and rejects any other
-   * {@code Iterable} at update time, since there is no general way to rebuild one. A model that
-   * uses a {@code Queue} or a {@code Deque} should declare the component as {@code List&lt;X&gt;}
-   * or {@code Set&lt;X&gt;} so the fixed-container companions apply instead.
+   * <p>Reading and writing are not symmetric here, and the asymmetry is the surprising part. Every
+   * {@code Iterable} enumerates, so {@code read}, {@code toList} and {@code count} work whatever the
+   * source is. A write has to rebuild, and the element traversal rebuilds only a {@code List} or a
+   * {@code Set} source, rejecting any other at update time. A path validated with {@code toList()}
+   * can therefore still throw on {@code update}. A model that uses a {@code Queue} or a
+   * {@code Deque} should declare the component as {@code List&lt;X&gt;} or {@code Set&lt;X&gt;} so
+   * the fixed-container companions apply instead.
+   *
+   * <p>The bound admits a path focused at a concrete container class ({@code ArrayList&lt;X&gt;}),
+   * which the fixed-container companions cannot accept because {@code Telescope} is invariant in
+   * its focus. Reads work; a write fails, because the rebuild produces the interface's default
+   * implementation and that cannot be stored back into a field declared at the subclass.
    */
   public static <S, C extends Iterable<X>, X> IterableTelescope<S, C, X> asIterable(final Telescope<S, C> path) {
     return new IterableTelescope<>(

--- a/core/src/main/java/io/github/eschizoid/telescope/Telescope.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/Telescope.java
@@ -390,10 +390,10 @@ public sealed class Telescope<
    * four fixed-container companions this one has no single container to name.
    *
    * <p>Reading and writing are not symmetric here, and the asymmetry is the surprising part. Every
-   * {@code Iterable} enumerates, so {@code read}, {@code toList} and {@code count} work whatever the
-   * source is. A write has to rebuild, and the element traversal rebuilds only a {@code List} or a
-   * {@code Set} source, rejecting any other at update time. A path validated with {@code toList()}
-   * can therefore still throw on {@code update}. A model that uses a {@code Queue} or a
+   * {@code Iterable} enumerates, so {@code read}, {@code toList} and {@code count} work whatever
+   * the source is. A write has to rebuild, and the element traversal rebuilds only a {@code List}
+   * or a {@code Set} source, rejecting any other at update time. A path validated with {@code
+   * toList()} can therefore still throw on {@code update}. A model that uses a {@code Queue} or a
    * {@code Deque} should declare the component as {@code List&lt;X&gt;} or {@code Set&lt;X&gt;} so
    * the fixed-container companions apply instead.
    *

--- a/core/src/main/java/io/github/eschizoid/telescope/Telescope.java
+++ b/core/src/main/java/io/github/eschizoid/telescope/Telescope.java
@@ -84,6 +84,7 @@ public sealed class Telescope<
   Telescope.SetTelescope,
   Telescope.MapTelescope,
   Telescope.OptionalTelescope,
+  Telescope.IterableTelescope,
   Telescope.BridgeTelescope {
 
   /**
@@ -372,6 +373,29 @@ public sealed class Telescope<
   /** Pre-built-fragment companion to {@link #asList} for {@code Set&lt;X&gt;} paths. */
   public static <S, X> SetTelescope<S, X> asSet(final Telescope<S, Set<X>> path) {
     return new SetTelescope<>(
+      path.optic,
+      path.fieldOptics,
+      path.chain,
+      path.firstHopName,
+      path.trail,
+      path.hops,
+      ContainerHop.promotion()
+    );
+  }
+
+  /**
+   * Pre-built-fragment companion to {@link #asList} for a path whose focus is an {@code Iterable}
+   * that is neither a {@code List} nor a {@code Set} — a {@code Collection&lt;X&gt;} or a bare
+   * {@code Iterable&lt;X&gt;}. The container type stays on the type parameter, because unlike the
+   * four fixed-container companions this one has no single container to name.
+   *
+   * <p>The element traversal rebuilds a {@code List} or a {@code Set} source and rejects any other
+   * {@code Iterable} at update time, since there is no general way to rebuild one. A model that
+   * uses a {@code Queue} or a {@code Deque} should declare the component as {@code List&lt;X&gt;}
+   * or {@code Set&lt;X&gt;} so the fixed-container companions apply instead.
+   */
+  public static <S, C extends Iterable<X>, X> IterableTelescope<S, C, X> asIterable(final Telescope<S, C> path) {
+    return new IterableTelescope<>(
       path.optic,
       path.fieldOptics,
       path.chain,
@@ -2502,6 +2526,39 @@ public sealed class Telescope<
     /** Step into set elements. Output is iteration-order-preserving (LinkedHashSet). */
     public Telescope<S, X> each() {
       return origin.descend(this, Traversals.eachSet(), "each", "collection");
+    }
+  }
+
+  /**
+   * A {@link Telescope} whose focus is an {@code Iterable&lt;X&gt;} that is neither a {@code List}
+   * nor a {@code Set}. Adds a compile-checked {@link #each()} terminal that descends into the
+   * elements via {@link Traversals#eachIterable()}, which dispatches on the runtime class to pick
+   * the rebuild shape.
+   *
+   * <p>Carries the container type as {@code C} so the declared type survives the step. The four
+   * fixed-container companions each name their container outright; this one stands for every
+   * remaining {@code Iterable} shape and so cannot.
+   */
+  public static final class IterableTelescope<S, C extends Iterable<X>, X> extends Telescope<S, C> {
+
+    private final ContainerHop<S> origin;
+
+    IterableTelescope(
+      final Traversal<S, C> optic,
+      final FieldOptics fieldOptics,
+      final Function<S, S> chain,
+      final String firstHopName,
+      final List<OpticNode> trail,
+      final List<Fusion.Hop> hops,
+      final ContainerHop<S> origin
+    ) {
+      super(optic, fieldOptics, chain, firstHopName, trail, hops);
+      this.origin = origin;
+    }
+
+    /** Step into the elements. The rebuild preserves a List or Set source and rejects any other. */
+    public Telescope<S, X> each() {
+      return origin.descend(this, Traversals.eachIterable(), "each", "collection");
     }
   }
 

--- a/core/src/test/java/io/github/eschizoid/telescope/AsIterableTest.java
+++ b/core/src/test/java/io/github/eschizoid/telescope/AsIterableTest.java
@@ -1,0 +1,82 @@
+package io.github.eschizoid.telescope;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayDeque;
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The fifth container companion, for a focus that is an {@code Iterable} but neither a {@code List}
+ * nor a {@code Set}. Its four siblings each name one container; this one stands for the rest, and
+ * that difference is what gives it a contract the others do not have.
+ *
+ * <p>Reading and writing are not symmetric through it. Every {@code Iterable} enumerates, so a read
+ * works whatever the source turns out to be. A write has to rebuild, and only a {@code List} or a
+ * {@code Set} source can be rebuilt — so a path that reads cleanly can still throw on update. The
+ * tests below pin both halves, because a suite that only reads would report the write as working.
+ */
+class AsIterableTest {
+
+  record Bag(Collection<String> items, String label) {}
+
+  private static Telescope<Bag, String> elements() {
+    return Telescope.asIterable(Telescope.of(Bag.class).field(Bag::items)).each();
+  }
+
+  @Test
+  @DisplayName("reads focus every element, whatever Iterable the field turns out to hold")
+  void readsEnumerateAnySource() {
+    // Three sources of different container kinds behind one declared type. A read has no rebuild
+    // to do, so the runtime class of the value cannot matter, and an ArrayDeque proves it.
+    assertEquals(List.of("a", "b"), elements().toList(new Bag(List.of("a", "b"), "l")));
+    assertEquals(List.of("a"), elements().toList(new Bag(new LinkedHashSet<>(List.of("a")), "l")));
+    assertEquals(List.of("q"), elements().toList(new Bag(new ArrayDeque<>(List.of("q")), "l")));
+  }
+
+  @Test
+  @DisplayName("a write through a List source rebuilds it and leaves its siblings alone")
+  void writeRebuildsAListSource() {
+    final var out = elements().update(new Bag(List.of("a", "b"), "keep"), String::toUpperCase);
+
+    assertEquals(List.of("A", "B"), List.copyOf(out.items()));
+    assertEquals("keep", out.label(), "the edit must not disturb an unrelated component");
+  }
+
+  @Test
+  @DisplayName("a write through a Set source rebuilds it as a set, not as a list")
+  void writeRebuildsASetSource() {
+    final var out = elements().update(new Bag(new LinkedHashSet<>(List.of("a", "b")), "l"), String::toUpperCase);
+
+    assertTrue(out.items() instanceof java.util.Set<String>, "the source's container kind survives the rebuild");
+    assertEquals(List.of("A", "B"), List.copyOf(out.items()));
+  }
+
+  @Test
+  @DisplayName("a write through a source that is neither refuses, where the matching read succeeded")
+  void writeRefusesAnUnrebuildableSource() {
+    // The asymmetry the javadoc names. This is the case a read-only test would report as healthy:
+    // the same source enumerated fine above.
+    final var deque = new Bag(new ArrayDeque<>(List.of("q")), "l");
+
+    final var thrown = assertThrows(IllegalArgumentException.class, () ->
+      elements().update(deque, String::toUpperCase)
+    );
+    assertTrue(
+      thrown.getMessage().contains("supports only List and Set sources"),
+      () -> "the refusal should name what it can rebuild; saw " + thrown.getMessage()
+    );
+  }
+
+  @Test
+  @DisplayName("a null container reads empty and writes through untouched")
+  void nullContainerIsInert() {
+    assertEquals(List.of(), elements().toList(new Bag(null, "l")));
+    assertEquals(new Bag(null, "l"), elements().update(new Bag(null, "l"), String::toUpperCase));
+  }
+}


### PR DESCRIPTION
Closes #380.

A record component declared `Collection<E>`, or a bare `Iterable<E>`, generated a container step that does not compile. The user's build breaks at the generated file. A component declared `List<E>` or `Set<E>` was unaffected — those land on typed branches.

## Two independent failures, both verified with real javac

The emitted step reached the element traversal like this:

```java
path.then(Telescope.<Collection<String>, String>wrap(
  io.github.eschizoid.telescope.internal.optics.collections.Traversals.eachIterable()))
```

`Telescope.wrap` is package-private — `Telescope` is a class, so a `static` member with no modifier is package-private exactly as its own javadoc says. Generated code lands in the consumer's package, so no consumer can call it:

```
error: <S,A>wrap(Traversal<S,A>) is not public in Telescope;
       cannot be accessed from outside package
```

And `internal.optics.collections` is qualified-exported to `:core` alone, so a consumer with its own `module-info.java` gets a second, separate error:

```
error: package ...internal.optics.collections is not visible
  (declared in module io.github.eschizoid.telescope.internal, which does not export it to com.example)
```

The control in both cases is the same record with the component declared `java.util.List<String>`, which compiles clean. Fixing only one of the two would leave the other broken, and exporting the internal package would contradict the two-layer boundary the lattice is built on.

## The fix

`Telescope.asIterable(...)` is the public companion this branch was missing, mirroring `asList`, `asSet`, `asMap` and `asOptional`. It returns `IterableTelescope<S, C, X>` whose `each()` descends through `Traversals.eachIterable()`.

It carries the container type as a third type parameter because, unlike the four fixed-container companions, this one stands for every remaining `Iterable` shape and so has no single container to name. The emitted step becomes:

```java
Telescope.<R, java.util.Collection<String>, String>asIterable(path).each()
```

## Why nothing caught it

The broken reference sits in a method body, and `ProcessorHarness.compile(...)` passes `-proc:only`, which completes declarations and stops before attributing bodies. Every existing assertion about that expression held vacuously.

`GeneratedCodeReachabilityTest` compiles through the full pipeline, which catches the access half, and asserts on the emitted text, which catches the exports half — no test here can be a modular consumer, so the text is the only available gate for that one. It runs over seven leaf shapes so the iterable rows have five controls beside them.

Revert-proof: restoring the old emission fails exactly the two iterable rows and leaves `List`, `Set`, `Map`, `Optional` and a scalar leaf green.

## Scope note

This adds public API — `asIterable`, `IterableTelescope`, and a `permits` entry on the sealed root. There is no way to fix this without one: generated code cannot name a package-private member or a non-exported package, so the route to the element traversal has to be public.

The wider class is size one — no other emitter in `:codegen` or `:lombok` names an `internal.*` type anywhere.
